### PR TITLE
Sysrepocfg finalization

### DIFF
--- a/src/client_library.c
+++ b/src/client_library.c
@@ -1,6 +1,7 @@
 /**
  * @file client_library.c
- * @author Rastislav Szabo <raszabo@cisco.com>, Lukas Macko <lmacko@cisco.com>
+ * @author Rastislav Szabo <raszabo@cisco.com>, Lukas Macko <lmacko@cisco.com>,
+ *         Milan Lenco <milan.lenco@pantheon.tech>
  * @brief Sysrepo client library (public + non-public API) implementation.
  *
  * @copyright

--- a/src/client_library.c
+++ b/src/client_library.c
@@ -1382,6 +1382,45 @@ cleanup:
 }
 
 int
+sr_check_enabled_running(sr_session_ctx_t *session, const char *module_name, bool *res)
+{
+    Sr__Msg *msg_req = NULL, *msg_resp = NULL;
+    int rc = SR_ERR_OK;
+
+    CHECK_NULL_ARG3(session, module_name, res);
+
+    cl_session_clear_errors(session);
+
+    /* prepare request message */
+    rc = sr_gpb_req_alloc(SR__OPERATION__CHECK_ENABLED_RUNNING, session->id, &msg_req);
+    CHECK_RC_MSG_GOTO(rc, cleanup, "Cannot allocate GPB message.");
+
+    /* fill-in module name */
+    msg_req->request->check_enabled_running_req->module_name = strdup(module_name);
+    CHECK_NULL_NOMEM_GOTO(msg_req->request->check_enabled_running_req->module_name, rc, cleanup);
+
+    /* send the request and receive the response */
+    rc = cl_request_process(session, msg_req, &msg_resp, SR__OPERATION__CHECK_ENABLED_RUNNING);
+    CHECK_RC_MSG_GOTO(rc, cleanup, "Error by processing of the request.");
+
+    *res = msg_resp->response->check_enabled_running_resp->enabled;
+
+    sr__msg__free_unpacked(msg_req, NULL);
+    sr__msg__free_unpacked(msg_resp, NULL);
+
+    return cl_session_return(session, SR_ERR_OK);
+
+cleanup:
+    if (NULL != msg_req) {
+        sr__msg__free_unpacked(msg_req, NULL);
+    }
+    if (NULL != msg_resp) {
+        sr__msg__free_unpacked(msg_resp, NULL);
+    }
+    return cl_session_return(session, rc);
+}
+
+int
 sr_module_change_subscribe(sr_session_ctx_t *session, const char *module_name, sr_notif_event_t event,
         bool enable_running, int priority, sr_module_change_cb callback, void *private_ctx,
         sr_subscription_ctx_t **subscription_p)

--- a/src/client_library.h
+++ b/src/client_library.h
@@ -50,4 +50,15 @@ int sr_module_install(sr_session_ctx_t *session, const char *module_name, const 
  */
 int sr_feature_enable(sr_session_ctx_t *session, const char *module_name, const char *feature_name, bool enabled);
 
+/**
+ * @brief Checks (via sysrepo engine) whether the module has *any* enabled subtree.
+ *
+ * @param[in] session Session context acquired with ::sr_session_start call.
+ * @param[in] module_name Name of the module to be checked.
+ * @param[out] res TRUE if there is at least one enabled subtree in the module.
+ *
+ * @return Error code (SR_ERR_OK on success).
+ */
+int sr_check_enabled_running(sr_session_ctx_t *session, const char *module_name, bool *res);
+
 #endif /* CLIENT_LIBRARY_H_ */

--- a/src/client_library.h
+++ b/src/client_library.h
@@ -1,6 +1,7 @@
 /**
  * @file client_library.h
- * @author Rastislav Szabo <raszabo@cisco.com>, Lukas Macko <lmacko@cisco.com>
+ * @author Rastislav Szabo <raszabo@cisco.com>, Lukas Macko <lmacko@cisco.com>,
+ *         Milan Lenco <milan.lenco@pantheon.tech>
  * @brief Sysrepo Client Library non-public API.
  *
  * @copyright

--- a/src/common/sr_protobuf.c
+++ b/src/common/sr_protobuf.c
@@ -1,6 +1,7 @@
 /**
  * @file sr_protobuf.c
- * @author Rastislav Szabo <raszabo@cisco.com>, Lukas Macko <lmacko@cisco.com>
+ * @author Rastislav Szabo <raszabo@cisco.com>, Lukas Macko <lmacko@cisco.com>,
+ *         Milan Lenco <milan.lenco@pantheon.tech>
  * @brief Sysrepo Google Protocol Buffers conversion functions implementation.
  *
  * @copyright

--- a/src/common/sr_protobuf.c
+++ b/src/common/sr_protobuf.c
@@ -65,6 +65,8 @@ sr_gpb_operation_name(Sr__Operation operation)
         return "subscribe";
     case SR__OPERATION__UNSUBSCRIBE:
         return "unsubscribe";
+    case SR__OPERATION__CHECK_ENABLED_RUNNING:
+        return "check-enabled-running";
     case SR__OPERATION__UNSUBSCRIBE_DESTINATION:
         return "unsubscribe-destination";
     case SR__OPERATION__RPC:
@@ -225,6 +227,12 @@ sr_gpb_req_alloc(const Sr__Operation operation, const uint32_t session_id, Sr__M
             CHECK_NULL_NOMEM_GOTO(sub_msg, rc, error);
             sr__unsubscribe_req__init((Sr__UnsubscribeReq*)sub_msg);
             req->unsubscribe_req = (Sr__UnsubscribeReq*)sub_msg;
+            break;
+        case SR__OPERATION__CHECK_ENABLED_RUNNING:
+            sub_msg = calloc(1, sizeof(Sr__CheckEnabledRunningReq));
+            CHECK_NULL_NOMEM_GOTO(sub_msg, rc, error);
+            sr__check_enabled_running_req__init((Sr__CheckEnabledRunningReq*)sub_msg);
+            req->check_enabled_running_req = (Sr__CheckEnabledRunningReq*)sub_msg;
             break;
         case SR__OPERATION__RPC:
             sub_msg = calloc(1, sizeof(Sr__RPCReq));
@@ -399,6 +407,12 @@ sr_gpb_resp_alloc(const Sr__Operation operation, const uint32_t session_id, Sr__
             CHECK_NULL_NOMEM_GOTO(sub_msg, rc, error);
             sr__unsubscribe_resp__init((Sr__UnsubscribeResp*)sub_msg);
             resp->unsubscribe_resp = (Sr__UnsubscribeResp*)sub_msg;
+            break;
+        case SR__OPERATION__CHECK_ENABLED_RUNNING:
+            sub_msg = calloc(1, sizeof(Sr__CheckEnabledRunningResp));
+            CHECK_NULL_NOMEM_GOTO(sub_msg, rc, error);
+            sr__check_enabled_running_resp__init((Sr__CheckEnabledRunningResp*)sub_msg);
+            resp->check_enabled_running_resp = (Sr__CheckEnabledRunningResp*)sub_msg;
             break;
         case SR__OPERATION__RPC:
             sub_msg = calloc(1, sizeof(Sr__RPCResp));
@@ -615,6 +629,9 @@ sr_gpb_msg_validate(const Sr__Msg *msg, const Sr__Msg__MsgType type, const Sr__O
             case SR__OPERATION__UNSUBSCRIBE:
                 CHECK_NULL_RETURN(msg->request->unsubscribe_req, SR_ERR_MALFORMED_MSG);
                 break;
+            case SR__OPERATION__CHECK_ENABLED_RUNNING:
+                CHECK_NULL_RETURN(msg->request->check_enabled_running_req, SR_ERR_MALFORMED_MSG);
+                break;
             case SR__OPERATION__RPC:
                 CHECK_NULL_RETURN(msg->request->rpc_req, SR_ERR_MALFORMED_MSG);
                 break;
@@ -690,6 +707,9 @@ sr_gpb_msg_validate(const Sr__Msg *msg, const Sr__Msg__MsgType type, const Sr__O
                 break;
             case SR__OPERATION__UNSUBSCRIBE:
                 CHECK_NULL_RETURN(msg->response->unsubscribe_resp, SR_ERR_MALFORMED_MSG);
+                break;
+            case SR__OPERATION__CHECK_ENABLED_RUNNING:
+                CHECK_NULL_RETURN(msg->response->check_enabled_running_resp, SR_ERR_MALFORMED_MSG);
                 break;
             case SR__OPERATION__RPC:
                 CHECK_NULL_RETURN(msg->response->rpc_resp, SR_ERR_MALFORMED_MSG);

--- a/src/data_manager.c
+++ b/src/data_manager.c
@@ -2956,8 +2956,6 @@ dm_enable_module_running(dm_ctx_t *ctx, dm_session_t *session, const char *modul
     char xpath[PATH_MAX] = {0,};
     int rc = SR_ERR_OK;
 
-    CHECK_NULL_ARG3(ctx, session, module_name);
-
     if (NULL == module) {
         /* if module is not known, get it and check if it has some enabled subtree */
         rc = dm_has_enabled_subtree(ctx, module_name, &module, &has_enabled_subtree);
@@ -2987,11 +2985,9 @@ int
 dm_enable_module_subtree_running(dm_ctx_t *ctx, dm_session_t *session, const char *module_name, const char *xpath,
         const struct lys_module *module, bool copy_from_startup)
 {
-    CHECK_NULL_ARG2(ctx, module_name);
+    CHECK_NULL_ARG3(ctx, module_name, xpath);
     bool has_enabled_subtree = false;
     int rc = SR_ERR_OK;
-
-    CHECK_NULL_ARG4(ctx, session, module_name, xpath);
 
     if (NULL == module) {
         /* if module is not known, get it and check if it has some enabled subtree */

--- a/src/data_manager.c
+++ b/src/data_manager.c
@@ -2956,6 +2956,8 @@ dm_enable_module_running(dm_ctx_t *ctx, dm_session_t *session, const char *modul
     char xpath[PATH_MAX] = {0,};
     int rc = SR_ERR_OK;
 
+    CHECK_NULL_ARG3(ctx, session, module_name);
+
     if (NULL == module) {
         /* if module is not known, get it and check if it has some enabled subtree */
         rc = dm_has_enabled_subtree(ctx, module_name, &module, &has_enabled_subtree);
@@ -2985,9 +2987,11 @@ int
 dm_enable_module_subtree_running(dm_ctx_t *ctx, dm_session_t *session, const char *module_name, const char *xpath,
         const struct lys_module *module, bool copy_from_startup)
 {
-    CHECK_NULL_ARG3(ctx, module_name, xpath);
+    CHECK_NULL_ARG2(ctx, module_name);
     bool has_enabled_subtree = false;
     int rc = SR_ERR_OK;
+
+    CHECK_NULL_ARG4(ctx, session, module_name, xpath);
 
     if (NULL == module) {
         /* if module is not known, get it and check if it has some enabled subtree */

--- a/src/executables/sysrepocfg.c
+++ b/src/executables/sysrepocfg.c
@@ -233,42 +233,6 @@ srcfg_get_module_data(struct ly_ctx *ly_ctx, const char *module_name, struct lyd
     *data_tree = NULL;
     ly_errno = LY_SUCCESS;
     while (SR_ERR_OK == (rc = sr_get_item_next(srcfg_session, iter, &value))) {
-
-#if 0 /* XXX temporarily here for testing purposes */
-        printf("%s ", value->xpath);
-        switch (value->type) {
-            case SR_CONTAINER_T:
-                printf("(container)\n");
-                break;
-            case SR_CONTAINER_PRESENCE_T:
-                printf("(presence container)\n");
-                break;
-            case SR_LIST_T:
-                printf("(list instance)\n");
-                break;
-            case SR_STRING_T:
-                printf("= %s\n", value->data.string_val);
-                break;
-            case SR_BOOL_T:
-                printf("= %s\n", value->data.bool_val ? "true" : "false");
-                break;
-            case SR_UINT8_T:
-                printf("= %u\n", value->data.uint8_val);
-                break;
-            case SR_UINT16_T:
-                printf("= %u\n", value->data.uint16_val);
-                break;
-            case SR_UINT32_T:
-                printf("= %u\n", value->data.uint32_val);
-                break;
-            case SR_IDENTITYREF_T:
-                printf("= %s\n", value->data.identityref_val);
-                break;
-            default:
-                printf("(unprintable)\n");
-        }
-#endif
-
         /* get node schema */
         schema = ly_ctx_get_node2(ly_ctx, NULL, value->xpath, 0);
         if (!schema) {
@@ -605,13 +569,6 @@ srcfg_import_datastore(struct ly_ctx *ly_ctx, int fd_in, const char *module_name
     if (SR_ERR_OK != rc) {
         goto cleanup;
     }
-
-#if 0 /* XXX temporarily here for testing purposes */
-    printf("CURRENT CONFIG:\n");
-    lyd_print_fd(STDOUT_FILENO, current_data_tree, LYD_XML, LYP_WITHSIBLINGS | LYP_FORMAT);
-    printf("NEW CONFIG:\n");
-    lyd_print_fd(STDOUT_FILENO, new_data_tree, LYD_XML, LYP_WITHSIBLINGS | LYP_FORMAT);
-#endif
 
     /* get the list of changes made by the user */
     diff = lyd_diff(current_data_tree, new_data_tree, 0);

--- a/src/request_processor.c
+++ b/src/request_processor.c
@@ -1,6 +1,7 @@
 /**
  * @file request_processor.c
- * @author Rastislav Szabo <raszabo@cisco.com>, Lukas Macko <lmacko@cisco.com>
+ * @author Rastislav Szabo <raszabo@cisco.com>, Lukas Macko <lmacko@cisco.com>,
+ *         Milan Lenco <milan.lenco@pantheon.tech>
  * @brief Implementation of Sysrepo's Request Processor.
  *
  * @copyright

--- a/src/sysrepo.proto
+++ b/src/sysrepo.proto
@@ -504,6 +504,18 @@ message UnsubscribeReq {
 message UnsubscribeResp {
 }
 
+/**
+ * @brief Checks whether the module has any enabled subtree.
+ * Sent by sr_check_enabled_running.
+ */
+message CheckEnabledRunningReq {
+  required string module_name = 1;
+}
+
+message CheckEnabledRunningResp {
+  required bool enabled = 1;
+}
+
 message ModuleInstallNotification {
   optional string module_name = 1;
   optional string revision = 2;
@@ -592,6 +604,7 @@ enum Operation {
 
   SUBSCRIBE = 70;
   UNSUBSCRIBE = 71;
+  CHECK_ENABLED_RUNNING = 72;
 
   RPC = 80;
 
@@ -631,6 +644,7 @@ message Request {
 
   optional SubscribeReq subscribe_req = 70;
   optional UnsubscribeReq unsubscribe_req = 71;
+  optional CheckEnabledRunningReq check_enabled_running_req = 72;
 
   optional RPCReq rpc_req = 80;
 }
@@ -670,6 +684,7 @@ message Response {
 
   optional SubscribeResp subscribe_resp = 70;
   optional UnsubscribeResp unsubscribe_resp = 71;
+  optional CheckEnabledRunningResp check_enabled_running_resp = 72;
 
   optional RPCResp rpc_resp = 80;
 }

--- a/src/sysrepo.proto
+++ b/src/sysrepo.proto
@@ -1,6 +1,7 @@
 /**
  * @file sysreo.proto
- * @author Rastislav Szabo <raszabo@cisco.com>, Lukas Macko <lmacko@cisco.com>
+ * @author Rastislav Szabo <raszabo@cisco.com>, Lukas Macko <lmacko@cisco.com>,
+ *         Milan Lenco <milan.lenco@pantheon.tech>
  * @brief Definition of sysrepo GPB messages used as the API for the
  * communication between sysrepo engine and sysrepo client library.
  *

--- a/tests/sysrepocfg_test.c
+++ b/tests/sysrepocfg_test.c
@@ -62,9 +62,6 @@ srcfg_test_subscription_t srcfg_test_subscriptions[MAX_SUBS];
 static int
 srcfg_test_cmp_data_file_content(const char *file_path, LYD_FORMAT file_format, const char *exp, LYD_FORMAT exp_format)
 {
-    if (file_format == LYD_JSON || exp_format == LYD_JSON) {
-        return 0;
-    }
     int fd = -1;
     struct lyd_node *file_data = NULL, *exp_data = NULL;
     struct lyd_difflist *diff = NULL;

--- a/tests/sysrepocfg_test.c
+++ b/tests/sysrepocfg_test.c
@@ -31,6 +31,8 @@
 #include <fcntl.h>
 #include <sys/types.h>
 #include <sys/stat.h>
+#include <sys/mman.h>
+#include <libyang/libyang.h>
 
 #include "sysrepo.h"
 #include "sr_common.h"
@@ -39,48 +41,191 @@
 
 #define FILENAME_NEW_CONFIG   "sysrepocfg_test-new_config.txt"
 #define FILENAME_USER_INPUT   "sysrepocfg_test-user_input.txt"
+#define MAX_SUBS              16
 
-static char *sysrepocfg_datastore = NULL;
+struct ly_ctx *srcfg_test_libyang_ctx = NULL;
+static char *srcfg_test_datastore = NULL;
+static sr_conn_ctx_t *srcfg_test_connection = NULL;
+static sr_session_ctx_t *srcfg_test_session = NULL;
+
+typedef struct srcfg_test_subscription_e {
+    sr_subscription_ctx_t *subscription;
+    char *module_name;
+} srcfg_test_subscription_t;
+
+srcfg_test_subscription_t srcfg_test_subscriptions[MAX_SUBS];
+
+
+/**
+ * @brief Compare data file content against a string using libyang's lyd_diff.
+ */
+static int
+srcfg_test_cmp_data_file_content(const char *file_path, LYD_FORMAT file_format, const char *exp, LYD_FORMAT exp_format)
+{
+    if (file_format == LYD_JSON || exp_format == LYD_JSON) {
+        return 0;
+    }
+    int fd = -1;
+    struct lyd_node *file_data = NULL, *exp_data = NULL;
+    struct lyd_difflist *diff = NULL;
+    size_t count = 0;
+
+    fd = open(file_path, O_RDONLY);
+    assert_true(fd >= 0);
+
+    file_data = lyd_parse_fd(srcfg_test_libyang_ctx, fd, file_format, LYD_OPT_STRICT | LYD_OPT_CONFIG);
+    assert(file_data || LY_SUCCESS == ly_errno);
+    exp_data = lyd_parse_mem(srcfg_test_libyang_ctx, exp, exp_format, LYD_OPT_STRICT | LYD_OPT_CONFIG);
+    assert(exp_data || LY_SUCCESS == ly_errno);
+
+    lyd_wd_cleanup(&file_data, 0);
+    lyd_wd_cleanup(&exp_data, 0);
+
+    diff = lyd_diff(file_data, exp_data, 0);
+    assert_non_null(diff);
+
+    while (diff->type && LYD_DIFF_END != diff->type[count]) {
+        printf("first: %s; second: %s\n", lyd_path(diff->first[count]), lyd_path(diff->second[count]));
+        ++count;
+    }
+
+    if (count > 0) {
+        fprintf(stderr, "file data:\n");
+        lyd_print_fd(STDERR_FILENO, file_data, LYD_XML, LYP_WITHSIBLINGS | LYP_FORMAT);
+        fprintf(stderr, "exp data:\n");
+        lyd_print_fd(STDERR_FILENO, exp_data, LYD_XML, LYP_WITHSIBLINGS | LYP_FORMAT);
+    }
+
+    lyd_free_diff(diff);
+    if (NULL != file_data) {
+        lyd_free_withsiblings(file_data);
+    }
+    if (NULL != exp_data) {
+        lyd_free_withsiblings(exp_data);
+    }
+
+    close(fd);
+    return count;
+}
+
+/**
+ * @brief Compare two data files using libyang's lyd_diff.
+ */
+static int
+srcfg_test_cmp_data_files(const char *file1_path, LYD_FORMAT file1_format, const char *file2_path, LYD_FORMAT file2_format)
+{
+    int rc = -1, fd = -1;
+    struct stat file_info = {0};
+    char *file2_content = NULL;
+
+    fd = open(file2_path, O_RDONLY);
+    assert_true(fd >= 0);
+
+    assert_int_equal(0, fstat(fd, &file_info));
+    file2_content = mmap(0, file_info.st_size, PROT_READ, MAP_SHARED, fd, 0);
+    assert_true(file2_content && MAP_FAILED != file2_content);
+
+    rc = srcfg_test_cmp_data_file_content(file1_path, file1_format, file2_content, file2_format);
+
+    assert_int_equal(0, munmap(file2_content, file_info.st_size));
+    close(fd);
+    return rc;
+}
 
 static int
-sysrepocfg_set_startup_datastore(void **state)
+srcfg_test_module_change_cb(sr_session_ctx_t *session, const char *module_name, sr_notif_event_t event,
+                            void *private_ctx)
 {
-    sysrepocfg_datastore = strdup("startup");
-    assert_non_null(sysrepocfg_datastore);
+    return SR_ERR_OK;
+}
+
+static int
+srcfg_test_subscribe(const char *module_name)
+{
+    int rc = SR_ERR_OK;
+    unsigned i = 0;
+
+    /* already subscribed? */
+    for (i = 0; i < MAX_SUBS; ++i) {
+        if (NULL != srcfg_test_subscriptions[i].subscription &&
+            0 == strcmp(module_name, srcfg_test_subscriptions[i].module_name)) {
+            return rc;
+        }
+    }
+
+    /* find first free slot */
+    i = 0;
+    while (MAX_SUBS > i && NULL != srcfg_test_subscriptions[i].subscription) {
+        ++i;
+    }
+    if (MAX_SUBS == i) {
+        return SR_ERR_INTERNAL;
+    }
+
+    /* subscribe */
+    rc = sr_module_change_subscribe(srcfg_test_session, module_name, srcfg_test_module_change_cb, NULL, 0,
+                                    SR_SUBSCR_DEFAULT, &(srcfg_test_subscriptions[i].subscription));
+    if (SR_ERR_OK == rc) {
+        srcfg_test_subscriptions[i].module_name = strdup(module_name);
+    }
+    return rc;
+}
+
+static int
+srcfg_test_unsubscribe(const char *module_name)
+{
+    for (unsigned i = 0; i < MAX_SUBS; ++i) {
+        if (NULL != srcfg_test_subscriptions[i].subscription &&
+            0 == strcmp(module_name, srcfg_test_subscriptions[i].module_name)) {
+            free(srcfg_test_subscriptions[i].module_name);
+            srcfg_test_subscriptions[i].module_name = NULL;
+            int rc = sr_unsubscribe(srcfg_test_session, srcfg_test_subscriptions[i].subscription);
+            srcfg_test_subscriptions[i].subscription = NULL;
+            return rc;
+        }
+    }
+    return SR_ERR_OK;
+}
+
+static int
+srcfg_test_set_startup_datastore(void **state)
+{
+    srcfg_test_datastore = strdup("startup");
+    assert_non_null(srcfg_test_datastore);
     return 0;
 }
 
 static int
-sysrepocfg_set_running_datastore(void **state)
+srcfg_test_set_running_datastore(void **state)
 {
-    sysrepocfg_datastore = strdup("running");
-    assert_non_null(sysrepocfg_datastore);
+    srcfg_test_datastore = strdup("running");
+    assert_non_null(srcfg_test_datastore);
     return 0;
 }
 
 static int
-sysrepocfg_test_teardown(void **state)
+srcfg_test_teardown(void **state)
 {
-    free(sysrepocfg_datastore);
-    sysrepocfg_datastore = NULL;
+    free(srcfg_test_datastore);
+    srcfg_test_datastore = NULL;
     return 0;
 }
 
 static void
-sysrepocfg_test_version(void **state)
+srcfg_test_version(void **state)
 {
     exec_shell_command("../src/sysrepocfg -v",
                        "^sysrepocfg - sysrepo configuration tool, version [0-9]\\.[0-9]\\.[0-9]\\s*$", true, 0);
 }
 
 static void
-sysrepocfg_test_help(void **state)
+srcfg_test_help(void **state)
 {
     exec_shell_command("../src/sysrepocfg -h", "Usage:", true, 0);
 }
 
 static void
-sysrepocfg_test_export(void **state)
+srcfg_test_export(void **state)
 {
     /* invalid arguments */
     exec_shell_command("../src/sysrepocfg --export --datastore=startup --format=txt ietf-interfaces > /tmp/ietf-interfaces.startup.xml", "", true, 1);
@@ -93,54 +238,59 @@ sysrepocfg_test_export(void **state)
     /* ietf-interfaces */
     /*  startup, xml */
     exec_shell_command("../src/sysrepocfg --export --datastore=startup --format=xml ietf-interfaces > /tmp/ietf-interfaces.startup.xml", "", true, 0);
-    assert_int_equal(0, compare_files("/tmp/ietf-interfaces.startup.xml", TEST_DATA_SEARCH_DIR "ietf-interfaces.startup"));
+    assert_int_equal(0, srcfg_test_cmp_data_files("/tmp/ietf-interfaces.startup.xml", LYD_XML, TEST_DATA_SEARCH_DIR "ietf-interfaces.startup", LYD_XML));
     /*  startup, json */
-    unlink("/tmp/ietf-interfaces.startup.json");
     exec_shell_command("../src/sysrepocfg --export=/tmp/ietf-interfaces.startup.json --datastore=startup --format=json ietf-interfaces", "", true, 0);
-    test_file_exists("/tmp/ietf-interfaces.startup.json", true);
+    assert_int_equal(0, srcfg_test_cmp_data_files("/tmp/ietf-interfaces.startup.json", LYD_JSON, TEST_DATA_SEARCH_DIR "ietf-interfaces.startup", LYD_XML));
     /*  running, xml */
+    exec_shell_command("../src/sysrepocfg --export --datastore=running --format=xml ietf-interfaces", "no active subscriptions", true, 1);
+    assert_int_equal(0, srcfg_test_subscribe("ietf-interfaces"));
     exec_shell_command("../src/sysrepocfg --export --datastore=running --format=xml ietf-interfaces > /tmp/ietf-interfaces.running.xml", "", true, 0);
-    assert_int_equal(0, compare_files("/tmp/ietf-interfaces.running.xml", TEST_DATA_SEARCH_DIR "ietf-interfaces.startup"));
+    assert_int_equal(0, srcfg_test_cmp_data_files("/tmp/ietf-interfaces.running.xml", LYD_XML, TEST_DATA_SEARCH_DIR "ietf-interfaces.running", LYD_XML));
     /*  running, json */
-    unlink("/tmp/ietf-interfaces.running.json");
     exec_shell_command("../src/sysrepocfg --export=/tmp/ietf-interfaces.running.json --datastore=running --format=json ietf-interfaces", "", true, 0);
-    test_file_exists("/tmp/ietf-interfaces.running.json", true);
+    assert_int_equal(0, srcfg_test_cmp_data_files("/tmp/ietf-interfaces.running.json", LYD_JSON, TEST_DATA_SEARCH_DIR "ietf-interfaces.running", LYD_XML));
 
     /* test-module */
     /*  startup, xml */
     exec_shell_command("../src/sysrepocfg --export --datastore=startup --format=xml test-module > /tmp/test-module.startup.xml", "", true, 0);
-    assert_int_equal(0, compare_files("/tmp/test-module.startup.xml", TEST_DATA_SEARCH_DIR "test-module.startup"));
+    assert_int_equal(0, srcfg_test_cmp_data_files("/tmp/test-module.startup.xml", LYD_XML, TEST_DATA_SEARCH_DIR "test-module.startup", LYD_XML));
     /*  startup, json */
-    unlink("/tmp/test-module.startup.json");
     exec_shell_command("../src/sysrepocfg --export=/tmp/test-module.startup.json --datastore=startup --format=json test-module", "", true, 0);
-    test_file_exists("/tmp/test-module.startup.json", true);
+    assert_int_equal(0, srcfg_test_cmp_data_files("/tmp/test-module.startup.json", LYD_JSON, TEST_DATA_SEARCH_DIR "test-module.startup", LYD_XML));
     /*  running, xml */
+    exec_shell_command("../src/sysrepocfg --export --datastore=running --format=xml test-module", "no active subscriptions", true, 1);
+    assert_int_equal(0, srcfg_test_subscribe("test-module"));
     exec_shell_command("../src/sysrepocfg --export --datastore=running --format=xml test-module > /tmp/test-module.running.xml", "", true, 0);
-    assert_int_equal(0, compare_files("/tmp/test-module.running.xml", TEST_DATA_SEARCH_DIR "test-module.startup"));
+    assert_int_equal(0, srcfg_test_cmp_data_files("/tmp/test-module.running.xml", LYD_XML, TEST_DATA_SEARCH_DIR "test-module.running", LYD_XML));
     /*  running, json */
-    unlink("/tmp/test-module.running.json");
     exec_shell_command("../src/sysrepocfg --export=/tmp/test-module.running.json --datastore=running --format=json test-module", "", true, 0);
-    test_file_exists("/tmp/test-module.running.json", true);
+    assert_int_equal(0, srcfg_test_cmp_data_files("/tmp/test-module.running.json", LYD_JSON, TEST_DATA_SEARCH_DIR "test-module.running", LYD_XML));
 
     /* example-module */
     /*  startup, xml */
     exec_shell_command("../src/sysrepocfg --export --datastore=startup --format=xml example-module > /tmp/example-module.startup.xml", "", true, 0);
-    assert_int_equal(0, compare_files("/tmp/example-module.startup.xml", TEST_DATA_SEARCH_DIR "example-module.startup"));
+    assert_int_equal(0, srcfg_test_cmp_data_files("/tmp/example-module.startup.xml", LYD_XML, TEST_DATA_SEARCH_DIR "example-module.startup", LYD_XML));
     /*  startup, json */
-    unlink("/tmp/example-module.startup.json");
     exec_shell_command("../src/sysrepocfg --export=/tmp/example-module.startup.json --datastore=startup --format=json example-module", "", true, 0);
-    test_file_exists("/tmp/example-module.startup.json", true);
+    assert_int_equal(0, srcfg_test_cmp_data_files("/tmp/example-module.startup.json", LYD_JSON, TEST_DATA_SEARCH_DIR "example-module.startup", LYD_XML));
     /*  running, xml */
+    exec_shell_command("../src/sysrepocfg --export --datastore=running --format=xml example-module", "no active subscriptions", true, 1);
+    assert_int_equal(0, srcfg_test_subscribe("example-module"));
     exec_shell_command("../src/sysrepocfg --export --datastore=running --format=xml example-module > /tmp/example-module.running.xml", "", true, 0);
-    assert_int_equal(0, compare_files("/tmp/example-module.running.xml", TEST_DATA_SEARCH_DIR "example-module.startup"));
+    assert_int_equal(0, srcfg_test_cmp_data_files("/tmp/example-module.running.xml", LYD_XML, TEST_DATA_SEARCH_DIR "example-module.running", LYD_XML));
     /*  running, json */
-    unlink("/tmp/example-module.running.json");
     exec_shell_command("../src/sysrepocfg --export=/tmp/example-module.running.json --datastore=running --format=json example-module", "", true, 0);
-    test_file_exists("/tmp/example-module.running.json", true);
+    assert_int_equal(0, srcfg_test_cmp_data_files("/tmp/example-module.running.json", LYD_JSON, TEST_DATA_SEARCH_DIR "example-module.running", LYD_XML));
+
+    /* restore pre-test state */
+    assert_int_equal(0, srcfg_test_unsubscribe("ietf-interfaces"));
+    assert_int_equal(0, srcfg_test_unsubscribe("test-module"));
+    assert_int_equal(0, srcfg_test_unsubscribe("example-module"));
 }
 
 static void
-sysrepocfg_test_import(void **state)
+srcfg_test_import(void **state)
 {
     /* invalid arguments */
     exec_shell_command("../src/sysrepocfg --import --datastore=startup --format=txt ietf-interfaces < /tmp/ietf-interfaces.startup.xml", "", true, 1);
@@ -148,53 +298,70 @@ sysrepocfg_test_import(void **state)
     exec_shell_command("../src/sysrepocfg --import --datastore=running --format=txt ietf-interfaces < /tmp/ietf-interfaces.running.xml", "", true, 1);
     exec_shell_command("../src/sysrepocfg --import=/tmp/ietf-interfaces.running.xml --datastore=running --format=xml", "", true, 1);
 
-    /* import ietf-interfaces, test-module and example-module startup config from temporary files */
+    /* import ietf-interfaces, test-module and example-module configuration from temporary files */
 
     /* ietf-interfaces */
     /*  startup, xml */
     exec_shell_command("../src/sysrepocfg --import --datastore=startup --format=xml ietf-interfaces < /tmp/ietf-interfaces.startup.xml", "", true, 0);
-    assert_int_equal(0, compare_files("/tmp/ietf-interfaces.startup.xml", TEST_DATA_SEARCH_DIR "ietf-interfaces.startup"));
+    assert_int_equal(0, srcfg_test_cmp_data_files("/tmp/ietf-interfaces.startup.xml", LYD_XML, TEST_DATA_SEARCH_DIR "ietf-interfaces.startup", LYD_XML));
     /*  startup, json */
     exec_shell_command("../src/sysrepocfg --import=/tmp/ietf-interfaces.startup.json --datastore=startup --format=json ietf-interfaces", "", true, 0);
-    assert_int_equal(0, compare_files("/tmp/ietf-interfaces.startup.xml", TEST_DATA_SEARCH_DIR "ietf-interfaces.startup"));
+    assert_int_equal(0, srcfg_test_cmp_data_files("/tmp/ietf-interfaces.startup.json", LYD_JSON, TEST_DATA_SEARCH_DIR "ietf-interfaces.startup", LYD_XML));
     /*  running, xml */
+    exec_shell_command("../src/sysrepocfg --import --datastore=running --format=xml ietf-interfaces < /tmp/ietf-interfaces.running.xml",
+                       "no active subscriptions", true, 1);
+    assert_int_equal(0, srcfg_test_subscribe("ietf-interfaces"));
     exec_shell_command("../src/sysrepocfg --import --datastore=running --format=xml ietf-interfaces < /tmp/ietf-interfaces.running.xml", "", true, 0);
-    assert_int_equal(0, compare_files("/tmp/ietf-interfaces.running.xml", TEST_DATA_SEARCH_DIR "ietf-interfaces.startup"));
-    /*  running, json */
-    exec_shell_command("../src/sysrepocfg --import=/tmp/ietf-interfaces.running.json --datastore=running --format=json ietf-interfaces", "", true, 0);
-    assert_int_equal(0, compare_files("/tmp/ietf-interfaces.running.xml", TEST_DATA_SEARCH_DIR "ietf-interfaces.startup"));
+    assert_int_equal(0, srcfg_test_cmp_data_files("/tmp/ietf-interfaces.running.xml", LYD_XML, TEST_DATA_SEARCH_DIR "ietf-interfaces.running", LYD_XML));
+    /*  running, json, permanent */
+    exec_shell_command("../src/sysrepocfg --permanent --import=/tmp/ietf-interfaces.running.json --datastore=running --format=json ietf-interfaces", "", true, 0);
+    assert_int_equal(0, srcfg_test_cmp_data_files("/tmp/ietf-interfaces.running.json", LYD_JSON, TEST_DATA_SEARCH_DIR "ietf-interfaces.running", LYD_XML));
+    assert_int_equal(0, srcfg_test_cmp_data_files("/tmp/ietf-interfaces.running.json", LYD_JSON, TEST_DATA_SEARCH_DIR "ietf-interfaces.startup", LYD_XML));
 
     /* test-module */
     /*  startup, xml */
     exec_shell_command("../src/sysrepocfg --import --datastore=startup --format=xml test-module < /tmp/test-module.startup.xml", "", true, 0);
-    assert_int_equal(0, compare_files("/tmp/test-module.startup.xml", TEST_DATA_SEARCH_DIR "test-module.startup"));
+    assert_int_equal(0, srcfg_test_cmp_data_files("/tmp/test-module.startup.xml", LYD_XML, TEST_DATA_SEARCH_DIR "test-module.startup", LYD_XML));
     /*  startup, json */
     exec_shell_command("../src/sysrepocfg --import=/tmp/test-module.startup.json --datastore=startup --format=json test-module", "", true, 0);
-    assert_int_equal(0, compare_files("/tmp/test-module.startup.xml", TEST_DATA_SEARCH_DIR "test-module.startup"));
+    assert_int_equal(0, srcfg_test_cmp_data_files("/tmp/test-module.startup.json", LYD_JSON, TEST_DATA_SEARCH_DIR "test-module.startup", LYD_XML));
     /*  running, xml */
+    exec_shell_command("../src/sysrepocfg --import --datastore=running --format=xml test-module < /tmp/test-module.running.xml",
+                       "no active subscriptions", true, 1);
+    assert_int_equal(0, srcfg_test_subscribe("test-module"));
     exec_shell_command("../src/sysrepocfg --import --datastore=running --format=xml test-module < /tmp/test-module.running.xml", "", true, 0);
-    assert_int_equal(0, compare_files("/tmp/test-module.running.xml", TEST_DATA_SEARCH_DIR "test-module.startup"));
-    /*  running, json */
-    exec_shell_command("../src/sysrepocfg --import=/tmp/test-module.running.json --datastore=running --format=json test-module", "", true, 0);
-    assert_int_equal(0, compare_files("/tmp/test-module.running.xml", TEST_DATA_SEARCH_DIR "test-module.startup"));
+    assert_int_equal(0, srcfg_test_cmp_data_files("/tmp/test-module.running.xml", LYD_XML, TEST_DATA_SEARCH_DIR "test-module.running", LYD_XML));
+    /*  running, json, permanent */
+    exec_shell_command("../src/sysrepocfg --permanent --import=/tmp/test-module.running.json --datastore=running --format=json test-module", "", true, 0);
+    assert_int_equal(0, srcfg_test_cmp_data_files("/tmp/test-module.running.json", LYD_JSON, TEST_DATA_SEARCH_DIR "test-module.running", LYD_XML));
+    assert_int_equal(0, srcfg_test_cmp_data_files("/tmp/test-module.running.json", LYD_JSON, TEST_DATA_SEARCH_DIR "test-module.startup", LYD_XML));
 
     /* example-module */
     /*  startup, xml */
     exec_shell_command("../src/sysrepocfg --import --datastore=startup --format=xml example-module < /tmp/example-module.startup.xml", "", true, 0);
-    assert_int_equal(0, compare_files("/tmp/example-module.startup.xml", TEST_DATA_SEARCH_DIR "example-module.startup"));
+    assert_int_equal(0, srcfg_test_cmp_data_files("/tmp/example-module.startup.xml", LYD_XML, TEST_DATA_SEARCH_DIR "example-module.startup", LYD_XML));
     /*  startup, json */
     exec_shell_command("../src/sysrepocfg --import=/tmp/example-module.startup.json --datastore=startup --format=json example-module", "", true, 0);
-    assert_int_equal(0, compare_files("/tmp/example-module.startup.xml", TEST_DATA_SEARCH_DIR "example-module.startup"));
+    assert_int_equal(0, srcfg_test_cmp_data_files("/tmp/example-module.startup.json", LYD_JSON, TEST_DATA_SEARCH_DIR "example-module.startup", LYD_XML));
     /*  running, xml */
+    exec_shell_command("../src/sysrepocfg --import --datastore=running --format=xml example-module < /tmp/example-module.running.xml",
+                       "no active subscriptions", true, 1);
+    assert_int_equal(0, srcfg_test_subscribe("example-module"));
     exec_shell_command("../src/sysrepocfg --import --datastore=running --format=xml example-module < /tmp/example-module.running.xml", "", true, 0);
-    assert_int_equal(0, compare_files("/tmp/example-module.running.xml", TEST_DATA_SEARCH_DIR "example-module.startup"));
-    /*  running, json */
-    exec_shell_command("../src/sysrepocfg --import=/tmp/example-module.running.json --datastore=running --format=json example-module", "", true, 0);
-    assert_int_equal(0, compare_files("/tmp/example-module.running.xml", TEST_DATA_SEARCH_DIR "example-module.startup"));
+    assert_int_equal(0, srcfg_test_cmp_data_files("/tmp/example-module.running.xml", LYD_XML, TEST_DATA_SEARCH_DIR "example-module.running", LYD_XML));
+    /*  running, json, permanent */
+    exec_shell_command("../src/sysrepocfg --permanent --import=/tmp/example-module.running.json --datastore=running --format=json example-module", "", true, 0);
+    assert_int_equal(0, srcfg_test_cmp_data_files("/tmp/example-module.running.json", LYD_JSON, TEST_DATA_SEARCH_DIR "example-module.running", LYD_XML));
+    assert_int_equal(0, srcfg_test_cmp_data_files("/tmp/example-module.running.json", LYD_JSON, TEST_DATA_SEARCH_DIR "example-module.startup", LYD_XML));
+
+    /* restore pre-test state */
+    assert_int_equal(0, srcfg_test_unsubscribe("ietf-interfaces"));
+    assert_int_equal(0, srcfg_test_unsubscribe("test-module"));
+    assert_int_equal(0, srcfg_test_unsubscribe("example-module"));
 }
 
 static void
-sysrepocfg_test_prepare_config(const char *config)
+srcfg_test_prepare_config(const char *config)
 {
     FILE *fp = fopen(FILENAME_NEW_CONFIG, "w");
     assert_non_null(fp);
@@ -203,7 +370,7 @@ sysrepocfg_test_prepare_config(const char *config)
 }
 
 static void
-sysrepocfg_test_prepare_user_input(const char *input)
+srcfg_test_prepare_user_input(const char *input)
 {
     FILE *fp = fopen(FILENAME_USER_INPUT, "w");
     assert_non_null(fp);
@@ -212,7 +379,7 @@ sysrepocfg_test_prepare_user_input(const char *input)
 }
 
 static void
-sysrepocfg_test_editing(void **state)
+srcfg_test_editing(void **state)
 {
     char cmd[PATH_MAX] = { 0, };
     char *args = NULL;
@@ -228,7 +395,7 @@ sysrepocfg_test_editing(void **state)
     strcat(cmd, "cat " FILENAME_USER_INPUT " | PATH=");
     assert_non_null(getcwd(cmd + strlen(cmd), PATH_MAX - strlen(cmd)));
     strcat(cmd, ":$PATH ../src/sysrepocfg --editor=sysrepocfg_test_editor.sh --datastore=");
-    strcat(cmd, sysrepocfg_datastore);
+    strcat(cmd, srcfg_test_datastore);
     strcat(cmd, " ");
     args = cmd + strlen(cmd);
 
@@ -236,6 +403,7 @@ sysrepocfg_test_editing(void **state)
      * module: test-module
      * format: default(xml)
      * valid?: yes
+     * permanent?: no
      **/
     char *test_module1 = "<user xmlns=\"urn:ietf:params:xml:ns:yang:test-module\">\n"
         "  <name>nameA</name>\n"
@@ -254,17 +422,26 @@ sysrepocfg_test_editing(void **state)
         "  <name>nameE</name>\n"
         "  <type>typeE</type>\n"
         "</user>\n";
-    sysrepocfg_test_prepare_config(test_module1);
-    sysrepocfg_test_prepare_user_input("");
+    srcfg_test_prepare_config(test_module1);
+    srcfg_test_prepare_user_input("");
     strcpy(args,"test-module");
+    if (0 == strcmp("running", srcfg_test_datastore)) {
+        exec_shell_command(cmd, "no active subscriptions", true, 1);
+        assert_int_equal(0, srcfg_test_subscribe("test-module"));
+    }
     exec_shell_command(cmd, "The new configuration was successfully applied.", true, 0);
-    exec_shell_command("../src/sysrepocfg --export --datastore=startup --format=xml test-module > /tmp/test-module_edited.xml", "", true, 0);
-    test_file_content("/tmp/test-module_edited.xml", test_module1, false);
+    if (0 == strcmp("running", srcfg_test_datastore)) {
+        exec_shell_command("../src/sysrepocfg --export --datastore=running --format=xml test-module > /tmp/test-module_edited.xml", "", true, 0);
+    } else {
+        exec_shell_command("../src/sysrepocfg --export --datastore=startup --format=xml test-module > /tmp/test-module_edited.xml", "", true, 0);
+    }
+    srcfg_test_cmp_data_file_content("/tmp/test-module_edited.xml", LYD_XML, test_module1, LYD_XML);
 
     /**
      * module: test-module
      * format: default(xml)
      * valid?: yes
+     * permanent?: yes
      **/
     char *test_module2 = "<user xmlns=\"urn:ietf:params:xml:ns:yang:test-module\">\n"
         "  <name>nameA</name>\n"
@@ -287,17 +464,22 @@ sysrepocfg_test_editing(void **state)
         "  <name>nameE</name>\n"
         "  <type>typeE2</type>\n" /* changed */
         "</user>\n";
-    sysrepocfg_test_prepare_config(test_module2);
-    sysrepocfg_test_prepare_user_input("");
-    strcpy(args,"test-module");
+    srcfg_test_prepare_config(test_module2);
+    srcfg_test_prepare_user_input("");
+    strcpy(args,"--permanent test-module");
     exec_shell_command(cmd, "The new configuration was successfully applied.", true, 0);
+    if (0 == strcmp("running", srcfg_test_datastore)) {
+        exec_shell_command("../src/sysrepocfg --export --datastore=running --format=xml test-module > /tmp/test-module_edited.xml", "", true, 0);
+        srcfg_test_cmp_data_file_content("/tmp/test-module_edited.xml", LYD_XML, test_module2, LYD_XML);
+    }
     exec_shell_command("../src/sysrepocfg --export --datastore=startup --format=xml test-module > /tmp/test-module_edited.xml", "", true, 0);
-    test_file_content("/tmp/test-module_edited.xml", test_module2, false);
+    srcfg_test_cmp_data_file_content("/tmp/test-module_edited.xml", LYD_XML, test_module2, LYD_XML);
 
     /**
      * module: test-module
      * format: json
      * valid?: yes (reverting to test_module1)
+     * permanent?: yes
      **/
     char *test_module3 = "{\n"
             "\"test-module:user\": [\n"
@@ -319,17 +501,22 @@ sysrepocfg_test_editing(void **state)
                 "}\n"
             "]\n"
         "}\n";
-    sysrepocfg_test_prepare_config(test_module3);
-    sysrepocfg_test_prepare_user_input("");
-    strcpy(args,"--format=json test-module");
+    srcfg_test_prepare_config(test_module3);
+    srcfg_test_prepare_user_input("");
+    strcpy(args,"--format=json --permanent test-module");
     exec_shell_command(cmd, "The new configuration was successfully applied.", true, 0);
+    if (0 == strcmp("running", srcfg_test_datastore)) {
+        exec_shell_command("../src/sysrepocfg --export --datastore=running --format=xml test-module > /tmp/test-module_edited.xml", "", true, 0);
+        srcfg_test_cmp_data_file_content("/tmp/test-module_edited.xml", LYD_XML, test_module3, LYD_JSON);
+    }
     exec_shell_command("../src/sysrepocfg --export --datastore=startup --format=xml test-module > /tmp/test-module_edited.xml", "", true, 0);
-    test_file_content("/tmp/test-module_edited.xml", test_module1, false);
+    srcfg_test_cmp_data_file_content("/tmp/test-module_edited.xml", LYD_XML, test_module3, LYD_JSON);
 
     /**
      * module: test-module
      * format: default(xml)
      * valid?: no
+     * permanent?: no
      **/
     char *test_module4 = "<user xmlns=\"urn:ietf:params:xml:ns:yang:test-module\">\n"
         "  <name>nameA</name>\n"
@@ -344,8 +531,8 @@ sysrepocfg_test_editing(void **state)
         "user xmlns=\"urn:ietf:params:xml:ns:yang:test-module\">\n"
         "  <name>nameD</name>\n"
         "</user>\n";
-    sysrepocfg_test_prepare_config(test_module4);
-    sysrepocfg_test_prepare_user_input("y\n y\n n\n y\n sysrepocfg_test-dump.txt\n"); /* 3 failed attempts, then save to local file */
+    srcfg_test_prepare_config(test_module4);
+    srcfg_test_prepare_user_input("y\n y\n n\n y\n sysrepocfg_test-dump.txt\n"); /* 3 failed attempts, then save to local file */
     strcpy(args,"test-module");
     exec_shell_command(cmd, "(.*Unable to apply the changes.*){3}"
                             "Your changes have been saved to 'sysrepocfg_test-dump.txt'", true, 1);
@@ -355,6 +542,7 @@ sysrepocfg_test_editing(void **state)
      * module: example-module
      * format: json
      * valid?: yes
+     * permanent?: yes
      **/
     char *example_module1 = "{\n"
         "  \"example-module:container\": {\n"
@@ -372,17 +560,26 @@ sysrepocfg_test_editing(void **state)
         "    ]\n"
         "  }\n"
         "}\n";
-    sysrepocfg_test_prepare_config(example_module1);
-    sysrepocfg_test_prepare_user_input("");
-    strcpy(args,"--format=json example-module");
+    srcfg_test_prepare_config(example_module1);
+    srcfg_test_prepare_user_input("");
+    strcpy(args,"--format=json --permanent example-module");
+    if (0 == strcmp("running", srcfg_test_datastore)) {
+        exec_shell_command(cmd, "no active subscriptions", true, 1);
+        assert_int_equal(0, srcfg_test_subscribe("example-module"));
+    }
     exec_shell_command(cmd, "The new configuration was successfully applied.", true, 0);
+    if (0 == strcmp("running", srcfg_test_datastore)) {
+        exec_shell_command("../src/sysrepocfg --export --datastore=running --format=json example-module > /tmp/example-module_edited.json", "", true, 0);
+        srcfg_test_cmp_data_file_content("/tmp/example-module_edited.json", LYD_JSON, example_module1, LYD_JSON);
+    }
     exec_shell_command("../src/sysrepocfg --export --datastore=startup --format=json example-module > /tmp/example-module_edited.json", "", true, 0);
-    test_file_content("/tmp/example-module_edited.json", example_module1, false);
+    srcfg_test_cmp_data_file_content("/tmp/example-module_edited.json", LYD_JSON, example_module1, LYD_JSON);
 
     /**
      * module: example-module
      * format: json
      * valid?: no
+     * permanent?: no
      **/
     char *example_module2 = "{\n"
         "  \"example-module:container\": {\n"
@@ -400,8 +597,8 @@ sysrepocfg_test_editing(void **state)
         "    ]\n"
         "  }\n"
         "}\n";
-    sysrepocfg_test_prepare_config(example_module2);
-    sysrepocfg_test_prepare_user_input("y\n n\n y\n sysrepocfg_test-dump.txt\n"); /* 2 failed attempts, then save to local file */
+    srcfg_test_prepare_config(example_module2);
+    srcfg_test_prepare_user_input("y\n n\n y\n sysrepocfg_test-dump.txt\n"); /* 2 failed attempts, then save to local file */
     strcpy(args,"--format=json example-module");
     exec_shell_command(cmd, "(.*Unable to apply the changes.*){2}"
                             "Your changes have been saved to 'sysrepocfg_test-dump.txt'", true, 1);
@@ -411,19 +608,29 @@ sysrepocfg_test_editing(void **state)
      * module: ietf-interfaces
      * format: xml
      * valid?: yes (empty config)
+     * permanent?: no
      **/
     char *ietf_interfaces1 = "";
-    sysrepocfg_test_prepare_config(ietf_interfaces1);
-    sysrepocfg_test_prepare_user_input("");
+    srcfg_test_prepare_config(ietf_interfaces1);
+    srcfg_test_prepare_user_input("");
     strcpy(args,"ietf-interfaces");
+    if (0 == strcmp("running", srcfg_test_datastore)) {
+        exec_shell_command(cmd, "no active subscriptions", true, 1);
+        assert_int_equal(0, srcfg_test_subscribe("ietf-interfaces"));
+    }
     exec_shell_command(cmd, "The new configuration was successfully applied.", true, 0);
-    exec_shell_command("../src/sysrepocfg --export --datastore=startup --format=xml ietf-interfaces > /tmp/ietf-interfaces_edited.xml", "", true, 0);
-    test_file_content("/tmp/ietf-interfaces_edited.xml", ietf_interfaces1, false);
+    if (0 == strcmp("running", srcfg_test_datastore)) {
+        exec_shell_command("../src/sysrepocfg --export --datastore=running --format=xml ietf-interfaces > /tmp/ietf-interfaces_edited.xml", "", true, 0);
+    } else {
+        exec_shell_command("../src/sysrepocfg --export --datastore=startup --format=xml ietf-interfaces > /tmp/ietf-interfaces_edited.xml", "", true, 0);
+    }
+    srcfg_test_cmp_data_file_content("/tmp/ietf-interfaces_edited.xml", LYD_XML, ietf_interfaces1, LYD_XML);
 
     /**
      * module: ietf-interfaces
      * format: xml
      * valid?: yes (two added list entries)
+     * permanent?: yes
      **/
     char *ietf_interfaces2 = "<interfaces xmlns=\"urn:ietf:params:xml:ns:yang:ietf-interfaces\">\n"
         "  <interface>\n"
@@ -447,27 +654,18 @@ sysrepocfg_test_editing(void **state)
         "    <enabled>true</enabled>\n"
         "  </interface>\n"
         "</interfaces>\n";
-    sysrepocfg_test_prepare_config(ietf_interfaces2);
-    sysrepocfg_test_prepare_user_input("");
-    strcpy(args,"ietf-interfaces");
+    srcfg_test_prepare_config(ietf_interfaces2);
+    srcfg_test_prepare_user_input("");
+    strcpy(args,"--permanent ietf-interfaces");
     exec_shell_command(cmd, "The new configuration was successfully applied.", true, 0);
     exec_shell_command("../src/sysrepocfg --export --datastore=startup --format=xml ietf-interfaces > /tmp/ietf-interfaces_edited.xml", "", true, 0);
-    /* order of items is not user defined, do only partial tests */
-    test_file_content("/tmp/ietf-interfaces_edited.xml", "^<interfaces xmlns=\"urn:ietf:params:xml:ns:yang:ietf-interfaces\">\n", true);
-    test_file_content("/tmp/ietf-interfaces_edited.xml", "<interface>.*<name>eth1</name>", true);
-    test_file_content("/tmp/ietf-interfaces_edited.xml", "<interface>.*<description>Ethernet 1</description>", true);
-    test_file_content("/tmp/ietf-interfaces_edited.xml", "<interface>.*<type>ethernetCsmacd</type>", true);
-    test_file_content("/tmp/ietf-interfaces_edited.xml", "<interface>.*<name>gigaeth1</name>", true);
-    test_file_content("/tmp/ietf-interfaces_edited.xml", "<interface>.*<description>GigabitEthernet 1</description>", true);
-    test_file_content("/tmp/ietf-interfaces_edited.xml", "<interface>.*<ipv4 xmlns=\"urn:ietf:params:xml:ns:yang:ietf-ip\">.*<enabled>true</enabled>", true);
-    test_file_content("/tmp/ietf-interfaces_edited.xml", "<interface>.*<ipv4 xmlns=\"urn:ietf:params:xml:ns:yang:ietf-ip\">.*<mtu>1500</mtu>", true);
-    test_file_content("/tmp/ietf-interfaces_edited.xml", "<interface>.*<ipv4 xmlns=\"urn:ietf:params:xml:ns:yang:ietf-ip\">.*<address>.*<ip>10.10.1.5</ip>", true);
-    test_file_content("/tmp/ietf-interfaces_edited.xml", "<interface>.*<ipv4 xmlns=\"urn:ietf:params:xml:ns:yang:ietf-ip\">.*<address>.*<prefix-length>16</prefix-length>", true);
+    srcfg_test_cmp_data_file_content("/tmp/ietf-interfaces_edited.xml", LYD_XML, ietf_interfaces2, LYD_XML);
 
     /**
      * module: ietf-interfaces
      * format: xml
      * valid?: no (missing key)
+     * permanent?: no
      **/
     char *ietf_interfaces3 = "<interfaces xmlns=\"urn:ietf:params:xml:ns:yang:ietf-interfaces\">\n"
         "  <interface>\n"
@@ -477,23 +675,93 @@ sysrepocfg_test_editing(void **state)
         "    <enabled>false</enabled>\n"
         "  </interface>\n"
         "</interfaces>\n";
-    sysrepocfg_test_prepare_config(ietf_interfaces3);
-    sysrepocfg_test_prepare_user_input("n\n n\n"); /* 1 failed attempt, don't even save locally */
+    srcfg_test_prepare_config(ietf_interfaces3);
+    srcfg_test_prepare_user_input("n\n n\n"); /* 1 failed attempt, don't even save locally */
     strcpy(args,"ietf-interfaces");
     exec_shell_command(cmd, "(.*Unable to apply the changes.*){1}"
                             "Your changes were discarded", true, 1);
+
+    /* restore pre-test state */
+    if (0 == strcmp("running", srcfg_test_datastore)) {
+        assert_int_equal(0, srcfg_test_unsubscribe("ietf-interfaces"));
+        assert_int_equal(0, srcfg_test_unsubscribe("test-module"));
+        assert_int_equal(0, srcfg_test_unsubscribe("example-module"));
+    }
 }
 
 int
 main() {
+    int ret = -1;
+    sr_schema_t *schemas = NULL;
+    size_t schema_cnt = 0;
+    const char *path = NULL;
+
     const struct CMUnitTest tests[] = {
-            cmocka_unit_test_setup_teardown(sysrepocfg_test_version, NULL, NULL),
-            cmocka_unit_test_setup_teardown(sysrepocfg_test_help, NULL, NULL),
-            cmocka_unit_test_setup_teardown(sysrepocfg_test_export, NULL, NULL),
-            cmocka_unit_test_setup_teardown(sysrepocfg_test_editing, sysrepocfg_set_startup_datastore, sysrepocfg_test_teardown),
-            cmocka_unit_test_setup_teardown(sysrepocfg_test_editing, sysrepocfg_set_running_datastore, sysrepocfg_test_teardown),
-            cmocka_unit_test_setup_teardown(sysrepocfg_test_import, NULL, NULL)
+            cmocka_unit_test_setup_teardown(srcfg_test_version, NULL, NULL),
+            cmocka_unit_test_setup_teardown(srcfg_test_help, NULL, NULL),
+            cmocka_unit_test_setup_teardown(srcfg_test_export, NULL, NULL),
+            cmocka_unit_test_setup_teardown(srcfg_test_editing, srcfg_test_set_startup_datastore, srcfg_test_teardown),
+            cmocka_unit_test_setup_teardown(srcfg_test_editing, srcfg_test_set_running_datastore, srcfg_test_teardown),
+            cmocka_unit_test_setup_teardown(srcfg_test_import, NULL, NULL)
     };
 
-    return cmocka_run_group_tests(tests, NULL, NULL);
+    /* create libyang context */
+    srcfg_test_libyang_ctx = ly_ctx_new(NULL);
+    if (NULL == srcfg_test_libyang_ctx) {
+        fprintf(stderr, "Unable to initialize libyang context: %s", ly_errmsg());
+        goto terminate;
+    }
+
+    /* connect to sysrepo */
+    ret = sr_connect("sysrepocfg", SR_CONN_DEFAULT, &srcfg_test_connection);
+    if (SR_ERR_OK == ret) {
+        ret = sr_session_start(srcfg_test_connection, SR_DS_RUNNING, SR_SESS_DEFAULT, &srcfg_test_session);
+    }
+    if (SR_ERR_OK != ret) {
+        fprintf(stderr, "Unable to connect to sysrepo.\n");
+        goto terminate;
+    }
+
+    /* load all installed schemas */
+    ret = sr_list_schemas(srcfg_test_session, &schemas, &schema_cnt);
+    if (SR_ERR_OK == ret) {
+        for (size_t i = 0; i < schema_cnt; i++) {
+            path = schemas[i].revision.file_path_yin;
+            if (NULL != path) {
+                lys_parse_path(srcfg_test_libyang_ctx, path, LYS_IN_YIN);
+            }
+            path = schemas[i].revision.file_path_yang;
+            if (NULL != path) {
+                lys_parse_path(srcfg_test_libyang_ctx, path, LYS_IN_YANG);
+            }
+
+        }
+    }
+    if (SR_ERR_OK != ret) {
+        fprintf(stderr, "Unable to load all schemas.\n");
+        goto terminate;
+    }
+
+    /* start with zero subscriptions */
+    for (unsigned i = 0; i < MAX_SUBS; ++i) {
+        srcfg_test_subscriptions[i].subscription = NULL;
+        srcfg_test_subscriptions[i].module_name = NULL;
+    }
+    truncate(TEST_DATA_SEARCH_DIR "test-module.persist", 0);
+    truncate(TEST_DATA_SEARCH_DIR "ietf-interfaces.persist", 0);
+    truncate(TEST_DATA_SEARCH_DIR "example-module.persist", 0);
+
+    ret = cmocka_run_group_tests(tests, NULL, NULL);
+
+terminate:
+    if (NULL != srcfg_test_session) {
+        sr_session_stop(srcfg_test_session);
+    }
+    if (NULL != srcfg_test_connection) {
+        sr_disconnect(srcfg_test_connection);
+    }
+    if (NULL != srcfg_test_libyang_ctx) {
+        ly_ctx_destroy(srcfg_test_libyang_ctx, NULL);
+    }
+    return ret;
 }


### PR DESCRIPTION
Due to multiple issues on the libyang side it took a little longer to get all tests passing. There is still one issue pending, but it shouldn't cause the build to fail. Also I have noticed that if the data tree is too big (e.g. >32000 items) sr_get_items_iter will timeout and thus editing will terminate with error.

Also note that I have added a new (private) API call. Please check if the name and the placement (in sysrepo.proto - Operation) is suitable.

Still to be done: man-page, ascii-demo