### PR TITLE
Candidate datastore support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,7 @@ set(SYSREPO_DESC "YANG-based system repository")
 # setup version
 set(SYSREPO_MAJOR_VERSION 0)
 set(SYSREPO_MINOR_VERSION 2)
-set(SYSREPO_MICRO_VERSION 1)
+set(SYSREPO_MICRO_VERSION 2)
 set(SYSREPO_VERSION ${SYSREPO_MAJOR_VERSION}.${SYSREPO_MINOR_VERSION}.${SYSREPO_MICRO_VERSION})
 
 # set default build type if not specified by user

--- a/doc/datastores.dox
+++ b/doc/datastores.dox
@@ -5,7 +5,7 @@
 Sysrepo supports \b startup \b running and \b candidate configuration datastores. Each configuration
 session created can perform operations on any of them. On session start the initial datastore
 is selected. All subsequent calls are tied to the chosen datastore. The datastore which
-the session is operating on, can be changed using ::sr_session_switch_ds.
+the session is operating can be changed using ::sr_session_switch_ds.
 
 The changes made within a session are not applied into the datastore
 until ::sr_commit is requested. While not committed, changes are visible only
@@ -34,10 +34,6 @@ When new configuration is committed into the running datastore, subscribed appli
 informed about it and should start using it. Be aware that that kind of
 change is not permanent - you need to copy the configuration to the startup
 datastore to make it permanent after application restart (::sr_copy_config).
-
-@note In sysrepo versions below 0.3.0, notifications are not implemented, and running datastore
-cannot be used. For testing purposes, an internal function ::rp_dt_enable_xpath can be
-called to enable a subtree in running datastore.
 
 @section cds Candidate Datastore
 The candidate configuration is a full configuration data set that serves as a work

--- a/doc/datastores.dox
+++ b/doc/datastores.dox
@@ -2,41 +2,47 @@
 
 @page ds_page Datastores & Sessions
 
-Sysrepo supports \b startup and \b running configuration datastores. Each configuration 
-session created in sysrepo is permanently tied to only one of them.
+Sysrepo supports \b startup \b running and \b candidate configuration datastores. Each configuration
+session created can perform operations on any of them. On session start the initial datastore
+is selected. All subsequent calls are tied to the chosen datastore. The datastore on which
+the session is operating, on can be changed using ::sr_session_switch_ds.
 
-Both startup and running datastores provide <b>implicit candidate</b> capability. 
-That means, that changes made within a session are not applied into the datastore 
-until ::sr_commit is requested. While not committed, changes are visible only 
-within the same configuration session.
+The changes made within a session are not applied into the datastore
+until ::sr_commit is requested. While not committed, changes are visible only
+within the same configuration session. This applies for all three datastores.
 
 
 @section sds Startup Datastore
 Startup datastore contains the configuration data that should be loaded by the
 controlled application or service when it starts. Each sysrepo-enabled application
-or service supports at least this datastore. 
+or service supports at least this datastore.
 
 
 @section rds Running Datastore
-Running datastore contains currently applied configuration and state data 
-of a running application or service. If the application is not running at the 
+Running datastore contains currently applied configuration and state data
+of a running application or service. If the application is not running at the
 moment for whatever reason, it will have no data in the running datastore.
 
 Not all applications support this datastore. If an application does not support running
 datastore, it won't have any data in it, regardless of whether it is running or not.
 
 To support running datastore, the application needs to subscribe for notifications about the
-changes made in the datastore. After the subscription, the data on subscribed paths 
+changes made in the datastore. After the subscription, the data on subscribed paths
 will be copied from startup to running datastore and become available for retrieval.
 
-When new configuration is committed into the running datastore, subscribed application is 
-informed about it and should start using it. Be aware that that kind of 
-change is not permanent - you need to copy the configuration to the startup 
+When new configuration is committed into the running datastore, subscribed application is
+informed about it and should start using it. Be aware that that kind of
+change is not permanent - you need to copy the configuration to the startup
 datastore to make it permanent after application restart (::sr_copy_config).
 
 @note In sysrepo versions below 0.3.0, notifications are not implemented, and running datastore
-cannot be used. For testing purposes, an internal function ::rp_dt_enable_xpath can be 
+cannot be used. For testing purposes, an internal function ::rp_dt_enable_xpath can be
 called to enable a subtree in running datastore.
+
+@section cds Candidate Datastore
+The candidate configuration is a full configuration data set that serves as a work
+place for creating and manipulating configuration data. ::sr_commit operation sets
+running configuration to the value of the candidate content.
 
 @section dscache Session Data Caching
 For faster processing, sysrepo caches configuration data within the session.
@@ -45,8 +51,8 @@ data model within the session. After that, all requests within the session
 operate on that session-local view of the data. By commit operation,
 changes made within the session are merged with the actual state of the datastore
 at the time of commit. That implies, that commit operation may possibly fail if
-datastore has been changed by another session in the meantime and the two changes 
-cannot be merged. To prevent this situation, the client should always use 
+datastore has been changed by another session in the meantime and the two changes
+cannot be merged. To prevent this situation, the client should always use
 locking capabilities of sysrepo in multi-user environments.
 
 Cached data will be released and the session will start operate on fresh data

--- a/doc/datastores.dox
+++ b/doc/datastores.dox
@@ -4,8 +4,8 @@
 
 Sysrepo supports \b startup \b running and \b candidate configuration datastores. Each configuration
 session created can perform operations on any of them. On session start the initial datastore
-is selected. All subsequent calls are tied to the chosen datastore. The datastore on which
-the session is operating, on can be changed using ::sr_session_switch_ds.
+is selected. All subsequent calls are tied to the chosen datastore. The datastore which
+the session is operating on, can be changed using ::sr_session_switch_ds.
 
 The changes made within a session are not applied into the datastore
 until ::sr_commit is requested. While not committed, changes are visible only

--- a/inc/sysrepo.h
+++ b/inc/sysrepo.h
@@ -319,7 +319,8 @@ void sr_disconnect(sr_conn_ctx_t *conn_ctx);
  *
  * @param[in] conn_ctx Connection context acquired with ::sr_connect call.
  * @param[in] datastore Datastore on which all sysrepo functions within this
- * session will operate. Functionality of some sysrepo calls does not depend on
+ * session will operate. Later on, datastore can be changed using
+ * ::sr_session_switch_ds call. Functionality of some sysrepo calls does not depend on
  * datastore. If your session will contain just calls like these, you can pass
  * any valid value (e.g. SR_RUNNING).
  * @param[in] opts Options overriding default session handling.
@@ -748,6 +749,9 @@ int sr_discard_changes(sr_session_ctx_t *session);
  * source datastore.
  *
  * If the target datastore exists, it is overwritten. Otherwise, a new one is created.
+ *
+ * @note Operation may fail, if it tries to copy a not enabled configuration to the
+ * running datastore.
  *
  * @param[in] session Session context acquired with ::sr_session_start call.
  * @param[in] module_name If specified, only limits the copy operation only to

--- a/inc/sysrepo.h
+++ b/inc/sysrepo.h
@@ -772,6 +772,7 @@ int sr_copy_config(sr_session_ctx_t *session, const char *module_name,
 /**
  * @brief Locks the datastore which the session is tied to. If there is
  * a module locked by the other session SR_ERR_LOCKED is returned.
+ * Operation fails if there is a modified data tree in session.
  *
  * All data models within the datastore will be locked for writing until
  * ::sr_unlock_datastore is called or until the session is stopped or terminated
@@ -800,7 +801,7 @@ int sr_unlock_datastore(sr_session_ctx_t *session);
 
 /**
  * @brief Locks specified data module within the datastore which the session
- * is tied to.
+ * is tied to. Operation fails if the data tree has been modified.
  *
  * Specified data module will be locked for writing in the datastore until
  * ::sr_unlock_module is called or until the session is stopped or terminated

--- a/inc/sysrepo.h
+++ b/inc/sysrepo.h
@@ -285,6 +285,8 @@ typedef enum sr_datastore_e {
     SR_DS_STARTUP = 0,    /**< Contains configuration data that should be loaded by the controlled application when it starts. */
     SR_DS_RUNNING = 1,    /**< Contains currently applied configuration and state data of a running application.
                                @note This datastore is supported only by applications that subscribe for notifications about the changes made in the datastore. */
+    SR_DS_CANDIDATE = 2,  /**< Contains configuration that can be manipulated without impacting the current configuration. It can be than
+                           * committed to the running or copied to a datastore. */
 } sr_datastore_t;
 
 /**

--- a/inc/sysrepo.h
+++ b/inc/sysrepo.h
@@ -159,7 +159,7 @@ typedef enum sr_error_e {
     SR_ERR_UNKNOWN_MODEL,      /**< Request includes unknown schema */
     SR_ERR_BAD_ELEMENT,        /**< Unknown element in existing schema */
     SR_ERR_VALIDATION_FAILED,  /**< Validation of the changes failed. */
-    SR_ERR_COMMIT_FAILED,      /**< Commit operation failed. */
+    SR_ERR_OPERATION_FAILED,   /**< An operation failed. */
     SR_ERR_DATA_EXISTS,        /**< Item already exists. */
     SR_ERR_DATA_MISSING,       /**< Item does not exists. */
     SR_ERR_UNAUTHORIZED,       /**< Operation not authorized. */

--- a/inc/sysrepo.h
+++ b/inc/sysrepo.h
@@ -739,9 +739,6 @@ int sr_discard_changes(sr_session_ctx_t *session);
  *
  * If the target datastore exists, it is overwritten. Otherwise, a new one is created.
  *
- * @note In the current implementation, running configuration datastore is not
- * supported as the destination datastore.
- *
  * @param[in] session Session context acquired with ::sr_session_start call.
  * @param[in] module_name If specified, only limits the copy operation only to
  * one specified module.

--- a/inc/sysrepo.h
+++ b/inc/sysrepo.h
@@ -390,6 +390,16 @@ int sr_session_stop(sr_session_ctx_t *session);
 int sr_session_refresh(sr_session_ctx_t *session);
 
 /**
+ * @brief Changes datastore to which the session is tied to. All subsequent
+ * calls will be issued on the chosen datastore.
+ *
+ * @param [in] session
+ * @param [in] ds
+ * @return Error code (SR_ERR_OK on success)
+ */
+int sr_session_switch_ds(sr_session_ctx_t *session, sr_datastore_t ds);
+
+/**
  * @brief Retrieves detailed information about the error that has occurred
  * during the last operation executed within provided session.
  *

--- a/src/cl_common.c
+++ b/src/cl_common.c
@@ -461,7 +461,7 @@ cl_request_process(sr_session_ctx_t *session, Sr__Msg *msg_req, Sr__Msg **msg_re
         /* log the error (except expected ones) */
         if (SR_ERR_NOT_FOUND != (*msg_resp)->response->result &&
                 SR_ERR_VALIDATION_FAILED != (*msg_resp)->response->result &&
-                SR_ERR_COMMIT_FAILED != (*msg_resp)->response->result) {
+                SR_ERR_OPERATION_FAILED != (*msg_resp)->response->result) {
             SR_LOG_ERR("Error by processing of the %s request (session id=%"PRIu32"): %s.",
                     sr_gpb_operation_name(msg_req->request->operation), session->id,
                 (NULL != (*msg_resp)->response->error && NULL != (*msg_resp)->response->error->message) ?

--- a/src/client_library.c
+++ b/src/client_library.c
@@ -404,6 +404,40 @@ cleanup:
 }
 
 int
+sr_session_switch_ds(sr_session_ctx_t* session, sr_datastore_t datastore)
+{
+    Sr__Msg *msg_req = NULL, *msg_resp = NULL;
+    int rc = SR_ERR_OK;
+
+    CHECK_NULL_ARG(session);
+    cl_session_clear_errors(session);
+
+    /* prepare session_switch ds message */
+    rc = sr_gpb_req_alloc(SR__OPERATION__SESSION_SWITCH_DS, session->id, &msg_req);
+    CHECK_RC_MSG_GOTO(rc, cleanup, "Cannot allocate GPB message.");
+
+    msg_req->request->session_switch_ds_req->datastore = sr_datastore_sr_to_gpb(datastore);
+
+    /* send the request and receive the response */
+    rc = cl_request_process(session, msg_req, &msg_resp, SR__OPERATION__SESSION_SWITCH_DS);
+    CHECK_RC_MSG_GOTO(rc, cleanup, "Error by processing of the request.");
+
+    sr__msg__free_unpacked(msg_req, NULL);
+    sr__msg__free_unpacked(msg_resp, NULL);
+
+    return cl_session_return(session, SR_ERR_OK);
+
+cleanup:
+    if (NULL != msg_req) {
+        sr__msg__free_unpacked(msg_req, NULL);
+    }
+    if (NULL != msg_resp) {
+        sr__msg__free_unpacked(msg_resp, NULL);
+    }
+    return cl_session_return(session, rc);
+}
+
+int
 sr_list_schemas(sr_session_ctx_t *session, sr_schema_t **schemas, size_t *schema_cnt)
 {
     Sr__Msg *msg_req = NULL, *msg_resp = NULL;

--- a/src/client_library.c
+++ b/src/client_library.c
@@ -971,13 +971,13 @@ sr_commit(sr_session_ctx_t *session)
 
     /* send the request and receive the response */
     rc = cl_request_process(session, msg_req, &msg_resp, SR__OPERATION__COMMIT);
-    if ((SR_ERR_OK != rc) && (SR_ERR_COMMIT_FAILED != rc)) {
+    if ((SR_ERR_OK != rc) && (SR_ERR_OPERATION_FAILED != rc)) {
         SR_LOG_ERR_MSG("Error by processing of commit request.");
         goto cleanup;
     }
 
     commit_resp = msg_resp->response->commit_resp;
-    if (SR_ERR_COMMIT_FAILED == rc) {
+    if (SR_ERR_OPERATION_FAILED == rc) {
         SR_LOG_ERR("Commit operation failed with %zu error(s).", commit_resp->n_errors);
 
         /* store commit errors within the session */

--- a/src/common/sr_common.c
+++ b/src/common/sr_common.c
@@ -44,7 +44,7 @@ const char *const sr_errlist[] = {
         "Requested schema model is not known",  /* SR_ERR_UNKNOWN_MODEL */
         "Request contains unknown element",     /* SR_ERR_BAD_ELEMENT */
         "Validation of the changes failed",     /* SR_ERR_VALIDATION_FAILED */
-        "Commit operation failed",              /* SR_ERR_COMMIT_FAILED */
+        "An operation failed",                  /* SR_ERR_OPERATION_FAILED */
         "The item already exists",              /* SR_ERR_DATA_EXISTS */
         "The item expected to exist is missing",/* SR_ERR_DATA_MISSING */
         "Operation not authorized",             /* SR_ERR_UNAUTHORIZED */

--- a/src/common/sr_constants.h.in
+++ b/src/common/sr_constants.h.in
@@ -52,6 +52,9 @@
 /** File extension of data files for running datastore */
 #define SR_RUNNING_FILE_EXT ".running"
 
+/** File extension of data files for candidate datastore */
+#define SR_CANDIDATE_FILE_EXT ".candidate"
+
 /** File extension of data lock files */
 #define SR_LOCK_FILE_EXT ".lock"
 

--- a/src/common/sr_protobuf.c
+++ b/src/common/sr_protobuf.c
@@ -1088,6 +1088,8 @@ Sr__DataStore
 sr_datastore_sr_to_gpb(const sr_datastore_t sr_ds)
 {
     switch (sr_ds) {
+        case SR_DS_CANDIDATE:
+            return SR__DATA_STORE__CANDIDATE;
         case SR_DS_RUNNING:
             return SR__DATA_STORE__RUNNING;
         case SR_DS_STARTUP:
@@ -1101,6 +1103,8 @@ sr_datastore_t
 sr_datastore_gpb_to_sr(Sr__DataStore gpb_ds)
 {
     switch (gpb_ds) {
+        case SR__DATA_STORE__CANDIDATE:
+            return SR_DS_CANDIDATE;
         case SR__DATA_STORE__RUNNING:
             return SR_DS_RUNNING;
         case SR__DATA_STORE__STARTUP:

--- a/src/common/sr_protobuf.c
+++ b/src/common/sr_protobuf.c
@@ -118,6 +118,12 @@ sr_gpb_req_alloc(const Sr__Operation operation, const uint32_t session_id, Sr__M
             sr__session_refresh_req__init((Sr__SessionRefreshReq*)sub_msg);
             req->session_refresh_req = (Sr__SessionRefreshReq*)sub_msg;
             break;
+        case SR__OPERATION__SESSION_SWITCH_DS:
+            sub_msg = calloc(1, sizeof(Sr__SessionSwitchDsReq));
+            CHECK_NULL_NOMEM_GOTO(sub_msg, rc, error);
+            sr__session_switch_ds_req__init((Sr__SessionSwitchDsReq*)sub_msg);
+            req->session_switch_ds_req = (Sr__SessionSwitchDsReq*)sub_msg;
+            break;
         case SR__OPERATION__LIST_SCHEMAS:
             sub_msg = calloc(1, sizeof(Sr__ListSchemasReq));
             CHECK_NULL_NOMEM_GOTO(sub_msg, rc, error);
@@ -285,6 +291,12 @@ sr_gpb_resp_alloc(const Sr__Operation operation, const uint32_t session_id, Sr__
            CHECK_NULL_NOMEM_GOTO(sub_msg, rc, error);
            sr__session_refresh_resp__init((Sr__SessionRefreshResp*)sub_msg);
            resp->session_refresh_resp = (Sr__SessionRefreshResp*)sub_msg;
+           break;
+        case SR__OPERATION__SESSION_SWITCH_DS:
+           sub_msg = calloc(1, sizeof(Sr__SessionSwitchDsResp));
+           CHECK_NULL_NOMEM_GOTO(sub_msg, rc, error);
+           sr__session_switch_ds_resp__init((Sr__SessionSwitchDsResp*)sub_msg);
+           resp->session_switch_ds_resp = (Sr__SessionSwitchDsResp*)sub_msg;
            break;
         case SR__OPERATION__LIST_SCHEMAS:
             sub_msg = calloc(1, sizeof(Sr__ListSchemasResp));

--- a/src/common/sr_utils.c
+++ b/src/common/sr_utils.c
@@ -644,6 +644,22 @@ sr_val_to_str(const sr_val_t *value, const struct lys_node *schema_node, char **
     return SR_ERR_OK;
 }
 
+const char *
+sr_ds_to_str(sr_datastore_t ds)
+{
+    const char *const sr_dslist[] = {
+        "startup",    /* SR_DS_STARTUP */
+        "running",    /* SR_DS_RUNNING */
+        "candidate",  /* SR_DS_CANDIDATE */
+    };
+
+    if (ds >= (sizeof(sr_dslist) / (sizeof *sr_dslist))) {
+        return "Unknown datastore";
+    } else {
+        return sr_dslist[ds];
+    }
+}
+
 void
 sr_free_val_content(sr_val_t *value)
 {

--- a/src/common/sr_utils.c
+++ b/src/common/sr_utils.c
@@ -162,7 +162,19 @@ sr_get_data_file_name(const char *data_search_dir, const char *module_name, cons
     char *tmp = NULL;
     int rc = sr_str_join(data_search_dir, module_name, &tmp);
     if (SR_ERR_OK == rc) {
-        char *suffix = SR_DS_STARTUP == ds ? SR_STARTUP_FILE_EXT : SR_RUNNING_FILE_EXT;
+        char *suffix = NULL;
+        switch (ds) {
+        case SR_DS_CANDIDATE:
+            suffix = SR_CANDIDATE_FILE_EXT;
+            break;
+        case SR_DS_RUNNING:
+            suffix = SR_RUNNING_FILE_EXT;
+            break;
+        case SR_DS_STARTUP:
+            /* fall through */
+        default:
+            suffix = SR_STARTUP_FILE_EXT;
+        }
         rc = sr_str_join(tmp, suffix, file_name);
         free(tmp);
         return rc;

--- a/src/common/sr_utils.c
+++ b/src/common/sr_utils.c
@@ -431,25 +431,6 @@ sr_lyd_unlink(dm_data_info_t *data_info, struct lyd_node *node)
     return SR_ERR_OK;
 }
 
-struct lyd_node *
-sr_lyd_new_path(dm_data_info_t *data_info, struct ly_ctx *ctx, const char *path, const char *value, int options)
-{
-    int rc = SR_ERR_OK;
-    CHECK_NULL_ARG_NORET2(rc, data_info, path);
-    if (SR_ERR_OK != rc){
-        return NULL;
-    }
-
-    struct lyd_node *new = NULL;
-    new = lyd_new_path(data_info->node, ctx, path, value, options);
-
-    if (NULL == data_info->node) {
-        data_info->node = new;
-    }
-
-    return new;
-}
-
 int
 sr_lyd_insert_before(dm_data_info_t *data_info, struct lyd_node *sibling, struct lyd_node *node)
 {

--- a/src/common/sr_utils.h
+++ b/src/common/sr_utils.h
@@ -249,6 +249,12 @@ sr_type_t sr_libyang_type_to_sysrepo(LY_DATA_TYPE t);
 int sr_val_to_str(const sr_val_t *value, const struct lys_node *schema_node, char **out);
 
 /**
+ * @brief Returns the string name of the datastore
+ * @param [in] ds
+ * @return Data store name
+ */
+const char * sr_ds_to_str(sr_datastore_t ds);
+/**
  * @brief Frees contents of the sr_val_t structure, does not free the
  * value structure itself.
  */

--- a/src/common/sr_utils.h
+++ b/src/common/sr_utils.h
@@ -215,18 +215,6 @@ struct lyd_node* sr_dup_datatree(struct lyd_node *root);
 int sr_lyd_unlink(dm_data_info_t *data_info, struct lyd_node *node);
 
 /**
- * @brief Call lyd_new_path if the data info does not contain a node attaches the created node.
- * @param [in] data_info
- * @param [in] ctx
- * @param [in] path
- * @param [in] value
- * @param [in] options
- * @return same as libyang's lyd_new_path
- */
-struct lyd_node *sr_lyd_new_path(dm_data_info_t *data_info, struct ly_ctx *ctx,
-        const char *path, const char *value, int options);
-
-/**
  * @brief Insert node after sibling and fixes the pointer in dm_data_info if needed.
  * @param [in] data_info
  * @param [in] sibling

--- a/src/data_manager.c
+++ b/src/data_manager.c
@@ -2183,10 +2183,11 @@ dm_copy_config(dm_ctx_t *dm_ctx, dm_session_t *session, const struct ly_set *mod
         sr_error_info_t *errors = NULL;
         size_t e_cnt = 0;
         rc = dm_validate_session_data_trees(dm_ctx, session, &errors, &e_cnt);
-        sr_free_errors(errors, e_cnt);
         if (SR_ERR_OK != rc) {
+            rc = dm_report_error(session, errors[0].message, errors[0].xpath, SR_ERR_VALIDATION_FAILED);
+            sr_free_errors(errors, e_cnt);
             SR_LOG_ERR_MSG("There is a invalid data tree, can not be copied");
-            return rc;
+            goto cleanup;
         }
     }
 

--- a/src/data_manager.c
+++ b/src/data_manager.c
@@ -2669,7 +2669,7 @@ dm_ly_ctx_get_node(dm_ctx_t *dm_ctx, struct ly_ctx *lyctx, const struct lys_node
         SR_LOG_ERR_MSG("Null argument passed to dm_ly_ctx_get_node");
         return NULL;
     }
-    const struct lys_node *result = SR_ERR_OK;
+    const struct lys_node *result = NULL;
     pthread_rwlock_rdlock(&dm_ctx->lyctx_lock);
     result = ly_ctx_get_node(lyctx, start, nodeid);
     pthread_rwlock_unlock(&dm_ctx->lyctx_lock);

--- a/src/data_manager.c
+++ b/src/data_manager.c
@@ -2937,3 +2937,19 @@ cleanup:
     sr_free_schemas(schemas, count);
     return rc;
 }
+
+int
+dm_is_model_modified(dm_ctx_t *dm_ctx, dm_session_t *session, const char *module_name, bool *res)
+{
+    CHECK_NULL_ARG3(dm_ctx, session, module_name);
+    int rc = SR_ERR_OK;
+    dm_data_info_t lookup = {0};
+    rc = dm_get_module(dm_ctx, module_name, NULL, &lookup.module);
+    CHECK_RC_MSG_RETURN(rc, "Dm get module failed");
+
+    dm_data_info_t *info  = NULL;
+
+    info = sr_btree_search(session->session_modules[session->datastore], &lookup);
+    *res = NULL != info ? info->modified : false;
+    return rc;
+}

--- a/src/data_manager.c
+++ b/src/data_manager.c
@@ -1962,7 +1962,7 @@ dm_commit_load_modified_models(dm_ctx_t *dm_ctx, const dm_session_t *session, dm
                 CHECK_RC_LOG_RETURN(rc, "Has not enabled check failed for module %s", info->module->name);
                 if (has_not_enabled) {
                     SR_LOG_ERR("There is a not enabled node in %s module, it can not be committed to the running", info->module->name);
-                    return SR_ERR_COMMIT_FAILED;
+                    return SR_ERR_OPERATION_FAILED;
                 }
             }
         }
@@ -2005,7 +2005,7 @@ dm_commit_load_modified_models(dm_ctx_t *dm_ctx, const dm_session_t *session, dm
         rc = sr_lock_fd(c_ctx->fds[count], true, false);
         if (SR_ERR_OK != rc) {
             SR_LOG_ERR("Locking of file '%s' failed: %s.", file_name, sr_strerror(rc));
-            rc = SR_ERR_COMMIT_FAILED;
+            rc = SR_ERR_OPERATION_FAILED;
             goto cleanup;
         }
         dm_data_info_t *di = NULL;

--- a/src/data_manager.c
+++ b/src/data_manager.c
@@ -2735,7 +2735,10 @@ dm_copy_modified_session_trees(dm_ctx_t *dm_ctx, dm_session_t *from, dm_session_
         new_info->module = info->module;
         new_info->timestamp = info->timestamp;
         lyd_free_withsiblings(new_info->node);
-        new_info->node = lyd_dup(info->node, 1);
+        new_info->node = NULL;
+        if (NULL != info->node) {
+            new_info->node = lyd_dup(info->node, 1);
+        }
 
         if (!existed) {
             sr_btree_insert(to->session_modules[to->datastore], new_info);
@@ -2773,8 +2776,10 @@ dm_copy_session_tree(dm_ctx_t *dm_ctx, dm_session_t *from, dm_session_t *to, con
     new_info->modified = info->modified;
     new_info->module = info->module;
     new_info->timestamp = info->timestamp;
-    tmp_node = lyd_dup(info->node, 1);
-    CHECK_NULL_NOMEM_ERROR(tmp_node, rc);
+    if (NULL != info->node) {
+        tmp_node = lyd_dup(info->node, 1);
+        CHECK_NULL_NOMEM_ERROR(tmp_node, rc);
+    }
 
     if (SR_ERR_OK == rc) {
         lyd_free_withsiblings(new_info->node);

--- a/src/data_manager.h
+++ b/src/data_manager.h
@@ -559,5 +559,55 @@ int dm_copy_all_models(dm_ctx_t *dm_ctx, dm_session_t *session, sr_datastore_t s
  */
 int dm_validate_rpc(dm_ctx_t *dm_ctx, dm_session_t *session, const char *rpc_xpath, sr_val_t *args, size_t arg_cnt, bool input);
 
+/**
+ * @brief Locks lyctx_lock and call lyd_get_node.
+ * @param [in] dm_ctx
+ * @param [in] data
+ * @param [in] expr
+ * @return set of nodes matching expr
+ */
+struct ly_set *dm_lyd_get_node(dm_ctx_t *dm_ctx, const struct lyd_node *data, const char *expr);
+
+/**
+ * @brief Locks lyctx_lock and call lyd_get_node2.
+ * @param [in] dm_ctx
+ * @param [in] data
+ * @param [in] sch_node
+ * @return set of instances of sch_node
+ */
+struct ly_set *dm_lyd_get_node2(dm_ctx_t *dm_ctx, const struct lyd_node *data, const struct lys_node *sch_node);
+
+/**
+ * @brief Locks the lyctx lock, subsequently calls lyd_new_path if the data info does not contain a node attaches the created node.
+ * @param [in] dm_ctx
+ * @param [in] data_info
+ * @param [in] ctx
+ * @param [in] path
+ * @param [in] value
+ * @param [in] options
+ * @return same as libyang's lyd_new_path
+ */
+struct lyd_node *dm_lyd_new_path(dm_ctx_t *dm_ctx, dm_data_info_t *data_info, struct ly_ctx *ctx,
+        const char *path, const char *value, int options);
+
+/**
+ * @brief Locks the lyctx lock, then call lyd_wd_add
+ * @param [in] dm_ctx
+ * @param [in] lyctx
+ * @param [in] root
+ * @param [in] options
+ * @return Error code
+ */
+int dm_lyd_wd_add(dm_ctx_t *dm_ctx, struct ly_ctx *lyctx, struct lyd_node **root, int options);
+
+/**
+ * @brief Locks the lyctx lock, then call ly_ctx_ge_node
+ * @param [in] dm_ctx
+ * @param [in] lyctx
+ * @param [in] start
+ * @param [in] nodeid
+ * @return Matched schema node
+ */
+const struct lys_node *dm_ly_ctx_get_node(dm_ctx_t *dm_ctx, struct ly_ctx *lyctx, const struct lys_node *start, const char *nodeid);
 /**@} Data manager*/
 #endif /* SRC_DATA_MANAGER_H_ */

--- a/src/data_manager.h
+++ b/src/data_manager.h
@@ -609,5 +609,55 @@ int dm_lyd_wd_add(dm_ctx_t *dm_ctx, struct ly_ctx *lyctx, struct lyd_node **root
  * @return Matched schema node
  */
 const struct lys_node *dm_ly_ctx_get_node(dm_ctx_t *dm_ctx, struct ly_ctx *lyctx, const struct lys_node *start, const char *nodeid);
+
+/**
+ * @brief Copies all modified data trees from one session to another.
+ * @note Corresponding operations are not copied so the changes may be overwritten by session refresh.
+ * @param [in] dm_ctx
+ * @param [in] from
+ * @param [in] to
+ * @return Error code (SR_ERR_OK on success)
+ */
+int dm_copy_modified_session_trees(dm_ctx_t *dm_ctx, dm_session_t *from, dm_session_t *to);
+
+/**
+ * @brief Copies the selected data tree from one session to another, if the module is not
+ * loaded in 'from' session, does nothing
+ * @param [in] dm_ctx
+ * @param [in] from
+ * @param [in] to
+ * @param [in] module_name
+ * @return Error code (SR_ERR_OK on success)
+ */
+int dm_copy_session_tree(dm_ctx_t *dm_ctx, dm_session_t *from, dm_session_t *to, const char *module_name);
+
+/**
+ * @brief Moves session data trees and operation from one session to another
+ * @param [in] dm_ctx
+ * @param [in] from
+ * @param [in] to
+ * @return Error code (SR_ERR_OK on success)
+ */
+int dm_move_session_tree_and_ops(dm_ctx_t *dm_ctx, dm_session_t *from, dm_session_t *to);
+
+/**
+ * @brief Changes the datastore to which the session is tied to. Subsequent operations
+ * will work on the selected datastore.
+ * @param [in] session
+ * @param [in] ds
+ * @return Error code (SR_ERR_OK on success)
+ */
+int dm_change_session_datastore(dm_session_t *session, sr_datastore_t ds);
+
+/**
+ * @brief Returns the set of all modules.
+ * @param [in] dm_ctx
+ * @param [in] session
+ * @param [in] enabled_only
+ * @param [out] result
+ * @return Error code (SR_ERR_OK on success)
+ */
+int dm_get_all_modules(dm_ctx_t *dm_ctx, dm_session_t *session, bool enabled_only, struct ly_set **result);
+
 /**@} Data manager*/
 #endif /* SRC_DATA_MANAGER_H_ */

--- a/src/data_manager.h
+++ b/src/data_manager.h
@@ -647,7 +647,7 @@ int dm_move_session_tree_and_ops(dm_ctx_t *dm_ctx, dm_session_t *from, dm_sessio
  * @param [in] ds
  * @return Error code (SR_ERR_OK on success)
  */
-int dm_change_session_datastore(dm_session_t *session, sr_datastore_t ds);
+int dm_session_switch_ds(dm_session_t *session, sr_datastore_t ds);
 
 /**
  * @brief Moves session data trees and operations (for all datastores) from one session to another.

--- a/src/data_manager.h
+++ b/src/data_manager.h
@@ -237,6 +237,20 @@ int dm_validate_session_data_trees(dm_ctx_t *dm_ctx, dm_session_t *session, sr_e
 int dm_discard_changes(dm_ctx_t *dm_ctx, dm_session_t *session);
 
 /**
+ * @brief Removes the modified flags from session copies of data trees.
+ * @param [in] session
+ * @return Error code (SR_ERR_OK on success)
+ */
+int dm_remove_modified_flag(dm_session_t *session);
+
+/**
+ * @brief Empties the list of operation associated with the session
+ * @param [in] session
+ * @return Error code (SR_ERR_OK on success)
+ */
+int dm_remove_session_operations(dm_session_t *session);
+
+/**
  * @brief Removes the session copies of the data trees that are not up to date.
  * Subsequent calls will load the fresh state.
  *

--- a/src/data_manager.h
+++ b/src/data_manager.h
@@ -611,7 +611,7 @@ int dm_lyd_wd_add(dm_ctx_t *dm_ctx, struct ly_ctx *lyctx, struct lyd_node **root
 const struct lys_node *dm_ly_ctx_get_node(dm_ctx_t *dm_ctx, struct ly_ctx *lyctx, const struct lys_node *start, const char *nodeid);
 
 /**
- * @brief Copies all modified data trees from one session to another.
+ * @brief Copies all modified data trees (in current datastore) from one session to another.
  * @note Corresponding operations are not copied so the changes may be overwritten by session refresh.
  * @param [in] dm_ctx
  * @param [in] from
@@ -621,8 +621,8 @@ const struct lys_node *dm_ly_ctx_get_node(dm_ctx_t *dm_ctx, struct ly_ctx *lyctx
 int dm_copy_modified_session_trees(dm_ctx_t *dm_ctx, dm_session_t *from, dm_session_t *to);
 
 /**
- * @brief Copies the selected data tree from one session to another, if the module is not
- * loaded in 'from' session, does nothing
+ * @brief Copies the selected data tree (in current datastore) from one session to another, if the module is not
+ * loaded in 'from' session, does nothing.
  * @param [in] dm_ctx
  * @param [in] from
  * @param [in] to
@@ -632,7 +632,7 @@ int dm_copy_modified_session_trees(dm_ctx_t *dm_ctx, dm_session_t *from, dm_sess
 int dm_copy_session_tree(dm_ctx_t *dm_ctx, dm_session_t *from, dm_session_t *to, const char *module_name);
 
 /**
- * @brief Moves session data trees and operation from one session to another
+ * @brief Moves session data trees and operations (in current datastore) from one session to another
  * @param [in] dm_ctx
  * @param [in] from
  * @param [in] to
@@ -648,6 +648,25 @@ int dm_move_session_tree_and_ops(dm_ctx_t *dm_ctx, dm_session_t *from, dm_sessio
  * @return Error code (SR_ERR_OK on success)
  */
 int dm_change_session_datastore(dm_session_t *session, sr_datastore_t ds);
+
+/**
+ * @brief Moves session data trees and operations (for all datastores) from one session to another.
+ * @param [in] dm_ctx
+ * @param [in] from
+ * @param [in] to
+ * @return Error code (SR_ERR_OK on success)
+ */
+int dm_move_session_tree_and_ops_all_ds(dm_ctx_t *dm_ctx, dm_session_t *from, dm_session_t *to);
+
+/**
+ * @brief Moves data trees from one datastore to another in the session
+ * @param [in] dm_ctx
+ * @param [in] session
+ * @param [in] from
+ * @param [in] to
+ * @return Error code (SR_ERR_OK)
+ */
+int dm_move_session_trees_in_session(dm_ctx_t *dm_ctx, dm_session_t *session, sr_datastore_t from, sr_datastore_t to);
 
 /**
  * @brief Returns the set of all modules.

--- a/src/data_manager.h
+++ b/src/data_manager.h
@@ -678,5 +678,14 @@ int dm_move_session_trees_in_session(dm_ctx_t *dm_ctx, dm_session_t *session, sr
  */
 int dm_get_all_modules(dm_ctx_t *dm_ctx, dm_session_t *session, bool enabled_only, struct ly_set **result);
 
+/**
+ * @brief If there is a session copy of the model, return modified flag.
+ * @param [in] dm_ctx
+ * @param [in] session
+ * @param [in] module_name
+ * @param [out] res - modified flag to be set.
+ * @return Error code (SR_ERR_OK on success)
+ */
+int dm_is_model_modified(dm_ctx_t *dm_ctx, dm_session_t *session, const char *module_name, bool *res);
 /**@} Data manager*/
 #endif /* SRC_DATA_MANAGER_H_ */

--- a/src/data_manager.h
+++ b/src/data_manager.h
@@ -434,7 +434,7 @@ bool dm_is_running_ds_session(dm_session_t *session);
  * @return Error code (SR_ERR_OK on success), SR_ERR_LOCKED if the module is locked
  * by other session, SR_ERR_UNAUTHORIZED if the file can no be locked because of permissions.
  */
-int dm_lock_module(dm_ctx_t *dm_ctx, dm_session_t *session, char *module_name);
+int dm_lock_module(dm_ctx_t *dm_ctx, dm_session_t *session, const char *module_name);
 
 /**
  * @brief Releases the lock.

--- a/src/request_processor.c
+++ b/src/request_processor.c
@@ -746,7 +746,7 @@ rp_switch_datastore_req_process(rp_ctx_t *rp_ctx, rp_session_t *session, Sr__Msg
         return SR_ERR_NOMEM;
     }
 
-    rc = rp_dt_switch_datastore(rp_ctx, session, msg->request->session_switch_ds_req->datastore);
+    rc = rp_dt_switch_datastore(rp_ctx, session, sr_datastore_gpb_to_sr(msg->request->session_switch_ds_req->datastore));
 
     /* set response code */
     resp->response->result = rc;

--- a/src/request_processor.c
+++ b/src/request_processor.c
@@ -787,13 +787,7 @@ rp_lock_req_process(const rp_ctx_t *rp_ctx, const rp_session_t *session, Sr__Msg
         return SR_ERR_NOMEM;
     }
 
-    if (NULL != msg->request->lock_req->module_name) {
-        /* module-level lock */
-        rc = dm_lock_module(rp_ctx->dm_ctx, session->dm_session, msg->request->lock_req->module_name);
-    } else {
-        /* datastore-level lock */
-        rc = dm_lock_datastore(rp_ctx->dm_ctx, session->dm_session);
-    }
+    rc = rp_dt_lock(rp_ctx, session, msg->request->lock_req->module_name);
 
     /* set response code */
     resp->response->result = rc;

--- a/src/request_processor.h
+++ b/src/request_processor.h
@@ -107,8 +107,6 @@ int rp_session_start(const rp_ctx_t *rp_ctx, const uint32_t session_id, const ac
  */
 int rp_session_stop(const rp_ctx_t *rp_ctx, rp_session_t *session);
 
-int rp_switch_datastore(rp_session_t *session, sr_datastore_t ds);
-
 /**
  * @brief Pass the message for processing in Request Processor.
  *

--- a/src/request_processor.h
+++ b/src/request_processor.h
@@ -107,6 +107,8 @@ int rp_session_start(const rp_ctx_t *rp_ctx, const uint32_t session_id, const ac
  */
 int rp_session_stop(const rp_ctx_t *rp_ctx, rp_session_t *session);
 
+int rp_switch_datastore(rp_session_t *session, sr_datastore_t ds);
+
 /**
  * @brief Pass the message for processing in Request Processor.
  *

--- a/src/rp_dt_edit.c
+++ b/src/rp_dt_edit.c
@@ -882,6 +882,7 @@ int
 rp_dt_copy_config(rp_ctx_t *rp_ctx, rp_session_t *session, const char *module_name, sr_datastore_t src, sr_datastore_t dst)
 {
     CHECK_NULL_ARG2(rp_ctx, session);
+    SR_LOG_INF("Copy config: %s -> %s, model: %s", sr_ds_to_str(src), sr_ds_to_str(dst), module_name);
     int rc = SR_ERR_OK;
     int prev_ds = session->datastore;
 

--- a/src/rp_dt_edit.c
+++ b/src/rp_dt_edit.c
@@ -883,14 +883,15 @@ rp_dt_copy_config(rp_ctx_t *rp_ctx, rp_session_t *session, const char *module_na
 {
     CHECK_NULL_ARG2(rp_ctx, session);
     int rc = SR_ERR_OK;
+    int prev_ds = session->datastore;
 
     if (src == dst) {
         return rc;
     }
 
     if ((SR_DS_CANDIDATE == src || SR_DS_CANDIDATE == dst) && SR_DS_CANDIDATE != session->datastore) {
-        SR_LOG_ERR_MSG("Copy config to/from candidate issued on non-candidate session");
-        return SR_ERR_INVAL_ARG;
+        rc = rp_dt_switch_datastore(rp_ctx, session, SR_DS_CANDIDATE);
+        CHECK_RC_MSG_RETURN(rc, "Datastore switch failed");
     }
 
     if (SR_DS_RUNNING != dst) {
@@ -906,6 +907,7 @@ rp_dt_copy_config(rp_ctx_t *rp_ctx, rp_session_t *session, const char *module_na
         rc = rp_dt_copy_config_to_running(rp_ctx, session, module_name, src);
     }
 
+    rp_dt_switch_datastore(rp_ctx, session, prev_ds);
     return rc;
 }
 

--- a/src/rp_dt_edit.c
+++ b/src/rp_dt_edit.c
@@ -260,7 +260,7 @@ rp_dt_delete_item(dm_ctx_t *dm_ctx, dm_session_t *session, const char *xpath, co
             }
         }
     }
-    lyd_wd_add(info->module->ctx, &info->node, LYD_WD_IMPL_TAG);
+    dm_lyd_wd_add(dm_ctx, info->module->ctx, &info->node, LYD_WD_IMPL_TAG);
 cleanup:
     ly_set_free(parents);
     ly_set_free(nodes);
@@ -357,7 +357,7 @@ rp_dt_set_item(dm_ctx_t *dm_ctx, dm_session_t *session, const char *xpath, const
             CHECK_NULL_NOMEM_GOTO(last_slash, rc, cleanup);
             char *parent_node = strndup(xpath, last_slash - xpath - 1);
             CHECK_NULL_NOMEM_GOTO(parent_node, rc, cleanup);
-            struct ly_set *res = lyd_get_node(info->node, parent_node);
+            struct ly_set *res = dm_lyd_get_node(dm_ctx, info->node, parent_node);
             free(parent_node);
             if (NULL == res || 0 == res->number) {
                 SR_LOG_ERR("A preceding node is missing '%s' create it or omit the non recursive option", xpath);
@@ -373,7 +373,7 @@ rp_dt_set_item(dm_ctx_t *dm_ctx, dm_session_t *session, const char *xpath, const
     int flags = (SR_EDIT_STRICT & options) ? 0 : LYD_PATH_OPT_UPDATE;
 
     /* create or update */
-    node = sr_lyd_new_path(info, module->ctx, xpath, new_value, flags);
+    node = dm_lyd_new_path(dm_ctx, info, module->ctx, xpath, new_value, flags);
     if (NULL == node && LY_SUCCESS != ly_errno) {
         SR_LOG_ERR("Setting of item failed %s %d", xpath, ly_vecode);
         if (LYVE_PATH_EXISTS == ly_vecode) {
@@ -395,7 +395,7 @@ rp_dt_set_item(dm_ctx_t *dm_ctx, dm_session_t *session, const char *xpath, const
     }
 
     /* add default nodes into the data tree */
-    lyd_wd_add(module->ctx, &info->node, LYD_WD_IMPL_TAG);
+    dm_lyd_wd_add(dm_ctx, module->ctx, &info->node, LYD_WD_IMPL_TAG);
 
 cleanup:
     free(new_value);
@@ -451,7 +451,7 @@ rp_dt_move_list(dm_ctx_t *dm_ctx, dm_session_t *session, const char *xpath, sr_m
             return rc;
         }
     } else {
-        struct ly_set *siblings = lyd_get_node2(info->node, node->schema);
+        struct ly_set *siblings = dm_lyd_get_node2(dm_ctx, info->node, node->schema);
 
         if (NULL == siblings || 0 == siblings->number) {
             SR_LOG_ERR_MSG("No siblings found");

--- a/src/rp_dt_edit.c
+++ b/src/rp_dt_edit.c
@@ -917,6 +917,6 @@ rp_dt_switch_datastore(rp_ctx_t *rp_ctx, rp_session_t *session, sr_datastore_t d
     CHECK_NULL_ARG3(rp_ctx, session, session->dm_session);
     int rc = SR_ERR_OK;
     session->datastore = ds;
-    rc = dm_change_session_datastore(session->dm_session, ds);
+    rc = dm_session_switch_ds(session->dm_session, ds);
     return rc;
 }

--- a/src/rp_dt_edit.c
+++ b/src/rp_dt_edit.c
@@ -709,7 +709,12 @@ cleanup:
 
     if (SR_ERR_OK == rc) {
         /* discard changes in session in next get_data_tree call newly committed content will be loaded */
-        rc = dm_discard_changes(rp_ctx->dm_ctx, session->dm_session);
+        if (SR_DS_CANDIDATE != session->datastore) {
+            rc = dm_discard_changes(rp_ctx->dm_ctx, session->dm_session);
+        } else {
+            dm_remove_session_operations(session->dm_session);
+            rc = dm_remove_modified_flag(session->dm_session);
+        }
         SR_LOG_DBG_MSG("Commit (7/7): finished successfully");
     }
     return rc;

--- a/src/rp_dt_edit.h
+++ b/src/rp_dt_edit.h
@@ -133,8 +133,25 @@ int rp_dt_commit(rp_ctx_t *rp_ctx, rp_session_t *session, sr_error_info_t **erro
  */
 int rp_dt_refresh_session(rp_ctx_t *rp_ctx, rp_session_t *session, sr_error_info_t **errors, size_t *err_cnt);
 
+/**
+ * @brief Copies the configuration from a datastore to another one.
+ * @param [in] rp_ctx
+ * @param [in] session
+ * @param [in] module_name
+ * @param [in] src
+ * @param [in] dst
+ * @return Error code (SR_ERR_OK on success)
+ */
 int rp_dt_copy_config(rp_ctx_t *rp_ctx, rp_session_t *session, const char *module_name, sr_datastore_t src, sr_datastore_t dst);
 
+/**
+ * @brief Changes the datastore of the session. Subsequent call will operate on the
+ * selected datastore.
+ * @param [in] rp_ctx
+ * @param [in] session
+ * @param [in] ds
+ * @return Error code (SR_ERR_OK on success)
+ */
 int rp_dt_switch_datastore(rp_ctx_t *rp_ctx, rp_session_t *session, sr_datastore_t ds);
 #endif /* RP_DT_EDIT_H */
 

--- a/src/rp_dt_edit.h
+++ b/src/rp_dt_edit.h
@@ -135,6 +135,7 @@ int rp_dt_refresh_session(rp_ctx_t *rp_ctx, rp_session_t *session, sr_error_info
 
 int rp_dt_copy_config(rp_ctx_t *rp_ctx, rp_session_t *session, const char *module_name, sr_datastore_t src, sr_datastore_t dst);
 
+int rp_dt_switch_datastore(rp_ctx_t *rp_ctx, rp_session_t *session, sr_datastore_t ds);
 #endif /* RP_DT_EDIT_H */
 
 /**

--- a/src/rp_dt_edit.h
+++ b/src/rp_dt_edit.h
@@ -132,6 +132,9 @@ int rp_dt_commit(rp_ctx_t *rp_ctx, rp_session_t *session, sr_error_info_t **erro
  * be merged
  */
 int rp_dt_refresh_session(rp_ctx_t *rp_ctx, rp_session_t *session, sr_error_info_t **errors, size_t *err_cnt);
+
+int rp_dt_copy_config(rp_ctx_t *rp_ctx, rp_session_t *session, const char *module_name, sr_datastore_t src, sr_datastore_t dst);
+
 #endif /* RP_DT_EDIT_H */
 
 /**

--- a/src/rp_dt_edit.h
+++ b/src/rp_dt_edit.h
@@ -153,6 +153,16 @@ int rp_dt_copy_config(rp_ctx_t *rp_ctx, rp_session_t *session, const char *modul
  * @return Error code (SR_ERR_OK on success)
  */
 int rp_dt_switch_datastore(rp_ctx_t *rp_ctx, rp_session_t *session, sr_datastore_t ds);
+
+/**
+ * @brief Locks a model or whole datastore. Lock can not be acquired if the session
+ * copy has been modified.
+ * @param [in] rp_ctx
+ * @param [in] session
+ * @param [in] module_name optional to lock only a particular model
+ * @return Error code (SR_ERR_OK on success)
+ */
+int rp_dt_lock(const rp_ctx_t *rp_ctx, const rp_session_t *session, const char *module_name);
 #endif /* RP_DT_EDIT_H */
 
 /**

--- a/src/rp_dt_get.c
+++ b/src/rp_dt_get.c
@@ -362,6 +362,7 @@ rp_dt_get_value_wrapper(rp_ctx_t *rp_ctx, rp_session_t *rp_session, const char *
 {
     CHECK_NULL_ARG4(rp_ctx, rp_ctx->dm_ctx, rp_session, rp_session->dm_session);
     CHECK_NULL_ARG2(xpath, value);
+    SR_LOG_INF("Get item request %s datastore, xpath: %s", sr_ds_to_str(rp_session->datastore), xpath);
 
     int rc = SR_ERR_INVAL_ARG;
     struct lyd_node *data_tree = NULL;

--- a/src/rp_dt_lookup.c
+++ b/src/rp_dt_lookup.c
@@ -33,7 +33,7 @@ rp_dt_find_nodes(const dm_ctx_t *dm_ctx, struct lyd_node *data_tree, const char 
         return SR_ERR_NOT_FOUND;
     }
     CHECK_NULL_ARG3(data_tree->schema, data_tree->schema->module, data_tree->schema->module->name);
-    struct ly_set *res = lyd_get_node(data_tree, xpath);
+    struct ly_set *res = dm_lyd_get_node((dm_ctx_t *)dm_ctx, data_tree, xpath);
     if (NULL == res) {
         SR_LOG_ERR_MSG("Lyd get node failed");
         return LY_EINVAL == ly_errno || LY_EVALID == ly_errno ? SR_ERR_INVAL_ARG : SR_ERR_INTERNAL;

--- a/src/sysrepo.proto
+++ b/src/sysrepo.proto
@@ -148,6 +148,20 @@ message SessionRefreshResp {
   repeated Error errors = 1;
 }
 
+/**
+ * @brief Changes the datastore to which the session is tied to.
+ */
+message SessionSwitchDsReq {
+  required DataStore datastore = 1;
+}
+
+/**
+ * @brief Response to sr_session_switch_ds request.
+ */
+message SessionSwitchDsResp {
+
+}
+
 ////////////////////////////////////////////////////////////////////////////////
 // Data Retrieval API (get / get-config functionality)
 ////////////////////////////////////////////////////////////////////////////////
@@ -540,6 +554,7 @@ enum Operation {
   SESSION_START = 10;
   SESSION_STOP = 11;
   SESSION_REFRESH = 12;
+  SESSION_SWITCH_DS = 13;
 
   LIST_SCHEMAS = 20;
   GET_SCHEMA = 21;
@@ -578,6 +593,7 @@ message Request {
   optional SessionStartReq session_start_req = 10;
   optional SessionStopReq session_stop_req = 11;
   optional SessionRefreshReq session_refresh_req = 12;
+  optional SessionSwitchDsReq session_switch_ds_req =13;
 
   optional ListSchemasReq list_schemas_req = 20;
   optional GetSchemaReq get_schema_req = 21;
@@ -616,6 +632,7 @@ message Response {
   optional SessionStartResp session_start_resp = 10;
   optional SessionStopResp session_stop_resp = 11;
   optional SessionRefreshResp session_refresh_resp = 12;
+  optional SessionSwitchDsResp session_switch_ds_resp = 13;
 
   optional ListSchemasResp list_schemas_resp = 20;
   optional GetSchemaResp get_schema_resp = 21;

--- a/src/sysrepo.proto
+++ b/src/sysrepo.proto
@@ -91,6 +91,7 @@ message Error {
 enum DataStore {
   STARTUP = 1;
   RUNNING = 2;
+  CANDIDATE = 3;
 }
 
 /**

--- a/swig/python/SysrepoWrappers/Session.py
+++ b/swig/python/SysrepoWrappers/Session.py
@@ -31,6 +31,9 @@ class Session:
     def __del__(self):
         sr.sr_session_stop(self.session)
 
+    def switch_ds(self, ds):
+        sr.sr_session_switch_ds(self.session, ds)
+
     def get_last_error(self):
         return sr.sr_get_last_error(self.session)
 

--- a/tests/cl_test.c
+++ b/tests/cl_test.c
@@ -1129,12 +1129,9 @@ cl_copy_config_test(void **state)
     rc = sr_session_start(conn, SR_DS_RUNNING, SR_SESS_DEFAULT, &session_running);
     assert_int_equal(rc, SR_ERR_OK);
 
-    /* copy to/from candidate is not allowed using the session associated with a different ds*/
-    rc = sr_copy_config(session_startup, NULL, SR_DS_CANDIDATE, SR_DS_STARTUP);
-    assert_int_equal(rc, SR_ERR_INVAL_ARG);
-
+    /* copy to/from candidate */
     rc = sr_copy_config(session_startup, NULL, SR_DS_STARTUP, SR_DS_CANDIDATE);
-    assert_int_equal(rc, SR_ERR_INVAL_ARG);
+    assert_int_equal(rc, SR_ERR_OK);
 
     /* copy-config all enabled models, currently none */
     rc = sr_copy_config(session_startup, NULL, SR_DS_RUNNING, SR_DS_STARTUP);

--- a/tests/cl_test.c
+++ b/tests/cl_test.c
@@ -832,6 +832,16 @@ cl_locking_test(void **state)
     rc = sr_lock_module(sessionB, "unknown-module");
     assert_int_equal(rc, SR_ERR_UNKNOWN_MODEL);
 
+    /* modified module can not be locked*/
+    rc = sr_delete_item(sessionB, "/test-module:main", SR_EDIT_DEFAULT);
+    assert_int_equal(SR_ERR_OK, rc);
+
+    rc = sr_lock_module(sessionB, "test-module");
+    assert_int_equal(rc, SR_ERR_OPERATION_FAILED);
+
+    rc = sr_lock_datastore(sessionB);
+    assert_int_equal(rc, SR_ERR_OPERATION_FAILED);
+
     /* stop the sessions */
     rc = sr_session_stop(sessionA);
     assert_int_equal(rc, SR_ERR_OK);

--- a/tests/cl_test.c
+++ b/tests/cl_test.c
@@ -1317,10 +1317,10 @@ candidate_ds_test(void **state)
 
     /* commit should fail because non enabled nodes are modified */
     rc = sr_commit(session_candidate);
-    assert_int_equal(SR_ERR_COMMIT_FAILED, rc);
+    assert_int_equal(SR_ERR_OPERATION_FAILED, rc);
 
     rc = sr_copy_config(session_candidate, "example-module", SR_DS_CANDIDATE, SR_DS_RUNNING);
-    assert_int_equal(SR_ERR_COMMIT_FAILED, rc);
+    assert_int_equal(SR_ERR_OPERATION_FAILED, rc);
 
     /* enable running DS for example-module */
     rc = sr_module_change_subscribe(session_startup, "example-module", true,

--- a/tests/cl_test.c
+++ b/tests/cl_test.c
@@ -1319,6 +1319,9 @@ candidate_ds_test(void **state)
     rc = sr_commit(session_candidate);
     assert_int_equal(SR_ERR_COMMIT_FAILED, rc);
 
+    rc = sr_copy_config(session_candidate, "example-module", SR_DS_CANDIDATE, SR_DS_RUNNING);
+    assert_int_equal(SR_ERR_COMMIT_FAILED, rc);
+
     /* enable running DS for example-module */
     rc = sr_module_change_subscribe(session_startup, "example-module", true,
             test_module_change_cb, &callback_called, &subscription);

--- a/tests/cl_test.c
+++ b/tests/cl_test.c
@@ -1337,6 +1337,23 @@ candidate_ds_test(void **state)
     assert_string_equal(value.data.string_val, val->data.string_val);
     sr_free_val(val);
 
+    /* copy config should work as well*/
+    value.data.string_val = "xyz";
+    rc = sr_set_item(session_candidate, value.xpath, &value, SR_EDIT_DEFAULT);
+    assert_int_equal(rc, SR_ERR_OK);
+
+    rc = sr_copy_config(session_candidate, "example-module", SR_DS_CANDIDATE, SR_DS_RUNNING);
+    assert_int_equal(SR_ERR_OK, rc);
+
+    rc = sr_session_refresh(session_running);
+    assert_int_equal(SR_ERR_OK, rc);
+
+    rc = sr_get_item(session_running, "/example-module:container/list[key1='key1'][key2='key2']/leaf", &val);
+    assert_int_equal(rc, SR_ERR_OK);
+    assert_int_equal(value.type, val->type);
+    assert_string_equal(value.data.string_val, val->data.string_val);
+    sr_free_val(val);
+
     /* stop the sessions */
     rc = sr_session_stop(session_startup);
     assert_int_equal(rc, SR_ERR_OK);

--- a/tests/cl_test.c
+++ b/tests/cl_test.c
@@ -1017,10 +1017,12 @@ test_module_change_cb(sr_session_ctx_t *session, const char *module_name, void *
     printf("Some data within the module '%s' has changed.\n", module_name);
 
     rc = sr_get_item(session, "/example-module:container/list[key1='key1'][key2='key2']/leaf", &value);
-    assert_int_equal(rc, SR_ERR_OK);
-
-    printf("New value for '%s' = '%s'\n", value->xpath, value->data.string_val);
-    sr_free_val(value);
+    if (SR_ERR_OK == rc) {
+        printf("New value for '%s' = '%s'\n", value->xpath, value->data.string_val);
+        sr_free_val(value);
+    } else {
+        printf("While retrieving '%s' error with code (%d) occured\n", "/example-module:container/list[key1='key1'][key2='key2']/leaf", rc);
+    }
 }
 
 static void

--- a/tests/rp_dt_edit_test.c
+++ b/tests/rp_dt_edit_test.c
@@ -1874,7 +1874,7 @@ copy_to_running_test(void **state)
 
     /* explictly select a module which is not enabled copy fails*/
     rc = rp_dt_copy_config(ctx, sessionB, "test-module", SR_DS_STARTUP, SR_DS_RUNNING);
-    assert_int_equal(SR_ERR_COMMIT_FAILED, rc);
+    assert_int_equal(SR_ERR_OPERATION_FAILED, rc);
 
     /* only enabled modules are copied, no module is enabled => no operation*/
     rc = rp_dt_copy_config(ctx, sessionA, NULL, SR_DS_CANDIDATE, SR_DS_RUNNING);
@@ -1890,7 +1890,7 @@ copy_to_running_test(void **state)
 
     /* copy of not enabled module to running should fail */
     rc = rp_dt_copy_config(ctx, sessionA, "test-module", SR_DS_CANDIDATE, SR_DS_RUNNING);
-    assert_int_equal(SR_ERR_COMMIT_FAILED, rc);
+    assert_int_equal(SR_ERR_OPERATION_FAILED, rc);
 
     test_rp_session_cleanup(ctx, sessionA);
     test_rp_session_cleanup(ctx, sessionB);

--- a/tests/rp_dt_edit_test.c
+++ b/tests/rp_dt_edit_test.c
@@ -1864,7 +1864,6 @@ copy_to_running_test(void **state)
     int rc = 0;
     rp_ctx_t *ctx = *state;
     rp_session_t *sessionA = NULL, *sessionB = NULL;
-    sr_val_t *value = NULL;
 
     test_rp_sesssion_create(ctx, SR_DS_CANDIDATE, &sessionA);
     test_rp_sesssion_create(ctx, SR_DS_STARTUP, &sessionB);


### PR DESCRIPTION
- locking of lyctx in data manager
- copy-config to running
- candidate commit
- modified models can not be locked
- switch session datastore