### PR TITLE
fix for sysrepoctl crash when owner of schema file does not exist

### DIFF
--- a/src/executables/sysrepoctl.c
+++ b/src/executables/sysrepoctl.c
@@ -120,7 +120,7 @@ srctl_print_module_owner(const char *module_name, char *buff)
         if(pw && gr) {
             snprintf(buff, PATH_MAX, "%s:%s", pw->pw_name, gr->gr_name);
         } else {
-            snprintf(buff, PATH_MAX, "%d:%d", info.st_uid, in.st_gid);
+            snprintf(buff, PATH_MAX, "%d:%d", info.st_uid, info.st_gid);
         }
     } else {
         snprintf(buff, PATH_MAX, " ");

--- a/src/executables/sysrepoctl.c
+++ b/src/executables/sysrepoctl.c
@@ -117,7 +117,11 @@ srctl_print_module_owner(const char *module_name, char *buff)
     if (0 == ret) {
         struct passwd *pw = getpwuid(info.st_uid);
         struct group  *gr = getgrgid(info.st_gid);
-        snprintf(buff, PATH_MAX, "%s:%s", pw->pw_name, gr->gr_name);
+        if(pw && gr) {
+            snprintf(buff, PATH_MAX, "%s:%s", pw->pw_name, gr->gr_name);
+        } else {
+            snprintf(buff, PATH_MAX, "%d:%d", info.st_uid, in.st_gid);
+        }
     } else {
         snprintf(buff, PATH_MAX, " ");
     }


### PR DESCRIPTION
I got this a crash when I use "sysrepoctl -l" in my VM, and I try to fix it.