### PR TITLE
Operation data schema analysis

### DIFF
--- a/src/module_dependencies.c
+++ b/src/module_dependencies.c
@@ -986,7 +986,7 @@ md_traverse_schema_tree(md_ctx_t *md_ctx, md_module_t *module, struct lys_node *
     if (NULL == root) {
         return SR_ERR_OK;
     }
-   
+
     module_schema = root->module;
     dest_module = (augment ? md_get_destination_module(md_ctx, root) : module);
     if (NULL == dest_module) {
@@ -1037,7 +1037,7 @@ md_traverse_schema_tree(md_ctx_t *md_ctx, md_module_t *module, struct lys_node *
                     /* some or all children carry operational data */
                     if ((intptr_t)node->priv & PRIV_CFG_SUBTREE) {
                         /* a mix of configuration and operational data amongst children */
-                        for (child = node->child; child && module_schema == child->module && SR_ERR_OK == rc; 
+                        for (child = node->child; child && module_schema == child->module && SR_ERR_OK == rc;
                              child = child->next) {
                             if (LYS_CONFIG_R & child->flags) {
                                 rc = md_add_subtree_ref(md_ctx, dest_module, dest_module->op_data_subtrees, module, child,

--- a/src/module_dependencies.h
+++ b/src/module_dependencies.h
@@ -51,27 +51,38 @@ typedef struct md_dep_s {
 } md_dep_t;
 
 /*
+ * @brief Structure referencing a subtree in the schema tree.
+ */
+typedef struct md_subtree_ref_s {
+    char *xpath;       /**< xpath pointing to the root of this subtree. */
+    md_module_t *orig; /**< Module which defines this subtree. */
+} md_subtree_ref_t;
+
+/*
  * @brief Data structure describing a single module in the context of inter-module dependencies.
  */
 typedef struct md_module_s {
-    char *name;                /**< Name of the module. */
-    char *revision_date;       /**< Revision date of the module. */
-    char *filepath;            /**< File path to the schema of the module. */
-    char *fullname;            /**< Fullname of the module (name+revision).
-                                    Normally not used and set to NULL, but can be filled using ::md_get_module_fullname. */
+    char *name;                   /**< Name of the module. */
+    char *revision_date;          /**< Revision date of the module. */
+    char *filepath;               /**< File path to the schema of the module. */
+    char *fullname;               /**< Fullname of the module (name+revision).
+                                       Normally not used and set to NULL, but can be filled using ::md_get_module_fullname. */
 
-    bool latest_revision;      /**< "true" if this is the latest installed revision of this module. */
+    bool latest_revision;         /**< "true" if this is the latest installed revision of this module. */
 
-    sr_llist_t *inst_ids;      /**< List of xpaths referencing all instance-identifiers in the module.
-                                    Items are of type (char *) */
+    sr_llist_t *inst_ids;         /**< List of xpaths referencing all instance-identifiers in the module.
+                                       Items are of type (md_subree_ref_t *) (one node subtrees) */
 
-    sr_llist_t *deps;          /**< Adjacency list for this module in the schema-based, transitively-closed, dependency graph,
-                                    i.e. the list of all modules that this module depends on. Items are of type (md_dep_t *) */
-    sr_llist_t *inv_deps;      /**< Adjacency list for this module in the inverted transitively-closed dependency graph,
-                                    i.e. the list of all modules that depend on this module. Items are of type (md_dep_t *) */
+    sr_llist_t *op_data_subtrees; /**< List of xpaths referencing all subtrees in the schema containing only operational data.
+                                       Items are of type (md_subtree_ref_t *) */
 
-    struct lyd_node *ly_data;  /**< libyang's representation of this data. For convenience. */
-    sr_llist_node_t *ll_node;  /**< Pointer to the node in ::md_ctx_t::modules which is used to store this instance. */
+    sr_llist_t *deps;             /**< Adjacency list for this module in the schema-based, transitively-closed, dependency graph,
+                                       i.e. the list of all modules that this module depends on. Items are of type (md_dep_t *) */
+    sr_llist_t *inv_deps;         /**< Adjacency list for this module in the inverted transitively-closed dependency graph,
+                                       i.e. the list of all modules that depend on this module. Items are of type (md_dep_t *) */
+
+    struct lyd_node *ly_data;     /**< libyang's representation of this data. For convenience. */
+    sr_llist_node_t *ll_node;     /**< Pointer to the node in ::md_ctx_t::modules which is used to store this instance. */
 } md_module_t;
 
 /*

--- a/tests/md_test.c
+++ b/tests/md_test.c
@@ -364,7 +364,7 @@ md_tests_setup(void **state)
 static int
 md_tests_teardown(void **state)
 {
-    //system("rm -f " TEST_SCHEMA_SEARCH_DIR TEST_MODULE_PREFIX "*");
+    system("rm -f " TEST_SCHEMA_SEARCH_DIR TEST_MODULE_PREFIX "*");
     return 0;
 }
 

--- a/yang/sysrepo-module-dependencies.yang
+++ b/yang/sysrepo-module-dependencies.yang
@@ -50,7 +50,7 @@ module sysrepo-module-dependencies {
 
       list dependency {
         key "module-name module-revision";
-        description "A dependency instance.";
+        description "An instance of module dependency.";
 
         leaf module-name {
             type string;
@@ -73,11 +73,52 @@ module sysrepo-module-dependencies {
     }
 
     container instance-identifiers {
-      description "List of xpaths referring to all leaf(-list)s in the module with the instance-identifier type.";
+      description "List of XPaths referring to all leaf(-list)s in the module with the instance-identifier type.";
 
-      leaf-list instance-identifier {
-        type string;
-        description "XPath (without keys) referring to a leaf or leaf-list with the instance-identifier type.";
+      list instance-identifier {
+        key "xpath orig-module-revision";
+        description "Single instance identifier summary.";
+
+        leaf xpath {
+          type string;
+          description "XPath (without keys) referring to a leaf or leaf-list with the instance-identifier type.";
+        }
+
+        leaf orig-module-name {
+          type string;
+          mandatory "true";
+          description "Name of a module that defines this instance identifier.";
+        }
+
+        leaf orig-module-revision {
+          type string;
+          description "Revision of a module that defines this instance identifier.";
+        }
+      }
+    }
+
+    container op-data-subtrees {
+      description "List of XPaths referring to all subtrees in the schema containing only operational data.";
+
+      list op-data-subtree {
+        key "xpath orig-module-revision";
+        description "Reference to a subtree with only operational data.";
+
+        leaf xpath {
+          type string;
+          description "XPath (without keys) referring to a root of a subtree carrying only operational data.";
+        }
+
+        leaf orig-module-name {
+          type string;
+          mandatory "true";
+          description "Name of a module that defines this subtree.";
+        }
+
+        leaf orig-module-revision {
+          type string;
+          description "Revision of a module that defines this subtree.";
+        }
       }
     }
   }


### PR DESCRIPTION
Also the algorithm for storing references to instance identifiers was found partly incorrect and fixed in this pull request (now instance identifiers and operational data references are retrieved and stored in very similar fashion and much of the code is shared).