### PR TITLE
rp_data_tree  + xp

### DIFF
--- a/src/rp_data_tree.c
+++ b/src/rp_data_tree.c
@@ -422,9 +422,7 @@ rp_dt_copy_value(const struct lyd_node_leaf_list *leaf, LY_DATA_TYPE type, sr_va
         value->data.uint64_val = leaf->value.uint64;
         return SR_ERR_OK;
     default:
-        if (NULL != leaf->schema && NULL != leaf->schema->name){
-            SR_LOG_ERR("Copy value failed for leaf '%s'", leaf->schema->name);
-        }
+        SR_LOG_ERR("Copy value failed for leaf '%s'", leaf->schema->name);
         return SR_ERR_INTERNAL;
     }
 }

--- a/src/sr_common.c
+++ b/src/sr_common.c
@@ -140,6 +140,9 @@ sr_free_val_t(sr_val_t *value){
     if (SR_STRING_T == value->type){
         free(value->data.string_val);
     }
+    else if (SR_IDENTITYREF_T == value->type){
+        free(value->data.identityref_val);
+    }
     free(value);
 }
 

--- a/src/sr_common.c
+++ b/src/sr_common.c
@@ -137,11 +137,23 @@ sr_libyang_type_to_sysrepo(LY_DATA_TYPE t)
 void
 sr_free_val_t(sr_val_t *value){
     free(value->xpath);
-    if (SR_STRING_T == value->type){
+    if (SR_BINARY_T == value->type){
+        free(value->data.binary_val);
+    }
+    else if (SR_STRING_T == value->type){
         free(value->data.string_val);
     }
     else if (SR_IDENTITYREF_T == value->type){
         free(value->data.identityref_val);
+    }
+    else if (SR_ENUM_T == value->type){
+        free(value->data.enum_val);
+    }
+    else if (SR_BINARY_T == value->type){
+        free(value->data.binary_val);
+    }
+    else if (SR_BITS_T == value->type){
+        free(value->data.bits_val);
     }
     free(value);
 }

--- a/src/xpath_processor.c
+++ b/src/xpath_processor.c
@@ -251,6 +251,7 @@ static sr_error_t xp_validate_list_nodes(xp_token_t *tokens, size_t token_count,
 {
     CHECK_NULL_ARG(err_token);
     enum xp_keys_state k = K_UNKNOWN;
+    bool key_name = false; /* set if insided the square bracket the key is set*/
 
     for (size_t i = 1; i < token_count; i++) {
         xp_token_t curr = tokens[i];
@@ -259,17 +260,22 @@ static sr_error_t xp_validate_list_nodes(xp_token_t *tokens, size_t token_count,
             k = K_UNKNOWN;
             *err_token = i;
             break;
+        case T_LSQB:
+            key_name = false;
+            break;
         case T_KEY_NAME:
-            if (k == K_UNKNOWN) {
+            if (K_UNKNOWN == k) {
                 k = K_LISTED;
-            } else if (k == K_OMITTED) {
+            } else if (K_OMITTED == k) {
                 return SR_ERR_INVAL_ARG;
             }
+            key_name = true;
             break;
         case T_KEY_VALUE:
-            if (k == K_UNKNOWN) {
+            if (K_UNKNOWN == k) {
                 k = K_OMITTED;
-            } else if (k == K_OMITTED) {
+            }
+            else if (K_LISTED == k && !key_name){
                 return SR_ERR_INVAL_ARG;
             }
             break;

--- a/src/xpath_processor.c
+++ b/src/xpath_processor.c
@@ -355,7 +355,7 @@ sr_error_t xp_char_to_loc_id(const char *xpath, xp_loc_id_t **loc)
                 xp_change_ns_to_node(cnt, tokens, node_index, &node_count);
                 MARK_TOKEN(T_SLASH);
                 state = S_NS;
-            } else if (cnt > 0 && tokens[cnt - 1] == T_KEY_NAME) {
+            } else if (cnt > 0 && tokens[cnt - 1] == T_NODE) {
                 if (!(isalnum(xpath[i]) || xpath[i] == '_' || xpath[i] == '-' || xpath[i] == '.')) {
                     SR_LOG_ERR("Invalid lexem '%c' in xpath: %s at position %zu", xpath[i], xpath, i);
                     return SR_ERR_INVAL_ARG;

--- a/src/xpath_processor.c
+++ b/src/xpath_processor.c
@@ -251,7 +251,7 @@ static sr_error_t xp_validate_list_nodes(xp_token_t *tokens, size_t token_count,
 {
     CHECK_NULL_ARG(err_token);
     enum xp_keys_state k = K_UNKNOWN;
-    bool key_name = false; /* set if insided the square bracket the key is set*/
+    bool key_name = false; /* set for each square bracket pair if the key_name is listed */
 
     for (size_t i = 1; i < token_count; i++) {
         xp_token_t curr = tokens[i];

--- a/test/data/iana-if-type.yang
+++ b/test/data/iana-if-type.yang
@@ -1,0 +1,1704 @@
+module iana-if-type {
+
+    yang-version 1;
+
+    namespace
+      "urn:ietf:params:xml:ns:yang:iana-if-type";
+
+    prefix ianaift;
+
+    import ietf-interfaces {
+      prefix if;
+    }
+
+    organization "IANA";
+
+    contact
+      "        Internet Assigned Numbers Authority
+
+     Postal: ICANN
+             4676 Admiralty Way, Suite 330
+             Marina del Rey, CA 90292
+
+     Tel:    +1 310 823 9358
+     <mailto:iana@iana.org>";
+
+    description
+      "This YANG module defines YANG identities for IANA-registered
+     interface types.
+
+     This YANG module is maintained by IANA and reflects the
+     'ifType definitions' registry.
+
+     The latest revision of this YANG module can be obtained from
+     the IANA web site.
+
+     Requests for new values should be made to IANA via
+     email (iana@iana.org).
+
+     Copyright (c) 2014 IETF Trust and the persons identified as
+     authors of the code.  All rights reserved.
+
+     Redistribution and use in source and binary forms, with or
+     without modification, is permitted pursuant to, and subject
+     to the license terms contained in, the Simplified BSD License
+     set forth in Section 4.c of the IETF Trust's Legal Provisions
+     Relating to IETF Documents
+     (http://trustee.ietf.org/license-info).
+
+     The initial version of this YANG module is part of RFC 7224;
+     see the RFC itself for full legal notices.";
+
+    reference
+      "IANA 'ifType definitions' registry.
+      <http://www.iana.org/assignments/smi-numbers>";
+
+
+    revision "2014-05-08" {
+      description "Initial revision.";
+      reference
+        "RFC 7224: IANA Interface Type YANG Module";
+
+    }
+
+
+    identity iana-interface-type {
+      base if:interface-type;
+      description
+        "This identity is used as a base for all interface types
+       defined in the 'ifType definitions' registry.";
+    }
+
+    identity other {
+      base iana-interface-type;
+    }
+
+    identity regular1822 {
+      base iana-interface-type;
+    }
+
+    identity hdh1822 {
+      base iana-interface-type;
+    }
+
+    identity ddnX25 {
+      base iana-interface-type;
+    }
+
+    identity rfc877x25 {
+      base iana-interface-type;
+      reference
+        "RFC 1382 - SNMP MIB Extension for the X.25 Packet Layer";
+
+    }
+
+    identity ethernetCsmacd {
+      base iana-interface-type;
+      description
+        "For all Ethernet-like interfaces, regardless of speed,
+       as per RFC 3635.";
+      reference
+        "RFC 3635 - Definitions of Managed Objects for the
+               Ethernet-like Interface Types";
+
+    }
+
+    identity iso88023Csmacd {
+      base iana-interface-type;
+      status deprecated;
+      description
+        "Deprecated via RFC 3635.
+       Use ethernetCsmacd(6) instead.";
+      reference
+        "RFC 3635 - Definitions of Managed Objects for the
+               Ethernet-like Interface Types";
+
+    }
+
+    identity iso88024TokenBus {
+      base iana-interface-type;
+    }
+
+    identity iso88025TokenRing {
+      base iana-interface-type;
+    }
+
+    identity iso88026Man {
+      base iana-interface-type;
+    }
+
+    identity starLan {
+      base iana-interface-type;
+      status deprecated;
+      description
+        "Deprecated via RFC 3635.
+       Use ethernetCsmacd(6) instead.";
+      reference
+        "RFC 3635 - Definitions of Managed Objects for the
+               Ethernet-like Interface Types";
+
+    }
+
+    identity proteon10Mbit {
+      base iana-interface-type;
+    }
+
+    identity proteon80Mbit {
+      base iana-interface-type;
+    }
+
+    identity hyperchannel {
+      base iana-interface-type;
+    }
+
+    identity fddi {
+      base iana-interface-type;
+      reference
+        "RFC 1512 - FDDI Management Information Base";
+
+    }
+
+    identity lapb {
+      base iana-interface-type;
+      reference
+        "RFC 1381 - SNMP MIB Extension for X.25 LAPB";
+
+    }
+
+    identity sdlc {
+      base iana-interface-type;
+    }
+
+    identity ds1 {
+      base iana-interface-type;
+      description "DS1-MIB.";
+      reference
+        "RFC 4805 - Definitions of Managed Objects for the
+               DS1, J1, E1, DS2, and E2 Interface Types";
+
+    }
+
+    identity e1 {
+      base iana-interface-type;
+      status obsolete;
+      description "Obsolete; see DS1-MIB.";
+      reference
+        "RFC 4805 - Definitions of Managed Objects for the
+               DS1, J1, E1, DS2, and E2 Interface Types";
+
+    }
+
+    identity basicISDN {
+      base iana-interface-type;
+      description
+        "No longer used.  See also RFC 2127.";
+    }
+
+    identity primaryISDN {
+      base iana-interface-type;
+      description
+        "No longer used.  See also RFC 2127.";
+    }
+
+    identity propPointToPointSerial {
+      base iana-interface-type;
+      description "Proprietary serial.";
+    }
+
+    identity ppp {
+      base iana-interface-type;
+    }
+
+    identity softwareLoopback {
+      base iana-interface-type;
+    }
+
+    identity eon {
+      base iana-interface-type;
+      description "CLNP over IP.";
+    }
+
+    identity ethernet3Mbit {
+      base iana-interface-type;
+    }
+
+    identity nsip {
+      base iana-interface-type;
+      description "XNS over IP.";
+    }
+
+    identity slip {
+      base iana-interface-type;
+      description "Generic SLIP.";
+    }
+
+    identity ultra {
+      base iana-interface-type;
+      description "Ultra Technologies.";
+    }
+
+    identity ds3 {
+      base iana-interface-type;
+      description "DS3-MIB.";
+      reference
+        "RFC 3896 - Definitions of Managed Objects for the
+               DS3/E3 Interface Type";
+
+    }
+
+    identity sip {
+      base iana-interface-type;
+      description "SMDS, coffee.";
+      reference
+        "RFC 1694 - Definitions of Managed Objects for SMDS
+               Interfaces using SMIv2";
+
+    }
+
+    identity frameRelay {
+      base iana-interface-type;
+      description "DTE only.";
+      reference
+        "RFC 2115 - Management Information Base for Frame Relay
+               DTEs Using SMIv2";
+
+    }
+
+    identity rs232 {
+      base iana-interface-type;
+      reference
+        "RFC 1659 - Definitions of Managed Objects for RS-232-like
+               Hardware Devices using SMIv2";
+
+    }
+
+    identity para {
+      base iana-interface-type;
+      description "Parallel-port.";
+      reference
+        "RFC 1660 - Definitions of Managed Objects for
+               Parallel-printer-like Hardware Devices using
+               SMIv2";
+
+    }
+
+    identity arcnet {
+      base iana-interface-type;
+      description "ARCnet.";
+    }
+
+    identity arcnetPlus {
+      base iana-interface-type;
+      description "ARCnet Plus.";
+    }
+
+    identity atm {
+      base iana-interface-type;
+      description "ATM cells.";
+    }
+
+    identity miox25 {
+      base iana-interface-type;
+      reference
+        "RFC 1461 - SNMP MIB extension for Multiprotocol
+               Interconnect over X.25";
+
+    }
+
+    identity sonet {
+      base iana-interface-type;
+      description "SONET or SDH.";
+    }
+
+    identity x25ple {
+      base iana-interface-type;
+      reference
+        "RFC 2127 - ISDN Management Information Base using SMIv2";
+
+    }
+
+    identity iso88022llc {
+      base iana-interface-type;
+    }
+
+    identity localTalk {
+      base iana-interface-type;
+    }
+
+    identity smdsDxi {
+      base iana-interface-type;
+    }
+
+    identity frameRelayService {
+      base iana-interface-type;
+      description "FRNETSERV-MIB.";
+      reference
+        "RFC 2954 - Definitions of Managed Objects for Frame
+               Relay Service";
+
+    }
+
+    identity v35 {
+      base iana-interface-type;
+    }
+
+    identity hssi {
+      base iana-interface-type;
+    }
+
+    identity hippi {
+      base iana-interface-type;
+    }
+
+    identity modem {
+      base iana-interface-type;
+      description "Generic modem.";
+    }
+
+    identity aal5 {
+      base iana-interface-type;
+      description "AAL5 over ATM.";
+    }
+
+    identity sonetPath {
+      base iana-interface-type;
+    }
+
+    identity sonetVT {
+      base iana-interface-type;
+    }
+
+    identity smdsIcip {
+      base iana-interface-type;
+      description
+        "SMDS InterCarrier Interface.";
+    }
+
+    identity propVirtual {
+      base iana-interface-type;
+      description
+        "Proprietary virtual/internal.";
+      reference
+        "RFC 2863 - The Interfaces Group MIB";
+
+    }
+
+    identity propMultiplexor {
+      base iana-interface-type;
+      description
+        "Proprietary multiplexing.";
+      reference
+        "RFC 2863 - The Interfaces Group MIB";
+
+    }
+
+    identity ieee80212 {
+      base iana-interface-type;
+      description "100BaseVG.";
+    }
+
+    identity fibreChannel {
+      base iana-interface-type;
+      description "Fibre Channel.";
+    }
+
+    identity hippiInterface {
+      base iana-interface-type;
+      description "HIPPI interfaces.";
+    }
+
+    identity frameRelayInterconnect {
+      base iana-interface-type;
+      status obsolete;
+      description
+        "Obsolete; use either
+       frameRelay(32) or frameRelayService(44).";
+    }
+
+    identity aflane8023 {
+      base iana-interface-type;
+      description
+        "ATM Emulated LAN for 802.3.";
+    }
+
+    identity aflane8025 {
+      base iana-interface-type;
+      description
+        "ATM Emulated LAN for 802.5.";
+    }
+
+    identity cctEmul {
+      base iana-interface-type;
+      description "ATM Emulated circuit.";
+    }
+
+    identity fastEther {
+      base iana-interface-type;
+      status deprecated;
+      description
+        "Obsoleted via RFC 3635.
+       ethernetCsmacd(6) should be used instead.";
+      reference
+        "RFC 3635 - Definitions of Managed Objects for the
+               Ethernet-like Interface Types";
+
+    }
+
+    identity isdn {
+      base iana-interface-type;
+      description "ISDN and X.25.";
+      reference
+        "RFC 1356 - Multiprotocol Interconnect on X.25 and ISDN
+               in the Packet Mode";
+
+    }
+
+    identity v11 {
+      base iana-interface-type;
+      description "CCITT V.11/X.21.";
+    }
+
+    identity v36 {
+      base iana-interface-type;
+      description "CCITT V.36.";
+    }
+
+    identity g703at64k {
+      base iana-interface-type;
+      description "CCITT G703 at 64Kbps.";
+    }
+
+    identity g703at2mb {
+      base iana-interface-type;
+      status obsolete;
+      description "Obsolete; see DS1-MIB.";
+    }
+
+    identity qllc {
+      base iana-interface-type;
+      description "SNA QLLC.";
+    }
+
+    identity fastEtherFX {
+      base iana-interface-type;
+      status deprecated;
+      description
+        "Obsoleted via RFC 3635.
+       ethernetCsmacd(6) should be used instead.";
+      reference
+        "RFC 3635 - Definitions of Managed Objects for the
+               Ethernet-like Interface Types";
+
+    }
+
+    identity channel {
+      base iana-interface-type;
+      description "Channel.";
+    }
+
+    identity ieee80211 {
+      base iana-interface-type;
+      description "Radio spread spectrum.";
+    }
+
+    identity ibm370parChan {
+      base iana-interface-type;
+      description
+        "IBM System 360/370 OEMI Channel.";
+    }
+
+    identity escon {
+      base iana-interface-type;
+      description
+        "IBM Enterprise Systems Connection.";
+    }
+
+    identity dlsw {
+      base iana-interface-type;
+      description "Data Link Switching.";
+    }
+
+    identity isdns {
+      base iana-interface-type;
+      description "ISDN S/T interface.";
+    }
+
+    identity isdnu {
+      base iana-interface-type;
+      description "ISDN U interface.";
+    }
+
+    identity lapd {
+      base iana-interface-type;
+      description "Link Access Protocol D.";
+    }
+
+    identity ipSwitch {
+      base iana-interface-type;
+      description "IP Switching Objects.";
+    }
+
+    identity rsrb {
+      base iana-interface-type;
+      description
+        "Remote Source Route Bridging.";
+    }
+
+    identity atmLogical {
+      base iana-interface-type;
+      description "ATM Logical Port.";
+      reference
+        "RFC 3606 - Definitions of Supplemental Managed Objects
+               for ATM Interface";
+
+    }
+
+    identity ds0 {
+      base iana-interface-type;
+      description "Digital Signal Level 0.";
+      reference
+        "RFC 2494 - Definitions of Managed Objects for the DS0
+               and DS0 Bundle Interface Type";
+
+    }
+
+    identity ds0Bundle {
+      base iana-interface-type;
+      description
+        "Group of ds0s on the same ds1.";
+      reference
+        "RFC 2494 - Definitions of Managed Objects for the DS0
+               and DS0 Bundle Interface Type";
+
+    }
+
+    identity bsc {
+      base iana-interface-type;
+      description "Bisynchronous Protocol.";
+    }
+
+    identity async {
+      base iana-interface-type;
+      description "Asynchronous Protocol.";
+    }
+
+    identity cnr {
+      base iana-interface-type;
+      description "Combat Net Radio.";
+    }
+
+    identity iso88025Dtr {
+      base iana-interface-type;
+      description "ISO 802.5r DTR.";
+    }
+
+    identity eplrs {
+      base iana-interface-type;
+      description "Ext Pos Loc Report Sys.";
+    }
+
+    identity arap {
+      base iana-interface-type;
+      description
+        "Appletalk Remote Access Protocol.";
+    }
+
+    identity propCnls {
+      base iana-interface-type;
+      description
+        "Proprietary Connectionless Protocol.";
+    }
+
+    identity hostPad {
+      base iana-interface-type;
+      description
+        "CCITT-ITU X.29 PAD Protocol.";
+    }
+
+    identity termPad {
+      base iana-interface-type;
+      description
+        "CCITT-ITU X.3 PAD Facility.";
+    }
+
+    identity frameRelayMPI {
+      base iana-interface-type;
+      description
+        "Multiproto Interconnect over FR.";
+    }
+
+    identity x213 {
+      base iana-interface-type;
+      description "CCITT-ITU X213.";
+    }
+
+    identity adsl {
+      base iana-interface-type;
+      description
+        "Asymmetric Digital Subscriber Loop.";
+    }
+
+    identity radsl {
+      base iana-interface-type;
+      description
+        "Rate-Adapt. Digital Subscriber Loop.";
+    }
+
+    identity sdsl {
+      base iana-interface-type;
+      description
+        "Symmetric Digital Subscriber Loop.";
+    }
+
+    identity vdsl {
+      base iana-interface-type;
+      description
+        "Very H-Speed Digital Subscrib. Loop.";
+    }
+
+    identity iso88025CRFPInt {
+      base iana-interface-type;
+      description "ISO 802.5 CRFP.";
+    }
+
+    identity myrinet {
+      base iana-interface-type;
+      description "Myricom Myrinet.";
+    }
+
+    identity voiceEM {
+      base iana-interface-type;
+      description
+        "Voice recEive and transMit.";
+    }
+
+    identity voiceFXO {
+      base iana-interface-type;
+      description
+        "Voice Foreign Exchange Office.";
+    }
+
+    identity voiceFXS {
+      base iana-interface-type;
+      description
+        "Voice Foreign Exchange Station.";
+    }
+
+    identity voiceEncap {
+      base iana-interface-type;
+      description "Voice encapsulation.";
+    }
+
+    identity voiceOverIp {
+      base iana-interface-type;
+      description
+        "Voice over IP encapsulation.";
+    }
+
+    identity atmDxi {
+      base iana-interface-type;
+      description "ATM DXI.";
+    }
+
+    identity atmFuni {
+      base iana-interface-type;
+      description "ATM FUNI.";
+    }
+
+    identity atmIma {
+      base iana-interface-type;
+      description "ATM IMA.";
+    }
+
+    identity pppMultilinkBundle {
+      base iana-interface-type;
+      description "PPP Multilink Bundle.";
+    }
+
+    identity ipOverCdlc {
+      base iana-interface-type;
+      description "IBM ipOverCdlc.";
+    }
+
+    identity ipOverClaw {
+      base iana-interface-type;
+      description
+        "IBM Common Link Access to Workstn.";
+    }
+
+    identity stackToStack {
+      base iana-interface-type;
+      description "IBM stackToStack.";
+    }
+
+    identity virtualIpAddress {
+      base iana-interface-type;
+      description "IBM VIPA.";
+    }
+
+    identity mpc {
+      base iana-interface-type;
+      description
+        "IBM multi-protocol channel support.";
+    }
+
+    identity ipOverAtm {
+      base iana-interface-type;
+      description "IBM ipOverAtm.";
+      reference
+        "RFC 2320 - Definitions of Managed Objects for Classical IP
+               and ARP Over ATM Using SMIv2 (IPOA-MIB)";
+
+    }
+
+    identity iso88025Fiber {
+      base iana-interface-type;
+      description
+        "ISO 802.5j Fiber Token Ring.";
+    }
+
+    identity tdlc {
+      base iana-interface-type;
+      description
+        "IBM twinaxial data link control.";
+    }
+
+    identity gigabitEthernet {
+      base iana-interface-type;
+      status deprecated;
+      description
+        "Obsoleted via RFC 3635.
+       ethernetCsmacd(6) should be used instead.";
+      reference
+        "RFC 3635 - Definitions of Managed Objects for the
+               Ethernet-like Interface Types";
+
+    }
+
+    identity hdlc {
+      base iana-interface-type;
+      description "HDLC.";
+    }
+
+    identity lapf {
+      base iana-interface-type;
+      description "LAP F.";
+    }
+
+    identity v37 {
+      base iana-interface-type;
+      description "V.37.";
+    }
+
+    identity x25mlp {
+      base iana-interface-type;
+      description "Multi-Link Protocol.";
+    }
+
+    identity x25huntGroup {
+      base iana-interface-type;
+      description "X25 Hunt Group.";
+    }
+
+    identity transpHdlc {
+      base iana-interface-type;
+      description "Transp HDLC.";
+    }
+
+    identity interleave {
+      base iana-interface-type;
+      description "Interleave channel.";
+    }
+
+    identity fast {
+      base iana-interface-type;
+      description "Fast channel.";
+    }
+
+    identity ip {
+      base iana-interface-type;
+      description
+        "IP (for APPN HPR in IP networks).";
+    }
+
+    identity docsCableMaclayer {
+      base iana-interface-type;
+      description "CATV Mac Layer.";
+    }
+
+    identity docsCableDownstream {
+      base iana-interface-type;
+      description
+        "CATV Downstream interface.";
+    }
+
+    identity docsCableUpstream {
+      base iana-interface-type;
+      description "CATV Upstream interface.";
+    }
+
+    identity a12MppSwitch {
+      base iana-interface-type;
+      description
+        "Avalon Parallel Processor.";
+    }
+
+    identity tunnel {
+      base iana-interface-type;
+      description "Encapsulation interface.";
+    }
+
+    identity coffee {
+      base iana-interface-type;
+      description "Coffee pot.";
+      reference
+        "RFC 2325 - Coffee MIB";
+
+    }
+
+    identity ces {
+      base iana-interface-type;
+      description
+        "Circuit Emulation Service.";
+    }
+
+    identity atmSubInterface {
+      base iana-interface-type;
+      description "ATM Sub Interface.";
+    }
+
+    identity l2vlan {
+      base iana-interface-type;
+      description
+        "Layer 2 Virtual LAN using 802.1Q.";
+    }
+
+    identity l3ipvlan {
+      base iana-interface-type;
+      description
+        "Layer 3 Virtual LAN using IP.";
+    }
+
+    identity l3ipxvlan {
+      base iana-interface-type;
+      description
+        "Layer 3 Virtual LAN using IPX.";
+    }
+
+    identity digitalPowerline {
+      base iana-interface-type;
+      description "IP over Power Lines.";
+    }
+
+    identity mediaMailOverIp {
+      base iana-interface-type;
+      description "Multimedia Mail over IP.";
+    }
+
+    identity dtm {
+      base iana-interface-type;
+      description
+        "Dynamic synchronous Transfer Mode.";
+    }
+
+    identity dcn {
+      base iana-interface-type;
+      description
+        "Data Communications Network.";
+    }
+
+    identity ipForward {
+      base iana-interface-type;
+      description "IP Forwarding Interface.";
+    }
+
+    identity msdsl {
+      base iana-interface-type;
+      description
+        "Multi-rate Symmetric DSL.";
+    }
+
+    identity ieee1394 {
+      base iana-interface-type;
+      description
+        "IEEE1394 High Performance Serial Bus.";
+    }
+
+    identity if-gsn {
+      base iana-interface-type;
+      description "HIPPI-6400.";
+    }
+
+    identity dvbRccMacLayer {
+      base iana-interface-type;
+      description "DVB-RCC MAC Layer.";
+    }
+
+    identity dvbRccDownstream {
+      base iana-interface-type;
+      description
+        "DVB-RCC Downstream Channel.";
+    }
+
+    identity dvbRccUpstream {
+      base iana-interface-type;
+      description
+        "DVB-RCC Upstream Channel.";
+    }
+
+    identity atmVirtual {
+      base iana-interface-type;
+      description "ATM Virtual Interface.";
+    }
+
+    identity mplsTunnel {
+      base iana-interface-type;
+      description
+        "MPLS Tunnel Virtual Interface.";
+    }
+
+    identity srp {
+      base iana-interface-type;
+      description "Spatial Reuse Protocol.";
+    }
+
+    identity voiceOverAtm {
+      base iana-interface-type;
+      description "Voice over ATM.";
+    }
+
+    identity voiceOverFrameRelay {
+      base iana-interface-type;
+      description "Voice Over Frame Relay.";
+    }
+
+    identity idsl {
+      base iana-interface-type;
+      description
+        "Digital Subscriber Loop over ISDN.";
+    }
+
+    identity compositeLink {
+      base iana-interface-type;
+      description
+        "Avici Composite Link Interface.";
+    }
+
+    identity ss7SigLink {
+      base iana-interface-type;
+      description "SS7 Signaling Link.";
+    }
+
+    identity propWirelessP2P {
+      base iana-interface-type;
+      description
+        "Prop. P2P wireless interface.";
+    }
+
+    identity frForward {
+      base iana-interface-type;
+      description "Frame Forward Interface.";
+    }
+
+    identity rfc1483 {
+      base iana-interface-type;
+      description
+        "Multiprotocol over ATM AAL5.";
+      reference
+        "RFC 1483 - Multiprotocol Encapsulation over ATM
+               Adaptation Layer 5";
+
+    }
+
+    identity usb {
+      base iana-interface-type;
+      description "USB Interface.";
+    }
+
+    identity ieee8023adLag {
+      base iana-interface-type;
+      description
+        "IEEE 802.3ad Link Aggregate.";
+    }
+
+    identity bgppolicyaccounting {
+      base iana-interface-type;
+      description "BGP Policy Accounting.";
+    }
+
+    identity frf16MfrBundle {
+      base iana-interface-type;
+      description
+        "FRF.16 Multilink Frame Relay.";
+    }
+
+    identity h323Gatekeeper {
+      base iana-interface-type;
+      description "H323 Gatekeeper.";
+    }
+
+    identity h323Proxy {
+      base iana-interface-type;
+      description
+        "H323 Voice and Video Proxy.";
+    }
+
+    identity mpls {
+      base iana-interface-type;
+      description "MPLS.";
+    }
+
+    identity mfSigLink {
+      base iana-interface-type;
+      description
+        "Multi-frequency signaling link.";
+    }
+
+    identity hdsl2 {
+      base iana-interface-type;
+      description
+        "High Bit-Rate DSL - 2nd generation.";
+    }
+
+    identity shdsl {
+      base iana-interface-type;
+      description "Multirate HDSL2.";
+    }
+
+    identity ds1FDL {
+      base iana-interface-type;
+      description
+        "Facility Data Link (4Kbps) on a DS1.";
+    }
+
+    identity pos {
+      base iana-interface-type;
+      description
+        "Packet over SONET/SDH Interface.";
+    }
+
+    identity dvbAsiIn {
+      base iana-interface-type;
+      description "DVB-ASI Input.";
+    }
+
+    identity dvbAsiOut {
+      base iana-interface-type;
+      description "DVB-ASI Output.";
+    }
+
+    identity plc {
+      base iana-interface-type;
+      description
+        "Power Line Communications.";
+    }
+
+    identity nfas {
+      base iana-interface-type;
+      description
+        "Non-Facility Associated Signaling.";
+    }
+
+    identity tr008 {
+      base iana-interface-type;
+      description "TR008.";
+    }
+
+    identity gr303RDT {
+      base iana-interface-type;
+      description "Remote Digital Terminal.";
+    }
+
+    identity gr303IDT {
+      base iana-interface-type;
+      description
+        "Integrated Digital Terminal.";
+    }
+
+    identity isup {
+      base iana-interface-type;
+      description "ISUP.";
+    }
+
+    identity propDocsWirelessMaclayer {
+      base iana-interface-type;
+      description
+        "Cisco proprietary Maclayer.";
+    }
+
+    identity propDocsWirelessDownstream {
+      base iana-interface-type;
+      description
+        "Cisco proprietary Downstream.";
+    }
+
+    identity propDocsWirelessUpstream {
+      base iana-interface-type;
+      description
+        "Cisco proprietary Upstream.";
+    }
+
+    identity hiperlan2 {
+      base iana-interface-type;
+      description
+        "HIPERLAN Type 2 Radio Interface.";
+    }
+
+    identity propBWAp2Mp {
+      base iana-interface-type;
+      description
+        "PropBroadbandWirelessAccesspt2Multipt (use of this value
+       for IEEE 802.16 WMAN interfaces as per IEEE Std 802.16f
+       is deprecated, and ieee80216WMAN(237) should be used
+       instead).";
+    }
+
+    identity sonetOverheadChannel {
+      base iana-interface-type;
+      description "SONET Overhead Channel.";
+    }
+
+    identity digitalWrapperOverheadChannel {
+      base iana-interface-type;
+      description "Digital Wrapper.";
+    }
+
+    identity aal2 {
+      base iana-interface-type;
+      description "ATM adaptation layer 2.";
+    }
+
+    identity radioMAC {
+      base iana-interface-type;
+      description
+        "MAC layer over radio links.";
+    }
+
+    identity atmRadio {
+      base iana-interface-type;
+      description "ATM over radio links.";
+    }
+
+    identity imt {
+      base iana-interface-type;
+      description "Inter-Machine Trunks.";
+    }
+
+    identity mvl {
+      base iana-interface-type;
+      description
+        "Multiple Virtual Lines DSL.";
+    }
+
+    identity reachDSL {
+      base iana-interface-type;
+      description "Long Reach DSL.";
+    }
+
+    identity frDlciEndPt {
+      base iana-interface-type;
+      description
+        "Frame Relay DLCI End Point.";
+    }
+
+    identity atmVciEndPt {
+      base iana-interface-type;
+      description "ATM VCI End Point.";
+    }
+
+    identity opticalChannel {
+      base iana-interface-type;
+      description "Optical Channel.";
+    }
+
+    identity opticalTransport {
+      base iana-interface-type;
+      description "Optical Transport.";
+    }
+
+    identity propAtm {
+      base iana-interface-type;
+      description "Proprietary ATM.";
+    }
+
+    identity voiceOverCable {
+      base iana-interface-type;
+      description
+        "Voice Over Cable Interface.";
+    }
+
+    identity infiniband {
+      base iana-interface-type;
+      description "Infiniband.";
+    }
+
+    identity teLink {
+      base iana-interface-type;
+      description "TE Link.";
+    }
+
+    identity q2931 {
+      base iana-interface-type;
+      description "Q.2931.";
+    }
+
+    identity virtualTg {
+      base iana-interface-type;
+      description "Virtual Trunk Group.";
+    }
+
+    identity sipTg {
+      base iana-interface-type;
+      description "SIP Trunk Group.";
+    }
+
+    identity sipSig {
+      base iana-interface-type;
+      description "SIP Signaling.";
+    }
+
+    identity docsCableUpstreamChannel {
+      base iana-interface-type;
+      description "CATV Upstream Channel.";
+    }
+
+    identity econet {
+      base iana-interface-type;
+      description "Acorn Econet.";
+    }
+
+    identity pon155 {
+      base iana-interface-type;
+      description
+        "FSAN 155Mb Symetrical PON interface.";
+    }
+
+    identity pon622 {
+      base iana-interface-type;
+      description
+        "FSAN 622Mb Symetrical PON interface.";
+    }
+
+    identity bridge {
+      base iana-interface-type;
+      description
+        "Transparent bridge interface.";
+    }
+
+    identity linegroup {
+      base iana-interface-type;
+      description
+        "Interface common to multiple lines.";
+    }
+
+    identity voiceEMFGD {
+      base iana-interface-type;
+      description
+        "Voice E&M Feature Group D.";
+    }
+
+    identity voiceFGDEANA {
+      base iana-interface-type;
+      description
+        "Voice FGD Exchange Access North American.";
+    }
+
+    identity voiceDID {
+      base iana-interface-type;
+      description
+        "Voice Direct Inward Dialing.";
+    }
+
+    identity mpegTransport {
+      base iana-interface-type;
+      description
+        "MPEG transport interface.";
+    }
+
+    identity sixToFour {
+      base iana-interface-type;
+      status deprecated;
+      description
+        "6to4 interface (DEPRECATED).";
+      reference
+        "RFC 4087 - IP Tunnel MIB";
+
+    }
+
+    identity gtp {
+      base iana-interface-type;
+      description
+        "GTP (GPRS Tunneling Protocol).";
+    }
+
+    identity pdnEtherLoop1 {
+      base iana-interface-type;
+      description "Paradyne EtherLoop 1.";
+    }
+
+    identity pdnEtherLoop2 {
+      base iana-interface-type;
+      description "Paradyne EtherLoop 2.";
+    }
+
+    identity opticalChannelGroup {
+      base iana-interface-type;
+      description "Optical Channel Group.";
+    }
+
+    identity homepna {
+      base iana-interface-type;
+      description "HomePNA ITU-T G.989.";
+    }
+
+    identity gfp {
+      base iana-interface-type;
+      description
+        "Generic Framing Procedure (GFP).";
+    }
+
+    identity ciscoISLvlan {
+      base iana-interface-type;
+      description
+        "Layer 2 Virtual LAN using Cisco ISL.";
+    }
+
+    identity actelisMetaLOOP {
+      base iana-interface-type;
+      description
+        "Acteleis proprietary MetaLOOP High Speed Link.";
+    }
+
+    identity fcipLink {
+      base iana-interface-type;
+      description "FCIP Link.";
+    }
+
+    identity rpr {
+      base iana-interface-type;
+      description
+        "Resilient Packet Ring Interface Type.";
+    }
+
+    identity qam {
+      base iana-interface-type;
+      description "RF Qam Interface.";
+    }
+
+    identity lmp {
+      base iana-interface-type;
+      description
+        "Link Management Protocol.";
+      reference
+        "RFC 4327 - Link Management Protocol (LMP) Management
+               Information Base (MIB)";
+
+    }
+
+    identity cblVectaStar {
+      base iana-interface-type;
+      description
+        "Cambridge Broadband Networks Limited VectaStar.";
+    }
+
+    identity docsCableMCmtsDownstream {
+      base iana-interface-type;
+      description
+        "CATV Modular CMTS Downstream Interface.";
+    }
+
+    identity adsl2 {
+      base iana-interface-type;
+      status deprecated;
+      description
+        "Asymmetric Digital Subscriber Loop Version 2
+       (DEPRECATED/OBSOLETED - please use adsl2plus(238)
+       instead).";
+      reference
+        "RFC 4706 - Definitions of Managed Objects for Asymmetric
+               Digital Subscriber Line 2 (ADSL2)";
+
+    }
+
+    identity macSecControlledIF {
+      base iana-interface-type;
+      description "MACSecControlled.";
+    }
+
+    identity macSecUncontrolledIF {
+      base iana-interface-type;
+      description "MACSecUncontrolled.";
+    }
+
+    identity aviciOpticalEther {
+      base iana-interface-type;
+      description
+        "Avici Optical Ethernet Aggregate.";
+    }
+
+    identity atmbond {
+      base iana-interface-type;
+      description "atmbond.";
+    }
+
+    identity voiceFGDOS {
+      base iana-interface-type;
+      description
+        "Voice FGD Operator Services.";
+    }
+
+    identity mocaVersion1 {
+      base iana-interface-type;
+      description
+        "MultiMedia over Coax Alliance (MoCA) Interface
+       as documented in information provided privately to IANA.";
+    }
+
+    identity ieee80216WMAN {
+      base iana-interface-type;
+      description
+        "IEEE 802.16 WMAN interface.";
+    }
+
+    identity adsl2plus {
+      base iana-interface-type;
+      description
+        "Asymmetric Digital Subscriber Loop Version 2 -
+       Version 2 Plus and all variants.";
+    }
+
+    identity dvbRcsMacLayer {
+      base iana-interface-type;
+      description "DVB-RCS MAC Layer.";
+      reference
+        "RFC 5728 - The SatLabs Group DVB-RCS MIB";
+
+    }
+
+    identity dvbTdm {
+      base iana-interface-type;
+      description "DVB Satellite TDM.";
+      reference
+        "RFC 5728 - The SatLabs Group DVB-RCS MIB";
+
+    }
+
+    identity dvbRcsTdma {
+      base iana-interface-type;
+      description "DVB-RCS TDMA.";
+      reference
+        "RFC 5728 - The SatLabs Group DVB-RCS MIB";
+
+    }
+
+    identity x86Laps {
+      base iana-interface-type;
+      description
+        "LAPS based on ITU-T X.86/Y.1323.";
+    }
+
+    identity wwanPP {
+      base iana-interface-type;
+      description "3GPP WWAN.";
+    }
+
+    identity wwanPP2 {
+      base iana-interface-type;
+      description "3GPP2 WWAN.";
+    }
+
+    identity voiceEBS {
+      base iana-interface-type;
+      description
+        "Voice P-phone EBS physical interface.";
+    }
+
+    identity ifPwType {
+      base iana-interface-type;
+      description
+        "Pseudowire interface type.";
+      reference
+        "RFC 5601 - Pseudowire (PW) Management Information Base (MIB)";
+
+    }
+
+    identity ilan {
+      base iana-interface-type;
+      description
+        "Internal LAN on a bridge per IEEE 802.1ap.";
+    }
+
+    identity pip {
+      base iana-interface-type;
+      description
+        "Provider Instance Port on a bridge per IEEE 802.1ah PBB.";
+    }
+
+    identity aluELP {
+      base iana-interface-type;
+      description
+        "Alcatel-Lucent Ethernet Link Protection.";
+    }
+
+    identity gpon {
+      base iana-interface-type;
+      description
+        "Gigabit-capable passive optical networks (G-PON) as per
+       ITU-T G.948.";
+    }
+
+    identity vdsl2 {
+      base iana-interface-type;
+      description
+        "Very high speed digital subscriber line Version 2
+       (as per ITU-T Recommendation G.993.2).";
+      reference
+        "RFC 5650 - Definitions of Managed Objects for Very High
+               Speed Digital Subscriber Line 2 (VDSL2)";
+
+    }
+
+    identity capwapDot11Profile {
+      base iana-interface-type;
+      description "WLAN Profile Interface.";
+      reference
+        "RFC 5834 - Control and Provisioning of Wireless Access
+               Points (CAPWAP) Protocol Binding MIB for
+               IEEE 802.11";
+
+    }
+
+    identity capwapDot11Bss {
+      base iana-interface-type;
+      description "WLAN BSS Interface.";
+      reference
+        "RFC 5834 - Control and Provisioning of Wireless Access
+               Points (CAPWAP) Protocol Binding MIB for
+               IEEE 802.11";
+
+    }
+
+    identity capwapWtpVirtualRadio {
+      base iana-interface-type;
+      description
+        "WTP Virtual Radio Interface.";
+      reference
+        "RFC 5833 - Control and Provisioning of Wireless Access
+               Points (CAPWAP) Protocol Base MIB";
+
+    }
+
+    identity bits {
+      base iana-interface-type;
+      description "bitsport.";
+    }
+
+    identity docsCableUpstreamRfPort {
+      base iana-interface-type;
+      description
+        "DOCSIS CATV Upstream RF Port.";
+    }
+
+    identity cableDownstreamRfPort {
+      base iana-interface-type;
+      description "CATV downstream RF Port.";
+    }
+
+    identity vmwareVirtualNic {
+      base iana-interface-type;
+      description
+        "VMware Virtual Network Interface.";
+    }
+
+    identity ieee802154 {
+      base iana-interface-type;
+      description
+        "IEEE 802.15.4 WPAN interface.";
+      reference
+        "IEEE 802.15.4-2006";
+
+    }
+
+    identity otnOdu {
+      base iana-interface-type;
+      description "OTN Optical Data Unit.";
+    }
+
+    identity otnOtu {
+      base iana-interface-type;
+      description
+        "OTN Optical channel Transport Unit.";
+    }
+
+    identity ifVfiType {
+      base iana-interface-type;
+      description
+        "VPLS Forwarding Instance Interface Type.";
+    }
+
+    identity g9981 {
+      base iana-interface-type;
+      description
+        "G.998.1 bonded interface.";
+    }
+
+    identity g9982 {
+      base iana-interface-type;
+      description
+        "G.998.2 bonded interface.";
+    }
+
+    identity g9983 {
+      base iana-interface-type;
+      description
+        "G.998.3 bonded interface.";
+    }
+
+    identity aluEpon {
+      base iana-interface-type;
+      description
+        "Ethernet Passive Optical Networks (E-PON).";
+    }
+
+    identity aluEponOnu {
+      base iana-interface-type;
+      description
+        "EPON Optical Network Unit.";
+    }
+
+    identity aluEponPhysicalUni {
+      base iana-interface-type;
+      description
+        "EPON physical User to Network interface.";
+    }
+
+    identity aluEponLogicalLink {
+      base iana-interface-type;
+      description
+        "The emulation of a point-to-point link over the EPON
+       layer.";
+    }
+
+    identity aluGponOnu {
+      base iana-interface-type;
+      description
+        "GPON Optical Network Unit.";
+      reference
+        "ITU-T G.984.2";
+
+    }
+
+    identity aluGponPhysicalUni {
+      base iana-interface-type;
+      description
+        "GPON physical User to Network interface.";
+      reference
+        "ITU-T G.984.2";
+
+    }
+
+    identity vmwareNicTeam {
+      base iana-interface-type;
+      description "VMware NIC Team.";
+    }
+  }  // module iana-if-type

--- a/test/data/iana-if-type.yin
+++ b/test/data/iana-if-type.yin
@@ -1,0 +1,1801 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module name="iana-if-type"
+        xmlns="urn:ietf:params:xml:ns:yang:yin:1"
+        xmlns:ianaift="urn:ietf:params:xml:ns:yang:iana-if-type"
+        xmlns:if="urn:ietf:params:xml:ns:yang:ietf-interfaces">
+  <yang-version value="1"/>
+  <namespace uri="urn:ietf:params:xml:ns:yang:iana-if-type"/>
+  <prefix value="ianaift"/>
+  <import module="ietf-interfaces">
+    <prefix value="if"/>
+  </import>
+  <organization>
+    <text>IANA</text>
+  </organization>
+  <contact>
+    <text>        Internet Assigned Numbers Authority
+
+Postal: ICANN
+      4676 Admiralty Way, Suite 330
+      Marina del Rey, CA 90292
+
+Tel:    +1 310 823 9358
+&lt;mailto:iana@iana.org&gt;</text>
+  </contact>
+  <description>
+    <text>This YANG module defines YANG identities for IANA-registered
+interface types.
+
+This YANG module is maintained by IANA and reflects the
+'ifType definitions' registry.
+
+The latest revision of this YANG module can be obtained from
+the IANA web site.
+
+Requests for new values should be made to IANA via
+email (iana@iana.org).
+
+Copyright (c) 2014 IETF Trust and the persons identified as
+authors of the code.  All rights reserved.
+
+Redistribution and use in source and binary forms, with or
+without modification, is permitted pursuant to, and subject
+to the license terms contained in, the Simplified BSD License
+set forth in Section 4.c of the IETF Trust's Legal Provisions
+Relating to IETF Documents
+(http://trustee.ietf.org/license-info).
+
+The initial version of this YANG module is part of RFC 7224;
+see the RFC itself for full legal notices.</text>
+  </description>
+  <reference>
+    <text>IANA 'ifType definitions' registry.
+&lt;http://www.iana.org/assignments/smi-numbers&gt;</text>
+  </reference>
+  <revision date="2014-05-08">
+    <description>
+      <text>Initial revision.</text>
+    </description>
+    <reference>
+      <text>RFC 7224: IANA Interface Type YANG Module</text>
+    </reference>
+  </revision>
+  <identity name="iana-interface-type">
+    <base name="if:interface-type"/>
+    <description>
+      <text>This identity is used as a base for all interface types
+defined in the 'ifType definitions' registry.</text>
+    </description>
+  </identity>
+  <identity name="other">
+    <base name="iana-interface-type"/>
+  </identity>
+  <identity name="regular1822">
+    <base name="iana-interface-type"/>
+  </identity>
+  <identity name="hdh1822">
+    <base name="iana-interface-type"/>
+  </identity>
+  <identity name="ddnX25">
+    <base name="iana-interface-type"/>
+  </identity>
+  <identity name="rfc877x25">
+    <base name="iana-interface-type"/>
+    <reference>
+      <text>RFC 1382 - SNMP MIB Extension for the X.25 Packet Layer</text>
+    </reference>
+  </identity>
+  <identity name="ethernetCsmacd">
+    <base name="iana-interface-type"/>
+    <description>
+      <text>For all Ethernet-like interfaces, regardless of speed,
+as per RFC 3635.</text>
+    </description>
+    <reference>
+      <text>RFC 3635 - Definitions of Managed Objects for the
+      Ethernet-like Interface Types</text>
+    </reference>
+  </identity>
+  <identity name="iso88023Csmacd">
+    <base name="iana-interface-type"/>
+    <status value="deprecated"/>
+    <description>
+      <text>Deprecated via RFC 3635.
+Use ethernetCsmacd(6) instead.</text>
+    </description>
+    <reference>
+      <text>RFC 3635 - Definitions of Managed Objects for the
+      Ethernet-like Interface Types</text>
+    </reference>
+  </identity>
+  <identity name="iso88024TokenBus">
+    <base name="iana-interface-type"/>
+  </identity>
+  <identity name="iso88025TokenRing">
+    <base name="iana-interface-type"/>
+  </identity>
+  <identity name="iso88026Man">
+    <base name="iana-interface-type"/>
+  </identity>
+  <identity name="starLan">
+    <base name="iana-interface-type"/>
+    <status value="deprecated"/>
+    <description>
+      <text>Deprecated via RFC 3635.
+Use ethernetCsmacd(6) instead.</text>
+    </description>
+    <reference>
+      <text>RFC 3635 - Definitions of Managed Objects for the
+      Ethernet-like Interface Types</text>
+    </reference>
+  </identity>
+  <identity name="proteon10Mbit">
+    <base name="iana-interface-type"/>
+  </identity>
+  <identity name="proteon80Mbit">
+    <base name="iana-interface-type"/>
+  </identity>
+  <identity name="hyperchannel">
+    <base name="iana-interface-type"/>
+  </identity>
+  <identity name="fddi">
+    <base name="iana-interface-type"/>
+    <reference>
+      <text>RFC 1512 - FDDI Management Information Base</text>
+    </reference>
+  </identity>
+  <identity name="lapb">
+    <base name="iana-interface-type"/>
+    <reference>
+      <text>RFC 1381 - SNMP MIB Extension for X.25 LAPB</text>
+    </reference>
+  </identity>
+  <identity name="sdlc">
+    <base name="iana-interface-type"/>
+  </identity>
+  <identity name="ds1">
+    <base name="iana-interface-type"/>
+    <description>
+      <text>DS1-MIB.</text>
+    </description>
+    <reference>
+      <text>RFC 4805 - Definitions of Managed Objects for the
+      DS1, J1, E1, DS2, and E2 Interface Types</text>
+    </reference>
+  </identity>
+  <identity name="e1">
+    <base name="iana-interface-type"/>
+    <status value="obsolete"/>
+    <description>
+      <text>Obsolete; see DS1-MIB.</text>
+    </description>
+    <reference>
+      <text>RFC 4805 - Definitions of Managed Objects for the
+      DS1, J1, E1, DS2, and E2 Interface Types</text>
+    </reference>
+  </identity>
+  <identity name="basicISDN">
+    <base name="iana-interface-type"/>
+    <description>
+      <text>No longer used.  See also RFC 2127.</text>
+    </description>
+  </identity>
+  <identity name="primaryISDN">
+    <base name="iana-interface-type"/>
+    <description>
+      <text>No longer used.  See also RFC 2127.</text>
+    </description>
+  </identity>
+  <identity name="propPointToPointSerial">
+    <base name="iana-interface-type"/>
+    <description>
+      <text>Proprietary serial.</text>
+    </description>
+  </identity>
+  <identity name="ppp">
+    <base name="iana-interface-type"/>
+  </identity>
+  <identity name="softwareLoopback">
+    <base name="iana-interface-type"/>
+  </identity>
+  <identity name="eon">
+    <base name="iana-interface-type"/>
+    <description>
+      <text>CLNP over IP.</text>
+    </description>
+  </identity>
+  <identity name="ethernet3Mbit">
+    <base name="iana-interface-type"/>
+  </identity>
+  <identity name="nsip">
+    <base name="iana-interface-type"/>
+    <description>
+      <text>XNS over IP.</text>
+    </description>
+  </identity>
+  <identity name="slip">
+    <base name="iana-interface-type"/>
+    <description>
+      <text>Generic SLIP.</text>
+    </description>
+  </identity>
+  <identity name="ultra">
+    <base name="iana-interface-type"/>
+    <description>
+      <text>Ultra Technologies.</text>
+    </description>
+  </identity>
+  <identity name="ds3">
+    <base name="iana-interface-type"/>
+    <description>
+      <text>DS3-MIB.</text>
+    </description>
+    <reference>
+      <text>RFC 3896 - Definitions of Managed Objects for the
+      DS3/E3 Interface Type</text>
+    </reference>
+  </identity>
+  <identity name="sip">
+    <base name="iana-interface-type"/>
+    <description>
+      <text>SMDS, coffee.</text>
+    </description>
+    <reference>
+      <text>RFC 1694 - Definitions of Managed Objects for SMDS
+      Interfaces using SMIv2</text>
+    </reference>
+  </identity>
+  <identity name="frameRelay">
+    <base name="iana-interface-type"/>
+    <description>
+      <text>DTE only.</text>
+    </description>
+    <reference>
+      <text>RFC 2115 - Management Information Base for Frame Relay
+      DTEs Using SMIv2</text>
+    </reference>
+  </identity>
+  <identity name="rs232">
+    <base name="iana-interface-type"/>
+    <reference>
+      <text>RFC 1659 - Definitions of Managed Objects for RS-232-like
+      Hardware Devices using SMIv2</text>
+    </reference>
+  </identity>
+  <identity name="para">
+    <base name="iana-interface-type"/>
+    <description>
+      <text>Parallel-port.</text>
+    </description>
+    <reference>
+      <text>RFC 1660 - Definitions of Managed Objects for
+      Parallel-printer-like Hardware Devices using
+      SMIv2</text>
+    </reference>
+  </identity>
+  <identity name="arcnet">
+    <base name="iana-interface-type"/>
+    <description>
+      <text>ARCnet.</text>
+    </description>
+  </identity>
+  <identity name="arcnetPlus">
+    <base name="iana-interface-type"/>
+    <description>
+      <text>ARCnet Plus.</text>
+    </description>
+  </identity>
+  <identity name="atm">
+    <base name="iana-interface-type"/>
+    <description>
+      <text>ATM cells.</text>
+    </description>
+  </identity>
+  <identity name="miox25">
+    <base name="iana-interface-type"/>
+    <reference>
+      <text>RFC 1461 - SNMP MIB extension for Multiprotocol
+      Interconnect over X.25</text>
+    </reference>
+  </identity>
+  <identity name="sonet">
+    <base name="iana-interface-type"/>
+    <description>
+      <text>SONET or SDH.</text>
+    </description>
+  </identity>
+  <identity name="x25ple">
+    <base name="iana-interface-type"/>
+    <reference>
+      <text>RFC 2127 - ISDN Management Information Base using SMIv2</text>
+    </reference>
+  </identity>
+  <identity name="iso88022llc">
+    <base name="iana-interface-type"/>
+  </identity>
+  <identity name="localTalk">
+    <base name="iana-interface-type"/>
+  </identity>
+  <identity name="smdsDxi">
+    <base name="iana-interface-type"/>
+  </identity>
+  <identity name="frameRelayService">
+    <base name="iana-interface-type"/>
+    <description>
+      <text>FRNETSERV-MIB.</text>
+    </description>
+    <reference>
+      <text>RFC 2954 - Definitions of Managed Objects for Frame
+      Relay Service</text>
+    </reference>
+  </identity>
+  <identity name="v35">
+    <base name="iana-interface-type"/>
+  </identity>
+  <identity name="hssi">
+    <base name="iana-interface-type"/>
+  </identity>
+  <identity name="hippi">
+    <base name="iana-interface-type"/>
+  </identity>
+  <identity name="modem">
+    <base name="iana-interface-type"/>
+    <description>
+      <text>Generic modem.</text>
+    </description>
+  </identity>
+  <identity name="aal5">
+    <base name="iana-interface-type"/>
+    <description>
+      <text>AAL5 over ATM.</text>
+    </description>
+  </identity>
+  <identity name="sonetPath">
+    <base name="iana-interface-type"/>
+  </identity>
+  <identity name="sonetVT">
+    <base name="iana-interface-type"/>
+  </identity>
+  <identity name="smdsIcip">
+    <base name="iana-interface-type"/>
+    <description>
+      <text>SMDS InterCarrier Interface.</text>
+    </description>
+  </identity>
+  <identity name="propVirtual">
+    <base name="iana-interface-type"/>
+    <description>
+      <text>Proprietary virtual/internal.</text>
+    </description>
+    <reference>
+      <text>RFC 2863 - The Interfaces Group MIB</text>
+    </reference>
+  </identity>
+  <identity name="propMultiplexor">
+    <base name="iana-interface-type"/>
+    <description>
+      <text>Proprietary multiplexing.</text>
+    </description>
+    <reference>
+      <text>RFC 2863 - The Interfaces Group MIB</text>
+    </reference>
+  </identity>
+  <identity name="ieee80212">
+    <base name="iana-interface-type"/>
+    <description>
+      <text>100BaseVG.</text>
+    </description>
+  </identity>
+  <identity name="fibreChannel">
+    <base name="iana-interface-type"/>
+    <description>
+      <text>Fibre Channel.</text>
+    </description>
+  </identity>
+  <identity name="hippiInterface">
+    <base name="iana-interface-type"/>
+    <description>
+      <text>HIPPI interfaces.</text>
+    </description>
+  </identity>
+  <identity name="frameRelayInterconnect">
+    <base name="iana-interface-type"/>
+    <status value="obsolete"/>
+    <description>
+      <text>Obsolete; use either
+frameRelay(32) or frameRelayService(44).</text>
+    </description>
+  </identity>
+  <identity name="aflane8023">
+    <base name="iana-interface-type"/>
+    <description>
+      <text>ATM Emulated LAN for 802.3.</text>
+    </description>
+  </identity>
+  <identity name="aflane8025">
+    <base name="iana-interface-type"/>
+    <description>
+      <text>ATM Emulated LAN for 802.5.</text>
+    </description>
+  </identity>
+  <identity name="cctEmul">
+    <base name="iana-interface-type"/>
+    <description>
+      <text>ATM Emulated circuit.</text>
+    </description>
+  </identity>
+  <identity name="fastEther">
+    <base name="iana-interface-type"/>
+    <status value="deprecated"/>
+    <description>
+      <text>Obsoleted via RFC 3635.
+ethernetCsmacd(6) should be used instead.</text>
+    </description>
+    <reference>
+      <text>RFC 3635 - Definitions of Managed Objects for the
+      Ethernet-like Interface Types</text>
+    </reference>
+  </identity>
+  <identity name="isdn">
+    <base name="iana-interface-type"/>
+    <description>
+      <text>ISDN and X.25.</text>
+    </description>
+    <reference>
+      <text>RFC 1356 - Multiprotocol Interconnect on X.25 and ISDN
+      in the Packet Mode</text>
+    </reference>
+  </identity>
+  <identity name="v11">
+    <base name="iana-interface-type"/>
+    <description>
+      <text>CCITT V.11/X.21.</text>
+    </description>
+  </identity>
+  <identity name="v36">
+    <base name="iana-interface-type"/>
+    <description>
+      <text>CCITT V.36.</text>
+    </description>
+  </identity>
+  <identity name="g703at64k">
+    <base name="iana-interface-type"/>
+    <description>
+      <text>CCITT G703 at 64Kbps.</text>
+    </description>
+  </identity>
+  <identity name="g703at2mb">
+    <base name="iana-interface-type"/>
+    <status value="obsolete"/>
+    <description>
+      <text>Obsolete; see DS1-MIB.</text>
+    </description>
+  </identity>
+  <identity name="qllc">
+    <base name="iana-interface-type"/>
+    <description>
+      <text>SNA QLLC.</text>
+    </description>
+  </identity>
+  <identity name="fastEtherFX">
+    <base name="iana-interface-type"/>
+    <status value="deprecated"/>
+    <description>
+      <text>Obsoleted via RFC 3635.
+ethernetCsmacd(6) should be used instead.</text>
+    </description>
+    <reference>
+      <text>RFC 3635 - Definitions of Managed Objects for the
+      Ethernet-like Interface Types</text>
+    </reference>
+  </identity>
+  <identity name="channel">
+    <base name="iana-interface-type"/>
+    <description>
+      <text>Channel.</text>
+    </description>
+  </identity>
+  <identity name="ieee80211">
+    <base name="iana-interface-type"/>
+    <description>
+      <text>Radio spread spectrum.</text>
+    </description>
+  </identity>
+  <identity name="ibm370parChan">
+    <base name="iana-interface-type"/>
+    <description>
+      <text>IBM System 360/370 OEMI Channel.</text>
+    </description>
+  </identity>
+  <identity name="escon">
+    <base name="iana-interface-type"/>
+    <description>
+      <text>IBM Enterprise Systems Connection.</text>
+    </description>
+  </identity>
+  <identity name="dlsw">
+    <base name="iana-interface-type"/>
+    <description>
+      <text>Data Link Switching.</text>
+    </description>
+  </identity>
+  <identity name="isdns">
+    <base name="iana-interface-type"/>
+    <description>
+      <text>ISDN S/T interface.</text>
+    </description>
+  </identity>
+  <identity name="isdnu">
+    <base name="iana-interface-type"/>
+    <description>
+      <text>ISDN U interface.</text>
+    </description>
+  </identity>
+  <identity name="lapd">
+    <base name="iana-interface-type"/>
+    <description>
+      <text>Link Access Protocol D.</text>
+    </description>
+  </identity>
+  <identity name="ipSwitch">
+    <base name="iana-interface-type"/>
+    <description>
+      <text>IP Switching Objects.</text>
+    </description>
+  </identity>
+  <identity name="rsrb">
+    <base name="iana-interface-type"/>
+    <description>
+      <text>Remote Source Route Bridging.</text>
+    </description>
+  </identity>
+  <identity name="atmLogical">
+    <base name="iana-interface-type"/>
+    <description>
+      <text>ATM Logical Port.</text>
+    </description>
+    <reference>
+      <text>RFC 3606 - Definitions of Supplemental Managed Objects
+      for ATM Interface</text>
+    </reference>
+  </identity>
+  <identity name="ds0">
+    <base name="iana-interface-type"/>
+    <description>
+      <text>Digital Signal Level 0.</text>
+    </description>
+    <reference>
+      <text>RFC 2494 - Definitions of Managed Objects for the DS0
+      and DS0 Bundle Interface Type</text>
+    </reference>
+  </identity>
+  <identity name="ds0Bundle">
+    <base name="iana-interface-type"/>
+    <description>
+      <text>Group of ds0s on the same ds1.</text>
+    </description>
+    <reference>
+      <text>RFC 2494 - Definitions of Managed Objects for the DS0
+      and DS0 Bundle Interface Type</text>
+    </reference>
+  </identity>
+  <identity name="bsc">
+    <base name="iana-interface-type"/>
+    <description>
+      <text>Bisynchronous Protocol.</text>
+    </description>
+  </identity>
+  <identity name="async">
+    <base name="iana-interface-type"/>
+    <description>
+      <text>Asynchronous Protocol.</text>
+    </description>
+  </identity>
+  <identity name="cnr">
+    <base name="iana-interface-type"/>
+    <description>
+      <text>Combat Net Radio.</text>
+    </description>
+  </identity>
+  <identity name="iso88025Dtr">
+    <base name="iana-interface-type"/>
+    <description>
+      <text>ISO 802.5r DTR.</text>
+    </description>
+  </identity>
+  <identity name="eplrs">
+    <base name="iana-interface-type"/>
+    <description>
+      <text>Ext Pos Loc Report Sys.</text>
+    </description>
+  </identity>
+  <identity name="arap">
+    <base name="iana-interface-type"/>
+    <description>
+      <text>Appletalk Remote Access Protocol.</text>
+    </description>
+  </identity>
+  <identity name="propCnls">
+    <base name="iana-interface-type"/>
+    <description>
+      <text>Proprietary Connectionless Protocol.</text>
+    </description>
+  </identity>
+  <identity name="hostPad">
+    <base name="iana-interface-type"/>
+    <description>
+      <text>CCITT-ITU X.29 PAD Protocol.</text>
+    </description>
+  </identity>
+  <identity name="termPad">
+    <base name="iana-interface-type"/>
+    <description>
+      <text>CCITT-ITU X.3 PAD Facility.</text>
+    </description>
+  </identity>
+  <identity name="frameRelayMPI">
+    <base name="iana-interface-type"/>
+    <description>
+      <text>Multiproto Interconnect over FR.</text>
+    </description>
+  </identity>
+  <identity name="x213">
+    <base name="iana-interface-type"/>
+    <description>
+      <text>CCITT-ITU X213.</text>
+    </description>
+  </identity>
+  <identity name="adsl">
+    <base name="iana-interface-type"/>
+    <description>
+      <text>Asymmetric Digital Subscriber Loop.</text>
+    </description>
+  </identity>
+  <identity name="radsl">
+    <base name="iana-interface-type"/>
+    <description>
+      <text>Rate-Adapt. Digital Subscriber Loop.</text>
+    </description>
+  </identity>
+  <identity name="sdsl">
+    <base name="iana-interface-type"/>
+    <description>
+      <text>Symmetric Digital Subscriber Loop.</text>
+    </description>
+  </identity>
+  <identity name="vdsl">
+    <base name="iana-interface-type"/>
+    <description>
+      <text>Very H-Speed Digital Subscrib. Loop.</text>
+    </description>
+  </identity>
+  <identity name="iso88025CRFPInt">
+    <base name="iana-interface-type"/>
+    <description>
+      <text>ISO 802.5 CRFP.</text>
+    </description>
+  </identity>
+  <identity name="myrinet">
+    <base name="iana-interface-type"/>
+    <description>
+      <text>Myricom Myrinet.</text>
+    </description>
+  </identity>
+  <identity name="voiceEM">
+    <base name="iana-interface-type"/>
+    <description>
+      <text>Voice recEive and transMit.</text>
+    </description>
+  </identity>
+  <identity name="voiceFXO">
+    <base name="iana-interface-type"/>
+    <description>
+      <text>Voice Foreign Exchange Office.</text>
+    </description>
+  </identity>
+  <identity name="voiceFXS">
+    <base name="iana-interface-type"/>
+    <description>
+      <text>Voice Foreign Exchange Station.</text>
+    </description>
+  </identity>
+  <identity name="voiceEncap">
+    <base name="iana-interface-type"/>
+    <description>
+      <text>Voice encapsulation.</text>
+    </description>
+  </identity>
+  <identity name="voiceOverIp">
+    <base name="iana-interface-type"/>
+    <description>
+      <text>Voice over IP encapsulation.</text>
+    </description>
+  </identity>
+  <identity name="atmDxi">
+    <base name="iana-interface-type"/>
+    <description>
+      <text>ATM DXI.</text>
+    </description>
+  </identity>
+  <identity name="atmFuni">
+    <base name="iana-interface-type"/>
+    <description>
+      <text>ATM FUNI.</text>
+    </description>
+  </identity>
+  <identity name="atmIma">
+    <base name="iana-interface-type"/>
+    <description>
+      <text>ATM IMA.</text>
+    </description>
+  </identity>
+  <identity name="pppMultilinkBundle">
+    <base name="iana-interface-type"/>
+    <description>
+      <text>PPP Multilink Bundle.</text>
+    </description>
+  </identity>
+  <identity name="ipOverCdlc">
+    <base name="iana-interface-type"/>
+    <description>
+      <text>IBM ipOverCdlc.</text>
+    </description>
+  </identity>
+  <identity name="ipOverClaw">
+    <base name="iana-interface-type"/>
+    <description>
+      <text>IBM Common Link Access to Workstn.</text>
+    </description>
+  </identity>
+  <identity name="stackToStack">
+    <base name="iana-interface-type"/>
+    <description>
+      <text>IBM stackToStack.</text>
+    </description>
+  </identity>
+  <identity name="virtualIpAddress">
+    <base name="iana-interface-type"/>
+    <description>
+      <text>IBM VIPA.</text>
+    </description>
+  </identity>
+  <identity name="mpc">
+    <base name="iana-interface-type"/>
+    <description>
+      <text>IBM multi-protocol channel support.</text>
+    </description>
+  </identity>
+  <identity name="ipOverAtm">
+    <base name="iana-interface-type"/>
+    <description>
+      <text>IBM ipOverAtm.</text>
+    </description>
+    <reference>
+      <text>RFC 2320 - Definitions of Managed Objects for Classical IP
+      and ARP Over ATM Using SMIv2 (IPOA-MIB)</text>
+    </reference>
+  </identity>
+  <identity name="iso88025Fiber">
+    <base name="iana-interface-type"/>
+    <description>
+      <text>ISO 802.5j Fiber Token Ring.</text>
+    </description>
+  </identity>
+  <identity name="tdlc">
+    <base name="iana-interface-type"/>
+    <description>
+      <text>IBM twinaxial data link control.</text>
+    </description>
+  </identity>
+  <identity name="gigabitEthernet">
+    <base name="iana-interface-type"/>
+    <status value="deprecated"/>
+    <description>
+      <text>Obsoleted via RFC 3635.
+ethernetCsmacd(6) should be used instead.</text>
+    </description>
+    <reference>
+      <text>RFC 3635 - Definitions of Managed Objects for the
+      Ethernet-like Interface Types</text>
+    </reference>
+  </identity>
+  <identity name="hdlc">
+    <base name="iana-interface-type"/>
+    <description>
+      <text>HDLC.</text>
+    </description>
+  </identity>
+  <identity name="lapf">
+    <base name="iana-interface-type"/>
+    <description>
+      <text>LAP F.</text>
+    </description>
+  </identity>
+  <identity name="v37">
+    <base name="iana-interface-type"/>
+    <description>
+      <text>V.37.</text>
+    </description>
+  </identity>
+  <identity name="x25mlp">
+    <base name="iana-interface-type"/>
+    <description>
+      <text>Multi-Link Protocol.</text>
+    </description>
+  </identity>
+  <identity name="x25huntGroup">
+    <base name="iana-interface-type"/>
+    <description>
+      <text>X25 Hunt Group.</text>
+    </description>
+  </identity>
+  <identity name="transpHdlc">
+    <base name="iana-interface-type"/>
+    <description>
+      <text>Transp HDLC.</text>
+    </description>
+  </identity>
+  <identity name="interleave">
+    <base name="iana-interface-type"/>
+    <description>
+      <text>Interleave channel.</text>
+    </description>
+  </identity>
+  <identity name="fast">
+    <base name="iana-interface-type"/>
+    <description>
+      <text>Fast channel.</text>
+    </description>
+  </identity>
+  <identity name="ip">
+    <base name="iana-interface-type"/>
+    <description>
+      <text>IP (for APPN HPR in IP networks).</text>
+    </description>
+  </identity>
+  <identity name="docsCableMaclayer">
+    <base name="iana-interface-type"/>
+    <description>
+      <text>CATV Mac Layer.</text>
+    </description>
+  </identity>
+  <identity name="docsCableDownstream">
+    <base name="iana-interface-type"/>
+    <description>
+      <text>CATV Downstream interface.</text>
+    </description>
+  </identity>
+  <identity name="docsCableUpstream">
+    <base name="iana-interface-type"/>
+    <description>
+      <text>CATV Upstream interface.</text>
+    </description>
+  </identity>
+  <identity name="a12MppSwitch">
+    <base name="iana-interface-type"/>
+    <description>
+      <text>Avalon Parallel Processor.</text>
+    </description>
+  </identity>
+  <identity name="tunnel">
+    <base name="iana-interface-type"/>
+    <description>
+      <text>Encapsulation interface.</text>
+    </description>
+  </identity>
+  <identity name="coffee">
+    <base name="iana-interface-type"/>
+    <description>
+      <text>Coffee pot.</text>
+    </description>
+    <reference>
+      <text>RFC 2325 - Coffee MIB</text>
+    </reference>
+  </identity>
+  <identity name="ces">
+    <base name="iana-interface-type"/>
+    <description>
+      <text>Circuit Emulation Service.</text>
+    </description>
+  </identity>
+  <identity name="atmSubInterface">
+    <base name="iana-interface-type"/>
+    <description>
+      <text>ATM Sub Interface.</text>
+    </description>
+  </identity>
+  <identity name="l2vlan">
+    <base name="iana-interface-type"/>
+    <description>
+      <text>Layer 2 Virtual LAN using 802.1Q.</text>
+    </description>
+  </identity>
+  <identity name="l3ipvlan">
+    <base name="iana-interface-type"/>
+    <description>
+      <text>Layer 3 Virtual LAN using IP.</text>
+    </description>
+  </identity>
+  <identity name="l3ipxvlan">
+    <base name="iana-interface-type"/>
+    <description>
+      <text>Layer 3 Virtual LAN using IPX.</text>
+    </description>
+  </identity>
+  <identity name="digitalPowerline">
+    <base name="iana-interface-type"/>
+    <description>
+      <text>IP over Power Lines.</text>
+    </description>
+  </identity>
+  <identity name="mediaMailOverIp">
+    <base name="iana-interface-type"/>
+    <description>
+      <text>Multimedia Mail over IP.</text>
+    </description>
+  </identity>
+  <identity name="dtm">
+    <base name="iana-interface-type"/>
+    <description>
+      <text>Dynamic synchronous Transfer Mode.</text>
+    </description>
+  </identity>
+  <identity name="dcn">
+    <base name="iana-interface-type"/>
+    <description>
+      <text>Data Communications Network.</text>
+    </description>
+  </identity>
+  <identity name="ipForward">
+    <base name="iana-interface-type"/>
+    <description>
+      <text>IP Forwarding Interface.</text>
+    </description>
+  </identity>
+  <identity name="msdsl">
+    <base name="iana-interface-type"/>
+    <description>
+      <text>Multi-rate Symmetric DSL.</text>
+    </description>
+  </identity>
+  <identity name="ieee1394">
+    <base name="iana-interface-type"/>
+    <description>
+      <text>IEEE1394 High Performance Serial Bus.</text>
+    </description>
+  </identity>
+  <identity name="if-gsn">
+    <base name="iana-interface-type"/>
+    <description>
+      <text>HIPPI-6400.</text>
+    </description>
+  </identity>
+  <identity name="dvbRccMacLayer">
+    <base name="iana-interface-type"/>
+    <description>
+      <text>DVB-RCC MAC Layer.</text>
+    </description>
+  </identity>
+  <identity name="dvbRccDownstream">
+    <base name="iana-interface-type"/>
+    <description>
+      <text>DVB-RCC Downstream Channel.</text>
+    </description>
+  </identity>
+  <identity name="dvbRccUpstream">
+    <base name="iana-interface-type"/>
+    <description>
+      <text>DVB-RCC Upstream Channel.</text>
+    </description>
+  </identity>
+  <identity name="atmVirtual">
+    <base name="iana-interface-type"/>
+    <description>
+      <text>ATM Virtual Interface.</text>
+    </description>
+  </identity>
+  <identity name="mplsTunnel">
+    <base name="iana-interface-type"/>
+    <description>
+      <text>MPLS Tunnel Virtual Interface.</text>
+    </description>
+  </identity>
+  <identity name="srp">
+    <base name="iana-interface-type"/>
+    <description>
+      <text>Spatial Reuse Protocol.</text>
+    </description>
+  </identity>
+  <identity name="voiceOverAtm">
+    <base name="iana-interface-type"/>
+    <description>
+      <text>Voice over ATM.</text>
+    </description>
+  </identity>
+  <identity name="voiceOverFrameRelay">
+    <base name="iana-interface-type"/>
+    <description>
+      <text>Voice Over Frame Relay.</text>
+    </description>
+  </identity>
+  <identity name="idsl">
+    <base name="iana-interface-type"/>
+    <description>
+      <text>Digital Subscriber Loop over ISDN.</text>
+    </description>
+  </identity>
+  <identity name="compositeLink">
+    <base name="iana-interface-type"/>
+    <description>
+      <text>Avici Composite Link Interface.</text>
+    </description>
+  </identity>
+  <identity name="ss7SigLink">
+    <base name="iana-interface-type"/>
+    <description>
+      <text>SS7 Signaling Link.</text>
+    </description>
+  </identity>
+  <identity name="propWirelessP2P">
+    <base name="iana-interface-type"/>
+    <description>
+      <text>Prop. P2P wireless interface.</text>
+    </description>
+  </identity>
+  <identity name="frForward">
+    <base name="iana-interface-type"/>
+    <description>
+      <text>Frame Forward Interface.</text>
+    </description>
+  </identity>
+  <identity name="rfc1483">
+    <base name="iana-interface-type"/>
+    <description>
+      <text>Multiprotocol over ATM AAL5.</text>
+    </description>
+    <reference>
+      <text>RFC 1483 - Multiprotocol Encapsulation over ATM
+      Adaptation Layer 5</text>
+    </reference>
+  </identity>
+  <identity name="usb">
+    <base name="iana-interface-type"/>
+    <description>
+      <text>USB Interface.</text>
+    </description>
+  </identity>
+  <identity name="ieee8023adLag">
+    <base name="iana-interface-type"/>
+    <description>
+      <text>IEEE 802.3ad Link Aggregate.</text>
+    </description>
+  </identity>
+  <identity name="bgppolicyaccounting">
+    <base name="iana-interface-type"/>
+    <description>
+      <text>BGP Policy Accounting.</text>
+    </description>
+  </identity>
+  <identity name="frf16MfrBundle">
+    <base name="iana-interface-type"/>
+    <description>
+      <text>FRF.16 Multilink Frame Relay.</text>
+    </description>
+  </identity>
+  <identity name="h323Gatekeeper">
+    <base name="iana-interface-type"/>
+    <description>
+      <text>H323 Gatekeeper.</text>
+    </description>
+  </identity>
+  <identity name="h323Proxy">
+    <base name="iana-interface-type"/>
+    <description>
+      <text>H323 Voice and Video Proxy.</text>
+    </description>
+  </identity>
+  <identity name="mpls">
+    <base name="iana-interface-type"/>
+    <description>
+      <text>MPLS.</text>
+    </description>
+  </identity>
+  <identity name="mfSigLink">
+    <base name="iana-interface-type"/>
+    <description>
+      <text>Multi-frequency signaling link.</text>
+    </description>
+  </identity>
+  <identity name="hdsl2">
+    <base name="iana-interface-type"/>
+    <description>
+      <text>High Bit-Rate DSL - 2nd generation.</text>
+    </description>
+  </identity>
+  <identity name="shdsl">
+    <base name="iana-interface-type"/>
+    <description>
+      <text>Multirate HDSL2.</text>
+    </description>
+  </identity>
+  <identity name="ds1FDL">
+    <base name="iana-interface-type"/>
+    <description>
+      <text>Facility Data Link (4Kbps) on a DS1.</text>
+    </description>
+  </identity>
+  <identity name="pos">
+    <base name="iana-interface-type"/>
+    <description>
+      <text>Packet over SONET/SDH Interface.</text>
+    </description>
+  </identity>
+  <identity name="dvbAsiIn">
+    <base name="iana-interface-type"/>
+    <description>
+      <text>DVB-ASI Input.</text>
+    </description>
+  </identity>
+  <identity name="dvbAsiOut">
+    <base name="iana-interface-type"/>
+    <description>
+      <text>DVB-ASI Output.</text>
+    </description>
+  </identity>
+  <identity name="plc">
+    <base name="iana-interface-type"/>
+    <description>
+      <text>Power Line Communications.</text>
+    </description>
+  </identity>
+  <identity name="nfas">
+    <base name="iana-interface-type"/>
+    <description>
+      <text>Non-Facility Associated Signaling.</text>
+    </description>
+  </identity>
+  <identity name="tr008">
+    <base name="iana-interface-type"/>
+    <description>
+      <text>TR008.</text>
+    </description>
+  </identity>
+  <identity name="gr303RDT">
+    <base name="iana-interface-type"/>
+    <description>
+      <text>Remote Digital Terminal.</text>
+    </description>
+  </identity>
+  <identity name="gr303IDT">
+    <base name="iana-interface-type"/>
+    <description>
+      <text>Integrated Digital Terminal.</text>
+    </description>
+  </identity>
+  <identity name="isup">
+    <base name="iana-interface-type"/>
+    <description>
+      <text>ISUP.</text>
+    </description>
+  </identity>
+  <identity name="propDocsWirelessMaclayer">
+    <base name="iana-interface-type"/>
+    <description>
+      <text>Cisco proprietary Maclayer.</text>
+    </description>
+  </identity>
+  <identity name="propDocsWirelessDownstream">
+    <base name="iana-interface-type"/>
+    <description>
+      <text>Cisco proprietary Downstream.</text>
+    </description>
+  </identity>
+  <identity name="propDocsWirelessUpstream">
+    <base name="iana-interface-type"/>
+    <description>
+      <text>Cisco proprietary Upstream.</text>
+    </description>
+  </identity>
+  <identity name="hiperlan2">
+    <base name="iana-interface-type"/>
+    <description>
+      <text>HIPERLAN Type 2 Radio Interface.</text>
+    </description>
+  </identity>
+  <identity name="propBWAp2Mp">
+    <base name="iana-interface-type"/>
+    <description>
+      <text>PropBroadbandWirelessAccesspt2Multipt (use of this value
+for IEEE 802.16 WMAN interfaces as per IEEE Std 802.16f
+is deprecated, and ieee80216WMAN(237) should be used
+instead).</text>
+    </description>
+  </identity>
+  <identity name="sonetOverheadChannel">
+    <base name="iana-interface-type"/>
+    <description>
+      <text>SONET Overhead Channel.</text>
+    </description>
+  </identity>
+  <identity name="digitalWrapperOverheadChannel">
+    <base name="iana-interface-type"/>
+    <description>
+      <text>Digital Wrapper.</text>
+    </description>
+  </identity>
+  <identity name="aal2">
+    <base name="iana-interface-type"/>
+    <description>
+      <text>ATM adaptation layer 2.</text>
+    </description>
+  </identity>
+  <identity name="radioMAC">
+    <base name="iana-interface-type"/>
+    <description>
+      <text>MAC layer over radio links.</text>
+    </description>
+  </identity>
+  <identity name="atmRadio">
+    <base name="iana-interface-type"/>
+    <description>
+      <text>ATM over radio links.</text>
+    </description>
+  </identity>
+  <identity name="imt">
+    <base name="iana-interface-type"/>
+    <description>
+      <text>Inter-Machine Trunks.</text>
+    </description>
+  </identity>
+  <identity name="mvl">
+    <base name="iana-interface-type"/>
+    <description>
+      <text>Multiple Virtual Lines DSL.</text>
+    </description>
+  </identity>
+  <identity name="reachDSL">
+    <base name="iana-interface-type"/>
+    <description>
+      <text>Long Reach DSL.</text>
+    </description>
+  </identity>
+  <identity name="frDlciEndPt">
+    <base name="iana-interface-type"/>
+    <description>
+      <text>Frame Relay DLCI End Point.</text>
+    </description>
+  </identity>
+  <identity name="atmVciEndPt">
+    <base name="iana-interface-type"/>
+    <description>
+      <text>ATM VCI End Point.</text>
+    </description>
+  </identity>
+  <identity name="opticalChannel">
+    <base name="iana-interface-type"/>
+    <description>
+      <text>Optical Channel.</text>
+    </description>
+  </identity>
+  <identity name="opticalTransport">
+    <base name="iana-interface-type"/>
+    <description>
+      <text>Optical Transport.</text>
+    </description>
+  </identity>
+  <identity name="propAtm">
+    <base name="iana-interface-type"/>
+    <description>
+      <text>Proprietary ATM.</text>
+    </description>
+  </identity>
+  <identity name="voiceOverCable">
+    <base name="iana-interface-type"/>
+    <description>
+      <text>Voice Over Cable Interface.</text>
+    </description>
+  </identity>
+  <identity name="infiniband">
+    <base name="iana-interface-type"/>
+    <description>
+      <text>Infiniband.</text>
+    </description>
+  </identity>
+  <identity name="teLink">
+    <base name="iana-interface-type"/>
+    <description>
+      <text>TE Link.</text>
+    </description>
+  </identity>
+  <identity name="q2931">
+    <base name="iana-interface-type"/>
+    <description>
+      <text>Q.2931.</text>
+    </description>
+  </identity>
+  <identity name="virtualTg">
+    <base name="iana-interface-type"/>
+    <description>
+      <text>Virtual Trunk Group.</text>
+    </description>
+  </identity>
+  <identity name="sipTg">
+    <base name="iana-interface-type"/>
+    <description>
+      <text>SIP Trunk Group.</text>
+    </description>
+  </identity>
+  <identity name="sipSig">
+    <base name="iana-interface-type"/>
+    <description>
+      <text>SIP Signaling.</text>
+    </description>
+  </identity>
+  <identity name="docsCableUpstreamChannel">
+    <base name="iana-interface-type"/>
+    <description>
+      <text>CATV Upstream Channel.</text>
+    </description>
+  </identity>
+  <identity name="econet">
+    <base name="iana-interface-type"/>
+    <description>
+      <text>Acorn Econet.</text>
+    </description>
+  </identity>
+  <identity name="pon155">
+    <base name="iana-interface-type"/>
+    <description>
+      <text>FSAN 155Mb Symetrical PON interface.</text>
+    </description>
+  </identity>
+  <identity name="pon622">
+    <base name="iana-interface-type"/>
+    <description>
+      <text>FSAN 622Mb Symetrical PON interface.</text>
+    </description>
+  </identity>
+  <identity name="bridge">
+    <base name="iana-interface-type"/>
+    <description>
+      <text>Transparent bridge interface.</text>
+    </description>
+  </identity>
+  <identity name="linegroup">
+    <base name="iana-interface-type"/>
+    <description>
+      <text>Interface common to multiple lines.</text>
+    </description>
+  </identity>
+  <identity name="voiceEMFGD">
+    <base name="iana-interface-type"/>
+    <description>
+      <text>Voice E&amp;M Feature Group D.</text>
+    </description>
+  </identity>
+  <identity name="voiceFGDEANA">
+    <base name="iana-interface-type"/>
+    <description>
+      <text>Voice FGD Exchange Access North American.</text>
+    </description>
+  </identity>
+  <identity name="voiceDID">
+    <base name="iana-interface-type"/>
+    <description>
+      <text>Voice Direct Inward Dialing.</text>
+    </description>
+  </identity>
+  <identity name="mpegTransport">
+    <base name="iana-interface-type"/>
+    <description>
+      <text>MPEG transport interface.</text>
+    </description>
+  </identity>
+  <identity name="sixToFour">
+    <base name="iana-interface-type"/>
+    <status value="deprecated"/>
+    <description>
+      <text>6to4 interface (DEPRECATED).</text>
+    </description>
+    <reference>
+      <text>RFC 4087 - IP Tunnel MIB</text>
+    </reference>
+  </identity>
+  <identity name="gtp">
+    <base name="iana-interface-type"/>
+    <description>
+      <text>GTP (GPRS Tunneling Protocol).</text>
+    </description>
+  </identity>
+  <identity name="pdnEtherLoop1">
+    <base name="iana-interface-type"/>
+    <description>
+      <text>Paradyne EtherLoop 1.</text>
+    </description>
+  </identity>
+  <identity name="pdnEtherLoop2">
+    <base name="iana-interface-type"/>
+    <description>
+      <text>Paradyne EtherLoop 2.</text>
+    </description>
+  </identity>
+  <identity name="opticalChannelGroup">
+    <base name="iana-interface-type"/>
+    <description>
+      <text>Optical Channel Group.</text>
+    </description>
+  </identity>
+  <identity name="homepna">
+    <base name="iana-interface-type"/>
+    <description>
+      <text>HomePNA ITU-T G.989.</text>
+    </description>
+  </identity>
+  <identity name="gfp">
+    <base name="iana-interface-type"/>
+    <description>
+      <text>Generic Framing Procedure (GFP).</text>
+    </description>
+  </identity>
+  <identity name="ciscoISLvlan">
+    <base name="iana-interface-type"/>
+    <description>
+      <text>Layer 2 Virtual LAN using Cisco ISL.</text>
+    </description>
+  </identity>
+  <identity name="actelisMetaLOOP">
+    <base name="iana-interface-type"/>
+    <description>
+      <text>Acteleis proprietary MetaLOOP High Speed Link.</text>
+    </description>
+  </identity>
+  <identity name="fcipLink">
+    <base name="iana-interface-type"/>
+    <description>
+      <text>FCIP Link.</text>
+    </description>
+  </identity>
+  <identity name="rpr">
+    <base name="iana-interface-type"/>
+    <description>
+      <text>Resilient Packet Ring Interface Type.</text>
+    </description>
+  </identity>
+  <identity name="qam">
+    <base name="iana-interface-type"/>
+    <description>
+      <text>RF Qam Interface.</text>
+    </description>
+  </identity>
+  <identity name="lmp">
+    <base name="iana-interface-type"/>
+    <description>
+      <text>Link Management Protocol.</text>
+    </description>
+    <reference>
+      <text>RFC 4327 - Link Management Protocol (LMP) Management
+      Information Base (MIB)</text>
+    </reference>
+  </identity>
+  <identity name="cblVectaStar">
+    <base name="iana-interface-type"/>
+    <description>
+      <text>Cambridge Broadband Networks Limited VectaStar.</text>
+    </description>
+  </identity>
+  <identity name="docsCableMCmtsDownstream">
+    <base name="iana-interface-type"/>
+    <description>
+      <text>CATV Modular CMTS Downstream Interface.</text>
+    </description>
+  </identity>
+  <identity name="adsl2">
+    <base name="iana-interface-type"/>
+    <status value="deprecated"/>
+    <description>
+      <text>Asymmetric Digital Subscriber Loop Version 2
+(DEPRECATED/OBSOLETED - please use adsl2plus(238)
+instead).</text>
+    </description>
+    <reference>
+      <text>RFC 4706 - Definitions of Managed Objects for Asymmetric
+      Digital Subscriber Line 2 (ADSL2)</text>
+    </reference>
+  </identity>
+  <identity name="macSecControlledIF">
+    <base name="iana-interface-type"/>
+    <description>
+      <text>MACSecControlled.</text>
+    </description>
+  </identity>
+  <identity name="macSecUncontrolledIF">
+    <base name="iana-interface-type"/>
+    <description>
+      <text>MACSecUncontrolled.</text>
+    </description>
+  </identity>
+  <identity name="aviciOpticalEther">
+    <base name="iana-interface-type"/>
+    <description>
+      <text>Avici Optical Ethernet Aggregate.</text>
+    </description>
+  </identity>
+  <identity name="atmbond">
+    <base name="iana-interface-type"/>
+    <description>
+      <text>atmbond.</text>
+    </description>
+  </identity>
+  <identity name="voiceFGDOS">
+    <base name="iana-interface-type"/>
+    <description>
+      <text>Voice FGD Operator Services.</text>
+    </description>
+  </identity>
+  <identity name="mocaVersion1">
+    <base name="iana-interface-type"/>
+    <description>
+      <text>MultiMedia over Coax Alliance (MoCA) Interface
+as documented in information provided privately to IANA.</text>
+    </description>
+  </identity>
+  <identity name="ieee80216WMAN">
+    <base name="iana-interface-type"/>
+    <description>
+      <text>IEEE 802.16 WMAN interface.</text>
+    </description>
+  </identity>
+  <identity name="adsl2plus">
+    <base name="iana-interface-type"/>
+    <description>
+      <text>Asymmetric Digital Subscriber Loop Version 2 -
+Version 2 Plus and all variants.</text>
+    </description>
+  </identity>
+  <identity name="dvbRcsMacLayer">
+    <base name="iana-interface-type"/>
+    <description>
+      <text>DVB-RCS MAC Layer.</text>
+    </description>
+    <reference>
+      <text>RFC 5728 - The SatLabs Group DVB-RCS MIB</text>
+    </reference>
+  </identity>
+  <identity name="dvbTdm">
+    <base name="iana-interface-type"/>
+    <description>
+      <text>DVB Satellite TDM.</text>
+    </description>
+    <reference>
+      <text>RFC 5728 - The SatLabs Group DVB-RCS MIB</text>
+    </reference>
+  </identity>
+  <identity name="dvbRcsTdma">
+    <base name="iana-interface-type"/>
+    <description>
+      <text>DVB-RCS TDMA.</text>
+    </description>
+    <reference>
+      <text>RFC 5728 - The SatLabs Group DVB-RCS MIB</text>
+    </reference>
+  </identity>
+  <identity name="x86Laps">
+    <base name="iana-interface-type"/>
+    <description>
+      <text>LAPS based on ITU-T X.86/Y.1323.</text>
+    </description>
+  </identity>
+  <identity name="wwanPP">
+    <base name="iana-interface-type"/>
+    <description>
+      <text>3GPP WWAN.</text>
+    </description>
+  </identity>
+  <identity name="wwanPP2">
+    <base name="iana-interface-type"/>
+    <description>
+      <text>3GPP2 WWAN.</text>
+    </description>
+  </identity>
+  <identity name="voiceEBS">
+    <base name="iana-interface-type"/>
+    <description>
+      <text>Voice P-phone EBS physical interface.</text>
+    </description>
+  </identity>
+  <identity name="ifPwType">
+    <base name="iana-interface-type"/>
+    <description>
+      <text>Pseudowire interface type.</text>
+    </description>
+    <reference>
+      <text>RFC 5601 - Pseudowire (PW) Management Information Base (MIB)</text>
+    </reference>
+  </identity>
+  <identity name="ilan">
+    <base name="iana-interface-type"/>
+    <description>
+      <text>Internal LAN on a bridge per IEEE 802.1ap.</text>
+    </description>
+  </identity>
+  <identity name="pip">
+    <base name="iana-interface-type"/>
+    <description>
+      <text>Provider Instance Port on a bridge per IEEE 802.1ah PBB.</text>
+    </description>
+  </identity>
+  <identity name="aluELP">
+    <base name="iana-interface-type"/>
+    <description>
+      <text>Alcatel-Lucent Ethernet Link Protection.</text>
+    </description>
+  </identity>
+  <identity name="gpon">
+    <base name="iana-interface-type"/>
+    <description>
+      <text>Gigabit-capable passive optical networks (G-PON) as per
+ITU-T G.948.</text>
+    </description>
+  </identity>
+  <identity name="vdsl2">
+    <base name="iana-interface-type"/>
+    <description>
+      <text>Very high speed digital subscriber line Version 2
+(as per ITU-T Recommendation G.993.2).</text>
+    </description>
+    <reference>
+      <text>RFC 5650 - Definitions of Managed Objects for Very High
+      Speed Digital Subscriber Line 2 (VDSL2)</text>
+    </reference>
+  </identity>
+  <identity name="capwapDot11Profile">
+    <base name="iana-interface-type"/>
+    <description>
+      <text>WLAN Profile Interface.</text>
+    </description>
+    <reference>
+      <text>RFC 5834 - Control and Provisioning of Wireless Access
+      Points (CAPWAP) Protocol Binding MIB for
+      IEEE 802.11</text>
+    </reference>
+  </identity>
+  <identity name="capwapDot11Bss">
+    <base name="iana-interface-type"/>
+    <description>
+      <text>WLAN BSS Interface.</text>
+    </description>
+    <reference>
+      <text>RFC 5834 - Control and Provisioning of Wireless Access
+      Points (CAPWAP) Protocol Binding MIB for
+      IEEE 802.11</text>
+    </reference>
+  </identity>
+  <identity name="capwapWtpVirtualRadio">
+    <base name="iana-interface-type"/>
+    <description>
+      <text>WTP Virtual Radio Interface.</text>
+    </description>
+    <reference>
+      <text>RFC 5833 - Control and Provisioning of Wireless Access
+      Points (CAPWAP) Protocol Base MIB</text>
+    </reference>
+  </identity>
+  <identity name="bits">
+    <base name="iana-interface-type"/>
+    <description>
+      <text>bitsport.</text>
+    </description>
+  </identity>
+  <identity name="docsCableUpstreamRfPort">
+    <base name="iana-interface-type"/>
+    <description>
+      <text>DOCSIS CATV Upstream RF Port.</text>
+    </description>
+  </identity>
+  <identity name="cableDownstreamRfPort">
+    <base name="iana-interface-type"/>
+    <description>
+      <text>CATV downstream RF Port.</text>
+    </description>
+  </identity>
+  <identity name="vmwareVirtualNic">
+    <base name="iana-interface-type"/>
+    <description>
+      <text>VMware Virtual Network Interface.</text>
+    </description>
+  </identity>
+  <identity name="ieee802154">
+    <base name="iana-interface-type"/>
+    <description>
+      <text>IEEE 802.15.4 WPAN interface.</text>
+    </description>
+    <reference>
+      <text>IEEE 802.15.4-2006</text>
+    </reference>
+  </identity>
+  <identity name="otnOdu">
+    <base name="iana-interface-type"/>
+    <description>
+      <text>OTN Optical Data Unit.</text>
+    </description>
+  </identity>
+  <identity name="otnOtu">
+    <base name="iana-interface-type"/>
+    <description>
+      <text>OTN Optical channel Transport Unit.</text>
+    </description>
+  </identity>
+  <identity name="ifVfiType">
+    <base name="iana-interface-type"/>
+    <description>
+      <text>VPLS Forwarding Instance Interface Type.</text>
+    </description>
+  </identity>
+  <identity name="g9981">
+    <base name="iana-interface-type"/>
+    <description>
+      <text>G.998.1 bonded interface.</text>
+    </description>
+  </identity>
+  <identity name="g9982">
+    <base name="iana-interface-type"/>
+    <description>
+      <text>G.998.2 bonded interface.</text>
+    </description>
+  </identity>
+  <identity name="g9983">
+    <base name="iana-interface-type"/>
+    <description>
+      <text>G.998.3 bonded interface.</text>
+    </description>
+  </identity>
+  <identity name="aluEpon">
+    <base name="iana-interface-type"/>
+    <description>
+      <text>Ethernet Passive Optical Networks (E-PON).</text>
+    </description>
+  </identity>
+  <identity name="aluEponOnu">
+    <base name="iana-interface-type"/>
+    <description>
+      <text>EPON Optical Network Unit.</text>
+    </description>
+  </identity>
+  <identity name="aluEponPhysicalUni">
+    <base name="iana-interface-type"/>
+    <description>
+      <text>EPON physical User to Network interface.</text>
+    </description>
+  </identity>
+  <identity name="aluEponLogicalLink">
+    <base name="iana-interface-type"/>
+    <description>
+      <text>The emulation of a point-to-point link over the EPON
+layer.</text>
+    </description>
+  </identity>
+  <identity name="aluGponOnu">
+    <base name="iana-interface-type"/>
+    <description>
+      <text>GPON Optical Network Unit.</text>
+    </description>
+    <reference>
+      <text>ITU-T G.984.2</text>
+    </reference>
+  </identity>
+  <identity name="aluGponPhysicalUni">
+    <base name="iana-interface-type"/>
+    <description>
+      <text>GPON physical User to Network interface.</text>
+    </description>
+    <reference>
+      <text>ITU-T G.984.2</text>
+    </reference>
+  </identity>
+  <identity name="vmwareNicTeam">
+    <base name="iana-interface-type"/>
+    <description>
+      <text>VMware NIC Team.</text>
+    </description>
+  </identity>
+</module>

--- a/test/data/ietf-inet-types.yang
+++ b/test/data/ietf-inet-types.yang
@@ -1,0 +1,454 @@
+module ietf-inet-types {
+
+    yang-version 1;
+
+    namespace
+      "urn:ietf:params:xml:ns:yang:ietf-inet-types";
+
+    prefix inet;
+
+    organization
+      "IETF NETMOD (NETCONF Data Modeling Language) Working Group";
+
+    contact
+      "WG Web:   <http://tools.ietf.org/wg/netmod/>
+    WG List:  <mailto:netmod@ietf.org>
+
+    WG Chair: David Kessens
+              <mailto:david.kessens@nsn.com>
+
+    WG Chair: Juergen Schoenwaelder
+              <mailto:j.schoenwaelder@jacobs-university.de>
+
+    Editor:   Juergen Schoenwaelder
+              <mailto:j.schoenwaelder@jacobs-university.de>";
+
+    description
+      "This module contains a collection of generally useful derived
+    YANG data types for Internet addresses and related things.
+
+    Copyright (c) 2013 IETF Trust and the persons identified as
+    authors of the code.  All rights reserved.
+
+    Redistribution and use in source and binary forms, with or
+    without modification, is permitted pursuant to, and subject
+    to the license terms contained in, the Simplified BSD License
+    set forth in Section 4.c of the IETF Trust's Legal Provisions
+    Relating to IETF Documents
+    (http://trustee.ietf.org/license-info).
+
+    This version of this YANG module is part of RFC 6991; see
+    the RFC itself for full legal notices.";
+
+    revision "2013-07-15" {
+      description
+        "This revision adds the following new data types:
+      - ip-address-no-zone
+      - ipv4-address-no-zone
+      - ipv6-address-no-zone";
+      reference
+        "RFC 6991: Common YANG Data Types";
+
+    }
+
+    revision "2010-09-24" {
+      description "Initial revision.";
+      reference
+        "RFC 6021: Common YANG Data Types";
+
+    }
+
+
+    typedef ip-version {
+      type enumeration {
+        enum "unknown" {
+          value 0;
+          description
+            "An unknown or unspecified version of the Internet
+          protocol.";
+        }
+        enum "ipv4" {
+          value 1;
+          description
+            "The IPv4 protocol as defined in RFC 791.";
+        }
+        enum "ipv6" {
+          value 2;
+          description
+            "The IPv6 protocol as defined in RFC 2460.";
+        }
+      }
+      description
+        "This value represents the version of the IP protocol.
+
+      In the value set and its semantics, this type is equivalent
+      to the InetVersion textual convention of the SMIv2.";
+      reference
+        "RFC  791: Internet Protocol
+         RFC 2460: Internet Protocol, Version 6 (IPv6) Specification
+         RFC 4001: Textual Conventions for Internet Network Addresses";
+
+    }
+
+    typedef dscp {
+      type uint8 {
+        range "0..63";
+      }
+      description
+        "The dscp type represents a Differentiated Services Code Point
+      that may be used for marking packets in a traffic stream.
+      In the value set and its semantics, this type is equivalent
+      to the Dscp textual convention of the SMIv2.";
+      reference
+        "RFC 3289: Management Information Base for the Differentiated
+              Services Architecture
+         RFC 2474: Definition of the Differentiated Services Field
+              (DS Field) in the IPv4 and IPv6 Headers
+         RFC 2780: IANA Allocation Guidelines For Values In
+              the Internet Protocol and Related Headers";
+
+    }
+
+    typedef ipv6-flow-label {
+      type uint32 {
+        range "0..1048575";
+      }
+      description
+        "The ipv6-flow-label type represents the flow identifier or Flow
+      Label in an IPv6 packet header that may be used to
+      discriminate traffic flows.
+
+      In the value set and its semantics, this type is equivalent
+      to the IPv6FlowLabel textual convention of the SMIv2.";
+      reference
+        "RFC 3595: Textual Conventions for IPv6 Flow Label
+         RFC 2460: Internet Protocol, Version 6 (IPv6) Specification";
+
+    }
+
+    typedef port-number {
+      type uint16 {
+        range "0..65535";
+      }
+      description
+        "The port-number type represents a 16-bit port number of an
+      Internet transport-layer protocol such as UDP, TCP, DCCP, or
+      SCTP.  Port numbers are assigned by IANA.  A current list of
+      all assignments is available from <http://www.iana.org/>.
+
+      Note that the port number value zero is reserved by IANA.  In
+      situations where the value zero does not make sense, it can
+      be excluded by subtyping the port-number type.
+      In the value set and its semantics, this type is equivalent
+      to the InetPortNumber textual convention of the SMIv2.";
+      reference
+        "RFC  768: User Datagram Protocol
+         RFC  793: Transmission Control Protocol
+         RFC 4960: Stream Control Transmission Protocol
+         RFC 4340: Datagram Congestion Control Protocol (DCCP)
+         RFC 4001: Textual Conventions for Internet Network Addresses";
+
+    }
+
+    typedef as-number {
+      type uint32;
+      description
+        "The as-number type represents autonomous system numbers
+      which identify an Autonomous System (AS).  An AS is a set
+      of routers under a single technical administration, using
+      an interior gateway protocol and common metrics to route
+      packets within the AS, and using an exterior gateway
+      protocol to route packets to other ASes.  IANA maintains
+      the AS number space and has delegated large parts to the
+      regional registries.
+
+      Autonomous system numbers were originally limited to 16
+      bits.  BGP extensions have enlarged the autonomous system
+      number space to 32 bits.  This type therefore uses an uint32
+      base type without a range restriction in order to support
+      a larger autonomous system number space.
+
+      In the value set and its semantics, this type is equivalent
+      to the InetAutonomousSystemNumber textual convention of
+      the SMIv2.";
+      reference
+        "RFC 1930: Guidelines for creation, selection, and registration
+              of an Autonomous System (AS)
+         RFC 4271: A Border Gateway Protocol 4 (BGP-4)
+         RFC 4001: Textual Conventions for Internet Network Addresses
+         RFC 6793: BGP Support for Four-Octet Autonomous System (AS)
+              Number Space";
+
+    }
+
+    typedef ip-address {
+      type union {
+        type ipv4-address;
+        type ipv6-address;
+      }
+      description
+        "The ip-address type represents an IP address and is IP
+      version neutral.  The format of the textual representation
+      implies the IP version.  This type supports scoped addresses
+      by allowing zone identifiers in the address format.";
+      reference
+        "RFC 4007: IPv6 Scoped Address Architecture";
+
+    }
+
+    typedef ipv4-address {
+      type string {
+        pattern
+          '(([0-9]|[1-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])(%[\p{N}\p{L}]+)?';
+      }
+      description
+        "The ipv4-address type represents an IPv4 address in
+       dotted-quad notation.  The IPv4 address may include a zone
+       index, separated by a % sign.
+
+       The zone index is used to disambiguate identical address
+       values.  For link-local addresses, the zone index will
+       typically be the interface index number or the name of an
+       interface.  If the zone index is not present, the default
+       zone of the device will be used.
+
+       The canonical format for the zone index is the numerical
+       format";
+    }
+
+    typedef ipv6-address {
+      type string {
+        pattern
+          '((:|[0-9a-fA-F]{0,4}):)([0-9a-fA-F]{0,4}:){0,5}((([0-9a-fA-F]{0,4}:)?(:|[0-9a-fA-F]{0,4}))|(((25[0-5]|2[0-4][0-9]|[01]?[0-9]?[0-9])\.){3}(25[0-5]|2[0-4][0-9]|[01]?[0-9]?[0-9])))(%[\p{N}\p{L}]+)?';
+        pattern
+          '(([^:]+:){6}(([^:]+:[^:]+)|(.*\..*)))|((([^:]+:)*[^:]+)?::(([^:]+:)*[^:]+)?)(%.+)?';
+      }
+      description
+        "The ipv6-address type represents an IPv6 address in full,
+      mixed, shortened, and shortened-mixed notation.  The IPv6
+      address may include a zone index, separated by a % sign.
+
+      The zone index is used to disambiguate identical address
+      values.  For link-local addresses, the zone index will
+      typically be the interface index number or the name of an
+      interface.  If the zone index is not present, the default
+      zone of the device will be used.
+
+
+
+      The canonical format of IPv6 addresses uses the textual
+      representation defined in Section 4 of RFC 5952.  The
+      canonical format for the zone index is the numerical
+      format as described in Section 11.2 of RFC 4007.";
+      reference
+        "RFC 4291: IP Version 6 Addressing Architecture
+         RFC 4007: IPv6 Scoped Address Architecture
+         RFC 5952: A Recommendation for IPv6 Address Text
+              Representation";
+
+    }
+
+    typedef ip-address-no-zone {
+      type union {
+        type ipv4-address-no-zone;
+        type ipv6-address-no-zone;
+      }
+      description
+        "The ip-address-no-zone type represents an IP address and is
+      IP version neutral.  The format of the textual representation
+      implies the IP version.  This type does not support scoped
+      addresses since it does not allow zone identifiers in the
+      address format.";
+      reference
+        "RFC 4007: IPv6 Scoped Address Architecture";
+
+    }
+
+    typedef ipv4-address-no-zone {
+      type ipv4-address {
+        pattern '[0-9\.]*';
+      }
+      description
+        "An IPv4 address without a zone index.  This type, derived from
+       ipv4-address, may be used in situations where the zone is
+       known from the context and hence no zone index is needed.";
+    }
+
+    typedef ipv6-address-no-zone {
+      type ipv6-address {
+        pattern '[0-9a-fA-F:\.]*';
+      }
+      description
+        "An IPv6 address without a zone index.  This type, derived from
+       ipv6-address, may be used in situations where the zone is
+       known from the context and hence no zone index is needed.";
+      reference
+        "RFC 4291: IP Version 6 Addressing Architecture
+         RFC 4007: IPv6 Scoped Address Architecture
+         RFC 5952: A Recommendation for IPv6 Address Text
+              Representation";
+
+    }
+
+    typedef ip-prefix {
+      type union {
+        type ipv4-prefix;
+        type ipv6-prefix;
+      }
+      description
+        "The ip-prefix type represents an IP prefix and is IP
+      version neutral.  The format of the textual representations
+      implies the IP version.";
+    }
+
+    typedef ipv4-prefix {
+      type string {
+        pattern
+          '(([0-9]|[1-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])/(([0-9])|([1-2][0-9])|(3[0-2]))';
+      }
+      description
+        "The ipv4-prefix type represents an IPv4 address prefix.
+      The prefix length is given by the number following the
+      slash character and must be less than or equal to 32.
+
+      A prefix length value of n corresponds to an IP address
+      mask that has n contiguous 1-bits from the most
+      significant bit (MSB) and all other bits set to 0.
+
+      The canonical format of an IPv4 prefix has all bits of
+      the IPv4 address set to zero that are not part of the
+      IPv4 prefix.";
+    }
+
+    typedef ipv6-prefix {
+      type string {
+        pattern
+          '((:|[0-9a-fA-F]{0,4}):)([0-9a-fA-F]{0,4}:){0,5}((([0-9a-fA-F]{0,4}:)?(:|[0-9a-fA-F]{0,4}))|(((25[0-5]|2[0-4][0-9]|[01]?[0-9]?[0-9])\.){3}(25[0-5]|2[0-4][0-9]|[01]?[0-9]?[0-9])))(/(([0-9])|([0-9]{2})|(1[0-1][0-9])|(12[0-8])))';
+        pattern
+          '(([^:]+:){6}(([^:]+:[^:]+)|(.*\..*)))|((([^:]+:)*[^:]+)?::(([^:]+:)*[^:]+)?)(/.+)';
+      }
+      description
+        "The ipv6-prefix type represents an IPv6 address prefix.
+      The prefix length is given by the number following the
+      slash character and must be less than or equal to 128.
+
+      A prefix length value of n corresponds to an IP address
+      mask that has n contiguous 1-bits from the most
+      significant bit (MSB) and all other bits set to 0.
+
+      The IPv6 address should have all bits that do not belong
+      to the prefix set to zero.
+
+      The canonical format of an IPv6 prefix has all bits of
+      the IPv6 address set to zero that are not part of the
+      IPv6 prefix.  Furthermore, the IPv6 address is represented
+      as defined in Section 4 of RFC 5952.";
+      reference
+        "RFC 5952: A Recommendation for IPv6 Address Text
+              Representation";
+
+    }
+
+    typedef domain-name {
+      type string {
+        length "1..253";
+        pattern
+          '((([a-zA-Z0-9_]([a-zA-Z0-9\-_]){0,61})?[a-zA-Z0-9]\.)*([a-zA-Z0-9_]([a-zA-Z0-9\-_]){0,61})?[a-zA-Z0-9]\.?)|\.';
+      }
+      description
+        "The domain-name type represents a DNS domain name.  The
+      name SHOULD be fully qualified whenever possible.
+
+      Internet domain names are only loosely specified.  Section
+      3.5 of RFC 1034 recommends a syntax (modified in Section
+      2.1 of RFC 1123).  The pattern above is intended to allow
+      for current practice in domain name use, and some possible
+      future expansion.  It is designed to hold various types of
+      domain names, including names used for A or AAAA records
+      (host names) and other records, such as SRV records.  Note
+      that Internet host names have a stricter syntax (described
+      in RFC 952) than the DNS recommendations in RFCs 1034 and
+      1123, and that systems that want to store host names in
+      schema nodes using the domain-name type are recommended to
+      adhere to this stricter standard to ensure interoperability.
+
+      The encoding of DNS names in the DNS protocol is limited
+      to 255 characters.  Since the encoding consists of labels
+      prefixed by a length bytes and there is a trailing NULL
+      byte, only 253 characters can appear in the textual dotted
+      notation.
+
+      The description clause of schema nodes using the domain-name
+      type MUST describe when and how these names are resolved to
+      IP addresses.  Note that the resolution of a domain-name value
+      may require to query multiple DNS records (e.g., A for IPv4
+      and AAAA for IPv6).  The order of the resolution process and
+      which DNS record takes precedence can either be defined
+      explicitly or may depend on the configuration of the
+      resolver.
+
+      Domain-name values use the US-ASCII encoding.  Their canonical
+      format uses lowercase US-ASCII characters.  Internationalized
+      domain names MUST be A-labels as per RFC 5890.";
+      reference
+        "RFC  952: DoD Internet Host Table Specification
+         RFC 1034: Domain Names - Concepts and Facilities
+         RFC 1123: Requirements for Internet Hosts -- Application
+              and Support
+         RFC 2782: A DNS RR for specifying the location of services
+              (DNS SRV)
+         RFC 5890: Internationalized Domain Names in Applications
+              (IDNA): Definitions and Document Framework";
+
+    }
+
+    typedef host {
+      type union {
+        type ip-address;
+        type domain-name;
+      }
+      description
+        "The host type represents either an IP address or a DNS
+      domain name.";
+    }
+
+    typedef uri {
+      type string;
+      description
+        "The uri type represents a Uniform Resource Identifier
+      (URI) as defined by STD 66.
+
+      Objects using the uri type MUST be in US-ASCII encoding,
+      and MUST be normalized as described by RFC 3986 Sections
+      6.2.1, 6.2.2.1, and 6.2.2.2.  All unnecessary
+      percent-encoding is removed, and all case-insensitive
+      characters are set to lowercase except for hexadecimal
+      digits, which are normalized to uppercase as described in
+      Section 6.2.2.1.
+
+      The purpose of this normalization is to help provide
+      unique URIs.  Note that this normalization is not
+      sufficient to provide uniqueness.  Two URIs that are
+      textually distinct after this normalization may still be
+      equivalent.
+
+      Objects using the uri type may restrict the schemes that
+      they permit.  For example, 'data:' and 'urn:' schemes
+      might not be appropriate.
+
+      A zero-length URI is not a valid URI.  This can be used to
+      express 'URI absent' where required.
+
+      In the value set and its semantics, this type is equivalent
+      to the Uri SMIv2 textual convention defined in RFC 5017.";
+      reference
+        "RFC 3986: Uniform Resource Identifier (URI): Generic Syntax
+         RFC 3305: Report from the Joint W3C/IETF URI Planning Interest
+              Group: Uniform Resource Identifiers (URIs), URLs,
+              and Uniform Resource Names (URNs): Clarifications
+              and Recommendations
+         RFC 5017: MIB Textual Conventions for Uniform Resource
+              Identifiers (URIs)";
+
+    }
+  }  // module ietf-inet-types

--- a/test/data/ietf-interfaces.yang
+++ b/test/data/ietf-interfaces.yang
@@ -1,0 +1,707 @@
+module ietf-interfaces {
+
+    yang-version 1;
+
+    namespace
+      "urn:ietf:params:xml:ns:yang:ietf-interfaces";
+
+    prefix if;
+
+    import ietf-yang-types {
+      prefix yang;
+    }
+
+    organization
+      "IETF NETMOD (NETCONF Data Modeling Language) Working Group";
+
+    contact
+      "WG Web:   <http://tools.ietf.org/wg/netmod/>
+     WG List:  <mailto:netmod@ietf.org>
+
+     WG Chair: Thomas Nadeau
+               <mailto:tnadeau@lucidvision.com>
+
+     WG Chair: Juergen Schoenwaelder
+               <mailto:j.schoenwaelder@jacobs-university.de>
+
+     Editor:   Martin Bjorklund
+               <mailto:mbj@tail-f.com>";
+
+    description
+      "This module contains a collection of YANG definitions for
+     managing network interfaces.
+
+     Copyright (c) 2014 IETF Trust and the persons identified as
+     authors of the code.  All rights reserved.
+
+     Redistribution and use in source and binary forms, with or
+     without modification, is permitted pursuant to, and subject
+     to the license terms contained in, the Simplified BSD License
+     set forth in Section 4.c of the IETF Trust's Legal Provisions
+     Relating to IETF Documents
+     (http://trustee.ietf.org/license-info).
+
+     This version of this YANG module is part of RFC 7223; see
+     the RFC itself for full legal notices.";
+
+    revision "2014-05-08" {
+      description "Initial revision.";
+      reference
+        "RFC 7223: A YANG Data Model for Interface Management";
+
+    }
+
+
+    typedef interface-ref {
+      type leafref {
+        path "/if:interfaces/if:interface/if:name";
+      }
+      description
+        "This type is used by data models that need to reference
+       configured interfaces.";
+    }
+
+    typedef interface-state-ref {
+      type leafref {
+        path "/if:interfaces-state/if:interface/if:name";
+      }
+      description
+        "This type is used by data models that need to reference
+       the operationally present interfaces.";
+    }
+
+    identity interface-type {
+      description
+        "Base identity from which specific interface types are
+       derived.";
+    }
+
+    feature arbitrary-names {
+      description
+        "This feature indicates that the device allows user-controlled
+       interfaces to be named arbitrarily.";
+    }
+
+    feature pre-provisioning {
+      description
+        "This feature indicates that the device supports
+       pre-provisioning of interface configuration, i.e., it is
+       possible to configure an interface whose physical interface
+       hardware is not present on the device.";
+    }
+
+    feature if-mib {
+      description
+        "This feature indicates that the device implements
+       the IF-MIB.";
+      reference
+        "RFC 2863: The Interfaces Group MIB";
+
+    }
+
+    container interfaces {
+      description
+        "Interface configuration parameters.";
+      list interface {
+        key "name";
+        description
+          "The list of configured interfaces on the device.
+
+         The operational state of an interface is available in the
+         /interfaces-state/interface list.  If the configuration of a
+         system-controlled interface cannot be used by the system
+         (e.g., the interface hardware present does not match the
+         interface type), then the configuration is not applied to
+         the system-controlled interface shown in the
+         /interfaces-state/interface list.  If the configuration
+         of a user-controlled interface cannot be used by the system,
+         the configured interface is not instantiated in the
+         /interfaces-state/interface list.";
+        leaf name {
+          type string;
+          description
+            "The name of the interface.
+
+           A device MAY restrict the allowed values for this leaf,
+           possibly depending on the type of the interface.
+           For system-controlled interfaces, this leaf is the
+           device-specific name of the interface.  The 'config false'
+           list /interfaces-state/interface contains the currently
+           existing interfaces on the device.
+
+           If a client tries to create configuration for a
+           system-controlled interface that is not present in the
+           /interfaces-state/interface list, the server MAY reject
+           the request if the implementation does not support
+           pre-provisioning of interfaces or if the name refers to
+           an interface that can never exist in the system.  A
+           NETCONF server MUST reply with an rpc-error with the
+           error-tag 'invalid-value' in this case.
+
+           If the device supports pre-provisioning of interface
+           configuration, the 'pre-provisioning' feature is
+           advertised.
+
+           If the device allows arbitrarily named user-controlled
+           interfaces, the 'arbitrary-names' feature is advertised.
+
+           When a configured user-controlled interface is created by
+           the system, it is instantiated with the same name in the
+           /interface-state/interface list.";
+        }
+
+        leaf description {
+          type string;
+          description
+            "A textual description of the interface.
+
+           A server implementation MAY map this leaf to the ifAlias
+           MIB object.  Such an implementation needs to use some
+           mechanism to handle the differences in size and characters
+           allowed between this leaf and ifAlias.  The definition of
+           such a mechanism is outside the scope of this document.
+
+           Since ifAlias is defined to be stored in non-volatile
+           storage, the MIB implementation MUST map ifAlias to the
+           value of 'description' in the persistently stored
+           datastore.
+
+           Specifically, if the device supports ':startup', when
+           ifAlias is read the device MUST return the value of
+           'description' in the 'startup' datastore, and when it is
+           written, it MUST be written to the 'running' and 'startup'
+           datastores.  Note that it is up to the implementation to
+
+           decide whether to modify this single leaf in 'startup' or
+           perform an implicit copy-config from 'running' to
+           'startup'.
+
+           If the device does not support ':startup', ifAlias MUST
+           be mapped to the 'description' leaf in the 'running'
+           datastore.";
+          reference
+            "RFC 2863: The Interfaces Group MIB - ifAlias";
+
+        }
+
+        leaf type {
+          type identityref {
+            base interface-type;
+          }
+          mandatory true;
+          description
+            "The type of the interface.
+
+           When an interface entry is created, a server MAY
+           initialize the type leaf with a valid value, e.g., if it
+           is possible to derive the type from the name of the
+           interface.
+
+           If a client tries to set the type of an interface to a
+           value that can never be used by the system, e.g., if the
+           type is not supported or if the type does not match the
+           name of the interface, the server MUST reject the request.
+           A NETCONF server MUST reply with an rpc-error with the
+           error-tag 'invalid-value' in this case.";
+          reference
+            "RFC 2863: The Interfaces Group MIB - ifType";
+
+        }
+
+        leaf enabled {
+          type boolean;
+          default "true";
+          description
+            "This leaf contains the configured, desired state of the
+           interface.
+
+           Systems that implement the IF-MIB use the value of this
+           leaf in the 'running' datastore to set
+           IF-MIB.ifAdminStatus to 'up' or 'down' after an ifEntry
+           has been initialized, as described in RFC 2863.
+
+
+
+           Changes in this leaf in the 'running' datastore are
+           reflected in ifAdminStatus, but if ifAdminStatus is
+           changed over SNMP, this leaf is not affected.";
+          reference
+            "RFC 2863: The Interfaces Group MIB - ifAdminStatus";
+
+        }
+
+        leaf link-up-down-trap-enable {
+          if-feature if-mib;
+          type enumeration {
+            enum "enabled" {
+              value 1;
+            }
+            enum "disabled" {
+              value 2;
+            }
+          }
+          description
+            "Controls whether linkUp/linkDown SNMP notifications
+           should be generated for this interface.
+
+           If this node is not configured, the value 'enabled' is
+           operationally used by the server for interfaces that do
+           not operate on top of any other interface (i.e., there are
+           no 'lower-layer-if' entries), and 'disabled' otherwise.";
+          reference
+            "RFC 2863: The Interfaces Group MIB -
+                  ifLinkUpDownTrapEnable";
+
+        }
+      }  // list interface
+    }  // container interfaces
+
+    container interfaces-state {
+      config false;
+      description
+        "Data nodes for the operational state of interfaces.";
+      list interface {
+        key "name";
+        description
+          "The list of interfaces on the device.
+
+         System-controlled interfaces created by the system are
+         always present in this list, whether they are configured or
+         not.";
+        leaf name {
+          type string;
+          description
+            "The name of the interface.
+
+           A server implementation MAY map this leaf to the ifName
+           MIB object.  Such an implementation needs to use some
+           mechanism to handle the differences in size and characters
+           allowed between this leaf and ifName.  The definition of
+           such a mechanism is outside the scope of this document.";
+          reference
+            "RFC 2863: The Interfaces Group MIB - ifName";
+
+        }
+
+        leaf type {
+          type identityref {
+            base interface-type;
+          }
+          mandatory true;
+          description
+            "The type of the interface.";
+          reference
+            "RFC 2863: The Interfaces Group MIB - ifType";
+
+        }
+
+        leaf admin-status {
+          if-feature if-mib;
+          type enumeration {
+            enum "up" {
+              value 1;
+              description
+                "Ready to pass packets.";
+            }
+            enum "down" {
+              value 2;
+              description
+                "Not ready to pass packets and not in some test mode.";
+            }
+            enum "testing" {
+              value 3;
+              description
+                "In some test mode.";
+            }
+          }
+          mandatory true;
+          description
+            "The desired state of the interface.
+
+           This leaf has the same read semantics as ifAdminStatus.";
+          reference
+            "RFC 2863: The Interfaces Group MIB - ifAdminStatus";
+
+        }
+
+        leaf oper-status {
+          type enumeration {
+            enum "up" {
+              value 1;
+              description
+                "Ready to pass packets.";
+            }
+            enum "down" {
+              value 2;
+              description
+                "The interface does not pass any packets.";
+            }
+            enum "testing" {
+              value 3;
+              description
+                "In some test mode.  No operational packets can
+               be passed.";
+            }
+            enum "unknown" {
+              value 4;
+              description
+                "Status cannot be determined for some reason.";
+            }
+            enum "dormant" {
+              value 5;
+              description
+                "Waiting for some external event.";
+            }
+            enum "not-present" {
+              value 6;
+              description
+                "Some component (typically hardware) is missing.";
+            }
+            enum "lower-layer-down" {
+              value 7;
+              description
+                "Down due to state of lower-layer interface(s).";
+            }
+          }
+          mandatory true;
+          description
+            "The current operational state of the interface.
+
+           This leaf has the same semantics as ifOperStatus.";
+          reference
+            "RFC 2863: The Interfaces Group MIB - ifOperStatus";
+
+        }
+
+        leaf last-change {
+          type yang:date-and-time;
+          description
+            "The time the interface entered its current operational
+           state.  If the current state was entered prior to the
+           last re-initialization of the local network management
+           subsystem, then this node is not present.";
+          reference
+            "RFC 2863: The Interfaces Group MIB - ifLastChange";
+
+        }
+
+        leaf if-index {
+          if-feature if-mib;
+          type int32 {
+            range "1..2147483647";
+          }
+          mandatory true;
+          description
+            "The ifIndex value for the ifEntry represented by this
+           interface.";
+          reference
+            "RFC 2863: The Interfaces Group MIB - ifIndex";
+
+        }
+
+        leaf phys-address {
+          type yang:phys-address;
+          description
+            "The interface's address at its protocol sub-layer.  For
+           example, for an 802.x interface, this object normally
+           contains a Media Access Control (MAC) address.  The
+           interface's media-specific modules must define the bit
+
+
+           and byte ordering and the format of the value of this
+           object.  For interfaces that do not have such an address
+           (e.g., a serial line), this node is not present.";
+          reference
+            "RFC 2863: The Interfaces Group MIB - ifPhysAddress";
+
+        }
+
+        leaf-list higher-layer-if {
+          type interface-state-ref;
+          description
+            "A list of references to interfaces layered on top of this
+           interface.";
+          reference
+            "RFC 2863: The Interfaces Group MIB - ifStackTable";
+
+        }
+
+        leaf-list lower-layer-if {
+          type interface-state-ref;
+          description
+            "A list of references to interfaces layered underneath this
+           interface.";
+          reference
+            "RFC 2863: The Interfaces Group MIB - ifStackTable";
+
+        }
+
+        leaf speed {
+          type yang:gauge64;
+          units "bits/second";
+          description
+            "An estimate of the interface's current bandwidth in bits
+             per second.  For interfaces that do not vary in
+             bandwidth or for those where no accurate estimation can
+             be made, this node should contain the nominal bandwidth.
+             For interfaces that have no concept of bandwidth, this
+             node is not present.";
+          reference
+            "RFC 2863: The Interfaces Group MIB -
+                  ifSpeed, ifHighSpeed";
+
+        }
+
+        container statistics {
+          description
+            "A collection of interface-related statistics objects.";
+          leaf discontinuity-time {
+            type yang:date-and-time;
+            mandatory true;
+            description
+              "The time on the most recent occasion at which any one or
+             more of this interface's counters suffered a
+             discontinuity.  If no such discontinuities have occurred
+             since the last re-initialization of the local management
+             subsystem, then this node contains the time the local
+             management subsystem re-initialized itself.";
+          }
+
+          leaf in-octets {
+            type yang:counter64;
+            description
+              "The total number of octets received on the interface,
+             including framing characters.
+
+             Discontinuities in the value of this counter can occur
+             at re-initialization of the management system, and at
+             other times as indicated by the value of
+             'discontinuity-time'.";
+            reference
+              "RFC 2863: The Interfaces Group MIB - ifHCInOctets";
+
+          }
+
+          leaf in-unicast-pkts {
+            type yang:counter64;
+            description
+              "The number of packets, delivered by this sub-layer to a
+             higher (sub-)layer, that were not addressed to a
+             multicast or broadcast address at this sub-layer.
+
+             Discontinuities in the value of this counter can occur
+             at re-initialization of the management system, and at
+             other times as indicated by the value of
+             'discontinuity-time'.";
+            reference
+              "RFC 2863: The Interfaces Group MIB - ifHCInUcastPkts";
+
+          }
+
+          leaf in-broadcast-pkts {
+            type yang:counter64;
+            description
+              "The number of packets, delivered by this sub-layer to a
+             higher (sub-)layer, that were addressed to a broadcast
+             address at this sub-layer.
+
+             Discontinuities in the value of this counter can occur
+             at re-initialization of the management system, and at
+             other times as indicated by the value of
+             'discontinuity-time'.";
+            reference
+              "RFC 2863: The Interfaces Group MIB -
+                  ifHCInBroadcastPkts";
+
+          }
+
+          leaf in-multicast-pkts {
+            type yang:counter64;
+            description
+              "The number of packets, delivered by this sub-layer to a
+             higher (sub-)layer, that were addressed to a multicast
+             address at this sub-layer.  For a MAC-layer protocol,
+             this includes both Group and Functional addresses.
+
+             Discontinuities in the value of this counter can occur
+             at re-initialization of the management system, and at
+             other times as indicated by the value of
+             'discontinuity-time'.";
+            reference
+              "RFC 2863: The Interfaces Group MIB -
+                  ifHCInMulticastPkts";
+
+          }
+
+          leaf in-discards {
+            type yang:counter32;
+            description
+              "The number of inbound packets that were chosen to be
+             discarded even though no errors had been detected to
+             prevent their being deliverable to a higher-layer
+             protocol.  One possible reason for discarding such a
+             packet could be to free up buffer space.
+
+             Discontinuities in the value of this counter can occur
+             at re-initialization of the management system, and at
+             other times as indicated by the value of
+             'discontinuity-time'.";
+            reference
+              "RFC 2863: The Interfaces Group MIB - ifInDiscards";
+
+          }
+
+          leaf in-errors {
+            type yang:counter32;
+            description
+              "For packet-oriented interfaces, the number of inbound
+             packets that contained errors preventing them from being
+             deliverable to a higher-layer protocol.  For character-
+             oriented or fixed-length interfaces, the number of
+             inbound transmission units that contained errors
+             preventing them from being deliverable to a higher-layer
+             protocol.
+
+             Discontinuities in the value of this counter can occur
+             at re-initialization of the management system, and at
+             other times as indicated by the value of
+             'discontinuity-time'.";
+            reference
+              "RFC 2863: The Interfaces Group MIB - ifInErrors";
+
+          }
+
+          leaf in-unknown-protos {
+            type yang:counter32;
+            description
+              "For packet-oriented interfaces, the number of packets
+             received via the interface that were discarded because
+             of an unknown or unsupported protocol.  For
+             character-oriented or fixed-length interfaces that
+             support protocol multiplexing, the number of
+             transmission units received via the interface that were
+             discarded because of an unknown or unsupported protocol.
+             For any interface that does not support protocol
+             multiplexing, this counter is not present.
+
+             Discontinuities in the value of this counter can occur
+             at re-initialization of the management system, and at
+             other times as indicated by the value of
+             'discontinuity-time'.";
+            reference
+              "RFC 2863: The Interfaces Group MIB - ifInUnknownProtos";
+
+          }
+
+          leaf out-octets {
+            type yang:counter64;
+            description
+              "The total number of octets transmitted out of the
+             interface, including framing characters.
+
+             Discontinuities in the value of this counter can occur
+             at re-initialization of the management system, and at
+             other times as indicated by the value of
+             'discontinuity-time'.";
+            reference
+              "RFC 2863: The Interfaces Group MIB - ifHCOutOctets";
+
+          }
+
+          leaf out-unicast-pkts {
+            type yang:counter64;
+            description
+              "The total number of packets that higher-level protocols
+             requested be transmitted, and that were not addressed
+             to a multicast or broadcast address at this sub-layer,
+             including those that were discarded or not sent.
+
+             Discontinuities in the value of this counter can occur
+             at re-initialization of the management system, and at
+             other times as indicated by the value of
+             'discontinuity-time'.";
+            reference
+              "RFC 2863: The Interfaces Group MIB - ifHCOutUcastPkts";
+
+          }
+
+          leaf out-broadcast-pkts {
+            type yang:counter64;
+            description
+              "The total number of packets that higher-level protocols
+             requested be transmitted, and that were addressed to a
+             broadcast address at this sub-layer, including those
+             that were discarded or not sent.
+
+             Discontinuities in the value of this counter can occur
+             at re-initialization of the management system, and at
+             other times as indicated by the value of
+             'discontinuity-time'.";
+            reference
+              "RFC 2863: The Interfaces Group MIB -
+                  ifHCOutBroadcastPkts";
+
+          }
+
+          leaf out-multicast-pkts {
+            type yang:counter64;
+            description
+              "The total number of packets that higher-level protocols
+             requested be transmitted, and that were addressed to a
+             multicast address at this sub-layer, including those
+             that were discarded or not sent.  For a MAC-layer
+             protocol, this includes both Group and Functional
+             addresses.
+
+             Discontinuities in the value of this counter can occur
+             at re-initialization of the management system, and at
+             other times as indicated by the value of
+             'discontinuity-time'.";
+            reference
+              "RFC 2863: The Interfaces Group MIB -
+                  ifHCOutMulticastPkts";
+
+          }
+
+          leaf out-discards {
+            type yang:counter32;
+            description
+              "The number of outbound packets that were chosen to be
+             discarded even though no errors had been detected to
+             prevent their being transmitted.  One possible reason
+             for discarding such a packet could be to free up buffer
+             space.
+
+             Discontinuities in the value of this counter can occur
+             at re-initialization of the management system, and at
+             other times as indicated by the value of
+             'discontinuity-time'.";
+            reference
+              "RFC 2863: The Interfaces Group MIB - ifOutDiscards";
+
+          }
+
+          leaf out-errors {
+            type yang:counter32;
+            description
+              "For packet-oriented interfaces, the number of outbound
+             packets that could not be transmitted because of errors.
+             For character-oriented or fixed-length interfaces, the
+             number of outbound transmission units that could not be
+             transmitted because of errors.
+
+
+
+
+             Discontinuities in the value of this counter can occur
+             at re-initialization of the management system, and at
+             other times as indicated by the value of
+             'discontinuity-time'.";
+            reference
+              "RFC 2863: The Interfaces Group MIB - ifOutErrors";
+
+          }
+        }  // container statistics
+      }  // list interface
+    }  // container interfaces-state
+  }  // module ietf-interfaces

--- a/test/data/ietf-interfaces.yin
+++ b/test/data/ietf-interfaces.yin
@@ -1,0 +1,721 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module name="ietf-interfaces"
+        xmlns="urn:ietf:params:xml:ns:yang:yin:1"
+        xmlns:if="urn:ietf:params:xml:ns:yang:ietf-interfaces"
+        xmlns:yang="urn:ietf:params:xml:ns:yang:ietf-yang-types">
+  <yang-version value="1"/>
+  <namespace uri="urn:ietf:params:xml:ns:yang:ietf-interfaces"/>
+  <prefix value="if"/>
+  <import module="ietf-yang-types">
+    <prefix value="yang"/>
+  </import>
+  <organization>
+    <text>IETF NETMOD (NETCONF Data Modeling Language) Working Group</text>
+  </organization>
+  <contact>
+    <text>WG Web:   &lt;http://tools.ietf.org/wg/netmod/&gt;
+WG List:  &lt;mailto:netmod@ietf.org&gt;
+
+WG Chair: Thomas Nadeau
+        &lt;mailto:tnadeau@lucidvision.com&gt;
+
+WG Chair: Juergen Schoenwaelder
+        &lt;mailto:j.schoenwaelder@jacobs-university.de&gt;
+
+Editor:   Martin Bjorklund
+        &lt;mailto:mbj@tail-f.com&gt;</text>
+  </contact>
+  <description>
+    <text>This module contains a collection of YANG definitions for
+managing network interfaces.
+
+Copyright (c) 2014 IETF Trust and the persons identified as
+authors of the code.  All rights reserved.
+
+Redistribution and use in source and binary forms, with or
+without modification, is permitted pursuant to, and subject
+to the license terms contained in, the Simplified BSD License
+set forth in Section 4.c of the IETF Trust's Legal Provisions
+Relating to IETF Documents
+(http://trustee.ietf.org/license-info).
+
+This version of this YANG module is part of RFC 7223; see
+the RFC itself for full legal notices.</text>
+  </description>
+  <revision date="2014-05-08">
+    <description>
+      <text>Initial revision.</text>
+    </description>
+    <reference>
+      <text>RFC 7223: A YANG Data Model for Interface Management</text>
+    </reference>
+  </revision>
+  <typedef name="interface-ref">
+    <type name="leafref">
+      <path value="/if:interfaces/if:interface/if:name"/>
+    </type>
+    <description>
+      <text>This type is used by data models that need to reference
+configured interfaces.</text>
+    </description>
+  </typedef>
+  <typedef name="interface-state-ref">
+    <type name="leafref">
+      <path value="/if:interfaces-state/if:interface/if:name"/>
+    </type>
+    <description>
+      <text>This type is used by data models that need to reference
+the operationally present interfaces.</text>
+    </description>
+  </typedef>
+  <identity name="interface-type">
+    <description>
+      <text>Base identity from which specific interface types are
+derived.</text>
+    </description>
+  </identity>
+  <feature name="arbitrary-names">
+    <description>
+      <text>This feature indicates that the device allows user-controlled
+interfaces to be named arbitrarily.</text>
+    </description>
+  </feature>
+  <feature name="pre-provisioning">
+    <description>
+      <text>This feature indicates that the device supports
+pre-provisioning of interface configuration, i.e., it is
+possible to configure an interface whose physical interface
+hardware is not present on the device.</text>
+    </description>
+  </feature>
+  <feature name="if-mib">
+    <description>
+      <text>This feature indicates that the device implements
+the IF-MIB.</text>
+    </description>
+    <reference>
+      <text>RFC 2863: The Interfaces Group MIB</text>
+    </reference>
+  </feature>
+  <container name="interfaces">
+    <description>
+      <text>Interface configuration parameters.</text>
+    </description>
+    <list name="interface">
+      <key value="name"/>
+      <description>
+        <text>The list of configured interfaces on the device.
+
+The operational state of an interface is available in the
+/interfaces-state/interface list.  If the configuration of a
+system-controlled interface cannot be used by the system
+(e.g., the interface hardware present does not match the
+interface type), then the configuration is not applied to
+the system-controlled interface shown in the
+/interfaces-state/interface list.  If the configuration
+of a user-controlled interface cannot be used by the system,
+the configured interface is not instantiated in the
+/interfaces-state/interface list.</text>
+      </description>
+      <leaf name="name">
+        <type name="string"/>
+        <description>
+          <text>The name of the interface.
+
+A device MAY restrict the allowed values for this leaf,
+possibly depending on the type of the interface.
+For system-controlled interfaces, this leaf is the
+device-specific name of the interface.  The 'config false'
+list /interfaces-state/interface contains the currently
+existing interfaces on the device.
+
+If a client tries to create configuration for a
+system-controlled interface that is not present in the
+/interfaces-state/interface list, the server MAY reject
+the request if the implementation does not support
+pre-provisioning of interfaces or if the name refers to
+an interface that can never exist in the system.  A
+NETCONF server MUST reply with an rpc-error with the
+error-tag 'invalid-value' in this case.
+
+If the device supports pre-provisioning of interface
+configuration, the 'pre-provisioning' feature is
+advertised.
+
+If the device allows arbitrarily named user-controlled
+interfaces, the 'arbitrary-names' feature is advertised.
+
+When a configured user-controlled interface is created by
+the system, it is instantiated with the same name in the
+/interface-state/interface list.</text>
+        </description>
+      </leaf>
+      <leaf name="description">
+        <type name="string"/>
+        <description>
+          <text>A textual description of the interface.
+
+A server implementation MAY map this leaf to the ifAlias
+MIB object.  Such an implementation needs to use some
+mechanism to handle the differences in size and characters
+allowed between this leaf and ifAlias.  The definition of
+such a mechanism is outside the scope of this document.
+
+Since ifAlias is defined to be stored in non-volatile
+storage, the MIB implementation MUST map ifAlias to the
+value of 'description' in the persistently stored
+datastore.
+
+Specifically, if the device supports ':startup', when
+ifAlias is read the device MUST return the value of
+'description' in the 'startup' datastore, and when it is
+written, it MUST be written to the 'running' and 'startup'
+datastores.  Note that it is up to the implementation to
+
+decide whether to modify this single leaf in 'startup' or
+perform an implicit copy-config from 'running' to
+'startup'.
+
+If the device does not support ':startup', ifAlias MUST
+be mapped to the 'description' leaf in the 'running'
+datastore.</text>
+        </description>
+        <reference>
+          <text>RFC 2863: The Interfaces Group MIB - ifAlias</text>
+        </reference>
+      </leaf>
+      <leaf name="type">
+        <type name="identityref">
+          <base name="interface-type"/>
+        </type>
+        <mandatory value="true"/>
+        <description>
+          <text>The type of the interface.
+
+When an interface entry is created, a server MAY
+initialize the type leaf with a valid value, e.g., if it
+is possible to derive the type from the name of the
+interface.
+
+If a client tries to set the type of an interface to a
+value that can never be used by the system, e.g., if the
+type is not supported or if the type does not match the
+name of the interface, the server MUST reject the request.
+A NETCONF server MUST reply with an rpc-error with the
+error-tag 'invalid-value' in this case.</text>
+        </description>
+        <reference>
+          <text>RFC 2863: The Interfaces Group MIB - ifType</text>
+        </reference>
+      </leaf>
+      <leaf name="enabled">
+        <type name="boolean"/>
+        <default value="true"/>
+        <description>
+          <text>This leaf contains the configured, desired state of the
+interface.
+
+Systems that implement the IF-MIB use the value of this
+leaf in the 'running' datastore to set
+IF-MIB.ifAdminStatus to 'up' or 'down' after an ifEntry
+has been initialized, as described in RFC 2863.
+
+
+
+Changes in this leaf in the 'running' datastore are
+reflected in ifAdminStatus, but if ifAdminStatus is
+changed over SNMP, this leaf is not affected.</text>
+        </description>
+        <reference>
+          <text>RFC 2863: The Interfaces Group MIB - ifAdminStatus</text>
+        </reference>
+      </leaf>
+      <leaf name="link-up-down-trap-enable">
+        <if-feature name="if-mib"/>
+        <type name="enumeration">
+          <enum name="enabled">
+            <value value="1"/>
+          </enum>
+          <enum name="disabled">
+            <value value="2"/>
+          </enum>
+        </type>
+        <description>
+          <text>Controls whether linkUp/linkDown SNMP notifications
+should be generated for this interface.
+
+If this node is not configured, the value 'enabled' is
+operationally used by the server for interfaces that do
+not operate on top of any other interface (i.e., there are
+no 'lower-layer-if' entries), and 'disabled' otherwise.</text>
+        </description>
+        <reference>
+          <text>RFC 2863: The Interfaces Group MIB -
+     ifLinkUpDownTrapEnable</text>
+        </reference>
+      </leaf>
+    </list>
+  </container>
+  <container name="interfaces-state">
+    <config value="false"/>
+    <description>
+      <text>Data nodes for the operational state of interfaces.</text>
+    </description>
+    <list name="interface">
+      <key value="name"/>
+      <description>
+        <text>The list of interfaces on the device.
+
+System-controlled interfaces created by the system are
+always present in this list, whether they are configured or
+not.</text>
+      </description>
+      <leaf name="name">
+        <type name="string"/>
+        <description>
+          <text>The name of the interface.
+
+A server implementation MAY map this leaf to the ifName
+MIB object.  Such an implementation needs to use some
+mechanism to handle the differences in size and characters
+allowed between this leaf and ifName.  The definition of
+such a mechanism is outside the scope of this document.</text>
+        </description>
+        <reference>
+          <text>RFC 2863: The Interfaces Group MIB - ifName</text>
+        </reference>
+      </leaf>
+      <leaf name="type">
+        <type name="identityref">
+          <base name="interface-type"/>
+        </type>
+        <mandatory value="true"/>
+        <description>
+          <text>The type of the interface.</text>
+        </description>
+        <reference>
+          <text>RFC 2863: The Interfaces Group MIB - ifType</text>
+        </reference>
+      </leaf>
+      <leaf name="admin-status">
+        <if-feature name="if-mib"/>
+        <type name="enumeration">
+          <enum name="up">
+            <value value="1"/>
+            <description>
+              <text>Ready to pass packets.</text>
+            </description>
+          </enum>
+          <enum name="down">
+            <value value="2"/>
+            <description>
+              <text>Not ready to pass packets and not in some test mode.</text>
+            </description>
+          </enum>
+          <enum name="testing">
+            <value value="3"/>
+            <description>
+              <text>In some test mode.</text>
+            </description>
+          </enum>
+        </type>
+        <mandatory value="true"/>
+        <description>
+          <text>The desired state of the interface.
+
+This leaf has the same read semantics as ifAdminStatus.</text>
+        </description>
+        <reference>
+          <text>RFC 2863: The Interfaces Group MIB - ifAdminStatus</text>
+        </reference>
+      </leaf>
+      <leaf name="oper-status">
+        <type name="enumeration">
+          <enum name="up">
+            <value value="1"/>
+            <description>
+              <text>Ready to pass packets.</text>
+            </description>
+          </enum>
+          <enum name="down">
+            <value value="2"/>
+            <description>
+              <text>The interface does not pass any packets.</text>
+            </description>
+          </enum>
+          <enum name="testing">
+            <value value="3"/>
+            <description>
+              <text>In some test mode.  No operational packets can
+be passed.</text>
+            </description>
+          </enum>
+          <enum name="unknown">
+            <value value="4"/>
+            <description>
+              <text>Status cannot be determined for some reason.</text>
+            </description>
+          </enum>
+          <enum name="dormant">
+            <value value="5"/>
+            <description>
+              <text>Waiting for some external event.</text>
+            </description>
+          </enum>
+          <enum name="not-present">
+            <value value="6"/>
+            <description>
+              <text>Some component (typically hardware) is missing.</text>
+            </description>
+          </enum>
+          <enum name="lower-layer-down">
+            <value value="7"/>
+            <description>
+              <text>Down due to state of lower-layer interface(s).</text>
+            </description>
+          </enum>
+        </type>
+        <mandatory value="true"/>
+        <description>
+          <text>The current operational state of the interface.
+
+This leaf has the same semantics as ifOperStatus.</text>
+        </description>
+        <reference>
+          <text>RFC 2863: The Interfaces Group MIB - ifOperStatus</text>
+        </reference>
+      </leaf>
+      <leaf name="last-change">
+        <type name="yang:date-and-time"/>
+        <description>
+          <text>The time the interface entered its current operational
+state.  If the current state was entered prior to the
+last re-initialization of the local network management
+subsystem, then this node is not present.</text>
+        </description>
+        <reference>
+          <text>RFC 2863: The Interfaces Group MIB - ifLastChange</text>
+        </reference>
+      </leaf>
+      <leaf name="if-index">
+        <if-feature name="if-mib"/>
+        <type name="int32">
+          <range value="1..2147483647"/>
+        </type>
+        <mandatory value="true"/>
+        <description>
+          <text>The ifIndex value for the ifEntry represented by this
+interface.</text>
+        </description>
+        <reference>
+          <text>RFC 2863: The Interfaces Group MIB - ifIndex</text>
+        </reference>
+      </leaf>
+      <leaf name="phys-address">
+        <type name="yang:phys-address"/>
+        <description>
+          <text>The interface's address at its protocol sub-layer.  For
+example, for an 802.x interface, this object normally
+contains a Media Access Control (MAC) address.  The
+interface's media-specific modules must define the bit
+
+
+and byte ordering and the format of the value of this
+object.  For interfaces that do not have such an address
+(e.g., a serial line), this node is not present.</text>
+        </description>
+        <reference>
+          <text>RFC 2863: The Interfaces Group MIB - ifPhysAddress</text>
+        </reference>
+      </leaf>
+      <leaf-list name="higher-layer-if">
+        <type name="interface-state-ref"/>
+        <description>
+          <text>A list of references to interfaces layered on top of this
+interface.</text>
+        </description>
+        <reference>
+          <text>RFC 2863: The Interfaces Group MIB - ifStackTable</text>
+        </reference>
+      </leaf-list>
+      <leaf-list name="lower-layer-if">
+        <type name="interface-state-ref"/>
+        <description>
+          <text>A list of references to interfaces layered underneath this
+interface.</text>
+        </description>
+        <reference>
+          <text>RFC 2863: The Interfaces Group MIB - ifStackTable</text>
+        </reference>
+      </leaf-list>
+      <leaf name="speed">
+        <type name="yang:gauge64"/>
+        <units name="bits/second"/>
+        <description>
+          <text>An estimate of the interface's current bandwidth in bits
+per second.  For interfaces that do not vary in
+bandwidth or for those where no accurate estimation can
+be made, this node should contain the nominal bandwidth.
+For interfaces that have no concept of bandwidth, this
+node is not present.</text>
+        </description>
+        <reference>
+          <text>RFC 2863: The Interfaces Group MIB -
+     ifSpeed, ifHighSpeed</text>
+        </reference>
+      </leaf>
+      <container name="statistics">
+        <description>
+          <text>A collection of interface-related statistics objects.</text>
+        </description>
+        <leaf name="discontinuity-time">
+          <type name="yang:date-and-time"/>
+          <mandatory value="true"/>
+          <description>
+            <text>The time on the most recent occasion at which any one or
+more of this interface's counters suffered a
+discontinuity.  If no such discontinuities have occurred
+since the last re-initialization of the local management
+subsystem, then this node contains the time the local
+management subsystem re-initialized itself.</text>
+          </description>
+        </leaf>
+        <leaf name="in-octets">
+          <type name="yang:counter64"/>
+          <description>
+            <text>The total number of octets received on the interface,
+including framing characters.
+
+Discontinuities in the value of this counter can occur
+at re-initialization of the management system, and at
+other times as indicated by the value of
+'discontinuity-time'.</text>
+          </description>
+          <reference>
+            <text>RFC 2863: The Interfaces Group MIB - ifHCInOctets</text>
+          </reference>
+        </leaf>
+        <leaf name="in-unicast-pkts">
+          <type name="yang:counter64"/>
+          <description>
+            <text>The number of packets, delivered by this sub-layer to a
+higher (sub-)layer, that were not addressed to a
+multicast or broadcast address at this sub-layer.
+
+Discontinuities in the value of this counter can occur
+at re-initialization of the management system, and at
+other times as indicated by the value of
+'discontinuity-time'.</text>
+          </description>
+          <reference>
+            <text>RFC 2863: The Interfaces Group MIB - ifHCInUcastPkts</text>
+          </reference>
+        </leaf>
+        <leaf name="in-broadcast-pkts">
+          <type name="yang:counter64"/>
+          <description>
+            <text>The number of packets, delivered by this sub-layer to a
+higher (sub-)layer, that were addressed to a broadcast
+address at this sub-layer.
+
+Discontinuities in the value of this counter can occur
+at re-initialization of the management system, and at
+other times as indicated by the value of
+'discontinuity-time'.</text>
+          </description>
+          <reference>
+            <text>RFC 2863: The Interfaces Group MIB -
+   ifHCInBroadcastPkts</text>
+          </reference>
+        </leaf>
+        <leaf name="in-multicast-pkts">
+          <type name="yang:counter64"/>
+          <description>
+            <text>The number of packets, delivered by this sub-layer to a
+higher (sub-)layer, that were addressed to a multicast
+address at this sub-layer.  For a MAC-layer protocol,
+this includes both Group and Functional addresses.
+
+Discontinuities in the value of this counter can occur
+at re-initialization of the management system, and at
+other times as indicated by the value of
+'discontinuity-time'.</text>
+          </description>
+          <reference>
+            <text>RFC 2863: The Interfaces Group MIB -
+   ifHCInMulticastPkts</text>
+          </reference>
+        </leaf>
+        <leaf name="in-discards">
+          <type name="yang:counter32"/>
+          <description>
+            <text>The number of inbound packets that were chosen to be
+discarded even though no errors had been detected to
+prevent their being deliverable to a higher-layer
+protocol.  One possible reason for discarding such a
+packet could be to free up buffer space.
+
+Discontinuities in the value of this counter can occur
+at re-initialization of the management system, and at
+other times as indicated by the value of
+'discontinuity-time'.</text>
+          </description>
+          <reference>
+            <text>RFC 2863: The Interfaces Group MIB - ifInDiscards</text>
+          </reference>
+        </leaf>
+        <leaf name="in-errors">
+          <type name="yang:counter32"/>
+          <description>
+            <text>For packet-oriented interfaces, the number of inbound
+packets that contained errors preventing them from being
+deliverable to a higher-layer protocol.  For character-
+oriented or fixed-length interfaces, the number of
+inbound transmission units that contained errors
+preventing them from being deliverable to a higher-layer
+protocol.
+
+Discontinuities in the value of this counter can occur
+at re-initialization of the management system, and at
+other times as indicated by the value of
+'discontinuity-time'.</text>
+          </description>
+          <reference>
+            <text>RFC 2863: The Interfaces Group MIB - ifInErrors</text>
+          </reference>
+        </leaf>
+        <leaf name="in-unknown-protos">
+          <type name="yang:counter32"/>
+          <description>
+            <text>For packet-oriented interfaces, the number of packets
+received via the interface that were discarded because
+of an unknown or unsupported protocol.  For
+character-oriented or fixed-length interfaces that
+support protocol multiplexing, the number of
+transmission units received via the interface that were
+discarded because of an unknown or unsupported protocol.
+For any interface that does not support protocol
+multiplexing, this counter is not present.
+
+Discontinuities in the value of this counter can occur
+at re-initialization of the management system, and at
+other times as indicated by the value of
+'discontinuity-time'.</text>
+          </description>
+          <reference>
+            <text>RFC 2863: The Interfaces Group MIB - ifInUnknownProtos</text>
+          </reference>
+        </leaf>
+        <leaf name="out-octets">
+          <type name="yang:counter64"/>
+          <description>
+            <text>The total number of octets transmitted out of the
+interface, including framing characters.
+
+Discontinuities in the value of this counter can occur
+at re-initialization of the management system, and at
+other times as indicated by the value of
+'discontinuity-time'.</text>
+          </description>
+          <reference>
+            <text>RFC 2863: The Interfaces Group MIB - ifHCOutOctets</text>
+          </reference>
+        </leaf>
+        <leaf name="out-unicast-pkts">
+          <type name="yang:counter64"/>
+          <description>
+            <text>The total number of packets that higher-level protocols
+requested be transmitted, and that were not addressed
+to a multicast or broadcast address at this sub-layer,
+including those that were discarded or not sent.
+
+Discontinuities in the value of this counter can occur
+at re-initialization of the management system, and at
+other times as indicated by the value of
+'discontinuity-time'.</text>
+          </description>
+          <reference>
+            <text>RFC 2863: The Interfaces Group MIB - ifHCOutUcastPkts</text>
+          </reference>
+        </leaf>
+        <leaf name="out-broadcast-pkts">
+          <type name="yang:counter64"/>
+          <description>
+            <text>The total number of packets that higher-level protocols
+requested be transmitted, and that were addressed to a
+broadcast address at this sub-layer, including those
+that were discarded or not sent.
+
+Discontinuities in the value of this counter can occur
+at re-initialization of the management system, and at
+other times as indicated by the value of
+'discontinuity-time'.</text>
+          </description>
+          <reference>
+            <text>RFC 2863: The Interfaces Group MIB -
+   ifHCOutBroadcastPkts</text>
+          </reference>
+        </leaf>
+        <leaf name="out-multicast-pkts">
+          <type name="yang:counter64"/>
+          <description>
+            <text>The total number of packets that higher-level protocols
+requested be transmitted, and that were addressed to a
+multicast address at this sub-layer, including those
+that were discarded or not sent.  For a MAC-layer
+protocol, this includes both Group and Functional
+addresses.
+
+Discontinuities in the value of this counter can occur
+at re-initialization of the management system, and at
+other times as indicated by the value of
+'discontinuity-time'.</text>
+          </description>
+          <reference>
+            <text>RFC 2863: The Interfaces Group MIB -
+   ifHCOutMulticastPkts</text>
+          </reference>
+        </leaf>
+        <leaf name="out-discards">
+          <type name="yang:counter32"/>
+          <description>
+            <text>The number of outbound packets that were chosen to be
+discarded even though no errors had been detected to
+prevent their being transmitted.  One possible reason
+for discarding such a packet could be to free up buffer
+space.
+
+Discontinuities in the value of this counter can occur
+at re-initialization of the management system, and at
+other times as indicated by the value of
+'discontinuity-time'.</text>
+          </description>
+          <reference>
+            <text>RFC 2863: The Interfaces Group MIB - ifOutDiscards</text>
+          </reference>
+        </leaf>
+        <leaf name="out-errors">
+          <type name="yang:counter32"/>
+          <description>
+            <text>For packet-oriented interfaces, the number of outbound
+packets that could not be transmitted because of errors.
+For character-oriented or fixed-length interfaces, the
+number of outbound transmission units that could not be
+transmitted because of errors.
+
+
+
+
+Discontinuities in the value of this counter can occur
+at re-initialization of the management system, and at
+other times as indicated by the value of
+'discontinuity-time'.</text>
+          </description>
+          <reference>
+            <text>RFC 2863: The Interfaces Group MIB - ifOutErrors</text>
+          </reference>
+        </leaf>
+      </container>
+    </list>
+  </container>
+</module>

--- a/test/data/ietf-ip.yang
+++ b/test/data/ietf-ip.yang
@@ -1,0 +1,742 @@
+module ietf-ip {
+
+    yang-version 1;
+
+    namespace
+      "urn:ietf:params:xml:ns:yang:ietf-ip";
+
+    prefix ip;
+
+    import ietf-interfaces {
+      prefix if;
+    }
+    import ietf-inet-types {
+      prefix inet;
+    }
+    import ietf-yang-types {
+      prefix yang;
+    }
+
+    organization
+      "IETF NETMOD (NETCONF Data Modeling Language) Working Group";
+
+    contact
+      "WG Web:   <http://tools.ietf.org/wg/netmod/>
+    WG List:  <mailto:netmod@ietf.org>
+
+    WG Chair: Thomas Nadeau
+              <mailto:tnadeau@lucidvision.com>
+
+    WG Chair: Juergen Schoenwaelder
+              <mailto:j.schoenwaelder@jacobs-university.de>
+
+    Editor:   Martin Bjorklund
+              <mailto:mbj@tail-f.com>";
+
+    description
+      "This module contains a collection of YANG definitions for
+    configuring IP implementations.
+
+    Copyright (c) 2014 IETF Trust and the persons identified as
+    authors of the code.  All rights reserved.
+
+    Redistribution and use in source and binary forms, with or
+    without modification, is permitted pursuant to, and subject
+    to the license terms contained in, the Simplified BSD License
+    set forth in Section 4.c of the IETF Trust's Legal Provisions
+    Relating to IETF Documents
+    (http://trustee.ietf.org/license-info).
+
+    This version of this YANG module is part of RFC 7277; see
+    the RFC itself for full legal notices.";
+
+    revision "2014-06-16" {
+      description "Initial revision.";
+      reference
+        "RFC 7277: A YANG Data Model for IP Management";
+
+    }
+
+
+    feature ipv4-non-contiguous-netmasks {
+      description
+        "Indicates support for configuring non-contiguous
+      subnet masks.";
+    }
+
+    feature ipv6-privacy-autoconf {
+      description
+        "Indicates support for Privacy Extensions for Stateless Address
+      Autoconfiguration in IPv6.";
+      reference
+        "RFC 4941: Privacy Extensions for Stateless Address
+              Autoconfiguration in IPv6";
+
+    }
+
+    typedef ip-address-origin {
+      type enumeration {
+        enum "other" {
+          value 0;
+          description
+            "None of the following.";
+        }
+        enum "static" {
+          value 1;
+          description
+            "Indicates that the address has been statically
+          configured - for example, using NETCONF or a Command Line
+          Interface.";
+        }
+        enum "dhcp" {
+          value 2;
+          description
+            "Indicates an address that has been assigned to this
+          system by a DHCP server.";
+        }
+        enum "link-layer" {
+          value 3;
+          description
+            "Indicates an address created by IPv6 stateless
+          autoconfiguration that embeds a link-layer address in its
+          interface identifier.";
+        }
+        enum "random" {
+          value 4;
+          description
+            "Indicates an address chosen by the system at
+
+          random, e.g., an IPv4 address within 169.254/16, an
+          RFC 4941 temporary address, or an RFC 7217 semantically
+          opaque address.";
+          reference
+            "RFC 4941: Privacy Extensions for Stateless Address
+                  Autoconfiguration in IPv6
+             RFC 7217: A Method for Generating Semantically Opaque
+                  Interface Identifiers with IPv6 Stateless
+                  Address Autoconfiguration (SLAAC)";
+
+        }
+      }
+      description
+        "The origin of an address.";
+    }
+
+    typedef neighbor-origin {
+      type enumeration {
+        enum "other" {
+          value 0;
+          description
+            "None of the following.";
+        }
+        enum "static" {
+          value 1;
+          description
+            "Indicates that the mapping has been statically
+          configured - for example, using NETCONF or a Command Line
+          Interface.";
+        }
+        enum "dynamic" {
+          value 2;
+          description
+            "Indicates that the mapping has been dynamically resolved
+          using, e.g., IPv4 ARP or the IPv6 Neighbor Discovery
+          protocol.";
+        }
+      }
+      description
+        "The origin of a neighbor entry.";
+    }
+
+    augment /if:interfaces/if:interface {
+      description
+        "Parameters for configuring IP on interfaces.
+
+      If an interface is not capable of running IP, the server
+      must not allow the client to configure these parameters.";
+      container ipv4 {
+        presence
+          "Enables IPv4 unless the 'enabled' leaf
+        (which defaults to 'true') is set to 'false'";
+        description
+          "Parameters for the IPv4 address family.";
+        leaf enabled {
+          type boolean;
+          default 'true';
+          description
+            "Controls whether IPv4 is enabled or disabled on this
+          interface.  When IPv4 is enabled, this interface is
+          connected to an IPv4 stack, and the interface can send
+          and receive IPv4 packets.";
+        }
+
+        leaf forwarding {
+          type boolean;
+          default 'false';
+          description
+            "Controls IPv4 packet forwarding of datagrams received by,
+          but not addressed to, this interface.  IPv4 routers
+          forward datagrams.  IPv4 hosts do not (except those
+          source-routed via the host).";
+        }
+
+        leaf mtu {
+          type uint16 {
+            range "68..max";
+          }
+          units "octets";
+          description
+            "The size, in octets, of the largest IPv4 packet that the
+          interface will send and receive.
+
+          The server may restrict the allowed values for this leaf,
+          depending on the interface's type.
+
+          If this leaf is not configured, the operationally used MTU
+          depends on the interface's type.";
+          reference
+            "RFC 791: Internet Protocol";
+
+        }
+
+        list address {
+          key "ip";
+          description
+            "The list of configured IPv4 addresses on the interface.";
+          leaf ip {
+            type inet:ipv4-address-no-zone;
+            description
+              "The IPv4 address on the interface.";
+          }
+
+          choice subnet {
+            mandatory true;
+            description
+              "The subnet can be specified as a prefix-length, or,
+            if the server supports non-contiguous netmasks, as
+            a netmask.";
+            leaf prefix-length {
+              type uint8 {
+                range "0..32";
+              }
+              description
+                "The length of the subnet prefix.";
+            }
+            leaf netmask {
+              if-feature ipv4-non-contiguous-netmasks;
+              type yang:dotted-quad;
+              description
+                "The subnet specified as a netmask.";
+            }
+          }  // choice subnet
+        }  // list address
+
+        list neighbor {
+          key "ip";
+          description
+            "A list of mappings from IPv4 addresses to
+          link-layer addresses.
+
+          Entries in this list are used as static entries in the
+          ARP Cache.";
+          reference
+            "RFC 826: An Ethernet Address Resolution Protocol";
+
+          leaf ip {
+            type inet:ipv4-address-no-zone;
+            description
+              "The IPv4 address of the neighbor node.";
+          }
+
+          leaf link-layer-address {
+            type yang:phys-address;
+            mandatory true;
+            description
+              "The link-layer address of the neighbor node.";
+          }
+        }  // list neighbor
+      }  // container ipv4
+
+      container ipv6 {
+        presence
+          "Enables IPv6 unless the 'enabled' leaf
+        (which defaults to 'true') is set to 'false'";
+        description
+          "Parameters for the IPv6 address family.";
+        leaf enabled {
+          type boolean;
+          default 'true';
+          description
+            "Controls whether IPv6 is enabled or disabled on this
+          interface.  When IPv6 is enabled, this interface is
+          connected to an IPv6 stack, and the interface can send
+          and receive IPv6 packets.";
+        }
+
+        leaf forwarding {
+          type boolean;
+          default 'false';
+          description
+            "Controls IPv6 packet forwarding of datagrams received by,
+          but not addressed to, this interface.  IPv6 routers
+          forward datagrams.  IPv6 hosts do not (except those
+          source-routed via the host).";
+          reference
+            "RFC 4861: Neighbor Discovery for IP version 6 (IPv6)
+                  Section 6.2.1, IsRouter";
+
+        }
+
+        leaf mtu {
+          type uint32 {
+            range "1280..max";
+          }
+          units "octets";
+          description
+            "The size, in octets, of the largest IPv6 packet that the
+          interface will send and receive.
+
+          The server may restrict the allowed values for this leaf,
+          depending on the interface's type.
+
+          If this leaf is not configured, the operationally used MTU
+          depends on the interface's type.";
+          reference
+            "RFC 2460: Internet Protocol, Version 6 (IPv6) Specification
+                  Section 5";
+
+        }
+
+        list address {
+          key "ip";
+          description
+            "The list of configured IPv6 addresses on the interface.";
+          leaf ip {
+            type inet:ipv6-address-no-zone;
+            description
+              "The IPv6 address on the interface.";
+          }
+
+          leaf prefix-length {
+            type uint8 {
+              range "0..128";
+            }
+            mandatory true;
+            description
+              "The length of the subnet prefix.";
+          }
+        }  // list address
+
+        list neighbor {
+          key "ip";
+          description
+            "A list of mappings from IPv6 addresses to
+          link-layer addresses.
+
+          Entries in this list are used as static entries in the
+          Neighbor Cache.";
+          reference
+            "RFC 4861: Neighbor Discovery for IP version 6 (IPv6)";
+
+          leaf ip {
+            type inet:ipv6-address-no-zone;
+            description
+              "The IPv6 address of the neighbor node.";
+          }
+
+          leaf link-layer-address {
+            type yang:phys-address;
+            mandatory true;
+            description
+              "The link-layer address of the neighbor node.";
+          }
+        }  // list neighbor
+
+        leaf dup-addr-detect-transmits {
+          type uint32;
+          default '1';
+          description
+            "The number of consecutive Neighbor Solicitation messages
+          sent while performing Duplicate Address Detection on a
+          tentative address.  A value of zero indicates that
+          Duplicate Address Detection is not performed on
+          tentative addresses.  A value of one indicates a single
+          transmission with no follow-up retransmissions.";
+          reference
+            "RFC 4862: IPv6 Stateless Address Autoconfiguration";
+
+        }
+
+        container autoconf {
+          description
+            "Parameters to control the autoconfiguration of IPv6
+          addresses, as described in RFC 4862.";
+          reference
+            "RFC 4862: IPv6 Stateless Address Autoconfiguration";
+
+          leaf create-global-addresses {
+            type boolean;
+            default 'true';
+            description
+              "If enabled, the host creates global addresses as
+            described in RFC 4862.";
+            reference
+              "RFC 4862: IPv6 Stateless Address Autoconfiguration
+                  Section 5.5";
+
+          }
+
+          leaf create-temporary-addresses {
+            if-feature ipv6-privacy-autoconf;
+            type boolean;
+            default 'false';
+            description
+              "If enabled, the host creates temporary addresses as
+            described in RFC 4941.";
+            reference
+              "RFC 4941: Privacy Extensions for Stateless Address
+                  Autoconfiguration in IPv6";
+
+          }
+
+          leaf temporary-valid-lifetime {
+            if-feature ipv6-privacy-autoconf;
+            type uint32;
+            units "seconds";
+            default '604800';
+            description
+              "The time period during which the temporary address
+            is valid.";
+            reference
+              "RFC 4941: Privacy Extensions for Stateless Address
+                  Autoconfiguration in IPv6
+                  - TEMP_VALID_LIFETIME";
+
+          }
+
+          leaf temporary-preferred-lifetime {
+            if-feature ipv6-privacy-autoconf;
+            type uint32;
+            units "seconds";
+            default '86400';
+            description
+              "The time period during which the temporary address is
+            preferred.";
+            reference
+              "RFC 4941: Privacy Extensions for Stateless Address
+                  Autoconfiguration in IPv6
+                  - TEMP_PREFERRED_LIFETIME";
+
+          }
+        }  // container autoconf
+      }  // container ipv6
+    }
+
+    augment /if:interfaces-state/if:interface {
+      description
+        "Data nodes for the operational state of IP on interfaces.";
+      container ipv4 {
+        presence
+          "Present if IPv4 is enabled on this interface";
+        config false;
+        description
+          "Interface-specific parameters for the IPv4 address family.";
+        leaf forwarding {
+          type boolean;
+          description
+            "Indicates whether IPv4 packet forwarding is enabled or
+          disabled on this interface.";
+        }
+
+        leaf mtu {
+          type uint16 {
+            range "68..max";
+          }
+          units "octets";
+          description
+            "The size, in octets, of the largest IPv4 packet that the
+          interface will send and receive.";
+          reference
+            "RFC 791: Internet Protocol";
+
+        }
+
+        list address {
+          key "ip";
+          description
+            "The list of IPv4 addresses on the interface.";
+          leaf ip {
+            type inet:ipv4-address-no-zone;
+            description
+              "The IPv4 address on the interface.";
+          }
+
+          choice subnet {
+            description
+              "The subnet can be specified as a prefix-length, or,
+            if the server supports non-contiguous netmasks, as
+            a netmask.";
+            leaf prefix-length {
+              type uint8 {
+                range "0..32";
+              }
+              description
+                "The length of the subnet prefix.";
+            }
+            leaf netmask {
+              if-feature ipv4-non-contiguous-netmasks;
+              type yang:dotted-quad;
+              description
+                "The subnet specified as a netmask.";
+            }
+          }  // choice subnet
+
+          leaf origin {
+            type ip-address-origin;
+            description
+              "The origin of this address.";
+          }
+        }  // list address
+
+        list neighbor {
+          key "ip";
+          description
+            "A list of mappings from IPv4 addresses to
+          link-layer addresses.
+
+          This list represents the ARP Cache.";
+          reference
+            "RFC 826: An Ethernet Address Resolution Protocol";
+
+          leaf ip {
+            type inet:ipv4-address-no-zone;
+            description
+              "The IPv4 address of the neighbor node.";
+          }
+
+          leaf link-layer-address {
+            type yang:phys-address;
+            description
+              "The link-layer address of the neighbor node.";
+          }
+
+          leaf origin {
+            type neighbor-origin;
+            description
+              "The origin of this neighbor entry.";
+          }
+        }  // list neighbor
+      }  // container ipv4
+
+      container ipv6 {
+        presence
+          "Present if IPv6 is enabled on this interface";
+        config false;
+        description
+          "Parameters for the IPv6 address family.";
+        leaf forwarding {
+          type boolean;
+          default 'false';
+          description
+            "Indicates whether IPv6 packet forwarding is enabled or
+          disabled on this interface.";
+          reference
+            "RFC 4861: Neighbor Discovery for IP version 6 (IPv6)
+                  Section 6.2.1, IsRouter";
+
+        }
+
+        leaf mtu {
+          type uint32 {
+            range "1280..max";
+          }
+          units "octets";
+          description
+            "The size, in octets, of the largest IPv6 packet that the
+          interface will send and receive.";
+          reference
+            "RFC 2460: Internet Protocol, Version 6 (IPv6) Specification
+                  Section 5";
+
+        }
+
+        list address {
+          key "ip";
+          description
+            "The list of IPv6 addresses on the interface.";
+          leaf ip {
+            type inet:ipv6-address-no-zone;
+            description
+              "The IPv6 address on the interface.";
+          }
+
+          leaf prefix-length {
+            type uint8 {
+              range "0..128";
+            }
+            mandatory true;
+            description
+              "The length of the subnet prefix.";
+          }
+
+          leaf origin {
+            type ip-address-origin;
+            description
+              "The origin of this address.";
+          }
+
+          leaf status {
+            type enumeration {
+              enum "preferred" {
+                value 0;
+                description
+                  "This is a valid address that can appear as the
+                destination or source address of a packet.";
+              }
+              enum "deprecated" {
+                value 1;
+                description
+                  "This is a valid but deprecated address that should
+                no longer be used as a source address in new
+                communications, but packets addressed to such an
+                address are processed as expected.";
+              }
+              enum "invalid" {
+                value 2;
+                description
+                  "This isn't a valid address, and it shouldn't appear
+                as the destination or source address of a packet.";
+              }
+              enum "inaccessible" {
+                value 3;
+                description
+                  "The address is not accessible because the interface
+                to which this address is assigned is not
+                operational.";
+              }
+              enum "unknown" {
+                value 4;
+                description
+                  "The status cannot be determined for some reason.";
+              }
+              enum "tentative" {
+                value 5;
+                description
+                  "The uniqueness of the address on the link is being
+                verified.  Addresses in this state should not be
+                used for general communication and should only be
+                used to determine the uniqueness of the address.";
+              }
+              enum "duplicate" {
+                value 6;
+                description
+                  "The address has been determined to be non-unique on
+                the link and so must not be used.";
+              }
+              enum "optimistic" {
+                value 7;
+                description
+                  "The address is available for use, subject to
+                restrictions, while its uniqueness on a link is
+                being verified.";
+              }
+            }
+            description
+              "The status of an address.  Most of the states correspond
+            to states from the IPv6 Stateless Address
+            Autoconfiguration protocol.";
+            reference
+              "RFC 4293: Management Information Base for the
+                  Internet Protocol (IP)
+                  - IpAddressStatusTC
+               RFC 4862: IPv6 Stateless Address Autoconfiguration";
+
+          }
+        }  // list address
+
+        list neighbor {
+          key "ip";
+          description
+            "A list of mappings from IPv6 addresses to
+          link-layer addresses.
+
+          This list represents the Neighbor Cache.";
+          reference
+            "RFC 4861: Neighbor Discovery for IP version 6 (IPv6)";
+
+          leaf ip {
+            type inet:ipv6-address-no-zone;
+            description
+              "The IPv6 address of the neighbor node.";
+          }
+
+          leaf link-layer-address {
+            type yang:phys-address;
+            description
+              "The link-layer address of the neighbor node.";
+          }
+
+          leaf origin {
+            type neighbor-origin;
+            description
+              "The origin of this neighbor entry.";
+          }
+
+          leaf is-router {
+            type empty;
+            description
+              "Indicates that the neighbor node acts as a router.";
+          }
+
+          leaf state {
+            type enumeration {
+              enum "incomplete" {
+                value 0;
+                description
+                  "Address resolution is in progress, and the link-layer
+                address of the neighbor has not yet been
+                determined.";
+              }
+              enum "reachable" {
+                value 1;
+                description
+                  "Roughly speaking, the neighbor is known to have been
+                reachable recently (within tens of seconds ago).";
+              }
+              enum "stale" {
+                value 2;
+                description
+                  "The neighbor is no longer known to be reachable, but
+                until traffic is sent to the neighbor no attempt
+                should be made to verify its reachability.";
+              }
+              enum "delay" {
+                value 3;
+                description
+                  "The neighbor is no longer known to be reachable, and
+                traffic has recently been sent to the neighbor.
+                Rather than probe the neighbor immediately, however,
+                delay sending probes for a short while in order to
+                give upper-layer protocols a chance to provide
+                reachability confirmation.";
+              }
+              enum "probe" {
+                value 4;
+                description
+                  "The neighbor is no longer known to be reachable, and
+                unicast Neighbor Solicitation probes are being sent
+                to verify reachability.";
+              }
+            }
+            description
+              "The Neighbor Unreachability Detection state of this
+            entry.";
+            reference
+              "RFC 4861: Neighbor Discovery for IP version 6 (IPv6)
+                  Section 7.3.2";
+
+          }
+        }  // list neighbor
+      }  // container ipv6
+    }
+  }  // module ietf-ip

--- a/test/data/ietf-ip.yin
+++ b/test/data/ietf-ip.yin
@@ -1,0 +1,777 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module name="ietf-ip"
+        xmlns="urn:ietf:params:xml:ns:yang:yin:1"
+        xmlns:ip="urn:ietf:params:xml:ns:yang:ietf-ip"
+        xmlns:if="urn:ietf:params:xml:ns:yang:ietf-interfaces"
+        xmlns:inet="urn:ietf:params:xml:ns:yang:ietf-inet-types"
+        xmlns:yang="urn:ietf:params:xml:ns:yang:ietf-yang-types">
+  <yang-version value="1"/>
+  <namespace uri="urn:ietf:params:xml:ns:yang:ietf-ip"/>
+  <prefix value="ip"/>
+  <import module="ietf-interfaces">
+    <prefix value="if"/>
+  </import>
+  <import module="ietf-inet-types">
+    <prefix value="inet"/>
+  </import>
+  <import module="ietf-yang-types">
+    <prefix value="yang"/>
+  </import>
+  <organization>
+    <text>IETF NETMOD (NETCONF Data Modeling Language) Working Group</text>
+  </organization>
+  <contact>
+    <text>WG Web:   &lt;http://tools.ietf.org/wg/netmod/&gt;
+WG List:  &lt;mailto:netmod@ietf.org&gt;
+
+WG Chair: Thomas Nadeau
+       &lt;mailto:tnadeau@lucidvision.com&gt;
+
+WG Chair: Juergen Schoenwaelder
+       &lt;mailto:j.schoenwaelder@jacobs-university.de&gt;
+
+Editor:   Martin Bjorklund
+       &lt;mailto:mbj@tail-f.com&gt;</text>
+  </contact>
+  <description>
+    <text>This module contains a collection of YANG definitions for
+configuring IP implementations.
+
+Copyright (c) 2014 IETF Trust and the persons identified as
+authors of the code.  All rights reserved.
+
+Redistribution and use in source and binary forms, with or
+without modification, is permitted pursuant to, and subject
+to the license terms contained in, the Simplified BSD License
+set forth in Section 4.c of the IETF Trust's Legal Provisions
+Relating to IETF Documents
+(http://trustee.ietf.org/license-info).
+
+This version of this YANG module is part of RFC 7277; see
+the RFC itself for full legal notices.</text>
+  </description>
+  <revision date="2014-06-16">
+    <description>
+      <text>Initial revision.</text>
+    </description>
+    <reference>
+      <text>RFC 7277: A YANG Data Model for IP Management</text>
+    </reference>
+  </revision>
+  <feature name="ipv4-non-contiguous-netmasks">
+    <description>
+      <text>Indicates support for configuring non-contiguous
+subnet masks.</text>
+    </description>
+  </feature>
+  <feature name="ipv6-privacy-autoconf">
+    <description>
+      <text>Indicates support for Privacy Extensions for Stateless Address
+Autoconfiguration in IPv6.</text>
+    </description>
+    <reference>
+      <text>RFC 4941: Privacy Extensions for Stateless Address
+     Autoconfiguration in IPv6</text>
+    </reference>
+  </feature>
+  <typedef name="ip-address-origin">
+    <type name="enumeration">
+      <enum name="other">
+        <value value="0"/>
+        <description>
+          <text>None of the following.</text>
+        </description>
+      </enum>
+      <enum name="static">
+        <value value="1"/>
+        <description>
+          <text>Indicates that the address has been statically
+configured - for example, using NETCONF or a Command Line
+Interface.</text>
+        </description>
+      </enum>
+      <enum name="dhcp">
+        <value value="2"/>
+        <description>
+          <text>Indicates an address that has been assigned to this
+system by a DHCP server.</text>
+        </description>
+      </enum>
+      <enum name="link-layer">
+        <value value="3"/>
+        <description>
+          <text>Indicates an address created by IPv6 stateless
+autoconfiguration that embeds a link-layer address in its
+interface identifier.</text>
+        </description>
+      </enum>
+      <enum name="random">
+        <value value="4"/>
+        <description>
+          <text>Indicates an address chosen by the system at
+
+random, e.g., an IPv4 address within 169.254/16, an
+RFC 4941 temporary address, or an RFC 7217 semantically
+opaque address.</text>
+        </description>
+        <reference>
+          <text>RFC 4941: Privacy Extensions for Stateless Address
+     Autoconfiguration in IPv6
+RFC 7217: A Method for Generating Semantically Opaque
+     Interface Identifiers with IPv6 Stateless
+     Address Autoconfiguration (SLAAC)</text>
+        </reference>
+      </enum>
+    </type>
+    <description>
+      <text>The origin of an address.</text>
+    </description>
+  </typedef>
+  <typedef name="neighbor-origin">
+    <type name="enumeration">
+      <enum name="other">
+        <value value="0"/>
+        <description>
+          <text>None of the following.</text>
+        </description>
+      </enum>
+      <enum name="static">
+        <value value="1"/>
+        <description>
+          <text>Indicates that the mapping has been statically
+configured - for example, using NETCONF or a Command Line
+Interface.</text>
+        </description>
+      </enum>
+      <enum name="dynamic">
+        <value value="2"/>
+        <description>
+          <text>Indicates that the mapping has been dynamically resolved
+using, e.g., IPv4 ARP or the IPv6 Neighbor Discovery
+protocol.</text>
+        </description>
+      </enum>
+    </type>
+    <description>
+      <text>The origin of a neighbor entry.</text>
+    </description>
+  </typedef>
+  <augment target-node="/if:interfaces/if:interface">
+    <description>
+      <text>Parameters for configuring IP on interfaces.
+
+If an interface is not capable of running IP, the server
+must not allow the client to configure these parameters.</text>
+    </description>
+    <container name="ipv4">
+      <presence value="Enables IPv4 unless the 'enabled' leaf&#10;(which defaults to 'true') is set to 'false'"/>
+      <description>
+        <text>Parameters for the IPv4 address family.</text>
+      </description>
+      <leaf name="enabled">
+        <type name="boolean"/>
+        <default value="true"/>
+        <description>
+          <text>Controls whether IPv4 is enabled or disabled on this
+interface.  When IPv4 is enabled, this interface is
+connected to an IPv4 stack, and the interface can send
+and receive IPv4 packets.</text>
+        </description>
+      </leaf>
+      <leaf name="forwarding">
+        <type name="boolean"/>
+        <default value="false"/>
+        <description>
+          <text>Controls IPv4 packet forwarding of datagrams received by,
+but not addressed to, this interface.  IPv4 routers
+forward datagrams.  IPv4 hosts do not (except those
+source-routed via the host).</text>
+        </description>
+      </leaf>
+      <leaf name="mtu">
+        <type name="uint16">
+          <range value="68..max"/>
+        </type>
+        <units name="octets"/>
+        <description>
+          <text>The size, in octets, of the largest IPv4 packet that the
+interface will send and receive.
+
+The server may restrict the allowed values for this leaf,
+depending on the interface's type.
+
+If this leaf is not configured, the operationally used MTU
+depends on the interface's type.</text>
+        </description>
+        <reference>
+          <text>RFC 791: Internet Protocol</text>
+        </reference>
+      </leaf>
+      <list name="address">
+        <key value="ip"/>
+        <description>
+          <text>The list of configured IPv4 addresses on the interface.</text>
+        </description>
+        <leaf name="ip">
+          <type name="inet:ipv4-address-no-zone"/>
+          <description>
+            <text>The IPv4 address on the interface.</text>
+          </description>
+        </leaf>
+        <choice name="subnet">
+          <mandatory value="true"/>
+          <description>
+            <text>The subnet can be specified as a prefix-length, or,
+if the server supports non-contiguous netmasks, as
+a netmask.</text>
+          </description>
+          <leaf name="prefix-length">
+            <type name="uint8">
+              <range value="0..32"/>
+            </type>
+            <description>
+              <text>The length of the subnet prefix.</text>
+            </description>
+          </leaf>
+          <leaf name="netmask">
+            <if-feature name="ipv4-non-contiguous-netmasks"/>
+            <type name="yang:dotted-quad"/>
+            <description>
+              <text>The subnet specified as a netmask.</text>
+            </description>
+          </leaf>
+        </choice>
+      </list>
+      <list name="neighbor">
+        <key value="ip"/>
+        <description>
+          <text>A list of mappings from IPv4 addresses to
+link-layer addresses.
+
+Entries in this list are used as static entries in the
+ARP Cache.</text>
+        </description>
+        <reference>
+          <text>RFC 826: An Ethernet Address Resolution Protocol</text>
+        </reference>
+        <leaf name="ip">
+          <type name="inet:ipv4-address-no-zone"/>
+          <description>
+            <text>The IPv4 address of the neighbor node.</text>
+          </description>
+        </leaf>
+        <leaf name="link-layer-address">
+          <type name="yang:phys-address"/>
+          <mandatory value="true"/>
+          <description>
+            <text>The link-layer address of the neighbor node.</text>
+          </description>
+        </leaf>
+      </list>
+    </container>
+    <container name="ipv6">
+      <presence value="Enables IPv6 unless the 'enabled' leaf&#10;(which defaults to 'true') is set to 'false'"/>
+      <description>
+        <text>Parameters for the IPv6 address family.</text>
+      </description>
+      <leaf name="enabled">
+        <type name="boolean"/>
+        <default value="true"/>
+        <description>
+          <text>Controls whether IPv6 is enabled or disabled on this
+interface.  When IPv6 is enabled, this interface is
+connected to an IPv6 stack, and the interface can send
+and receive IPv6 packets.</text>
+        </description>
+      </leaf>
+      <leaf name="forwarding">
+        <type name="boolean"/>
+        <default value="false"/>
+        <description>
+          <text>Controls IPv6 packet forwarding of datagrams received by,
+but not addressed to, this interface.  IPv6 routers
+forward datagrams.  IPv6 hosts do not (except those
+source-routed via the host).</text>
+        </description>
+        <reference>
+          <text>RFC 4861: Neighbor Discovery for IP version 6 (IPv6)
+     Section 6.2.1, IsRouter</text>
+        </reference>
+      </leaf>
+      <leaf name="mtu">
+        <type name="uint32">
+          <range value="1280..max"/>
+        </type>
+        <units name="octets"/>
+        <description>
+          <text>The size, in octets, of the largest IPv6 packet that the
+interface will send and receive.
+
+The server may restrict the allowed values for this leaf,
+depending on the interface's type.
+
+If this leaf is not configured, the operationally used MTU
+depends on the interface's type.</text>
+        </description>
+        <reference>
+          <text>RFC 2460: Internet Protocol, Version 6 (IPv6) Specification
+     Section 5</text>
+        </reference>
+      </leaf>
+      <list name="address">
+        <key value="ip"/>
+        <description>
+          <text>The list of configured IPv6 addresses on the interface.</text>
+        </description>
+        <leaf name="ip">
+          <type name="inet:ipv6-address-no-zone"/>
+          <description>
+            <text>The IPv6 address on the interface.</text>
+          </description>
+        </leaf>
+        <leaf name="prefix-length">
+          <type name="uint8">
+            <range value="0..128"/>
+          </type>
+          <mandatory value="true"/>
+          <description>
+            <text>The length of the subnet prefix.</text>
+          </description>
+        </leaf>
+      </list>
+      <list name="neighbor">
+        <key value="ip"/>
+        <description>
+          <text>A list of mappings from IPv6 addresses to
+link-layer addresses.
+
+Entries in this list are used as static entries in the
+Neighbor Cache.</text>
+        </description>
+        <reference>
+          <text>RFC 4861: Neighbor Discovery for IP version 6 (IPv6)</text>
+        </reference>
+        <leaf name="ip">
+          <type name="inet:ipv6-address-no-zone"/>
+          <description>
+            <text>The IPv6 address of the neighbor node.</text>
+          </description>
+        </leaf>
+        <leaf name="link-layer-address">
+          <type name="yang:phys-address"/>
+          <mandatory value="true"/>
+          <description>
+            <text>The link-layer address of the neighbor node.</text>
+          </description>
+        </leaf>
+      </list>
+      <leaf name="dup-addr-detect-transmits">
+        <type name="uint32"/>
+        <default value="1"/>
+        <description>
+          <text>The number of consecutive Neighbor Solicitation messages
+sent while performing Duplicate Address Detection on a
+tentative address.  A value of zero indicates that
+Duplicate Address Detection is not performed on
+tentative addresses.  A value of one indicates a single
+transmission with no follow-up retransmissions.</text>
+        </description>
+        <reference>
+          <text>RFC 4862: IPv6 Stateless Address Autoconfiguration</text>
+        </reference>
+      </leaf>
+      <container name="autoconf">
+        <description>
+          <text>Parameters to control the autoconfiguration of IPv6
+addresses, as described in RFC 4862.</text>
+        </description>
+        <reference>
+          <text>RFC 4862: IPv6 Stateless Address Autoconfiguration</text>
+        </reference>
+        <leaf name="create-global-addresses">
+          <type name="boolean"/>
+          <default value="true"/>
+          <description>
+            <text>If enabled, the host creates global addresses as
+described in RFC 4862.</text>
+          </description>
+          <reference>
+            <text>RFC 4862: IPv6 Stateless Address Autoconfiguration
+   Section 5.5</text>
+          </reference>
+        </leaf>
+        <leaf name="create-temporary-addresses">
+          <if-feature name="ipv6-privacy-autoconf"/>
+          <type name="boolean"/>
+          <default value="false"/>
+          <description>
+            <text>If enabled, the host creates temporary addresses as
+described in RFC 4941.</text>
+          </description>
+          <reference>
+            <text>RFC 4941: Privacy Extensions for Stateless Address
+   Autoconfiguration in IPv6</text>
+          </reference>
+        </leaf>
+        <leaf name="temporary-valid-lifetime">
+          <if-feature name="ipv6-privacy-autoconf"/>
+          <type name="uint32"/>
+          <units name="seconds"/>
+          <default value="604800"/>
+          <description>
+            <text>The time period during which the temporary address
+is valid.</text>
+          </description>
+          <reference>
+            <text>RFC 4941: Privacy Extensions for Stateless Address
+   Autoconfiguration in IPv6
+   - TEMP_VALID_LIFETIME</text>
+          </reference>
+        </leaf>
+        <leaf name="temporary-preferred-lifetime">
+          <if-feature name="ipv6-privacy-autoconf"/>
+          <type name="uint32"/>
+          <units name="seconds"/>
+          <default value="86400"/>
+          <description>
+            <text>The time period during which the temporary address is
+preferred.</text>
+          </description>
+          <reference>
+            <text>RFC 4941: Privacy Extensions for Stateless Address
+   Autoconfiguration in IPv6
+   - TEMP_PREFERRED_LIFETIME</text>
+          </reference>
+        </leaf>
+      </container>
+    </container>
+  </augment>
+  <augment target-node="/if:interfaces-state/if:interface">
+    <description>
+      <text>Data nodes for the operational state of IP on interfaces.</text>
+    </description>
+    <container name="ipv4">
+      <presence value="Present if IPv4 is enabled on this interface"/>
+      <config value="false"/>
+      <description>
+        <text>Interface-specific parameters for the IPv4 address family.</text>
+      </description>
+      <leaf name="forwarding">
+        <type name="boolean"/>
+        <description>
+          <text>Indicates whether IPv4 packet forwarding is enabled or
+disabled on this interface.</text>
+        </description>
+      </leaf>
+      <leaf name="mtu">
+        <type name="uint16">
+          <range value="68..max"/>
+        </type>
+        <units name="octets"/>
+        <description>
+          <text>The size, in octets, of the largest IPv4 packet that the
+interface will send and receive.</text>
+        </description>
+        <reference>
+          <text>RFC 791: Internet Protocol</text>
+        </reference>
+      </leaf>
+      <list name="address">
+        <key value="ip"/>
+        <description>
+          <text>The list of IPv4 addresses on the interface.</text>
+        </description>
+        <leaf name="ip">
+          <type name="inet:ipv4-address-no-zone"/>
+          <description>
+            <text>The IPv4 address on the interface.</text>
+          </description>
+        </leaf>
+        <choice name="subnet">
+          <description>
+            <text>The subnet can be specified as a prefix-length, or,
+if the server supports non-contiguous netmasks, as
+a netmask.</text>
+          </description>
+          <leaf name="prefix-length">
+            <type name="uint8">
+              <range value="0..32"/>
+            </type>
+            <description>
+              <text>The length of the subnet prefix.</text>
+            </description>
+          </leaf>
+          <leaf name="netmask">
+            <if-feature name="ipv4-non-contiguous-netmasks"/>
+            <type name="yang:dotted-quad"/>
+            <description>
+              <text>The subnet specified as a netmask.</text>
+            </description>
+          </leaf>
+        </choice>
+        <leaf name="origin">
+          <type name="ip-address-origin"/>
+          <description>
+            <text>The origin of this address.</text>
+          </description>
+        </leaf>
+      </list>
+      <list name="neighbor">
+        <key value="ip"/>
+        <description>
+          <text>A list of mappings from IPv4 addresses to
+link-layer addresses.
+
+This list represents the ARP Cache.</text>
+        </description>
+        <reference>
+          <text>RFC 826: An Ethernet Address Resolution Protocol</text>
+        </reference>
+        <leaf name="ip">
+          <type name="inet:ipv4-address-no-zone"/>
+          <description>
+            <text>The IPv4 address of the neighbor node.</text>
+          </description>
+        </leaf>
+        <leaf name="link-layer-address">
+          <type name="yang:phys-address"/>
+          <description>
+            <text>The link-layer address of the neighbor node.</text>
+          </description>
+        </leaf>
+        <leaf name="origin">
+          <type name="neighbor-origin"/>
+          <description>
+            <text>The origin of this neighbor entry.</text>
+          </description>
+        </leaf>
+      </list>
+    </container>
+    <container name="ipv6">
+      <presence value="Present if IPv6 is enabled on this interface"/>
+      <config value="false"/>
+      <description>
+        <text>Parameters for the IPv6 address family.</text>
+      </description>
+      <leaf name="forwarding">
+        <type name="boolean"/>
+        <default value="false"/>
+        <description>
+          <text>Indicates whether IPv6 packet forwarding is enabled or
+disabled on this interface.</text>
+        </description>
+        <reference>
+          <text>RFC 4861: Neighbor Discovery for IP version 6 (IPv6)
+     Section 6.2.1, IsRouter</text>
+        </reference>
+      </leaf>
+      <leaf name="mtu">
+        <type name="uint32">
+          <range value="1280..max"/>
+        </type>
+        <units name="octets"/>
+        <description>
+          <text>The size, in octets, of the largest IPv6 packet that the
+interface will send and receive.</text>
+        </description>
+        <reference>
+          <text>RFC 2460: Internet Protocol, Version 6 (IPv6) Specification
+     Section 5</text>
+        </reference>
+      </leaf>
+      <list name="address">
+        <key value="ip"/>
+        <description>
+          <text>The list of IPv6 addresses on the interface.</text>
+        </description>
+        <leaf name="ip">
+          <type name="inet:ipv6-address-no-zone"/>
+          <description>
+            <text>The IPv6 address on the interface.</text>
+          </description>
+        </leaf>
+        <leaf name="prefix-length">
+          <type name="uint8">
+            <range value="0..128"/>
+          </type>
+          <mandatory value="true"/>
+          <description>
+            <text>The length of the subnet prefix.</text>
+          </description>
+        </leaf>
+        <leaf name="origin">
+          <type name="ip-address-origin"/>
+          <description>
+            <text>The origin of this address.</text>
+          </description>
+        </leaf>
+        <leaf name="status">
+          <type name="enumeration">
+            <enum name="preferred">
+              <value value="0"/>
+              <description>
+                <text>This is a valid address that can appear as the
+destination or source address of a packet.</text>
+              </description>
+            </enum>
+            <enum name="deprecated">
+              <value value="1"/>
+              <description>
+                <text>This is a valid but deprecated address that should
+no longer be used as a source address in new
+communications, but packets addressed to such an
+address are processed as expected.</text>
+              </description>
+            </enum>
+            <enum name="invalid">
+              <value value="2"/>
+              <description>
+                <text>This isn't a valid address, and it shouldn't appear
+as the destination or source address of a packet.</text>
+              </description>
+            </enum>
+            <enum name="inaccessible">
+              <value value="3"/>
+              <description>
+                <text>The address is not accessible because the interface
+to which this address is assigned is not
+operational.</text>
+              </description>
+            </enum>
+            <enum name="unknown">
+              <value value="4"/>
+              <description>
+                <text>The status cannot be determined for some reason.</text>
+              </description>
+            </enum>
+            <enum name="tentative">
+              <value value="5"/>
+              <description>
+                <text>The uniqueness of the address on the link is being
+verified.  Addresses in this state should not be
+used for general communication and should only be
+used to determine the uniqueness of the address.</text>
+              </description>
+            </enum>
+            <enum name="duplicate">
+              <value value="6"/>
+              <description>
+                <text>The address has been determined to be non-unique on
+the link and so must not be used.</text>
+              </description>
+            </enum>
+            <enum name="optimistic">
+              <value value="7"/>
+              <description>
+                <text>The address is available for use, subject to
+restrictions, while its uniqueness on a link is
+being verified.</text>
+              </description>
+            </enum>
+          </type>
+          <description>
+            <text>The status of an address.  Most of the states correspond
+to states from the IPv6 Stateless Address
+Autoconfiguration protocol.</text>
+          </description>
+          <reference>
+            <text>RFC 4293: Management Information Base for the
+   Internet Protocol (IP)
+   - IpAddressStatusTC
+RFC 4862: IPv6 Stateless Address Autoconfiguration</text>
+          </reference>
+        </leaf>
+      </list>
+      <list name="neighbor">
+        <key value="ip"/>
+        <description>
+          <text>A list of mappings from IPv6 addresses to
+link-layer addresses.
+
+This list represents the Neighbor Cache.</text>
+        </description>
+        <reference>
+          <text>RFC 4861: Neighbor Discovery for IP version 6 (IPv6)</text>
+        </reference>
+        <leaf name="ip">
+          <type name="inet:ipv6-address-no-zone"/>
+          <description>
+            <text>The IPv6 address of the neighbor node.</text>
+          </description>
+        </leaf>
+        <leaf name="link-layer-address">
+          <type name="yang:phys-address"/>
+          <description>
+            <text>The link-layer address of the neighbor node.</text>
+          </description>
+        </leaf>
+        <leaf name="origin">
+          <type name="neighbor-origin"/>
+          <description>
+            <text>The origin of this neighbor entry.</text>
+          </description>
+        </leaf>
+        <leaf name="is-router">
+          <type name="empty"/>
+          <description>
+            <text>Indicates that the neighbor node acts as a router.</text>
+          </description>
+        </leaf>
+        <leaf name="state">
+          <type name="enumeration">
+            <enum name="incomplete">
+              <value value="0"/>
+              <description>
+                <text>Address resolution is in progress, and the link-layer
+address of the neighbor has not yet been
+determined.</text>
+              </description>
+            </enum>
+            <enum name="reachable">
+              <value value="1"/>
+              <description>
+                <text>Roughly speaking, the neighbor is known to have been
+reachable recently (within tens of seconds ago).</text>
+              </description>
+            </enum>
+            <enum name="stale">
+              <value value="2"/>
+              <description>
+                <text>The neighbor is no longer known to be reachable, but
+until traffic is sent to the neighbor no attempt
+should be made to verify its reachability.</text>
+              </description>
+            </enum>
+            <enum name="delay">
+              <value value="3"/>
+              <description>
+                <text>The neighbor is no longer known to be reachable, and
+traffic has recently been sent to the neighbor.
+Rather than probe the neighbor immediately, however,
+delay sending probes for a short while in order to
+give upper-layer protocols a chance to provide
+reachability confirmation.</text>
+              </description>
+            </enum>
+            <enum name="probe">
+              <value value="4"/>
+              <description>
+                <text>The neighbor is no longer known to be reachable, and
+unicast Neighbor Solicitation probes are being sent
+to verify reachability.</text>
+              </description>
+            </enum>
+          </type>
+          <description>
+            <text>The Neighbor Unreachability Detection state of this
+entry.</text>
+          </description>
+          <reference>
+            <text>RFC 4861: Neighbor Discovery for IP version 6 (IPv6)
+   Section 7.3.2</text>
+          </reference>
+        </leaf>
+      </list>
+    </container>
+  </augment>
+</module>

--- a/test/data/ietf-yang-types.yang
+++ b/test/data/ietf-yang-types.yang
@@ -1,0 +1,474 @@
+module ietf-yang-types {
+
+  namespace "urn:ietf:params:xml:ns:yang:ietf-yang-types";
+  prefix "yang";
+
+  organization
+   "IETF NETMOD (NETCONF Data Modeling Language) Working Group";
+
+  contact
+   "WG Web:   <http://tools.ietf.org/wg/netmod/>
+    WG List:  <mailto:netmod@ietf.org>
+
+    WG Chair: David Kessens
+              <mailto:david.kessens@nsn.com>
+
+    WG Chair: Juergen Schoenwaelder
+              <mailto:j.schoenwaelder@jacobs-university.de>
+
+    Editor:   Juergen Schoenwaelder
+              <mailto:j.schoenwaelder@jacobs-university.de>";
+
+  description
+   "This module contains a collection of generally useful derived
+    YANG data types.
+
+    Copyright (c) 2013 IETF Trust and the persons identified as
+    authors of the code.  All rights reserved.
+
+    Redistribution and use in source and binary forms, with or
+    without modification, is permitted pursuant to, and subject
+    to the license terms contained in, the Simplified BSD License
+    set forth in Section 4.c of the IETF Trust's Legal Provisions
+    Relating to IETF Documents
+    (http://trustee.ietf.org/license-info).
+
+    This version of this YANG module is part of RFC 6991; see
+    the RFC itself for full legal notices.";
+
+  revision 2013-07-15 {
+    description
+     "This revision adds the following new data types:
+      - yang-identifier
+      - hex-string
+      - uuid
+      - dotted-quad";
+    reference
+     "RFC 6991: Common YANG Data Types";
+  }
+
+  revision 2010-09-24 {
+    description
+     "Initial revision.";
+    reference
+     "RFC 6021: Common YANG Data Types";
+  }
+
+  /*** collection of counter and gauge types ***/
+
+  typedef counter32 {
+    type uint32;
+    description
+     "The counter32 type represents a non-negative integer
+      that monotonically increases until it reaches a
+      maximum value of 2^32-1 (4294967295 decimal), when it
+      wraps around and starts increasing again from zero.
+
+      Counters have no defined 'initial' value, and thus, a
+      single value of a counter has (in general) no information
+      content.  Discontinuities in the monotonically increasing
+      value normally occur at re-initialization of the
+      management system, and at other times as specified in the
+      description of a schema node using this type.  If such
+      other times can occur, for example, the creation of
+      a schema node of type counter32 at times other than
+      re-initialization, then a corresponding schema node
+      should be defined, with an appropriate type, to indicate
+      the last discontinuity.
+
+      The counter32 type should not be used for configuration
+      schema nodes.  A default statement SHOULD NOT be used in
+      combination with the type counter32.
+
+      In the value set and its semantics, this type is equivalent
+      to the Counter32 type of the SMIv2.";
+    reference
+     "RFC 2578: Structure of Management Information Version 2
+                (SMIv2)";
+  }
+
+  typedef zero-based-counter32 {
+    type yang:counter32;
+    default "0";
+    description
+     "The zero-based-counter32 type represents a counter32
+      that has the defined 'initial' value zero.
+
+      A schema node of this type will be set to zero (0) on creation
+      and will thereafter increase monotonically until it reaches
+      a maximum value of 2^32-1 (4294967295 decimal), when it
+      wraps around and starts increasing again from zero.
+
+      Provided that an application discovers a new schema node
+      of this type within the minimum time to wrap, it can use the
+      'initial' value as a delta.  It is important for a management
+      station to be aware of this minimum time and the actual time
+      between polls, and to discard data if the actual time is too
+      long or there is no defined minimum time.
+
+      In the value set and its semantics, this type is equivalent
+      to the ZeroBasedCounter32 textual convention of the SMIv2.";
+    reference
+      "RFC 4502: Remote Network Monitoring Management Information
+                 Base Version 2";
+  }
+
+  typedef counter64 {
+    type uint64;
+    description
+     "The counter64 type represents a non-negative integer
+      that monotonically increases until it reaches a
+      maximum value of 2^64-1 (18446744073709551615 decimal),
+      when it wraps around and starts increasing again from zero.
+
+      Counters have no defined 'initial' value, and thus, a
+      single value of a counter has (in general) no information
+      content.  Discontinuities in the monotonically increasing
+      value normally occur at re-initialization of the
+      management system, and at other times as specified in the
+      description of a schema node using this type.  If such
+      other times can occur, for example, the creation of
+      a schema node of type counter64 at times other than
+      re-initialization, then a corresponding schema node
+      should be defined, with an appropriate type, to indicate
+      the last discontinuity.
+
+      The counter64 type should not be used for configuration
+      schema nodes.  A default statement SHOULD NOT be used in
+      combination with the type counter64.
+
+      In the value set and its semantics, this type is equivalent
+      to the Counter64 type of the SMIv2.";
+    reference
+     "RFC 2578: Structure of Management Information Version 2
+                (SMIv2)";
+  }
+
+  typedef zero-based-counter64 {
+    type yang:counter64;
+    default "0";
+    description
+     "The zero-based-counter64 type represents a counter64 that
+      has the defined 'initial' value zero.
+
+      A schema node of this type will be set to zero (0) on creation
+      and will thereafter increase monotonically until it reaches
+      a maximum value of 2^64-1 (18446744073709551615 decimal),
+      when it wraps around and starts increasing again from zero.
+
+      Provided that an application discovers a new schema node
+      of this type within the minimum time to wrap, it can use the
+      'initial' value as a delta.  It is important for a management
+      station to be aware of this minimum time and the actual time
+      between polls, and to discard data if the actual time is too
+      long or there is no defined minimum time.
+
+      In the value set and its semantics, this type is equivalent
+      to the ZeroBasedCounter64 textual convention of the SMIv2.";
+    reference
+     "RFC 2856: Textual Conventions for Additional High Capacity
+                Data Types";
+  }
+
+  typedef gauge32 {
+    type uint32;
+    description
+     "The gauge32 type represents a non-negative integer, which
+      may increase or decrease, but shall never exceed a maximum
+      value, nor fall below a minimum value.  The maximum value
+      cannot be greater than 2^32-1 (4294967295 decimal), and
+      the minimum value cannot be smaller than 0.  The value of
+      a gauge32 has its maximum value whenever the information
+      being modeled is greater than or equal to its maximum
+      value, and has its minimum value whenever the information
+      being modeled is smaller than or equal to its minimum value.
+      If the information being modeled subsequently decreases
+      below (increases above) the maximum (minimum) value, the
+      gauge32 also decreases (increases).
+
+      In the value set and its semantics, this type is equivalent
+      to the Gauge32 type of the SMIv2.";
+    reference
+     "RFC 2578: Structure of Management Information Version 2
+                (SMIv2)";
+  }
+
+  typedef gauge64 {
+    type uint64;
+    description
+     "The gauge64 type represents a non-negative integer, which
+      may increase or decrease, but shall never exceed a maximum
+      value, nor fall below a minimum value.  The maximum value
+      cannot be greater than 2^64-1 (18446744073709551615), and
+      the minimum value cannot be smaller than 0.  The value of
+      a gauge64 has its maximum value whenever the information
+      being modeled is greater than or equal to its maximum
+      value, and has its minimum value whenever the information
+      being modeled is smaller than or equal to its minimum value.
+      If the information being modeled subsequently decreases
+      below (increases above) the maximum (minimum) value, the
+      gauge64 also decreases (increases).
+
+      In the value set and its semantics, this type is equivalent
+      to the CounterBasedGauge64 SMIv2 textual convention defined
+      in RFC 2856";
+    reference
+     "RFC 2856: Textual Conventions for Additional High Capacity
+                Data Types";
+  }
+
+  /*** collection of identifier-related types ***/
+
+  typedef object-identifier {
+    type string {
+      pattern '(([0-1](\.[1-3]?[0-9]))|(2\.(0|([1-9]\d*))))'
+            + '(\.(0|([1-9]\d*)))*';
+    }
+    description
+     "The object-identifier type represents administratively
+      assigned names in a registration-hierarchical-name tree.
+
+      Values of this type are denoted as a sequence of numerical
+      non-negative sub-identifier values.  Each sub-identifier
+      value MUST NOT exceed 2^32-1 (4294967295).  Sub-identifiers
+      are separated by single dots and without any intermediate
+      whitespace.
+
+      The ASN.1 standard restricts the value space of the first
+      sub-identifier to 0, 1, or 2.  Furthermore, the value space
+      of the second sub-identifier is restricted to the range
+      0 to 39 if the first sub-identifier is 0 or 1.  Finally,
+      the ASN.1 standard requires that an object identifier
+      has always at least two sub-identifiers.  The pattern
+      captures these restrictions.
+
+      Although the number of sub-identifiers is not limited,
+      module designers should realize that there may be
+      implementations that stick with the SMIv2 limit of 128
+      sub-identifiers.
+
+      This type is a superset of the SMIv2 OBJECT IDENTIFIER type
+      since it is not restricted to 128 sub-identifiers.  Hence,
+      this type SHOULD NOT be used to represent the SMIv2 OBJECT
+      IDENTIFIER type; the object-identifier-128 type SHOULD be
+      used instead.";
+    reference
+     "ISO9834-1: Information technology -- Open Systems
+      Interconnection -- Procedures for the operation of OSI
+      Registration Authorities: General procedures and top
+      arcs of the ASN.1 Object Identifier tree";
+  }
+
+  typedef object-identifier-128 {
+    type object-identifier {
+      pattern '\d*(\.\d*){1,127}';
+    }
+    description
+     "This type represents object-identifiers restricted to 128
+      sub-identifiers.
+
+      In the value set and its semantics, this type is equivalent
+      to the OBJECT IDENTIFIER type of the SMIv2.";
+    reference
+     "RFC 2578: Structure of Management Information Version 2
+                (SMIv2)";
+  }
+
+  typedef yang-identifier {
+    type string {
+      length "1..max";
+      pattern '[a-zA-Z_][a-zA-Z0-9\-_.]*';
+      pattern '.|..|[^xX].*|.[^mM].*|..[^lL].*';
+    }
+    description
+      "A YANG identifier string as defined by the 'identifier'
+       rule in Section 12 of RFC 6020.  An identifier must
+       start with an alphabetic character or an underscore
+       followed by an arbitrary sequence of alphabetic or
+       numeric characters, underscores, hyphens, or dots.
+
+       A YANG identifier MUST NOT start with any possible
+       combination of the lowercase or uppercase character
+       sequence 'xml'.";
+    reference
+      "RFC 6020: YANG - A Data Modeling Language for the Network
+                 Configuration Protocol (NETCONF)";
+  }
+
+  /*** collection of types related to date and time***/
+
+  typedef date-and-time {
+    type string {
+      pattern '\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d+)?'
+            + '(Z|[\+\-]\d{2}:\d{2})';
+    }
+    description
+     "The date-and-time type is a profile of the ISO 8601
+      standard for representation of dates and times using the
+      Gregorian calendar.  The profile is defined by the
+      date-time production in Section 5.6 of RFC 3339.
+
+      The date-and-time type is compatible with the dateTime XML
+      schema type with the following notable exceptions:
+
+      (a) The date-and-time type does not allow negative years.
+
+      (b) The date-and-time time-offset -00:00 indicates an unknown
+          time zone (see RFC 3339) while -00:00 and +00:00 and Z
+          all represent the same time zone in dateTime.
+
+      (c) The canonical format (see below) of data-and-time values
+          differs from the canonical format used by the dateTime XML
+          schema type, which requires all times to be in UTC using
+          the time-offset 'Z'.
+
+      This type is not equivalent to the DateAndTime textual
+      convention of the SMIv2 since RFC 3339 uses a different
+      separator between full-date and full-time and provides
+      higher resolution of time-secfrac.
+
+      The canonical format for date-and-time values with a known time
+      zone uses a numeric time zone offset that is calculated using
+      the device's configured known offset to UTC time.  A change of
+      the device's offset to UTC time will cause date-and-time values
+      to change accordingly.  Such changes might happen periodically
+      in case a server follows automatically daylight saving time
+      (DST) time zone offset changes.  The canonical format for
+      date-and-time values with an unknown time zone (usually
+      referring to the notion of local time) uses the time-offset
+      -00:00.";
+    reference
+     "RFC 3339: Date and Time on the Internet: Timestamps
+      RFC 2579: Textual Conventions for SMIv2
+      XSD-TYPES: XML Schema Part 2: Datatypes Second Edition";
+  }
+
+  typedef timeticks {
+    type uint32;
+    description
+     "The timeticks type represents a non-negative integer that
+      represents the time, modulo 2^32 (4294967296 decimal), in
+      hundredths of a second between two epochs.  When a schema
+      node is defined that uses this type, the description of
+      the schema node identifies both of the reference epochs.
+
+      In the value set and its semantics, this type is equivalent
+      to the TimeTicks type of the SMIv2.";
+    reference
+     "RFC 2578: Structure of Management Information Version 2
+                (SMIv2)";
+  }
+
+  typedef timestamp {
+    type yang:timeticks;
+    description
+     "The timestamp type represents the value of an associated
+      timeticks schema node at which a specific occurrence
+      happened.  The specific occurrence must be defined in the
+      description of any schema node defined using this type.  When
+      the specific occurrence occurred prior to the last time the
+      associated timeticks attribute was zero, then the timestamp
+      value is zero.  Note that this requires all timestamp values
+      to be reset to zero when the value of the associated timeticks
+      attribute reaches 497+ days and wraps around to zero.
+
+      The associated timeticks schema node must be specified
+      in the description of any schema node using this type.
+
+      In the value set and its semantics, this type is equivalent
+      to the TimeStamp textual convention of the SMIv2.";
+    reference
+     "RFC 2579: Textual Conventions for SMIv2";
+  }
+
+  /*** collection of generic address types ***/
+
+  typedef phys-address {
+    type string {
+      pattern '([0-9a-fA-F]{2}(:[0-9a-fA-F]{2})*)?';
+    }
+
+    description
+     "Represents media- or physical-level addresses represented
+      as a sequence octets, each octet represented by two hexadecimal
+      numbers.  Octets are separated by colons.  The canonical
+      representation uses lowercase characters.
+
+      In the value set and its semantics, this type is equivalent
+      to the PhysAddress textual convention of the SMIv2.";
+    reference
+     "RFC 2579: Textual Conventions for SMIv2";
+  }
+
+  typedef mac-address {
+    type string {
+      pattern '[0-9a-fA-F]{2}(:[0-9a-fA-F]{2}){5}';
+    }
+    description
+     "The mac-address type represents an IEEE 802 MAC address.
+      The canonical representation uses lowercase characters.
+
+      In the value set and its semantics, this type is equivalent
+      to the MacAddress textual convention of the SMIv2.";
+    reference
+     "IEEE 802: IEEE Standard for Local and Metropolitan Area
+                Networks: Overview and Architecture
+      RFC 2579: Textual Conventions for SMIv2";
+  }
+
+  /*** collection of XML-specific types ***/
+
+  typedef xpath1.0 {
+    type string;
+    description
+     "This type represents an XPATH 1.0 expression.
+
+      When a schema node is defined that uses this type, the
+      description of the schema node MUST specify the XPath
+      context in which the XPath expression is evaluated.";
+    reference
+     "XPATH: XML Path Language (XPath) Version 1.0";
+  }
+
+  /*** collection of string types ***/
+
+  typedef hex-string {
+    type string {
+      pattern '([0-9a-fA-F]{2}(:[0-9a-fA-F]{2})*)?';
+    }
+    description
+     "A hexadecimal string with octets represented as hex digits
+      separated by colons.  The canonical representation uses
+      lowercase characters.";
+  }
+
+  typedef uuid {
+    type string {
+      pattern '[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-'
+            + '[0-9a-fA-F]{4}-[0-9a-fA-F]{12}';
+    }
+    description
+     "A Universally Unique IDentifier in the string representation
+      defined in RFC 4122.  The canonical representation uses
+      lowercase characters.
+
+      The following is an example of a UUID in string representation:
+      f81d4fae-7dec-11d0-a765-00a0c91e6bf6
+      ";
+    reference
+     "RFC 4122: A Universally Unique IDentifier (UUID) URN
+                Namespace";
+  }
+
+  typedef dotted-quad {
+    type string {
+      pattern
+        '(([0-9]|[1-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])\.){3}'
+      + '([0-9]|[1-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])';
+    }
+    description
+      "An unsigned 32-bit number expressed in the dotted-quad
+       notation, i.e., four octets written as decimal numbers
+       and separated with the '.' (full stop) character.";
+  }
+}

--- a/test/data/test-module.yang
+++ b/test/data/test-module.yang
@@ -1,0 +1,35 @@
+module test-module {
+  namespace "urn:ietf:params:xml:ns:yang:test-module";
+  prefix tm;
+
+  organization "organization";
+  description
+    "example yang module";
+  contact
+    "example@example.org";
+
+  leaf decided {
+    type enumeration {
+      enum "yes" {
+        value 1;
+      }
+      enum "no" {
+        value 2;
+      }
+      enum "maybe" {
+        value 3;
+      }
+    }
+  }
+  leaf options {
+    type bits {
+      bit strict;
+      bit recursive;
+      bit logging;
+    }
+  }
+  leaf raw {
+    type binary;
+  }
+}
+

--- a/test/data/test-module.yin
+++ b/test/data/test-module.yin
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module name="test-module"
+        xmlns="urn:ietf:params:xml:ns:yang:yin:1"
+        xmlns:tm="urn:ietf:params:xml:ns:yang:test-module">
+  <namespace uri="urn:ietf:params:xml:ns:yang:test-module"/>
+  <prefix value="tm"/>
+  <organization>
+    <text>organization</text>
+  </organization>
+  <description>
+    <text>example yang module</text>
+  </description>
+  <contact>
+    <text>example@example.org</text>
+  </contact>
+  <leaf name="decided">
+    <type name="enumeration">
+      <enum name="yes">
+        <value value="1"/>
+      </enum>
+      <enum name="no">
+        <value value="2"/>
+      </enum>
+      <enum name="maybe">
+        <value value="3"/>
+      </enum>
+    </type>
+  </leaf>
+  <leaf name="options">
+    <type name="bits">
+      <bit name="strict"/>
+      <bit name="recursive"/>
+      <bit name="logging"/>
+    </type>
+  </leaf>
+  <leaf name="raw">
+    <type name="binary"/>
+  </leaf>
+</module>

--- a/test/rp_datatree_test.c
+++ b/test/rp_datatree_test.c
@@ -98,6 +98,185 @@ void createDataTreeWithAugments(struct ly_ctx *ctx, struct lyd_node **root){
 
 }
 
+void createDataTreeIETFinterfaces(struct ly_ctx *ctx, struct lyd_node **root){
+
+    const struct lys_module *module_interfaces = ly_ctx_get_module(ctx, "ietf-interfaces", NULL);
+    const struct lys_module *module_ip = ly_ctx_get_module(ctx, "ietf-ip", NULL);
+
+    struct lyd_node *node = NULL;
+
+    *root = lyd_new(NULL, module_interfaces, "interfaces");
+    node = lyd_new(*root, module_interfaces, "interface");
+    lyd_new_leaf(node, module_interfaces, "name", "eth0");
+    lyd_new_leaf(node, module_interfaces, "description", "Ethernet 0");
+    lyd_new_leaf(node, module_interfaces, "type", "ethernetCsmacd");
+    lyd_new_leaf(node, module_interfaces, "enabled", "true");
+    node = lyd_new(node, module_ip, "ipv4");
+    lyd_new_leaf(node, module_ip, "enabled", "true");
+    lyd_new_leaf(node, module_ip, "mtu", "1500");
+    node = lyd_new(node, module_ip, "address");
+    lyd_new_leaf(node, module_ip, "ip", "192.168.2.100");
+    lyd_new_leaf(node, module_ip, "prefix-length", "24");
+
+    node = lyd_new(*root, module_interfaces, "interface");
+    lyd_new_leaf(node, module_interfaces, "name", "eth1");
+    lyd_new_leaf(node, module_interfaces, "description", "Ethernet 1");
+    lyd_new_leaf(node, module_interfaces, "type", "ethernetCsmacd");
+    lyd_new_leaf(node, module_interfaces, "enabled", "true");
+    node = lyd_new(node, module_ip, "ipv4");
+    lyd_new_leaf(node, module_ip, "enabled", "true");
+    lyd_new_leaf(node, module_ip, "mtu", "1500");
+    node = lyd_new(node, module_ip, "address");
+    lyd_new_leaf(node, module_ip, "ip", "10.10.1.5");
+    lyd_new_leaf(node, module_ip, "prefix-length", "16");
+
+    node = lyd_new(*root, module_interfaces, "interface");
+    lyd_new_leaf(node, module_interfaces, "name", "gigaeth0");
+    lyd_new_leaf(node, module_interfaces, "description", "GigabitEthernet 0");
+    lyd_new_leaf(node, module_interfaces, "type", "ethernetCsmacd");
+    lyd_new_leaf(node, module_interfaces, "enabled", "false");
+
+    assert_int_equal(0, lyd_validate(*root, LYD_OPT_STRICT));
+
+}
+
+/**
+ * Function expects the values under xpath
+ * "/ietf-interfaces:interfaces/interface[name='eth0']"
+ */
+void check_ietf_interfaces_int_values(sr_val_t **values, size_t count){
+    for (size_t i = 0; i < count; i++) {
+        xp_loc_id_t *loc_id = NULL;
+        sr_val_t *v = values[i];
+        assert_int_equal(SR_ERR_OK, xp_char_to_loc_id(v->xpath, &loc_id));
+        if (XP_CMP_NODE(loc_id, XP_GET_NODE_COUNT(loc_id)-1, "name")){
+            assert_int_equal(SR_STRING_T, v->type);
+            assert_string_equal("eth0", v->data.string_val);
+        }
+        else if (XP_CMP_NODE(loc_id, XP_GET_NODE_COUNT(loc_id)-1, "type")){
+            assert_int_equal(SR_IDENTITYREF_T, v->type);
+            assert_string_equal("ethernetCsmacd", v->data.identityref_val);
+        }
+        else if (XP_CMP_NODE(loc_id, XP_GET_NODE_COUNT(loc_id)-1, "enabled")){
+            assert_int_equal(SR_BOOL_T, v->type);
+            assert_true(v->data.bool_val);
+        }
+        xp_free_loc_id(loc_id);
+    }
+}
+
+/**
+ * Function expect the values under xpath
+ * /ietf-interfaces:interfaces/interface[name='eth0']/ietf-ip:ipv4
+ */
+void check_ietf_interfaces_ipv4_values(sr_val_t **values, size_t count){
+    for (size_t i = 0; i < count; i++) {
+         xp_loc_id_t *loc_id = NULL;
+         sr_val_t *v = values[i];
+         assert_int_equal(SR_ERR_OK, xp_char_to_loc_id(v->xpath, &loc_id));
+         if (XP_CMP_NODE(loc_id, XP_GET_NODE_COUNT(loc_id)-1, "enabled")){
+             assert_int_equal(SR_BOOL_T, v->type);
+             assert_true(v->data.bool_val);
+         }
+         else if (XP_CMP_NODE(loc_id, XP_GET_NODE_COUNT(loc_id)-1, "mtu")){
+             assert_int_equal(SR_UINT16_T, v->type);
+             assert_int_equal(1500, v->data.uint32_val);
+         }
+         else if (XP_CMP_NODE(loc_id, XP_GET_NODE_COUNT(loc_id), "address")){
+             assert_int_equal(SR_LIST_T, v->type);
+         }
+         xp_free_loc_id(loc_id);
+     }
+}
+
+
+/**
+ * Function expects the values under xpath
+ * /ietf-interfaces:interfaces/interface[name='eth0']/ietf-ip:ipv4/address[ip='192.168.2.100']
+ */
+void check_ietf_interfaces_addr_values(sr_val_t **values, size_t count){
+    for (size_t i = 0; i < count; i++) {
+        xp_loc_id_t *loc_id = NULL;
+        sr_val_t *v = values[i];
+        assert_int_equal(SR_ERR_OK, xp_char_to_loc_id(v->xpath, &loc_id));
+        if (XP_CMP_NODE(loc_id, XP_GET_NODE_COUNT(loc_id)-1, "ip")){
+            assert_int_equal(SR_STRING_T, v->type);
+            assert_string_equal("192.168.2.100", v->data.string_val);
+        }
+        else if (XP_CMP_NODE(loc_id, XP_GET_NODE_COUNT(loc_id)-1, "prefix-length")){
+            assert_int_equal(SR_UINT8_T, v->type);
+            assert_int_equal(24, v->data.uint8_val);
+        }
+        xp_free_loc_id(loc_id);
+    }
+}
+
+void ietf_interfaces_test(void **state){
+    int rc = 0;
+    dm_ctx_t *ctx = *state;
+    dm_session_t *ses_ctx = NULL;
+    struct lyd_node *data_tree = NULL;
+    dm_session_start(ctx, &ses_ctx);
+    rc = dm_get_datatree(ctx, ses_ctx, "example-module", &data_tree);
+    assert_int_equal(SR_ERR_OK, rc);
+
+    struct lyd_node *root = NULL;
+    createDataTreeIETFinterfaces(data_tree->schema->module->ctx, &root);
+    assert_non_null(root);
+
+    sr_val_t **values;
+    size_t count;
+
+#define INTERFACES "/ietf-interfaces:interfaces"
+    rc = rp_dt_get_values_xpath(ctx, root, INTERFACES, &values, &count);
+    assert_int_equal(SR_ERR_OK, rc);
+    assert_int_equal(3, count);
+    for (size_t i = 0; i < count; i++) {
+        assert_int_equal(0, strncmp(INTERFACES, values[i]->xpath, strlen(INTERFACES)));
+        puts(values[i]->xpath);
+        sr_free_val_t(values[i]);
+    }
+    free(values);
+
+#define INTERFACE_ETH0 "/ietf-interfaces:interfaces/interface[name='eth0']"
+    rc = rp_dt_get_values_xpath(ctx, root, INTERFACE_ETH0, &values, &count);
+    assert_int_equal(SR_ERR_OK, rc);
+    check_ietf_interfaces_int_values(values, count);
+    for (size_t i = 0; i < count; i++) {
+        assert_int_equal(0, strncmp(INTERFACE_ETH0, values[i]->xpath, strlen(INTERFACE_ETH0)));
+        puts(values[i]->xpath);
+        sr_free_val_t(values[i]);
+    }
+    free(values);
+
+#define INTERFACE_ETH0_IPV4 "/ietf-interfaces:interfaces/interface[name='eth0']/ietf-ip:ipv4"
+    rc = rp_dt_get_values_xpath(ctx, root, INTERFACE_ETH0_IPV4, &values, &count);
+    assert_int_equal(SR_ERR_OK, rc);
+    check_ietf_interfaces_ipv4_values(values, count);
+    for (size_t i = 0; i < count; i++) {
+        assert_int_equal(0, strncmp(INTERFACE_ETH0_IPV4, values[i]->xpath, strlen(INTERFACE_ETH0_IPV4)));
+        puts(values[i]->xpath);
+        sr_free_val_t(values[i]);
+    }
+    free(values);
+
+#define INTERFACE_ETH0_IPV4_IP "/ietf-interfaces:interfaces/interface[name='eth0']/ietf-ip:ipv4/address[ip='192.168.2.100']"
+    rc = rp_dt_get_values_xpath(ctx, root, INTERFACE_ETH0_IPV4_IP, &values, &count);
+    assert_int_equal(SR_ERR_OK, rc);
+    check_ietf_interfaces_addr_values(values, count);
+    for (size_t i = 0; i < count; i++) {
+        assert_int_equal(0, strncmp(INTERFACE_ETH0_IPV4_IP, values[i]->xpath, strlen(INTERFACE_ETH0_IPV4_IP)));
+        puts(values[i]->xpath);
+        sr_free_val_t(values[i]);
+    }
+    free(values);
+
+    sr_free_datatree(root);
+    dm_session_stop(ctx, ses_ctx);
+}
+
+
+
 
 void get_values_test(void **state){
     int rc = 0;
@@ -337,6 +516,7 @@ int main(){
             cmocka_unit_test(get_value_test),
             cmocka_unit_test(get_values_test),
             cmocka_unit_test(get_values_with_augments_test),
+            cmocka_unit_test(ietf_interfaces_test),
     };
     return cmocka_run_group_tests(tests, setup, teardown);
 }

--- a/test/rp_datatree_test.c
+++ b/test/rp_datatree_test.c
@@ -540,6 +540,35 @@ void get_node_test_found(void **state)
 
 }
 
+void get_nodes_test(void **state){
+    int rc = 0;
+    dm_ctx_t *ctx = *state;
+    dm_session_t *ses_ctx = NULL;
+    struct lyd_node *data_tree = NULL;
+    dm_session_start(ctx, &ses_ctx);
+    rc = dm_get_datatree(ctx, ses_ctx, "example-module", &data_tree);
+    assert_int_equal(SR_ERR_OK, rc);
+
+    struct lyd_node *root = NULL;
+    createDataTree(data_tree->schema->module->ctx, &root);
+    assert_non_null(root);
+
+    struct lyd_node **nodes = NULL;
+    size_t count = 0;
+
+
+#define EXAMPLE_LIST "/example-module:container/list[key1='key1'][key2='key2']"
+    rc = rp_dt_get_nodes_xpath(ctx, root, EXAMPLE_LIST, &nodes, &count);
+    assert_int_equal(SR_ERR_OK, rc);
+    assert_int_equal(3, count);
+
+    free(nodes);
+
+    sr_free_datatree(root);
+    dm_session_stop(ctx, ses_ctx);
+
+}
+
 void get_node_test_not_found(void **state)
 {
     int rc = 0;
@@ -588,6 +617,7 @@ int main(){
             cmocka_unit_test(get_values_with_augments_test),
             cmocka_unit_test(ietf_interfaces_test),
             cmocka_unit_test(get_values_test_module_test),
+            cmocka_unit_test(get_nodes_test)
     };
     return cmocka_run_group_tests(tests, setup, teardown);
 }

--- a/test/xp_parser_test.c
+++ b/test/xp_parser_test.c
@@ -122,12 +122,26 @@ void check_parsing(void **state){
    assert_int_not_equal(0,xp_char_to_loc_id("/ns:cont/list[k1='abc'][va2]", &l));
    assert_int_not_equal(0,xp_char_to_loc_id("/ns:cont/list[k1=']", &l));
 
-   /* apostroph can not be ommitted */
+   /* apostroph can not be omitted */
    assert_int_not_equal(0,xp_char_to_loc_id("/cont/l[k=abc]", &l));
    assert_int_not_equal(0,xp_char_to_loc_id("/c/l[abc]", &l));
 
    assert_int_not_equal(0,xp_char_to_loc_id("/ns:ns:c/l[abc]", &l));
    assert_int_not_equal(0,xp_char_to_loc_id("/c/l[abc]", &l));
+
+   /* Invalid characters*/
+   assert_int_not_equal(0,xp_char_to_loc_id("/model%:leaf", &l));
+   assert_int_not_equal(0,xp_char_to_loc_id("/%model:leaf", &l));
+   assert_int_not_equal(0,xp_char_to_loc_id("/model:%leaf", &l));
+   assert_int_not_equal(0,xp_char_to_loc_id("/model:lea%f", &l));
+   assert_int_not_equal(0,xp_char_to_loc_id("/model:list[ab%='k1']/leaf", &l));
+
+   /* Either all keys are listed or all are omitted */
+   assert_int_not_equal(0,xp_char_to_loc_id("/model:list[a='k1']['k2']/leaf", &l));
+   assert_int_not_equal(0,xp_char_to_loc_id("/model:list['k1'][b='k2']/leaf", &l));
+
+
+
 }
 
 int main(){

--- a/test/xp_parser_test.c
+++ b/test/xp_parser_test.c
@@ -130,11 +130,11 @@ void check_parsing(void **state){
    assert_int_not_equal(0,xp_char_to_loc_id("/c/l[abc]", &l));
 
    /* Invalid characters*/
-   assert_int_not_equal(0,xp_char_to_loc_id("/model%:leaf", &l));
-   assert_int_not_equal(0,xp_char_to_loc_id("/%model:leaf", &l));
-   assert_int_not_equal(0,xp_char_to_loc_id("/model:%leaf", &l));
-   assert_int_not_equal(0,xp_char_to_loc_id("/model:lea%f", &l));
-   assert_int_not_equal(0,xp_char_to_loc_id("/model:list[ab%='k1']/leaf", &l));
+   assert_int_not_equal(0,xp_char_to_loc_id("/model^:leaf", &l));
+   assert_int_not_equal(0,xp_char_to_loc_id("/^model:leaf", &l));
+   assert_int_not_equal(0,xp_char_to_loc_id("/model:^leaf", &l));
+   assert_int_not_equal(0,xp_char_to_loc_id("/model:lea^f", &l));
+   assert_int_not_equal(0,xp_char_to_loc_id("/model:list[ab^='k1']/leaf", &l));
 
    /* Either all keys are listed or all are omitted */
    assert_int_not_equal(0,xp_char_to_loc_id("/model:list[a='k1']['k2']/leaf", &l));


### PR DESCRIPTION
- support for all yang type in `rp_dt_get_values` except instance_id
- example with ietf-interfaces
- xp fix parsing validation of list keys