### PR TITLE
Load config from startup to running for each subscription

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,7 @@ set(SYSREPO_DESC "YANG-based system repository")
 # setup version
 set(SYSREPO_MAJOR_VERSION 0)
 set(SYSREPO_MINOR_VERSION 3)
-set(SYSREPO_MICRO_VERSION 4)
+set(SYSREPO_MICRO_VERSION 5)
 set(SYSREPO_VERSION ${SYSREPO_MAJOR_VERSION}.${SYSREPO_MINOR_VERSION}.${SYSREPO_MICRO_VERSION})
 
 # set default build type if not specified by user

--- a/inc/sysrepo.h
+++ b/inc/sysrepo.h
@@ -860,6 +860,7 @@ typedef enum sr_subscr_flag_e {
                                    ::sr_subtree_change_subscribe calls it (among other things) means that:
                                    - the subscriber is the "owner" of the subscribed data tree and and the data tree will be
                                    activated in the running datastore while this subcription is alive (can be changed with SR_SUBSCR_PASSIVE flag)
+                                   - configuration data or the subscribed module or subtree is copied from startup to running datastore
                                    - the callback will be called just after the changes have been committed to the datastore
                                    (can be changed with SR_SUBSCR_VERIFIER flag). */
     SR_SUBSCR_CTX_REUSE = 1,  /**< This option enables the application to re-use an already existing subscription context

--- a/src/data_manager.c
+++ b/src/data_manager.c
@@ -1225,6 +1225,7 @@ dm_remove_not_enabled_nodes(dm_data_info_t *info)
             sr_lyd_unlink(info, iter);
             lyd_free_withsiblings(iter);
         }
+        sr_list_rm(stack, iter);
     }
 
 cleanup:
@@ -1290,6 +1291,7 @@ dm_has_not_enabled_nodes(dm_data_info_t *info, bool *res)
             *res = true;
             goto cleanup;
         }
+        sr_list_rm(stack, iter);
     }
     *res = false;
 
@@ -2922,13 +2924,13 @@ dm_copy_subtree_startup_running(dm_ctx_t *ctx, dm_session_t *session, const stru
             char *node_xpath = lyd_path(node);
             CHECK_NULL_NOMEM_GOTO(node_xpath, rc, cleanup);
             dm_lyd_new_path(ctx, candidate_info, ctx->ly_ctx, node_xpath,
-                    ((struct lyd_node_leaf_list *) node)->value_str, 0);
+                    ((struct lyd_node_leaf_list *) node)->value_str, LYD_PATH_OPT_UPDATE);
             free(node_xpath);
         } else {
             /* list or container */
             if (NULL != node->parent) {
                 char *parent_xpath = lyd_path(node->parent);
-                dm_lyd_new_path(ctx, candidate_info, ctx->ly_ctx, parent_xpath, NULL, 0);
+                dm_lyd_new_path(ctx, candidate_info, ctx->ly_ctx, parent_xpath, NULL, LYD_PATH_OPT_UPDATE);
                 /* create or find parent node */
                 rc = rp_dt_find_node(ctx, candidate_info->node, parent_xpath, false, &parent);
                 free(parent_xpath);

--- a/src/data_manager.c
+++ b/src/data_manager.c
@@ -36,6 +36,7 @@
 #include "access_control.h"
 #include "notification_processor.h"
 #include "persistence_manager.h"
+#include "rp_dt_edit.h"
 
 /**
  * @brief number of supported data stores - length of arrays used in session
@@ -2865,10 +2866,102 @@ dm_enable_module_running(dm_ctx_t *ctx, dm_session_t *session, const char *modul
             node = node->next;
         }
     }
-    if (SR_ERR_OK == rc && copy_from_startup && !has_enabled_subtree) {
-        /* if no subtree was already enabled within the module, copy the data from startup */
+    if (SR_ERR_OK == rc && copy_from_startup) {
+        /* copy the config if requested - subscription does not contain SR_SUBSCR_PASSIVE flag */
         rc = dm_copy_module(ctx, session, module_name, SR_DS_STARTUP, SR_DS_RUNNING);
     }
+    return rc;
+}
+
+static int
+dm_copy_subtree_startup_running(dm_ctx_t *ctx, dm_session_t *session, const struct lys_module *module, const char *xpath)
+{
+    CHECK_NULL_ARG4(ctx, session, module, xpath);
+    int rc = SR_ERR_OK;
+    struct ly_set *nodes = NULL;
+    dm_session_t *startup_session = NULL;
+    dm_data_info_t *startup_info = NULL;
+    dm_data_info_t *candidate_info = NULL;
+    struct lyd_node *node = NULL, *parent = NULL;
+
+    /* mark currently selected datastore */
+    int ds = session->datastore;
+
+    rc = dm_session_start(ctx, session->user_credentials, SR_DS_STARTUP, &startup_session);
+    CHECK_RC_MSG_RETURN(rc, "Failed to start a temporary session");
+
+    /* select nodes by xpath from startup */
+    rc = dm_get_data_info(ctx, startup_session, module->name, &startup_info);
+    CHECK_RC_MSG_GOTO(rc, cleanup, "Get info for startup config failed");
+
+    if (NULL == startup_info->node) {
+        SR_LOG_DBG("Startup config for module '%s' is empty nothing to copy", module->name);
+    }
+
+    /* switch to candidate */
+    session->datastore = SR_DS_CANDIDATE;
+    rc = dm_get_data_info(ctx, session, module->name, &candidate_info);
+    CHECK_RC_MSG_GOTO(rc, cleanup, "Get info failed");
+
+    /* remove previous config from running */
+    rc = rp_dt_delete_item(ctx, session, xpath, SR_EDIT_DEFAULT);
+    CHECK_RC_LOG_GOTO(rc, cleanup, "Delete of previous values in running failed xpath %s", xpath);
+
+    /* select a part of configuration to be enabled */
+    rc = rp_dt_find_nodes(ctx, startup_info->node, xpath, false, &nodes);
+    if (SR_ERR_NOT_FOUND == rc) {
+        SR_LOG_DBG("Subtree %s of enabled configuration is empty", xpath);
+        rc = SR_ERR_OK;
+    }
+    CHECK_RC_MSG_GOTO(rc, cleanup, "Find nodes for configuration to be enabled failed");
+
+    /* insert selected nodes */
+    for (unsigned i = 0; NULL != nodes && i < nodes->number; i++) {
+        node = nodes->set.d[i];
+        if ((LYS_LEAF | LYS_LEAFLIST) & node->schema->nodetype) {
+            char *node_xpath = lyd_path(node);
+            CHECK_NULL_NOMEM_GOTO(node_xpath, rc, cleanup);
+            dm_lyd_new_path(ctx, candidate_info, ctx->ly_ctx, node_xpath,
+                    ((struct lyd_node_leaf_list *) node)->value_str, 0);
+            free(node_xpath);
+        } else {
+            /* list or container */
+            if (NULL != node->parent) {
+                char *parent_xpath = lyd_path(node->parent);
+                dm_lyd_new_path(ctx, candidate_info, ctx->ly_ctx, parent_xpath, NULL, 0);
+                /* create or find parent node */
+                rc = rp_dt_find_node(ctx, candidate_info->node, parent_xpath, false, &parent);
+                free(parent_xpath);
+                CHECK_RC_MSG_GOTO(rc, cleanup, "Failed to find parent node");
+            }
+            /* duplicate data tree */
+            sr_lyd_unlink(startup_info, node);
+
+            /* attach to parent */
+            if (NULL != parent) {
+                if (0 != lyd_insert(parent, node)) {
+                    SR_LOG_ERR_MSG("Node insert failed");
+                    lyd_free_withsiblings(node);
+                }
+            } else {
+                rc = sr_lyd_insert_after(candidate_info, candidate_info->node, node);
+                if (SR_ERR_OK != rc) {
+                    lyd_free_withsiblings(node);
+                    SR_LOG_ERR_MSG("Node insert failed");
+                }
+            }
+        }
+    }
+
+    /* copy module candidate -> running */
+    rc = dm_copy_module(ctx, session, module->name, SR_DS_CANDIDATE, SR_DS_RUNNING);
+
+cleanup:
+    ly_set_free(nodes);
+    dm_session_stop(ctx, startup_session);
+    /* switch back to previously selected datastore */
+    session->datastore = ds;
+
     return rc;
 }
 
@@ -2885,18 +2978,15 @@ dm_enable_module_subtree_running(dm_ctx_t *ctx, dm_session_t *session, const cha
     if (NULL == module) {
         /* if module is not known, get it and check if it has some enabled subtree */
         rc = dm_has_enabled_subtree(ctx, module_name, &module, &has_enabled_subtree);
+        CHECK_RC_LOG_RETURN(rc, "Has enabled subtree failed for module %s", module_name);
     }
-    if (SR_ERR_OK == rc) {
-        /* enable the subtree specified by xpath */
-        rc = rp_dt_enable_xpath(ctx, session, xpath);
-    }
-    if (SR_ERR_OK == rc && copy_from_startup) {
-        if (!has_enabled_subtree) {
-            /* no subtree was already enabled within the module, copy the data from startup */
-            rc = dm_copy_module(ctx, session, module_name, SR_DS_STARTUP, SR_DS_RUNNING);
-        } else {
-            // TODO: if something was already enabled, we should still copy fresh data of specified subtree from startup
-        }
+
+    /* enable the subtree specified by xpath */
+    rc = rp_dt_enable_xpath(ctx, session, xpath);
+    CHECK_RC_LOG_RETURN(rc, "Enabling of xpath %s failed", xpath);
+
+    if (copy_from_startup) {
+        rc = dm_copy_subtree_startup_running(ctx, session, module, xpath);
     }
     return rc;
 }

--- a/tests/python/NotificationTest.py
+++ b/tests/python/NotificationTest.py
@@ -54,13 +54,19 @@ class NotificationTester(SysrepoTester):
             print n
 
         self.tc.assertEqual(len(expected), len(self.notifications))
+
+        ex_sorted = sorted(expected, key=lambda e: e[1])
+        notif_sorted = sorted(self.notifications, key=lambda e: e[1])
         for i in range(len(expected)):
-            self.tc.assertEqual(self.notifications[i][0], expected[i][0])
-            self.tc.assertEqual(self.notifications[i][1], expected[i][1])
+            self.tc.assertEqual(ex_sorted[i][0], notif_sorted[i][0])
+            self.tc.assertEqual(ex_sorted[i][1], notif_sorted[i][1])
 
     def checkNoNotificationArrived(self):
         self.tc.assertFalse(os.path.isfile(self.filename))
 
+    def deleteNotifications(self):
+        if os.path.isfile(self.filename):
+            os.unlink(self.filename)
 
 class NotificationTest(unittest.TestCase):
 
@@ -93,8 +99,14 @@ class NotificationTest(unittest.TestCase):
         srd.add_step(srd.waitStep)
         tester.add_step(tester.waitStep)
         subscriber.add_step(subscriber.subscribeStep, "/ietf-interfaces:interfaces")
-        subscriber2.add_step(subscriber2.subscribeStep, "/ietf-interfaces:interfaces/interface/ietf-ip:ipv4/address")
+        subscriber2.add_step(subscriber2.waitStep)
         subscriber3.add_step(subscriber3.subscribeStep, "/example-module:container")
+
+        srd.add_step(srd.waitStep)
+        tester.add_step(tester.waitStep)
+        subscriber.add_step(subscriber.waitStep)
+        subscriber2.add_step(subscriber2.subscribeStep, "/ietf-interfaces:interfaces/interface/ietf-ip:ipv4/address")
+        subscriber3.add_step(subscriber3.waitStep)
 
         srd.add_step(srd.waitStep)
         tester.add_step(tester.deleteItemStep, "/ietf-interfaces:interfaces/interface[name='eth0']")
@@ -175,8 +187,14 @@ class NotificationTest(unittest.TestCase):
         srd.add_step(srd.waitStep)
         tester.add_step(tester.waitStep)
         subscriber.add_step(subscriber.subscribeStep, "/ietf-interfaces:interfaces")
-        subscriber2.add_step(subscriber2.subscribeStep, "/ietf-interfaces:interfaces/interface/ietf-ip:ipv4")
+        subscriber2.add_step(subscriber2.waitStep)
         subscriber3.add_step(subscriber3.subscribeStep, "/example-module:container")
+
+        srd.add_step(srd.waitStep)
+        tester.add_step(tester.waitStep)
+        subscriber.add_step(subscriber.waitStep)
+        subscriber2.add_step(subscriber2.subscribeStep, "/ietf-interfaces:interfaces/interface/ietf-ip:ipv4")
+        subscriber3.add_step(subscriber3.waitStep)
 
         srd.add_step(srd.waitStep)
         tester.add_step(tester.setItemStep, "/ietf-interfaces:interfaces/interface[name='eth0']/ietf-ip:ipv4/enabled", Value(leaf_type=SR_BOOL_T, value= False))
@@ -243,8 +261,14 @@ class NotificationTest(unittest.TestCase):
         srd.add_step(srd.waitStep)
         tester.add_step(tester.waitStep)
         subscriber.add_step(subscriber.subscribeStep, "/ietf-interfaces:interfaces")
-        subscriber2.add_step(subscriber2.subscribeStep, "/ietf-interfaces:interfaces/interface/ietf-ip:ipv4/address")
+        subscriber2.add_step(subscriber2.waitStep)
         subscriber3.add_step(subscriber3.subscribeStep, "/example-module:container")
+
+        srd.add_step(srd.waitStep)
+        tester.add_step(tester.waitStep)
+        subscriber.add_step(subscriber.waitStep)
+        subscriber2.add_step(subscriber2.subscribeStep, "/ietf-interfaces:interfaces/interface/ietf-ip:ipv4/address")
+        subscriber3.add_step(subscriber3.waitStep)
 
         srd.add_step(srd.waitStep)
         tester.add_step(tester.setItemStep, "/ietf-interfaces:interfaces/interface[name='eth0']/ietf-ip:ipv4/enabled", Value(leaf_type=SR_BOOL_T, value= False))
@@ -332,11 +356,33 @@ class NotificationTest(unittest.TestCase):
         subscriber3.add_step(subscriber3.waitStep)
         subscriber4.add_step(subscriber4.waitStep)
 
+        #subscribe synchronously
         srd.add_step(srd.waitStep)
         tester.add_step(tester.waitStep)
         subscriber.add_step(subscriber.subscribeStep, "/ietf-interfaces:interfaces")
+        subscriber2.add_step(subscriber2.waitStep)
+        subscriber3.add_step(subscriber3.waitStep)
+        subscriber4.add_step(subscriber4.waitStep)
+
+        srd.add_step(srd.waitStep)
+        tester.add_step(tester.waitStep)
+        subscriber.add_step(subscriber.waitStep)
         subscriber2.add_step(subscriber2.subscribeStep, "/ietf-interfaces:interfaces")
+        subscriber3.add_step(subscriber3.waitStep)
+        subscriber4.add_step(subscriber4.waitStep)
+
+        srd.add_step(srd.waitStep)
+        tester.add_step(tester.waitStep)
+        subscriber.add_step(subscriber.waitStep)
+        subscriber2.add_step(subscriber2.waitStep)
         subscriber3.add_step(subscriber3.subscribeStep, "/ietf-interfaces:interfaces")
+        subscriber4.add_step(subscriber4.waitStep)
+
+        srd.add_step(srd.waitStep)
+        tester.add_step(tester.waitStep)
+        subscriber.add_step(subscriber.waitStep)
+        subscriber2.add_step(subscriber2.waitStep)
+        subscriber3.add_step(subscriber3.waitStep)
         subscriber4.add_step(subscriber4.subscribeStep, "/ietf-interfaces:interfaces")
 
         srd.add_step(srd.waitStep)

--- a/tests/python/TestModule.py
+++ b/tests/python/TestModule.py
@@ -157,7 +157,7 @@ def create_ietf_interfaces():
     v = Value("/ietf-interfaces:interfaces/interface[name='eth0']/description", SR_STRING_T, "Ethernet 0");
     session.set_item(v.xpath, v)
 
-    v = Value("/ietf-interfaces:interfaces/interface[name='eth0']/enabled", SR_BOOL_T, "true");
+    v = Value("/ietf-interfaces:interfaces/interface[name='eth0']/enabled", SR_BOOL_T, True);
     session.set_item(v.xpath, v)
 
     v = Value("/ietf-interfaces:interfaces/interface[name='eth0']/ietf-ip:ipv4/address[ip='192.168.2.100']/prefix-length", SR_UINT8_T, 24)
@@ -175,7 +175,7 @@ def create_ietf_interfaces():
     v = Value("/ietf-interfaces:interfaces/interface[name='eth1']/description", SR_STRING_T, "Ethernet 1");
     session.set_item(v.xpath, v)
 
-    v = Value("/ietf-interfaces:interfaces/interface[name='eth1']/enabled", SR_BOOL_T, "true");
+    v = Value("/ietf-interfaces:interfaces/interface[name='eth1']/enabled", SR_BOOL_T, True);
     session.set_item(v.xpath, v)
 
     v = Value("/ietf-interfaces:interfaces/interface[name='eth1']/ietf-ip:ipv4/address[ip='10.10.1.5']/prefix-length", SR_UINT8_T, 16)
@@ -193,7 +193,7 @@ def create_ietf_interfaces():
     v = Value("/ietf-interfaces:interfaces/interface[name='gigaeth0']/description", SR_STRING_T, "GigabitEthernet 0");
     session.set_item(v.xpath, v)
 
-    v = Value("/ietf-interfaces:interfaces/interface[name='gigaeth0']/enabled", SR_BOOL_T, "false");
+    v = Value("/ietf-interfaces:interfaces/interface[name='gigaeth0']/enabled", SR_BOOL_T, False);
 
     session.commit()
 

--- a/tests/rp_dt_running_test.c
+++ b/tests/rp_dt_running_test.c
@@ -108,6 +108,12 @@ enable_subtree_test(void **state)
    /* check ietf-interfaces:interfaces */
    assert_true(dm_is_node_enabled(module->data));
 
+   rc = rp_dt_validate_node_xpath(ctx->dm_ctx, session->dm_session, "/ietf-interfaces:interfaces/interface/type", &module, &match);
+   assert_int_equal(SR_ERR_OK, rc);
+
+   /* check manadatory leaf is enabled when its parent is enabled */
+   assert_true(dm_is_node_enabled(match));
+
    rc = rp_dt_enable_xpath(ctx->dm_ctx, session->dm_session, "/ietf-interfaces:interfaces/interface/ietf-ip:ipv4/address");
    assert_int_equal(SR_ERR_OK, rc);
 


### PR DESCRIPTION
- fix subscribe for subtree - copy only a part of configuration
- enable mandatory leaves in container/lists which is enabled and not enabled with children
- other fixes