### PR TITLE
Log + comments + Fix #192

### DIFF
--- a/src/common/sr_constants.h.in
+++ b/src/common/sr_constants.h.in
@@ -86,7 +86,7 @@
 #define SR_DEAMON_WORK_DIR "/"
 
 /** Sysrepo daemon log level <0 - 4>. */
-#define SR_DAEMON_LOG_LEVEL 3
+#define SR_DAEMON_LOG_LEVEL 2
 
 /** Sysrepo daemon initialization timeout (in seconds). */
 #define SR_DAEMON_INIT_TIMEOUT 10

--- a/src/common/sr_helpers.h
+++ b/src/common/sr_helpers.h
@@ -348,39 +348,39 @@
         }                                    \
     } while(0)
 
-#define RWLOCK_WRLOCK_TIMED_CHECK_RETURN(MUTEX) \
+#define RWLOCK_WRLOCK_TIMED_CHECK_RETURN(RWLOCK) \
     do {                                     \
         struct timespec ts = {0};            \
         int ret = 0;                         \
         clock_gettime(CLOCK_REALTIME, &ts);  \
         ts.tv_sec += MUTEX_WAIT_TIME;        \
-        ret = pthread_rwlock_timedwrlock(MUTEX, &ts); \
+        ret = pthread_rwlock_timedwrlock(RWLOCK, &ts); \
         if (0 != ret) {                            \
             SR_LOG_ERR("rwlock can not be locked %s", sr_strerror_safe(errno));   \
             return SR_ERR_TIME_OUT;          \
         }                                    \
     } while(0)
 
-#define RWLOCK_RDLOCK_TIMED_CHECK_RETURN(MUTEX) \
+#define RWLOCK_RDLOCK_TIMED_CHECK_RETURN(RWLOCK) \
     do {                                     \
         struct timespec ts = {0};            \
         int ret = 0;                         \
         clock_gettime(CLOCK_REALTIME, &ts);  \
         ts.tv_sec += MUTEX_WAIT_TIME;        \
-        ret = pthread_rwlock_timedrdlock(MUTEX, &ts); \
+        ret = pthread_rwlock_timedrdlock(RWLOCK, &ts); \
         if (0 != ret) {                            \
             SR_LOG_ERR("rwlock can not be locked %s", sr_strerror_safe(errno));   \
             return SR_ERR_TIME_OUT;          \
         }                                    \
     } while(0)
 
-#define RWLOCK_WRLOCK_TIMED_CHECK_GOTO(MUTEX, RC, LABEL) \
+#define RWLOCK_WRLOCK_TIMED_CHECK_GOTO(RWLOCK, RC, LABEL) \
     do {                                     \
         struct timespec ts = {0};            \
         int ret = 0;                         \
         clock_gettime(CLOCK_REALTIME, &ts);  \
         ts.tv_sec += MUTEX_WAIT_TIME;        \
-        ret = pthread_rwlock_timedwrlock(MUTEX, &ts); \
+        ret = pthread_rwlock_timedwrlock(RWLOCK, &ts); \
         if (0 != ret) {                            \
             SR_LOG_ERR("rwlock can not be locked %s", sr_strerror_safe(errno));   \
             rc = SR_ERR_TIME_OUT;            \
@@ -388,13 +388,13 @@
         }                                    \
     } while(0)
 
-#define RWLOCK_RDLOCK_TIMED_CHECK_GOTO(MUTEX, RC, LABEL) \
+#define RWLOCK_RDLOCK_TIMED_CHECK_GOTO(RWLOCK, RC, LABEL) \
     do {                                     \
         struct timespec ts = {0};            \
         int ret = 0;                         \
         clock_gettime(CLOCK_REALTIME, &ts);  \
         ts.tv_sec += MUTEX_WAIT_TIME;        \
-        ret = pthread_rwlock_timedrdlock(MUTEX, &ts); \
+        ret = pthread_rwlock_timedrdlock(RWLOCK, &ts); \
         if (0 != ret) {                            \
             SR_LOG_ERR("rwlock can not be locked %s", sr_strerror_safe(errno));   \
             rc = SR_ERR_TIME_OUT;            \

--- a/src/common/sr_logger.h
+++ b/src/common/sr_logger.h
@@ -171,9 +171,9 @@ void sr_logger_cleanup();
 void sr_log_to_cb(sr_log_level_t level, const char *format, ...);
 
 /**
- * @breif Prints string representation of errno using strerror_r and return pointer
+ * @brief Prints string representation of errno using strerror_r and returns pointer
  * to the thread local buffer.
- * @param [in] errno
+ * @param [in] err_code
  * @return Pointer to error message (do not free)
  */
 const char *sr_strerror_safe(int err_code);

--- a/src/common/sr_utils.h
+++ b/src/common/sr_utils.h
@@ -319,7 +319,7 @@ void sr_free_errors(sr_error_info_t *sr_errors, size_t sr_error_cnt);
 void sr_free_schema(sr_schema_t *schema);
 
 /**
- * @breif Frees the changes
+ * @brief Frees the changes array
  * @param [in] changes
  * @param [in] count
  */

--- a/src/data_manager.c
+++ b/src/data_manager.c
@@ -1599,6 +1599,8 @@ dm_get_schema(dm_ctx_t *dm_ctx, const char *module_name, const char *module_revi
     CHECK_NULL_ARG2(dm_ctx, module_name);
     int rc = SR_ERR_OK;
 
+    SR_LOG_INF("Get schema '%s', revision: '%s', submodule: '%s'", module_name, module_revision, submodule_name);
+
     pthread_rwlock_rdlock(&dm_ctx->lyctx_lock);
     const struct lys_module *module = ly_ctx_get_module(dm_ctx->ly_ctx, module_name, module_revision);
     if (NULL == module) {
@@ -2596,6 +2598,7 @@ dm_feature_enable(dm_ctx_t *dm_ctx, const char *module_name, const char *feature
         return SR_ERR_UNKNOWN_MODEL;
     }
     rc = enable ? lys_features_enable(module, feature_name) : lys_features_disable(module, feature_name);
+    SR_LOG_DBG("%s feature '%s' in module '%s'", enable ? "Enabling" : "Disabling", feature_name, module_name);
     pthread_rwlock_unlock(&dm_ctx->lyctx_lock);
 
     if (1 == rc) {

--- a/src/data_manager.c
+++ b/src/data_manager.c
@@ -2001,6 +2001,9 @@ dm_get_diff_type_to_string(LYD_DIFFTYPE type)
     return diff_states[type];
 }
 
+/**
+ * @brief Compares subscriptions by priority.
+ */
 int
 dm_subs_cmp(const void *a, const void *b)
 {

--- a/src/data_manager.c
+++ b/src/data_manager.c
@@ -700,6 +700,8 @@ dm_unlock_module(dm_ctx_t *dm_ctx, dm_session_t *session, char *modul_name)
     char *lock_file = NULL;
     size_t i = 0;
 
+    SR_LOG_INF("Unlock request module='%s'", modul_name);
+
     rc = sr_get_lock_data_file_name(dm_ctx->data_search_dir, modul_name, session->datastore, &lock_file);
     CHECK_RC_MSG_RETURN(rc, "Lock file name can not be created");
 
@@ -783,6 +785,7 @@ int
 dm_unlock_datastore(dm_ctx_t *dm_ctx, dm_session_t *session)
 {
     CHECK_NULL_ARG2(dm_ctx, session);
+    SR_LOG_INF_MSG("Unlock datastore request");
 
     while (session->locked_files->count > 0) {
         dm_unlock_file(dm_ctx->locking_ctx, (char *) session->locked_files->data[0]);

--- a/src/data_manager.h
+++ b/src/data_manager.h
@@ -139,8 +139,12 @@ typedef struct dm_commit_context_s {
     sr_btree_t *prev_data_trees;/**< data trees in the state before commit */
 } dm_commit_context_t;
 
+/**
+ * @brief Structure holds commit contexts for the purposes of notification
+ * session.
+ */
 typedef struct dm_c_ctxs_s {
-    sr_btree_t *tree;      /**< Array of commit context used for notifications */
+    sr_btree_t *tree;      /**< Tree of commit context used for notifications */
     pthread_rwlock_t lock; /**< rwlock to access c_ctxs */
 } dm_commit_ctxs_t;
 

--- a/src/executables/sysrepocfg.c
+++ b/src/executables/sysrepocfg.c
@@ -162,6 +162,7 @@ srcfg_ly_init(struct ly_ctx **ly_ctx, const char *module_name)
     struct dirent *ep = NULL;
     char *delim = NULL;
     char schema_filename[PATH_MAX] = { 0, };
+    const struct lys_module *module = NULL;
 
     CHECK_NULL_ARG2(ly_ctx, module_name);
 
@@ -204,7 +205,13 @@ srcfg_ly_init(struct ly_ctx **ly_ctx, const char *module_name)
                 snprintf(schema_filename, PATH_MAX, "%s%s", srcfg_schema_search_dir, ep->d_name);
                 /* load the schema into the context */
                 SR_LOG_DBG("Loading module schema: '%s'.", schema_filename);
-                lys_parse_path(*ly_ctx, schema_filename, fmt);
+                module = lys_parse_path(*ly_ctx, schema_filename, fmt);
+                if (NULL == module) {
+                    continue;
+                }
+                for (uint8_t i = 0; i < module->features_size; i++) {
+                    lys_features_enable(module, module->features[i].name);
+                }
 #if 0
             }
 #endif

--- a/src/rp_dt_edit.c
+++ b/src/rp_dt_edit.c
@@ -523,6 +523,8 @@ rp_dt_move_list_wrapper(rp_ctx_t *rp_ctx, rp_session_t *session, const char *xpa
 
     int rc = SR_ERR_OK;
 
+    SR_LOG_INF("Move item request %s datastore, xpath: %s", sr_ds_to_str(session->datastore), xpath);
+
     rc = ac_check_node_permissions(session->ac_session, xpath, AC_OPER_READ_WRITE);
     CHECK_RC_LOG_RETURN(rc, "Access control check failed for xpath '%s'", xpath);
 
@@ -544,6 +546,8 @@ rp_dt_set_item_wrapper(rp_ctx_t *rp_ctx, rp_session_t *session, const char *xpat
     CHECK_NULL_ARG5(rp_ctx, rp_ctx->dm_ctx, session, session->dm_session, xpath);
 
     int rc = SR_ERR_OK;
+
+    SR_LOG_INF("Set item request %s datastore, xpath: %s", sr_ds_to_str(session->datastore), xpath);
 
     rc = ac_check_node_permissions(session->ac_session, xpath, AC_OPER_READ_WRITE);
     if (SR_ERR_OK != rc) {
@@ -569,6 +573,8 @@ rp_dt_delete_item_wrapper(rp_ctx_t *rp_ctx, rp_session_t *session, const char *x
 {
     CHECK_NULL_ARG5(rp_ctx, rp_ctx->dm_ctx, session, session->dm_session, xpath);
     int rc = SR_ERR_OK;
+
+    SR_LOG_INF("Delete item request %s datastore, xpath: %s", sr_ds_to_str(session->datastore), xpath);
 
     rc = ac_check_node_permissions(session->ac_session, xpath, AC_OPER_READ_WRITE);
     CHECK_RC_LOG_RETURN(rc, "Access control check failed for xpath '%s'", xpath);
@@ -781,6 +787,8 @@ rp_dt_refresh_session(rp_ctx_t *rp_ctx, rp_session_t *session, sr_error_info_t *
     *err_cnt = 0;
     *errors = NULL;
 
+    SR_LOG_INF("Refresh session request %s datastore", sr_ds_to_str(session->datastore));
+
     /* update models and retrieve list of data models-to be skipped in replay */
     rc = dm_update_session_data_trees(rp_ctx->dm_ctx, session->dm_session, &up_to_date);
     if (SR_ERR_OK != rc) {
@@ -935,6 +943,7 @@ rp_dt_switch_datastore(rp_ctx_t *rp_ctx, rp_session_t *session, sr_datastore_t d
 {
     CHECK_NULL_ARG3(rp_ctx, session, session->dm_session);
     int rc = SR_ERR_OK;
+    SR_LOG_INF("Switch datastore request %s -> %s", sr_ds_to_str(session->datastore), sr_ds_to_str(ds));
     session->datastore = ds;
     rc = dm_session_switch_ds(session->dm_session, ds);
     return rc;
@@ -946,6 +955,8 @@ rp_dt_lock(const rp_ctx_t *rp_ctx, const rp_session_t *session, const char *modu
     CHECK_NULL_ARG2(rp_ctx, session);
     int rc = SR_ERR_OK;
     bool modif = false;
+
+    SR_LOG_INF("Lock request module: '%s', datastore %s", module_name, sr_ds_to_str(session->datastore));
 
     sr_schema_t *schemas = NULL;
     size_t count = 0;

--- a/src/rp_dt_edit.c
+++ b/src/rp_dt_edit.c
@@ -428,7 +428,9 @@ rp_dt_set_item(dm_ctx_t *dm_ctx, dm_session_t *session, const char *xpath, const
     }
 
     /* add default nodes into the data tree */
-    dm_lyd_wd_add(dm_ctx, module->ctx, &info->node, LYD_WD_IMPL_TAG);
+    if (node != NULL) {
+        dm_lyd_wd_add(dm_ctx, module->ctx, &info->node, LYD_WD_IMPL_TAG | LYD_OPT_NOSIBLINGS);
+    }
 
 cleanup:
     free(new_value);

--- a/src/rp_dt_get.c
+++ b/src/rp_dt_get.c
@@ -245,7 +245,7 @@ rp_dt_get_values_wrapper(rp_ctx_t *rp_ctx, rp_session_t *rp_session, const char 
     rc = dm_get_datatree(rp_ctx->dm_ctx, rp_session->dm_session, data_tree_name, &data_tree);
     if (SR_ERR_OK != rc) {
         if (SR_ERR_NOT_FOUND != rc) {
-            SR_LOG_ERR("Getting data tree failed (%d) for xpath '%s'", rc, xpath);
+            SR_LOG_ERR("Getting data tree failed (%s) for xpath '%s'", strerror(rc), xpath);
         }
         goto cleanup;
     }

--- a/src/rp_dt_get.h
+++ b/src/rp_dt_get.h
@@ -92,9 +92,10 @@ int rp_dt_get_values_wrapper_with_opts(rp_ctx_t *rp_ctx, rp_session_t *rp_sessio
 
 /**
  * @brief Fills the values from the array of nodes. The length of the
- * values array is equal to the count of the nodes in nodes set
+ * values array is equal to the count of the nodes in nodes set.
  * @param [in] nodes
  * @param [out] values
+ * @param [out] value_cnt
  * @return Error code (SR_ERR_OK on success)
  */
 int rp_dt_get_values_from_nodes(struct ly_set *nodes, sr_val_t **values, size_t *value_cnt);

--- a/src/rp_dt_xpath.c
+++ b/src/rp_dt_xpath.c
@@ -295,6 +295,9 @@ rp_dt_find_in_choice(dm_ctx_t *dm_ctx, dm_session_t *session, const char *xpath,
     CHECK_NULL_ARG5(dm_ctx, xpath, trimmed_xpath, module, match);
     /* libyang err_msg is used to parse the match and unmatch part */
     int rc = SR_ERR_BAD_ELEMENT;
+    /**
+     * @brief Maximum length of node name
+     */
     #define MAX_NODE_NAME_LEN 100
     char *unmatch_part = NULL;
     char *err_msg = NULL;

--- a/tests/sysrepocfg_test.c
+++ b/tests/sysrepocfg_test.c
@@ -686,7 +686,7 @@ srcfg_test_editing(void **state)
     sr_session_ctx_t *session = NULL;
     assert_int_equal(SR_ERR_OK, sr_connect("sysrepocfg_test", SR_CONN_DEFAULT, &conn));
     assert_non_null(conn);
-    sr_log_stderr(SR_LL_DBG);
+
     assert_int_equal(SR_ERR_OK, sr_session_start(conn, SR_DS_STARTUP, SR_SESS_DEFAULT, &session));
     sr_feature_enable(session, "ietf-ip", "ipv4-non-contiguous-netmasks", false);
 

--- a/tests/sysrepocfg_test.c
+++ b/tests/sysrepocfg_test.c
@@ -38,6 +38,8 @@
 #include "sr_common.h"
 #include "test_data.h"
 #include "system_helper.h"
+#include "client_library.h"
+#include "test_module_helper.h"
 
 #define FILENAME_NEW_CONFIG   "sysrepocfg_test-new_config.txt"
 #define FILENAME_USER_INPUT   "sysrepocfg_test-user_input.txt"
@@ -187,6 +189,7 @@ srcfg_test_unsubscribe(const char *module_name)
 static int
 srcfg_test_set_startup_datastore(void **state)
 {
+    createDataTreeIETFinterfacesModule();
     srcfg_test_datastore = strdup("startup");
     assert_non_null(srcfg_test_datastore);
     return 0;
@@ -195,6 +198,7 @@ srcfg_test_set_startup_datastore(void **state)
 static int
 srcfg_test_set_running_datastore(void **state)
 {
+    createDataTreeIETFinterfacesModule();
     srcfg_test_datastore = strdup("running");
     assert_non_null(srcfg_test_datastore);
     return 0;
@@ -678,6 +682,84 @@ srcfg_test_editing(void **state)
     exec_shell_command(cmd, "(.*Unable to apply the changes.*){1}"
                             "Your changes were discarded", true, 1);
 
+    sr_conn_ctx_t *conn = NULL;
+    sr_session_ctx_t *session = NULL;
+    assert_int_equal(SR_ERR_OK, sr_connect("sysrepocfg_test", SR_CONN_DEFAULT, &conn));
+    assert_non_null(conn);
+    sr_log_stderr(SR_LL_DBG);
+    assert_int_equal(SR_ERR_OK, sr_session_start(conn, SR_DS_STARTUP, SR_SESS_DEFAULT, &session));
+    sr_feature_enable(session, "ietf-ip", "ipv4-non-contiguous-netmasks", false);
+
+    /**
+     * module: ietf-interfaces
+     * format: xml
+     * valid?: no (not enabled feature)
+     * permanent?: no
+     **/
+    char *ietf_interfaces4 = "<interfaces xmlns=\"urn:ietf:params:xml:ns:yang:ietf-interfaces\">\n"
+        "  <interface>\n"
+        "    <name>eth1</name>\n"
+        "    <description>Ethernet 1</description>\n"
+        "    <type>ethernetCsmacd</type>\n"
+        "    <enabled>true</enabled>\n"
+        "    <ipv4 xmlns=\"urn:ietf:params:xml:ns:yang:ietf-ip\">\n"
+        "      <enabled>true</enabled>\n"
+        "      <mtu>1500</mtu>\n"
+        "      <address>\n"
+        "        <ip>10.10.1.5</ip>\n"
+    // node if-feature ipv4-non-contiguous-netmasks
+        "        <netmask>255.255.0.0</netmask>\n"
+        "      </address>\n"
+        "    </ipv4>\n"
+        "  </interface>\n"
+        "</interfaces>\n";
+    srcfg_test_prepare_config(ietf_interfaces4);
+    srcfg_test_prepare_user_input("n\n n\n"); /* 1 failed attempt, don't even save locally */
+    strcpy(args,"ietf-interfaces");
+    exec_shell_command(cmd, "(.*Unable to apply the changes.*){1}"
+                            "Your changes were discarded", true, 1);
+
+
+
+    sr_feature_enable(session, "ietf-ip", "ipv4-non-contiguous-netmasks", true);
+    /**
+     * module: ietf-interfaces
+     * format: xml
+     * valid?: yes
+     * permanent?: no
+     **/
+    char *ietf_interfaces5 = "<interfaces xmlns=\"urn:ietf:params:xml:ns:yang:ietf-interfaces\">\n"
+        "  <interface>\n"
+        "    <name>eth1</name>\n"
+        "    <description>Ethernet 1</description>\n"
+        "    <type>ethernetCsmacd</type>\n"
+        "    <enabled>true</enabled>\n"
+        "    <ipv4 xmlns=\"urn:ietf:params:xml:ns:yang:ietf-ip\">\n"
+        "      <enabled>true</enabled>\n"
+        "      <mtu>1500</mtu>\n"
+        "      <address>\n"
+        "        <ip>10.10.1.5</ip>\n"
+    // node if-feature ipv4-non-contiguous-netmasks
+        "        <netmask>255.255.0.0</netmask>\n"
+        "      </address>\n"
+        "    </ipv4>\n"
+        "  </interface>\n"
+        "</interfaces>\n";
+    srcfg_test_prepare_config(ietf_interfaces5);
+    srcfg_test_prepare_user_input("");
+    strcpy(args,"ietf-interfaces");
+    exec_shell_command(cmd, "The new configuration was successfully applied.", true, 0);
+    if (0 == strcmp("running", srcfg_test_datastore)) {
+        exec_shell_command("../src/sysrepocfg --export --datastore=running --format=xml ietf-interfaces > /tmp/ietf-interfaces_edited.xml", "", true, 0);
+    } else {
+        exec_shell_command("../src/sysrepocfg --export --datastore=startup --format=xml ietf-interfaces > /tmp/ietf-interfaces_edited.xml", "", true, 0);
+    }
+    srcfg_test_cmp_data_file_content("/tmp/ietf-interfaces_edited.xml", LYD_XML, ietf_interfaces5, LYD_XML);
+
+    sr_feature_enable(session, "ietf-ip", "ipv4-non-contiguous-netmasks", false);
+    sr_session_stop(session);
+    sr_disconnect(conn);
+
     /* restore pre-test state */
     if (0 == strcmp("running", srcfg_test_datastore)) {
         assert_int_equal(0, srcfg_test_unsubscribe("ietf-interfaces"));
@@ -692,6 +774,8 @@ main() {
     sr_schema_t *schemas = NULL;
     size_t schema_cnt = 0;
     const char *path = NULL;
+    const struct lys_module *module = NULL;
+    uint32_t idx = 0;
 
     const struct CMUnitTest tests[] = {
             cmocka_unit_test_setup_teardown(srcfg_test_version, NULL, NULL),
@@ -732,6 +816,11 @@ main() {
                 lys_parse_path(srcfg_test_libyang_ctx, path, LYS_IN_YANG);
             }
 
+        }
+        while (NULL != (module = ly_ctx_get_module_iter(srcfg_test_libyang_ctx, &idx))) {
+            for (int i = 0; i < module->features_size; i++) {
+                lys_features_enable(module, module->features[i].name);
+            }
         }
     }
     if (SR_ERR_OK != ret) {


### PR DESCRIPTION
Ad fix:
- sysrepoctl won't be supported for import/export config, sysrepocfg should be used instead
- issue was fixed in sysrepocfg
- notice: config will not be loadble, if there is an configuration node for disabled feature