### PR TITLE
RPC tree data API

### DIFF
--- a/inc/sysrepo.h
+++ b/inc/sysrepo.h
@@ -102,6 +102,26 @@ typedef enum sr_type_e {
     SR_UINT64_T,       /**< 64-bit unsigned integer ([RFC 6020 sec 9.2](http://tools.ietf.org/html/rfc6020#section-9.2)) */
 } sr_type_t;
 
+/** Data of an element (if applicable), properly set according to the type. */
+typedef union sr_data_u {
+    char *binary_val;       /**< Base64-encoded binary data ([RFC 6020 sec 9.8](http://tools.ietf.org/html/rfc6020#section-9.8)) */
+    char *bits_val;         /**< A set of bits or flags ([RFC 6020 sec 9.7](http://tools.ietf.org/html/rfc6020#section-9.7)) */
+    bool bool_val;          /**< A boolean value ([RFC 6020 sec 9.5](http://tools.ietf.org/html/rfc6020#section-9.5)) */
+    double decimal64_val;   /**< 64-bit signed decimal number ([RFC 6020 sec 9.3](http://tools.ietf.org/html/rfc6020#section-9.3)) */
+    char *enum_val;         /**< A string from enumerated strings list ([RFC 6020 sec 9.6](http://tools.ietf.org/html/rfc6020#section-9.6)) */
+    char *identityref_val;  /**< A reference to an abstract identity ([RFC 6020 sec 9.10](http://tools.ietf.org/html/rfc6020#section-9.10)) */
+    char *instanceid_val;   /**< References a data tree node ([RFC 6020 sec 9.13](http://tools.ietf.org/html/rfc6020#section-9.13)) */
+    int8_t int8_val;        /**< 8-bit signed integer ([RFC 6020 sec 9.2](http://tools.ietf.org/html/rfc6020#section-9.2)) */
+    int16_t int16_val;      /**< 16-bit signed integer ([RFC 6020 sec 9.2](http://tools.ietf.org/html/rfc6020#section-9.2)) */
+    int32_t int32_val;      /**< 32-bit signed integer ([RFC 6020 sec 9.2](http://tools.ietf.org/html/rfc6020#section-9.2)) */
+    int64_t int64_val;      /**< 64-bit signed integer ([RFC 6020 sec 9.2](http://tools.ietf.org/html/rfc6020#section-9.2)) */
+    char *string_val;       /**< Human-readable string ([RFC 6020 sec 9.4](http://tools.ietf.org/html/rfc6020#section-9.4)) */
+    uint8_t uint8_val;      /**< 8-bit unsigned integer ([RFC 6020 sec 9.2](http://tools.ietf.org/html/rfc6020#section-9.2)) */
+    uint16_t uint16_val;    /**< 16-bit unsigned integer ([RFC 6020 sec 9.2](http://tools.ietf.org/html/rfc6020#section-9.2)) */
+    uint32_t uint32_val;    /**< 32-bit unsigned integer ([RFC 6020 sec 9.2](http://tools.ietf.org/html/rfc6020#section-9.2)) */
+    uint64_t uint64_val;    /**< 64-bit unsigned integer ([RFC 6020 sec 9.2](http://tools.ietf.org/html/rfc6020#section-9.2)) */
+} sr_data_t;
+
 /**
  * @brief Structure that contains value of an data element stored in the sysrepo datastore.
  */
@@ -120,25 +140,42 @@ typedef struct sr_val_s {
     bool dflt;
 
     /** Data of an element (if applicable), properly set according to the type. */
-    union {
-        char *binary_val;       /**< Base64-encoded binary data ([RFC 6020 sec 9.8](http://tools.ietf.org/html/rfc6020#section-9.8)) */
-        char *bits_val;         /**< A set of bits or flags ([RFC 6020 sec 9.7](http://tools.ietf.org/html/rfc6020#section-9.7)) */
-        bool bool_val;          /**< A boolean value ([RFC 6020 sec 9.5](http://tools.ietf.org/html/rfc6020#section-9.5)) */
-        double decimal64_val;   /**< 64-bit signed decimal number ([RFC 6020 sec 9.3](http://tools.ietf.org/html/rfc6020#section-9.3)) */
-        char *enum_val;         /**< A string from enumerated strings list ([RFC 6020 sec 9.6](http://tools.ietf.org/html/rfc6020#section-9.6)) */
-        char *identityref_val;  /**< A reference to an abstract identity ([RFC 6020 sec 9.10](http://tools.ietf.org/html/rfc6020#section-9.10)) */
-        char *instanceid_val;   /**< References a data tree node ([RFC 6020 sec 9.13](http://tools.ietf.org/html/rfc6020#section-9.13)) */
-        int8_t int8_val;        /**< 8-bit signed integer ([RFC 6020 sec 9.2](http://tools.ietf.org/html/rfc6020#section-9.2)) */
-        int16_t int16_val;      /**< 16-bit signed integer ([RFC 6020 sec 9.2](http://tools.ietf.org/html/rfc6020#section-9.2)) */
-        int32_t int32_val;      /**< 32-bit signed integer ([RFC 6020 sec 9.2](http://tools.ietf.org/html/rfc6020#section-9.2)) */
-        int64_t int64_val;      /**< 64-bit signed integer ([RFC 6020 sec 9.2](http://tools.ietf.org/html/rfc6020#section-9.2)) */
-        char *string_val;       /**< Human-readable string ([RFC 6020 sec 9.4](http://tools.ietf.org/html/rfc6020#section-9.4)) */
-        uint8_t uint8_val;      /**< 8-bit unsigned integer ([RFC 6020 sec 9.2](http://tools.ietf.org/html/rfc6020#section-9.2)) */
-        uint16_t uint16_val;    /**< 16-bit unsigned integer ([RFC 6020 sec 9.2](http://tools.ietf.org/html/rfc6020#section-9.2)) */
-        uint32_t uint32_val;    /**< 32-bit unsigned integer ([RFC 6020 sec 9.2](http://tools.ietf.org/html/rfc6020#section-9.2)) */
-        uint64_t uint64_val;    /**< 64-bit unsigned integer ([RFC 6020 sec 9.2](http://tools.ietf.org/html/rfc6020#section-9.2)) */
-    } data;
+    sr_data_t data;
+
 } sr_val_t;
+
+/**
+ * @brief A data element stored in the sysrepo datastore represented as a tree node.
+ *
+ * @note Can be safely casted to sr_val_t, only *xpath* member will point to node name rather
+ * than to an actual xpath.
+ */
+typedef struct sr_node_s {
+    /**
+     * Name of the node.
+     */
+    char *name;
+
+    /** Type of an element. */
+    sr_type_t type;
+
+    /** Flag for default node (applicable only for leaves) */
+    bool dflt;
+
+    /** Data of an element (if applicable), properly set according to the type. */
+    sr_data_t data;
+
+    /**
+     * Name of the module that defines scheme of this node.
+     */
+    char *module_name;
+
+    /**< Array of node's direct descendands */
+    struct sr_node_s *children;
+
+    /**< Number of child nodes */
+    size_t children_cnt;
+} sr_node_t;
 
 /**
  * @brief Sysrepo error codes.
@@ -1135,6 +1172,24 @@ typedef int (*sr_rpc_cb)(const char *xpath, const sr_val_t *input, const size_t 
         sr_val_t **output, size_t *output_cnt, void *private_ctx);
 
 /**
+ * @brief Callback to be called by the delivery of RPC specified by xpath.
+ * This RPC callback variant operates with sysrepo trees rather than with sysrepo values,
+ * use it with ::sr_rpc_subscribe_tree and ::sr_rpc_send_tree.
+ *
+ * @param[in] xpath XPath identifying the RPC.
+ * @param[in] input Array of input parameters (represented as trees).
+ * @param[in] input_cnt Number of input parameters.
+ * @param[out] output Array of output parameters (represented as trees). Should be allocated on heap,
+ * will be freed by sysrepo after sending of the RPC response.
+ * @param[out] output_cnt Number of output parameters.
+ * @param[in] private_ctx Private context opaque to sysrepo, as passed to ::sr_rpc_subscribe call.
+ *
+ * @return Error code (SR_ERR_OK on success).
+ */
+typedef int (*sr_rpc_tree_cb)(const char *xpath, const sr_node_t *input, const size_t input_cnt,
+        sr_node_t **output, size_t *output_cnt, void *private_ctx);
+
+/**
  * @brief Subscribes for delivery of RPC specified by xpath.
  *
  * @param[in] session Session context acquired with ::sr_session_start call.
@@ -1150,6 +1205,25 @@ typedef int (*sr_rpc_cb)(const char *xpath, const sr_val_t *input, const size_t 
  */
 int sr_rpc_subscribe(sr_session_ctx_t *session, const char *xpath, sr_rpc_cb callback, void *private_ctx,
         sr_subscr_options_t opts, sr_subscription_ctx_t **subscription);
+
+/**
+ * @brief Subscribes for delivery of RPC specified by xpath. Unlike ::sr_rpc_subscribe, this
+ * function expects callback of type ::sr_rpc_tree_cb, therefore use this version if you prefer
+ * to manipulate with RPC input and output data organized in a list of trees.
+ *
+ * @param[in] session Session context acquired with ::sr_session_start call.
+ * @param[in] xpath XPath identifying the RPC.
+ * @param[in] callback Callback to be called when the RPC is called.
+ * @param[in] private_ctx Private context passed to the callback function, opaque to sysrepo.
+ * @param[in] opts Options overriding default behavior of the subscription, it is supposed to be
+ * a bitwise OR-ed value of any ::sr_subscr_flag_t flags.
+ * @param[in,out] subscription Subscription context that is supposed to be released by ::sr_unsubscribe.
+ * @note An existing context may be passed in case that SR_SUBSCR_CTX_REUSE option is specified.
+ *
+ * @return Error code (SR_ERR_OK on success).
+ */
+int sr_rpc_subscribe_tree(sr_session_ctx_t *session, const char *xpath, sr_rpc_tree_cb callback,
+        void *private_ctx, sr_subscr_options_t opts, sr_subscription_ctx_t **subscription);
 
 /**
  * @brief Sends a RPC specified by xpath and waits for the result.
@@ -1169,6 +1243,23 @@ int sr_rpc_subscribe(sr_session_ctx_t *session, const char *xpath, sr_rpc_cb cal
 int sr_rpc_send(sr_session_ctx_t *session, const char *xpath,
         const sr_val_t *input,  const size_t input_cnt, sr_val_t **output, size_t *output_cnt);
 
+/**
+ * @brief Sends a RPC specified by xpath and waits for the result. Input and output data
+ * are represented as arrays of subtrees reflecting the scheme of RPC arguments,
+ * rather than a flat enumeration of all values.
+ *
+ * @param[in] session Session context acquired with ::sr_session_start call.
+ * @param[in] xpath XPath identifying the RPC.
+ * @param[in] input Array of input parameters (organized in trees).
+ * @param[in] input_cnt Number of input parameters.
+ * @param[out] output Array of output parameters (organized in trees).
+ * Will be allocated by sysrepo and should be freed by caller using ::sr_free_trees.
+ * @param[out] output_cnt Number of output parameters.
+ *
+ * @return Error code (SR_ERR_OK on success).
+ */
+int sr_rpc_send_tree(sr_session_ctx_t *session, const char *xpath,
+        const sr_node_t *input,  const size_t input_cnt, sr_node_t **output, size_t *output_cnt);
 
 ////////////////////////////////////////////////////////////////////////////////
 // Operational Data API - EXPERIMENTAL (work in progress) !!!
@@ -1231,7 +1322,7 @@ int sr_dp_get_items_subscribe(sr_session_ctx_t *session, const char *xpath, sr_d
  * @param[in] xpath XPath identifying the event notification.
  * @param[in] values Array of all nodes that hold some data in event notification subtree.
  * @param[in] values_cnt Number of items inside the values array.
- * @param[in] private_ctx Private context opaque to sysrepo, 
+ * @param[in] private_ctx Private context opaque to sysrepo,
  * as passed to ::sr_event_notif_subscribe call.
  *
  * @return Error code (SR_ERR_OK on success).
@@ -1253,7 +1344,7 @@ typedef void (*sr_event_notif_cb)(const char *xpath, const sr_val_t *values, con
  *
  * @return Error code (SR_ERR_OK on success).
  */
-int sr_event_notif_subscribe(sr_session_ctx_t *session, const char *xpath, 
+int sr_event_notif_subscribe(sr_session_ctx_t *session, const char *xpath,
         sr_event_notif_cb callback, void *private_ctx, sr_subscr_options_t opts,
         sr_subscription_ctx_t **subscription);
 
@@ -1314,6 +1405,21 @@ void sr_free_change_iter(sr_change_iter_t *iter);
  * @param [in] count Number of elements stored in the array.
  */
 void sr_free_schemas(sr_schema_t *schemas, size_t count);
+
+/**
+ * @brief Frees sysrepo tree data.
+ *
+ * @param[in] tree Tree data to be freed.
+ */
+void sr_free_tree(sr_node_t *tree);
+
+/**
+ * @brief Frees array of sysrepo trees. For each tree, the ::sr_free_tree is called too.
+ *
+ * @param[in] trees
+ * @param[in] count length of array
+ */
+void sr_free_trees(sr_node_t *trees, size_t count);
 
 /**@} cl */
 

--- a/inc/sysrepo.h
+++ b/inc/sysrepo.h
@@ -136,7 +136,12 @@ typedef struct sr_val_s {
     /** Type of an element. */
     sr_type_t type;
 
-    /** Flag for default node (applicable only for leaves) */
+    /**
+     * Flag for node with default value (applicable only for leaves).
+     * It is set to TRUE only if the value was *implicitly* set by the datastore as per
+     * module schema. Explicitly set/modified data element (through the sysrepo API) always
+     * has this flag unset regardless of the entered value.
+     */
     bool dflt;
 
     /** Data of an element (if applicable), properly set according to the type. */

--- a/src/cl_subscription_manager.c
+++ b/src/cl_subscription_manager.c
@@ -792,7 +792,7 @@ cl_sm_rpc_process(cl_sm_ctx_t *sm_ctx, cl_sm_conn_ctx_t *conn, Sr__Msg *msg)
                     &resp->response->rpc_resp->n_output);
         } else if (NULL != output_tree) {
             rc = sr_trees_sr_to_gpb(output_tree, output_cnt, &resp->response->rpc_resp->output_tree,
-                    &resp->response->rpc_resp->n_output);
+                    &resp->response->rpc_resp->n_output_tree);
         }
         CHECK_RC_MSG_GOTO(rc, cleanup, "Error by copying RPC output arguments to GPB.");
     }

--- a/src/cl_subscription_manager.c
+++ b/src/cl_subscription_manager.c
@@ -731,6 +731,7 @@ cl_sm_rpc_process(cl_sm_ctx_t *sm_ctx, cl_sm_conn_ctx_t *conn, Sr__Msg *msg)
     cl_sm_subscription_ctx_t subscription_lookup = { 0, };
     Sr__Msg *resp = NULL;
     sr_val_t *input = NULL, *output = NULL;
+    sr_node_t *input_tree = NULL, *output_tree = NULL;
     size_t input_cnt = 0, output_cnt = 0;
     int rc = SR_ERR_OK, rpc_rc = SR_ERR_OK;
 
@@ -739,7 +740,12 @@ cl_sm_rpc_process(cl_sm_ctx_t *sm_ctx, cl_sm_conn_ctx_t *conn, Sr__Msg *msg)
     SR_LOG_DBG("Received a RPC request for subscription id=%"PRIu32".", msg->request->rpc_req->subscription_id);
 
     /* copy input values from GPB */
-    rc = sr_values_gpb_to_sr(msg->request->rpc_req->input, msg->request->rpc_req->n_input, &input, &input_cnt);
+    if (msg->request->rpc_req->n_input) {
+        rc = sr_values_gpb_to_sr(msg->request->rpc_req->input, msg->request->rpc_req->n_input, &input, &input_cnt);
+    } else if (msg->request->rpc_req->n_input_tree) {
+        rc = sr_trees_gpb_to_sr(msg->request->rpc_req->input_tree, msg->request->rpc_req->n_input_tree,
+                                &input_tree, &input_cnt);
+    }
     CHECK_RC_MSG_GOTO(rc, cleanup, "Error by copying RPC input arguments from GPB.");
 
     pthread_mutex_lock(&sm_ctx->subscriptions_lock);
@@ -755,11 +761,19 @@ cl_sm_rpc_process(cl_sm_ctx_t *sm_ctx, cl_sm_conn_ctx_t *conn, Sr__Msg *msg)
 
     SR_LOG_DBG("Calling RPC callback for subscription id=%"PRIu32".", subscription->id);
 
-    rpc_rc = subscription->callback.rpc_cb(
-            msg->request->rpc_req->xpath,
-            input, input_cnt,
-            &output, &output_cnt,
-            subscription->private_ctx);
+    if (SR_API_VALUES == subscription->api_variant) {
+        rpc_rc = subscription->callback.rpc_cb(
+                        msg->request->rpc_req->xpath,
+                        input, input_cnt,
+                        &output, &output_cnt,
+                        subscription->private_ctx);
+    } else {
+        rpc_rc = subscription->callback.rpc_tree_cb(
+                        msg->request->rpc_req->xpath,
+                        input_tree, input_cnt,
+                        &output_tree, &output_cnt,
+                        subscription->private_ctx);
+    }
 
     pthread_mutex_unlock(&sm_ctx->subscriptions_lock);
 
@@ -773,7 +787,13 @@ cl_sm_rpc_process(cl_sm_ctx_t *sm_ctx, cl_sm_conn_ctx_t *conn, Sr__Msg *msg)
 
     /* copy output values to GPB */
     if (SR_ERR_OK == rpc_rc) {
-        rc = sr_values_sr_to_gpb(output, output_cnt, &resp->response->rpc_resp->output, &resp->response->rpc_resp->n_output);
+        if (NULL != output) {
+            rc = sr_values_sr_to_gpb(output, output_cnt, &resp->response->rpc_resp->output,
+                    &resp->response->rpc_resp->n_output);
+        } else if (NULL != output_tree) {
+            rc = sr_trees_sr_to_gpb(output_tree, output_cnt, &resp->response->rpc_resp->output_tree,
+                    &resp->response->rpc_resp->n_output);
+        }
         CHECK_RC_MSG_GOTO(rc, cleanup, "Error by copying RPC output arguments to GPB.");
     }
 
@@ -783,6 +803,8 @@ cl_sm_rpc_process(cl_sm_ctx_t *sm_ctx, cl_sm_conn_ctx_t *conn, Sr__Msg *msg)
 cleanup:
     sr_free_values(input, input_cnt);
     sr_free_values(output, output_cnt);
+    sr_free_trees(input_tree, input_cnt);
+    sr_free_trees(output_tree, output_cnt);
     if (NULL != resp) {
         sr__msg__free_unpacked(resp, NULL);
     }

--- a/src/cl_subscription_manager.h
+++ b/src/cl_subscription_manager.h
@@ -52,7 +52,7 @@ typedef union cl_sm_callback_u {
         sr_subtree_change_cb subtree_change_cb;  /**< Callback to be called by subtree change event. */
         sr_dp_get_items_cb dp_get_items_cb;      /**< Callback to be called by operational data requests. */
         sr_rpc_cb rpc_cb;                        /**< Callback to be called by RPC delivery. */
-        sr_rpc_tree_cb rpc_tree_cb;              /**< Callback to be called by RFC delivery -- the *tree* variant */
+        sr_rpc_tree_cb rpc_tree_cb;              /**< Callback to be called by RPC delivery -- the *tree* variant */
         sr_event_notif_cb event_notif_cb;        /**< Callback to be called by event notification delivery. */
 } cl_sm_callback_t;
 

--- a/src/cl_subscription_manager.h
+++ b/src/cl_subscription_manager.h
@@ -45,6 +45,17 @@ typedef struct cl_sm_ctx_s cl_sm_ctx_t;
  */
 typedef struct cl_sm_server_ctx_s cl_sm_server_ctx_t;
 
+typedef union cl_sm_callback_u {
+        sr_feature_enable_cb feature_enable_cb;  /**< Callback to be called by feature enable/disable event. */
+        sr_module_install_cb module_install_cb;  /**< Callback to be called by module (un)install event. */
+        sr_module_change_cb module_change_cb;    /**< Callback to be called by module change event. */
+        sr_subtree_change_cb subtree_change_cb;  /**< Callback to be called by subtree change event. */
+        sr_dp_get_items_cb dp_get_items_cb;      /**< Callback to be called by operational data requests. */
+        sr_rpc_cb rpc_cb;                        /**< Callback to be called by RPC delivery. */
+        sr_rpc_tree_cb rpc_tree_cb;              /**< Callback to be called by RFC delivery -- the *tree* variant */
+        sr_event_notif_cb event_notif_cb;        /**< Callback to be called by event notification delivery. */
+} cl_sm_callback_t;
+
 /**
  * @brief Sysrepo subscription context.
  */
@@ -53,15 +64,8 @@ typedef struct cl_sm_subscription_ctx_s {
     const char *delivery_address;                /**< Address where the notification messages should be delivered. */
     uint32_t id;                                 /**< Library-local subscription identifier. */
     const char *module_name;                     /**< Name of the YANG module witch the subscription is tied to.*/
-    union {
-        sr_feature_enable_cb feature_enable_cb;  /**< Callback to be called by feature enable/disable event. */
-        sr_module_install_cb module_install_cb;  /**< Callback to be called by module (un)install event. */
-        sr_module_change_cb module_change_cb;    /**< Callback to be called by module change event. */
-        sr_subtree_change_cb subtree_change_cb;  /**< Callback to be called by subtree change event. */
-        sr_dp_get_items_cb dp_get_items_cb;      /**< Callback to be called by operational data requests. */
-        sr_rpc_cb rpc_cb;                        /**< Callback to be called by RPC delivery. */
-        sr_event_notif_cb event_notif_cb;        /**< Callback to be called by event notification delivery. */
-    } callback;
+    cl_sm_callback_t callback;                   /**< Callback to be called when the associated notification/action triggers. */
+    sr_api_variant_t api_variant;                /**< API variant -- values vs. nodes (relevant for the callback type only) */
     cl_sm_ctx_t *sm_ctx;                         /**< Associated Subscription Manager context. */
     sr_session_ctx_t *data_session;              /**< Pointer to a data session that can be used from notification callbacks. */
     void *private_ctx;                           /**< Private context pointer, opaque to sysrepo. */

--- a/src/client_library.c
+++ b/src/client_library.c
@@ -190,8 +190,8 @@ cleanup:
  */
 static int
 cl_subscription_init(sr_session_ctx_t *session, Sr__SubscriptionType type, const char *module_name,
-        void *private_ctx, sr_subscription_ctx_t **sr_subscription_p, cl_sm_subscription_ctx_t **sm_subscription_p,
-        Sr__Msg **msg_req_p)
+        sr_api_variant_t api_variant, void *private_ctx, sr_subscription_ctx_t **sr_subscription_p,
+        cl_sm_subscription_ctx_t **sm_subscription_p, Sr__Msg **msg_req_p)
 {
     Sr__Msg *msg_req = NULL;
     sr_subscription_ctx_t *sr_subscription = NULL;
@@ -223,6 +223,7 @@ cl_subscription_init(sr_session_ctx_t *session, Sr__SubscriptionType type, const
     rc = cl_sm_subscription_init(cl_sm_ctx, server_ctx, &sm_subscription);
     CHECK_RC_MSG_GOTO(rc, cleanup, "Error by initialization of the subscription in the Subscription Manager.");
 
+    sm_subscription->api_variant = api_variant;
     sm_subscription->type = type;
     sm_subscription->private_ctx = private_ctx;
     if (NULL != module_name) {
@@ -1403,7 +1404,7 @@ sr_module_install_subscribe(sr_session_ctx_t *session, sr_module_install_cb call
     if (opts & SR_SUBSCR_CTX_REUSE) {
         sr_subscription = *subscription_p;
     }
-    rc = cl_subscription_init(session, SR__SUBSCRIPTION_TYPE__MODULE_INSTALL_SUBS, NULL,
+    rc = cl_subscription_init(session, SR__SUBSCRIPTION_TYPE__MODULE_INSTALL_SUBS, NULL, SR_API_VALUES,
             private_ctx, &sr_subscription, &sm_subscription, &msg_req);
     CHECK_RC_MSG_GOTO(rc, cleanup, "Error by initialization of the subscription in the client library.");
 
@@ -1449,7 +1450,7 @@ sr_feature_enable_subscribe(sr_session_ctx_t *session, sr_feature_enable_cb call
     if (opts & SR_SUBSCR_CTX_REUSE) {
         sr_subscription = *subscription_p;
     }
-    rc = cl_subscription_init(session, SR__SUBSCRIPTION_TYPE__FEATURE_ENABLE_SUBS, NULL,
+    rc = cl_subscription_init(session, SR__SUBSCRIPTION_TYPE__FEATURE_ENABLE_SUBS, NULL, SR_API_VALUES,
             private_ctx, &sr_subscription, &sm_subscription, &msg_req);
     CHECK_RC_MSG_GOTO(rc, cleanup, "Error by initialization of the subscription in the client library.");
 
@@ -1534,7 +1535,7 @@ sr_module_change_subscribe(sr_session_ctx_t *session, const char *module_name, s
     if (opts & SR_SUBSCR_CTX_REUSE) {
         sr_subscription = *subscription_p;
     }
-    rc = cl_subscription_init(session, SR__SUBSCRIPTION_TYPE__MODULE_CHANGE_SUBS, module_name,
+    rc = cl_subscription_init(session, SR__SUBSCRIPTION_TYPE__MODULE_CHANGE_SUBS, module_name, SR_API_VALUES,
             private_ctx, &sr_subscription, &sm_subscription, &msg_req);
     CHECK_RC_MSG_GOTO(rc, cleanup, "Error by initialization of the subscription in the client library.");
 
@@ -1598,7 +1599,7 @@ sr_subtree_change_subscribe(sr_session_ctx_t *session, const char *xpath, sr_sub
     if (opts & SR_SUBSCR_CTX_REUSE) {
         sr_subscription = *subscription_p;
     }
-    rc = cl_subscription_init(session, SR__SUBSCRIPTION_TYPE__SUBTREE_CHANGE_SUBS, module_name,
+    rc = cl_subscription_init(session, SR__SUBSCRIPTION_TYPE__SUBTREE_CHANGE_SUBS, module_name, SR_API_VALUES,
             private_ctx, &sr_subscription, &sm_subscription, &msg_req);
     CHECK_RC_MSG_GOTO(rc, cleanup, "Error by initialization of the subscription in the client library.");
 
@@ -1944,9 +1945,25 @@ cleanup:
     return cl_session_return(session, rc);
 }
 
-int
-sr_rpc_subscribe(sr_session_ctx_t *session, const char *xpath, sr_rpc_cb callback,
-        void *private_ctx, sr_subscr_options_t opts, sr_subscription_ctx_t **subscription_p)
+/**
+ * @brief Subscribes for delivery of RPC specified by xpath.
+ *
+ * @param[in] sr_api_variant_t API variant.
+ * @param[in] session Session context acquired with ::sr_session_start call.
+ * @param[in] xpath XPath identifying the RPC.
+ * @param[in] callback Callback to be called when the RPC is called.
+ * @param[in] private_ctx Private context passed to the callback function, opaque to sysrepo.
+ * @param[in] opts Options overriding default behavior of the subscription, it is supposed to be
+ * a bitwise OR-ed value of any ::sr_subscr_flag_t flags.
+ * @param[in,out] subscription Subscription context that is supposed to be released by ::sr_unsubscribe.
+ * @note An existing context may be passed in case that SR_SUBSCR_CTX_REUSE option is specified.
+ *
+ * @return Error code (SR_ERR_OK on success).
+ */
+static int
+cl_rpc_subscribe(sr_api_variant_t api_variant, sr_session_ctx_t *session, const char *xpath,
+        cl_sm_callback_t callback, void *private_ctx, sr_subscr_options_t opts,
+        sr_subscription_ctx_t **subscription_p)
 {
     Sr__Msg *msg_req = NULL, *msg_resp = NULL;
     sr_subscription_ctx_t *sr_subscription = NULL;
@@ -1954,7 +1971,7 @@ sr_rpc_subscribe(sr_session_ctx_t *session, const char *xpath, sr_rpc_cb callbac
     char *module_name = NULL;
     int rc = SR_ERR_OK;
 
-    CHECK_NULL_ARG3(session, callback, subscription_p);
+    CHECK_NULL_ARG2(session, subscription_p);
 
     cl_session_clear_errors(session);
 
@@ -1966,11 +1983,11 @@ sr_rpc_subscribe(sr_session_ctx_t *session, const char *xpath, sr_rpc_cb callbac
     if (opts & SR_SUBSCR_CTX_REUSE) {
         sr_subscription = *subscription_p;
     }
-    rc = cl_subscription_init(session, SR__SUBSCRIPTION_TYPE__RPC_SUBS, module_name,
+    rc = cl_subscription_init(session, SR__SUBSCRIPTION_TYPE__RPC_SUBS, module_name, api_variant,
             private_ctx, &sr_subscription, &sm_subscription, &msg_req);
     CHECK_RC_MSG_GOTO(rc, cleanup, "Error by initialization of the subscription in the client library.");
 
-    sm_subscription->callback.rpc_cb = callback;
+    sm_subscription->callback = callback;
 
     /* Fill-in GPB subscription information */
     msg_req->request->subscribe_req->type = SR__SUBSCRIPTION_TYPE__RPC_SUBS;
@@ -2002,6 +2019,24 @@ cleanup:
     }
     free(module_name);
     return cl_session_return(session, rc);
+}
+
+int
+sr_rpc_subscribe(sr_session_ctx_t *session, const char *xpath, sr_rpc_cb callback,
+        void *private_ctx, sr_subscr_options_t opts, sr_subscription_ctx_t **subscription_p)
+{
+    cl_sm_callback_t callback_u;
+    callback_u.rpc_cb = callback;
+    return cl_rpc_subscribe(SR_API_VALUES, session, xpath, callback_u, private_ctx, opts, subscription_p);
+}
+
+int
+sr_rpc_subscribe_tree(sr_session_ctx_t *session, const char *xpath, sr_rpc_tree_cb callback,
+        void *private_ctx, sr_subscr_options_t opts, sr_subscription_ctx_t **subscription_p)
+{
+    cl_sm_callback_t callback_u;
+    callback_u.rpc_tree_cb = callback;
+    return cl_rpc_subscribe(SR_API_TREES, session, xpath, callback_u, private_ctx, opts, subscription_p);
 }
 
 int
@@ -2053,6 +2088,54 @@ cleanup:
 }
 
 int
+sr_rpc_send_tree(sr_session_ctx_t *session, const char *xpath,
+        const sr_node_t *input,  const size_t input_cnt, sr_node_t **output, size_t *output_cnt)
+{
+    Sr__Msg *msg_req = NULL, *msg_resp = NULL;
+    int rc = SR_ERR_OK;
+
+    CHECK_NULL_ARG3(session, session->conn_ctx, xpath);
+
+    cl_session_clear_errors(session);
+
+    /* prepare RPC message */
+    rc = sr_gpb_req_alloc(SR__OPERATION__RPC, session->id, &msg_req);
+    CHECK_RC_MSG_GOTO(rc, cleanup, "Cannot allocate GPB message.");
+
+    /* set arguments */
+    msg_req->request->rpc_req->xpath = strdup(xpath);
+    CHECK_NULL_NOMEM_GOTO(msg_req->request->rpc_req->xpath, rc, cleanup);
+
+    /* set input arguments */
+    rc = sr_trees_sr_to_gpb(input, input_cnt, &msg_req->request->rpc_req->input_tree, &msg_req->request->rpc_req->n_input_tree);
+    CHECK_RC_MSG_GOTO(rc, cleanup, "Error by copying RPC input arguments to GPB.");
+
+    /* send the request and receive the response */
+    rc = cl_request_process(session, msg_req, &msg_resp, SR__OPERATION__RPC);
+    CHECK_RC_MSG_GOTO(rc, cleanup, "Error by processing of the request.");
+
+    if (NULL != output) {
+        /* set output arguments */
+        rc = sr_trees_gpb_to_sr(msg_resp->response->rpc_resp->output_tree, msg_resp->response->rpc_resp->n_output_tree, output, output_cnt);
+        CHECK_RC_MSG_GOTO(rc, cleanup, "Error by copying RPC output arguments from GPB.");
+    }
+
+    sr__msg__free_unpacked(msg_req, NULL);
+    sr__msg__free_unpacked(msg_resp, NULL);
+
+    return cl_session_return(session, SR_ERR_OK);
+
+cleanup:
+    if (NULL != msg_req) {
+        sr__msg__free_unpacked(msg_req, NULL);
+    }
+    if (NULL != msg_resp) {
+        sr__msg__free_unpacked(msg_resp, NULL);
+    }
+    return cl_session_return(session, rc);
+}
+
+int
 sr_dp_get_items_subscribe(sr_session_ctx_t *session, const char *xpath, sr_dp_get_items_cb callback, void *private_ctx,
         sr_subscr_options_t opts, sr_subscription_ctx_t **subscription_p)
 {
@@ -2074,7 +2157,7 @@ sr_dp_get_items_subscribe(sr_session_ctx_t *session, const char *xpath, sr_dp_ge
     if (opts & SR_SUBSCR_CTX_REUSE) {
         sr_subscription = *subscription_p;
     }
-    rc = cl_subscription_init(session, SR__SUBSCRIPTION_TYPE__DP_GET_ITEMS_SUBS, module_name,
+    rc = cl_subscription_init(session, SR__SUBSCRIPTION_TYPE__DP_GET_ITEMS_SUBS, module_name, SR_API_VALUES,
             private_ctx, &sr_subscription, &sm_subscription, &msg_req);
     CHECK_RC_MSG_GOTO(rc, cleanup, "Error by initialization of the subscription in the client library.");
 
@@ -2137,7 +2220,7 @@ sr_event_notif_subscribe(sr_session_ctx_t *session, const char *xpath, sr_event_
     if (opts & SR_SUBSCR_CTX_REUSE) {
         sr_subscription = *subscription_p;
     }
-    rc = cl_subscription_init(session, SR__SUBSCRIPTION_TYPE__EVENT_NOTIF_SUBS, module_name,
+    rc = cl_subscription_init(session, SR__SUBSCRIPTION_TYPE__EVENT_NOTIF_SUBS, module_name, SR_API_VALUES,
             private_ctx, &sr_subscription, &sm_subscription, &msg_req);
     CHECK_RC_MSG_GOTO(rc, cleanup, "Error by initialization of the subscription in the client library.");
 

--- a/src/common/sr_common.c
+++ b/src/common/sr_common.c
@@ -92,3 +92,23 @@ sr_free_schemas(sr_schema_t *schemas, size_t count)
         free(schemas);
     }
 }
+
+void
+sr_free_tree(sr_node_t *tree)
+{
+    if (NULL != tree) {
+        sr_free_tree_content(tree);
+        free(tree);
+    }
+}
+
+void
+sr_free_trees(sr_node_t *trees, size_t count)
+{
+    if (NULL != trees) {
+        for (size_t i = 0; i < count; i++) {
+            sr_free_tree_content(trees + i);
+        }
+        free(trees);
+    }
+}

--- a/src/common/sr_protobuf.c
+++ b/src/common/sr_protobuf.c
@@ -978,7 +978,7 @@ sr_set_val_t_value_in_gpb(const sr_val_t *value, Sr__Value *gpb_value){
 
     if (NULL != value->xpath) {
         gpb_value->xpath = strdup(value->xpath);
-        CHECK_NULL_NOMEM_RETURN(value->xpath);
+        CHECK_NULL_NOMEM_RETURN(gpb_value->xpath);
     }
 
     gpb_value->dflt = value->dflt;
@@ -1340,6 +1340,184 @@ cleanup:
         sr_free_val_content(&sr_values[i]);
     }
     free(sr_values);
+    return rc;
+}
+
+int
+sr_dup_tree_to_gpb(const sr_node_t *sr_tree, Sr__Node **gpb_tree)
+{
+    CHECK_NULL_ARG2(sr_tree, gpb_tree);
+    int rc = SR_ERR_OK;
+    Sr__Node *gpb;
+
+    gpb = calloc(1, sizeof(*gpb));
+    CHECK_NULL_NOMEM_RETURN(gpb);
+
+    sr__node__init(gpb);
+    gpb->n_children = 0;
+
+    /* set members which are common with sr_val_t */
+    rc = sr_set_val_t_type_in_gpb((sr_val_t *)sr_tree, gpb->value);
+    if (SR_ERR_OK != rc){
+        SR_LOG_ERR("Setting value type in gpb tree failed for node '%s'", sr_tree->name);
+        goto cleanup;
+    }
+
+    rc = sr_set_val_t_value_in_gpb((sr_val_t *)sr_tree, gpb->value);
+    if (SR_ERR_OK != rc) {
+        SR_LOG_ERR("Setting value in gpb tree failed for node '%s'", sr_tree->name);
+        goto cleanup;
+    }
+
+    /* module_name */
+    if (NULL != sr_tree->module_name) {
+        gpb->module_name = strdup(sr_tree->module_name);
+        CHECK_NULL_NOMEM_GOTO(gpb->module_name, rc, cleanup);
+    }
+
+    /* recursively duplicate children */
+    gpb->children = calloc(sr_tree->children_cnt, sizeof(*gpb->children));
+    CHECK_NULL_NOMEM_GOTO(gpb->children, rc, cleanup);
+    for (size_t i = 0; i < sr_tree->children_cnt; ++i) {
+        rc = sr_dup_tree_to_gpb(sr_tree->children + i, gpb->children + i);
+        if (SR_ERR_OK == rc) {
+            goto cleanup;
+        }
+        ++gpb->n_children;
+    }
+
+    *gpb_tree = gpb;
+    return rc;
+
+cleanup:
+    sr__node__free_unpacked(gpb, NULL);
+    return rc;
+}
+
+int
+sr_dup_gpb_to_tree(const Sr__Node *gpb_tree, sr_node_t **sr_tree)
+{
+    CHECK_NULL_ARG2(gpb_tree, sr_tree);
+    sr_node_t *tree = NULL;
+    int rc = SR_ERR_INTERNAL;
+
+    tree = calloc(1, sizeof(*tree));
+    CHECK_NULL_NOMEM_RETURN(tree);
+
+    rc = sr_copy_gpb_to_tree(gpb_tree, tree);
+    if (SR_ERR_OK != rc) {
+        free(tree);
+        return rc;
+    }
+
+    *sr_tree = tree;
+    return rc;
+}
+
+int
+sr_copy_gpb_to_tree(const Sr__Node *gpb_tree, sr_node_t *sr_tree)
+{
+    CHECK_NULL_ARG2(gpb_tree, sr_tree);
+    int rc = SR_ERR_INTERNAL;
+
+    /* members common with sr_val_t */
+    rc = sr_set_gpb_type_in_val_t(gpb_tree->value, (sr_val_t *)sr_tree);
+    if (SR_ERR_OK != rc) {
+        SR_LOG_ERR_MSG("Setting value type in for sr_value_t failed");
+        return rc;
+    }
+
+    rc = sr_set_gpb_value_in_val_t(gpb_tree->value, (sr_val_t *)sr_tree);
+    if (SR_ERR_OK != rc) {
+        SR_LOG_ERR_MSG("Setting value in for sr_value_t failed");
+        return rc;
+    }
+
+    /* module_name */
+    if (NULL != gpb_tree->module_name) {
+        sr_tree->module_name = strdup(gpb_tree->module_name);
+        CHECK_NULL_NOMEM_GOTO(sr_tree->module_name, rc, cleanup);
+    }
+
+    /* recursively copy children */
+    sr_tree->children_cnt = 0;
+    sr_tree->children = calloc(gpb_tree->n_children, sizeof(*sr_tree));
+    CHECK_NULL_NOMEM_GOTO(sr_tree, rc, cleanup);
+
+    for (size_t i = 0; i < gpb_tree->n_children; ++i) {
+        rc = sr_copy_gpb_to_tree(gpb_tree->children[i], sr_tree->children + i);
+        if (SR_ERR_OK != rc) {
+            goto cleanup;
+        }
+        ++sr_tree->children_cnt;
+    }
+
+cleanup:
+    if (SR_ERR_OK != rc) {
+        sr_free_tree_content(sr_tree);
+    }
+    return rc;
+}
+
+int
+sr_trees_sr_to_gpb(const sr_node_t *sr_trees, const size_t sr_tree_cnt, Sr__Node ***gpb_trees_p, size_t *gpb_tree_cnt_p)
+{
+    Sr__Node **gpb_trees = NULL;
+    int rc = SR_ERR_OK;
+
+    CHECK_NULL_ARG2(gpb_trees_p, gpb_tree_cnt_p);
+
+    if ((NULL != sr_trees) && (sr_tree_cnt > 0)) {
+        gpb_trees = calloc(sr_tree_cnt, sizeof(*gpb_trees));
+        CHECK_NULL_NOMEM_RETURN(gpb_trees);
+
+        for (size_t i = 0; i < sr_tree_cnt; i++) {
+            rc = sr_dup_tree_to_gpb(&sr_trees[i], &gpb_trees[i]);
+            CHECK_RC_MSG_GOTO(rc, cleanup, "Unable to duplicate sysrepo tree to GPB.");
+        }
+    }
+
+    *gpb_trees_p = gpb_trees;
+    *gpb_tree_cnt_p = sr_tree_cnt;
+
+    return SR_ERR_OK;
+
+cleanup:
+    for (size_t i = 0; i < sr_tree_cnt; i++) {
+        sr__node__free_unpacked(gpb_trees[i], NULL);
+    }
+    free(gpb_trees);
+    return rc;
+}
+
+int
+sr_trees_gpb_to_sr(Sr__Node **gpb_trees, size_t gpb_tree_cnt, sr_node_t **sr_trees_p, size_t *sr_tree_cnt_p)
+{
+    sr_node_t *sr_trees = NULL;
+    int rc = SR_ERR_OK;
+
+    CHECK_NULL_ARG2(sr_trees_p, sr_tree_cnt_p);
+
+    if ((NULL != gpb_trees) && (gpb_tree_cnt > 0)) {
+        sr_trees = calloc(gpb_tree_cnt, sizeof(*sr_trees));
+        CHECK_NULL_NOMEM_RETURN(sr_trees);
+
+        for (size_t i = 0; i < gpb_tree_cnt; i++) {
+            rc = sr_copy_gpb_to_tree(gpb_trees[i], &sr_trees[i]);
+            CHECK_RC_MSG_GOTO(rc, cleanup, "Unable to duplicate GPB tree to sysrepo tree.");
+        }
+    }
+
+    *sr_trees_p = sr_trees;
+    *sr_tree_cnt_p = gpb_tree_cnt;
+
+    return SR_ERR_OK;
+
+cleanup:
+    for (size_t i = 0; i < gpb_tree_cnt; i++) {
+        sr_free_tree_content(&sr_trees[i]);
+    }
+    free(sr_trees);
     return rc;
 }
 

--- a/src/common/sr_protobuf.h
+++ b/src/common/sr_protobuf.h
@@ -119,7 +119,7 @@ int sr_gpb_msg_validate(const Sr__Msg *msg, const Sr__Msg__MsgType type, const S
 int sr_gpb_msg_validate_notif(const Sr__Msg *msg, const Sr__SubscriptionType type);
 
 /**
- * @brief Allocates and fills gpb structure form sr_val_t.
+ * @brief Allocates and fills gpb structure from sr_val_t.
  * @param [in] value
  * @param [out] gpb_value
  * @return err_code
@@ -166,6 +166,58 @@ int sr_values_sr_to_gpb(const sr_val_t *sr_values, const size_t sr_value_cnt, Sr
  * @return Error code (SR_ERR_OK on success).
  */
 int sr_values_gpb_to_sr(Sr__Value **gpb_values, size_t gpb_value_cnt, sr_val_t **sr_values, size_t *sr_value_cnt);
+
+/**
+ * @brief Allocates and copies tree data from the sysrepo tree-representation (based on sr_node_t) into
+ * the GPB tree-representation (based on Sr__Node).
+ *
+ * @param [in] sr_tree Sysrepo tree.
+ * @param [out] gpb_tree GPB tree.
+ * @return err_code
+ */
+int sr_dup_tree_to_gpb(const sr_node_t *sr_tree, Sr__Node **gpb_tree);
+
+/**
+ * @brief Allocates and copies tree data from the GPB tree-representation (based on Sr__Node) into
+ * the sysrepo tree-representation (based on sr_node_t).
+ *
+ * @param [in] gpb_tree GPB tree.
+ * @param [out] sr_tree Sysrepo tree.
+ * @return err_code
+ */
+int sr_dup_gpb_to_tree(const Sr__Node *gpb_tree, sr_node_t **sr_tree);
+
+/**
+ * @brief Fill sysrepo tree content from gpb.
+ * @param [in] gpb_tree
+ * @param [out] sr_tree
+ * @return err_code
+ */
+int sr_copy_gpb_to_tree(const Sr__Node *gpb_tree, sr_node_t *sr_tree);
+
+/**
+ * @brief Copies and transforms an array of sysrepo trees into the array of GPB-represented trees.
+ *
+ * @param[in] sr_trees Array of sysrepo trees.
+ * @param[in] sr_tree_cnt Number of trees.
+ * @param[out] gpb_trees array of GPB trees.
+ * @param[out] gpb_tree_cnt Number of GPB trees as returned in gpb_trees.
+ *
+ * @return Error code (SR_ERR_OK on success).
+ */
+int sr_trees_sr_to_gpb(const sr_node_t *sr_trees, const size_t sr_tree_cnt, Sr__Node ***gpb_trees, size_t *gpb_tree_cnt);
+
+/**
+ * @brief Copies and transforms an array of GPB trees into the array of sysrepo-represented trees.
+ *
+ * @param[in] gpb_trees array of GPB trees.
+ * @param[in] gpb_tree_cnt Number of GPB trees.
+ * @param[out] sr_trees Array of sysrepo trees.
+ * @param[out] sr_tree_cnt Number of sysrepo trees as returned in sr_trees.
+ *
+ * @return Error code (SR_ERR_OK on success).
+ */
+int sr_trees_gpb_to_sr(Sr__Node **gpb_trees, size_t gpb_tree_cnt, sr_node_t **sr_trees, size_t *sr_tree_cnt);
 
 /**
  * @brief Fills the gpb structures from the set of changes

--- a/src/common/sr_utils.c
+++ b/src/common/sr_utils.c
@@ -986,6 +986,260 @@ sr_val_to_str(const sr_val_t *value, const struct lys_node *schema_node, char **
     return SR_ERR_OK;
 }
 
+/**
+ * @brief Copy and convert content of a libyang node and its descendands into a sysrepo tree.
+ *
+ * @param [in] ly_ctx libyang context
+ * @param [in] parent Parent node.
+ * @param [in] child Child node.
+ * @param [in] node libyang node.
+ * @param [out] sr_tree Returned sysrepo tree.
+ */
+static int
+sr_copy_node_to_tree_internal(struct ly_ctx *ly_ctx, const struct lyd_node *parent, const struct lyd_node *node,
+        sr_node_t *sr_tree)
+{
+    int rc = SR_ERR_OK;
+    struct lyd_node_leaf_list *data_leaf = NULL;
+    struct lys_node_container *cont = NULL;
+    size_t child_cnt = 0, i = 0;
+    const struct lyd_node *child = NULL;
+
+    CHECK_NULL_ARG3(ly_ctx, node, sr_tree);
+
+    /* unset in case the input structure wasn't initialized */
+    memset(sr_tree, '\0', sizeof(*sr_tree));
+
+    /* copy node name */
+    sr_tree->name = strdup(node->schema->name);
+    CHECK_NULL_NOMEM_GOTO(sr_tree->name, rc, cleanup);
+
+    /* copy value and type */
+    switch (node->schema->nodetype) {
+        case LYS_LEAF:
+        case LYS_LEAFLIST:
+            data_leaf = (struct lyd_node_leaf_list *)node;
+            sr_tree->type = sr_libyang_leaf_get_type(data_leaf);
+            rc = sr_libyang_leaf_copy_value(data_leaf, (sr_val_t *)sr_tree);
+            if (SR_ERR_OK != rc) {
+                SR_LOG_ERR("Error returned from sr_libyang_leaf_copy_value: %s.", sr_strerror(rc));
+                goto cleanup;
+            }
+            break;
+        case LYS_CONTAINER:
+            cont = (struct lys_node_container *)node;
+            sr_tree->type = cont->presence != NULL ? SR_CONTAINER_PRESENCE_T : SR_CONTAINER_T;
+            break;
+        case LYS_LIST:
+            sr_tree->type = SR_LIST_T;
+            break;
+        default:
+            SR_LOG_ERR("Detected unsupported node data type (schema name: %s).", sr_tree->name);
+            rc = SR_ERR_UNSUPPORTED;
+            goto cleanup;
+    }
+
+    /* dflt flag */
+    sr_tree->dflt = node->dflt;
+
+    /* set module_name */
+    if (NULL == parent || lyd_node_module(parent) != lyd_node_module(node)) {
+        sr_tree->module_name = strdup(lyd_node_module(node)->name);
+        CHECK_NULL_NOMEM_GOTO(sr_tree->module_name, rc, cleanup);
+    }
+
+    /* copy children */
+    if ((LYS_CONTAINER | LYS_LIST) & node->schema->nodetype) {
+        child = node->child;
+        while (child) {
+            ++child_cnt;
+            child = child->next;
+        }
+        sr_tree->children = calloc(child_cnt, sizeof(sr_node_t));
+        CHECK_NULL_NOMEM_GOTO(sr_tree->children, rc, cleanup);
+        child = node->child;
+        i = 0;
+        while (child) {
+            rc = sr_copy_node_to_tree_internal(ly_ctx, node, child, sr_tree->children + i);
+            if (SR_ERR_OK != rc) {
+                goto cleanup;
+            }
+            child = child->next;
+            ++i;
+            ++sr_tree->children_cnt;
+        }
+    }
+
+cleanup:
+    if (SR_ERR_OK != rc) {
+        sr_free_tree_content(sr_tree);
+    }
+    return rc;
+}
+
+int
+sr_copy_node_to_tree(struct ly_ctx *ly_ctx, const struct lyd_node *node, sr_node_t *sr_tree)
+{
+    return sr_copy_node_to_tree_internal(ly_ctx, NULL, node, sr_tree);
+}
+
+int
+sr_nodes_to_trees(struct ly_ctx *ly_ctx, struct ly_set *nodes, sr_node_t **sr_trees, size_t *count)
+{
+    int rc = 0;
+    sr_node_t *trees = NULL;
+    size_t i = 0;
+
+    CHECK_NULL_ARG4(ly_ctx, nodes, sr_trees, count);
+
+    trees = calloc(nodes->number, sizeof(sr_node_t));
+    CHECK_NULL_NOMEM_RETURN(trees);
+
+    for (i = 0; i < nodes->number && 0 == rc; ++i) {
+        rc = sr_copy_node_to_tree(ly_ctx, nodes->set.d[i], trees + i);
+    }
+
+    if (SR_ERR_OK == rc) {
+        *sr_trees = trees;
+        *count = nodes->number;
+    } else {
+        sr_free_trees(trees, i);
+    }
+    return rc;
+}
+
+static int
+sr_subtree_to_dt(struct ly_ctx *ly_ctx, const sr_node_t *sr_tree, bool output, struct lyd_node *parent,
+        const char *xpath, struct lyd_node **data_tree)
+{
+    int ret = 0;
+    struct lyd_node *node = NULL;
+    struct ly_set *nodeset = NULL;
+    const struct lys_module *module = NULL;
+    const struct lys_node *sch_node = NULL;
+    char *string_val = NULL;
+
+    CHECK_NULL_ARG3(ly_ctx, sr_tree, data_tree);
+
+    if (NULL == parent && NULL == xpath) {
+        return SR_ERR_INVAL_ARG;
+    }
+
+    if (NULL != parent) {
+        /* get module */
+        if (NULL != sr_tree->module_name) {
+            module = ly_ctx_get_module(ly_ctx, sr_tree->module_name, NULL);
+        } else {
+            module = lyd_node_module(parent);
+        }
+        if (NULL == module) {
+            SR_LOG_ERR("Failed to obtain module schema for node: %s.", sr_tree->name);
+            return SR_ERR_INTERNAL;
+        }
+    }
+
+    switch (sr_tree->type) {
+        case SR_LIST_T:
+        case SR_CONTAINER_T:
+        case SR_CONTAINER_PRESENCE_T:
+            /* create the inner node in the tree */
+            if (NULL == parent) {
+                node = lyd_new_path(*data_tree, ly_ctx, xpath, NULL, output ? LYD_PATH_OPT_OUTPUT : 0);
+                if (NULL == *data_tree) {
+                    *data_tree = node;
+                }
+                if (NULL == node) {
+                    SR_LOG_ERR("Failed to create tree root node with xpath: %s.", xpath);
+                    return SR_ERR_INTERNAL;
+                }
+                nodeset = lyd_get_node(*data_tree, xpath);
+                if (NULL == nodeset || 1 != nodeset->number) {
+                    SR_LOG_ERR("Failed to obtain newly created tree root node with xpath: %s.", xpath);
+                    return SR_ERR_INTERNAL;
+                }
+                node = nodeset->set.d[0];
+            } else {
+                node = lyd_new(parent, module, sr_tree->name);
+            }
+            /* process children */
+            for (size_t i = 0; i < sr_tree->children_cnt && SR_ERR_OK == ret; ++i) {
+                ret = sr_subtree_to_dt(ly_ctx, sr_tree->children + i, output, node, NULL, data_tree);
+            }
+            return ret;
+
+        case SR_UNKNOWN_T:
+            SR_LOG_ERR("Detected unsupported node data type (schema name: %s).", sr_tree->name);
+            return SR_ERR_UNSUPPORTED;
+
+        default: /* leaf */
+            /* get node schema */
+            if (NULL == parent) {
+                sch_node = ly_ctx_get_node2(ly_ctx, NULL, xpath, (output ? 0 : 1));
+            } else {
+                sch_node = ly_ctx_get_node2(ly_ctx, parent->schema, sr_tree->name, (output ? 0 : 1));
+            }
+            if (NULL == sch_node) {
+                SR_LOG_ERR("Unable to get the schema node for a sysrepo node ('%s'): %s", sr_tree->name, ly_errmsg());
+                return SR_ERR_INTERNAL;
+            }
+            /* copy argument value to string */
+            ret = sr_val_to_str((sr_val_t *)sr_tree, sch_node, &string_val);
+            if (SR_ERR_OK != ret) {
+                SR_LOG_ERR("Unable to convert value to string for sysrepo node: %s.", sr_tree->name);
+                return ret;
+            }
+            /* create the leaf in the tree */
+            if (NULL == parent) {
+                node = lyd_new_path(*data_tree, ly_ctx, xpath, string_val, output ? LYD_PATH_OPT_OUTPUT : 0);
+                free(string_val);
+                if (NULL == *data_tree) {
+                    *data_tree = node;
+                }
+                if (NULL == node) {
+                    SR_LOG_ERR("Failed to create tree root node (leaf) ('%s'): %s", xpath, ly_errmsg());
+                    return SR_ERR_INTERNAL;
+                }
+            } else {
+                node = lyd_new_leaf(parent, module, sr_tree->name, string_val);
+                free(string_val);
+                if (NULL == node) {
+                    SR_LOG_ERR("Unable to add leaf node (named '%s'): %s", sr_tree->name, ly_errmsg());
+                    return SR_ERR_INTERNAL;
+                }
+            }
+            return SR_ERR_OK;
+    }
+}
+
+int
+sr_tree_to_dt(struct ly_ctx *ly_ctx, const sr_node_t *sr_tree, const char *root_xpath, bool output, struct lyd_node **data_tree)
+{
+    int rc = 0;
+    char *xpath = NULL;
+
+    CHECK_NULL_ARG2(ly_ctx, data_tree);
+
+    if (NULL == sr_tree) {
+        return SR_ERR_OK;
+    }
+    if (NULL == root_xpath && NULL == sr_tree->module_name) {
+        return SR_ERR_INVAL_ARG;
+    }
+
+    if (NULL == root_xpath) {
+        xpath = calloc(strlen(sr_tree->name) + strlen(sr_tree->module_name) + 3, sizeof(*xpath));
+        CHECK_NULL_NOMEM_RETURN(xpath);
+        strcat(xpath, "/");
+        strcat(xpath, sr_tree->module_name);
+        strcat(xpath, ":");
+        strcat(xpath, sr_tree->name);
+    }
+
+    rc = sr_subtree_to_dt(ly_ctx, sr_tree, output, NULL, NULL == root_xpath ? xpath : root_xpath, data_tree);
+    free(xpath);
+    return rc;
+}
+
 const char *
 sr_ds_to_str(sr_datastore_t ds)
 {
@@ -1049,6 +1303,17 @@ sr_free_values_arr_range(sr_val_t **values, size_t from, size_t to)
         }
         free(values);
     }
+}
+
+void
+sr_free_tree_content(sr_node_t *tree)
+{
+    for (size_t i = 0; i < tree->children_cnt; ++i) {
+        sr_free_tree_content(tree->children + i);
+    }
+    free(tree->children);
+    free(tree->module_name);
+    sr_free_val_content((sr_val_t *)tree);
 }
 
 void

--- a/src/common/sr_utils.h
+++ b/src/common/sr_utils.h
@@ -47,6 +47,13 @@ typedef struct sr_change_s {
     sr_val_t *old_value;        /**< Prev value, NULL in case of SR_OP_CREATED, predcessor in case of SR_OP_MOVED */
 }sr_change_t;
 
+/**
+ * @brief Internal structures used across sysrepo to differentiate between supported variants of API.
+ */
+typedef enum sr_api_variant_e {
+    SR_API_VALUES = 0,
+    SR_API_TREES = 1
+} sr_api_variant_t;
 
 /**
  * @defgroup utils Utility Functions
@@ -294,11 +301,47 @@ int sr_libyang_leaf_copy_value(const struct lyd_node_leaf_list *leaf, sr_val_t *
 int sr_val_to_str(const sr_val_t *value, const struct lys_node *schema_node, char **out);
 
 /**
+ * @brief Copy and convert content of a libyang node and its descendands into a sysrepo tree.
+ *
+ * @param [in] ly_ctx libyang context
+ * @param [in] node libyang node.
+ * @param [out] sr_tree Returned sysrepo tree.
+ */
+int sr_copy_node_to_tree(struct ly_ctx *ly_ctx, const struct lyd_node *node, sr_node_t *sr_tree);
+
+/**
+ * @brief Convert a set of libyang nodes into an array of sysrepo trees. For each node a corresponding
+ * sysrepo (sub)tree is constructed. It is assumed that the input nodes are not descendands and predecessors
+ * of each other! With this assumption the links between the output trees does not need to be considered which
+ * significantly decreses the cost of this operation.
+ *
+ * @param [in] ly_ctx libyang context
+ * @param [in] nodes A set of libyang nodes.
+ * @param [out] sr_trees Returned array of sysrepo trees.
+ * @param [out] count Number of returned trees.
+ */
+int sr_nodes_to_trees(struct ly_ctx *ly_ctx, struct ly_set *nodes, sr_node_t **sr_trees, size_t *count);
+
+/**
+ * @brief Convert a sysrepo tree into a libyang data tree.
+ * @note data_tree is extended with the converted tree, not overwritten.
+ *
+ * @param [in] ly_ctx libyang context.
+ * @param [in] sr_tree Sysrepo tree (based on sr_node_t).
+ * @param [in] root_xpath XPath referencing the tree root (can be NULL for top-level trees).
+ * @param [in] output Is sr_tree an RPC/Action output?
+ * @param [out] data_tree libyang data tree that will get extended with the converted sysrepo tree.
+ */
+int sr_tree_to_dt(struct ly_ctx *ly_ctx, const sr_node_t *sr_tree, const char *root_xpath, bool output,
+        struct lyd_node **data_tree);
+
+/**
  * @brief Returns the string name of the datastore
  * @param [in] ds
  * @return Data store name
  */
 const char * sr_ds_to_str(sr_datastore_t ds);
+
 /**
  * @brief Frees contents of the sr_val_t structure, does not free the
  * value structure itself.
@@ -321,6 +364,11 @@ void sr_free_values_arr(sr_val_t **values, size_t count);
  * @param [in] to
  */
 void sr_free_values_arr_range(sr_val_t **values, const size_t from, const size_t to);
+
+/**
+ * @brief Frees contents of a sysrepo tree, does not free the root node itself.
+ */
+void sr_free_tree_content(sr_node_t *tree);
 
 /**
  * @brief Frees an array of detailed error information.
@@ -373,7 +421,6 @@ void sr_daemonize_signal_success(pid_t parent_pid);
  * @return Error code (SR_ERR_OK on success)
  */
 int sr_clock_get_time(clockid_t clock_id, struct timespec *ts);
-
 
 /**
  * @brief Sets correct permissions on provided socket directory according to the

--- a/src/common/sr_utils.h
+++ b/src/common/sr_utils.h
@@ -48,7 +48,7 @@ typedef struct sr_change_s {
 }sr_change_t;
 
 /**
- * @brief Internal structures used across sysrepo to differentiate between supported variants of API.
+ * @brief Internal structure used across sysrepo to differentiate between supported variants of API.
  */
 typedef enum sr_api_variant_e {
     SR_API_VALUES = 0,

--- a/src/data_manager.h
+++ b/src/data_manager.h
@@ -4,8 +4,8 @@
  * @brief Data manager provides access to schemas and data trees managed by sysrepo. It allows to
  * read, lock and edit the data models.
  * @file data_manager.h
- * @author Rastislav Szabo <raszabo@cisco.com>, Lukas Macko <lmacko@cisco.com>
- *
+ * @author Rastislav Szabo <raszabo@cisco.com>, Lukas Macko <lmacko@cisco.com>,
+ *         Milan Lenco <milan.lenco@pantheon.tech>
  *
  * @copyright
  * Copyright 2015 Cisco Systems, Inc.
@@ -659,6 +659,18 @@ int dm_copy_all_models(dm_ctx_t *dm_ctx, dm_session_t *session, sr_datastore_t s
 int dm_validate_rpc(dm_ctx_t *dm_ctx, dm_session_t *session, const char *rpc_xpath, sr_val_t **args, size_t *arg_cnt, bool input);
 
 /**
+ * @brief Validates content of a RPC request or reply with arguments represented using sr_node_t.
+ * @param [in] dm_ctx DM context.
+ * @param [in] session DM session.
+ * @param [in] rpc_xpath XPath of the RPC.
+ * @param [in] args Input/output arguments of the RPC (can be changed inside of the function).
+ * @param [in] arg_cnt Number of input/output arguments provided (can be changed inside of the function).
+ * @param [in] input TRUE if input arguments were provided, FALSE if output.
+ * @return Error code (SR_ERR_OK on success)
+ */
+int dm_validate_rpc_tree(dm_ctx_t *dm_ctx, dm_session_t *session, const char *rpc_xpath, sr_node_t **args, size_t *arg_cnt, bool input);
+
+/**
  * @brief Validates content of an event notification request.
  * @param [in] dm_ctx DM context.
  * @param [in] session DM session.
@@ -668,6 +680,17 @@ int dm_validate_rpc(dm_ctx_t *dm_ctx, dm_session_t *session, const char *rpc_xpa
  * @return Error code (SR_ERR_OK on success)
  */
 int dm_validate_event_notif(dm_ctx_t *dm_ctx, dm_session_t *session, const char *notif_xpath, sr_val_t **values, size_t *values_cnt);
+
+/**
+ * @brief Validates content of an event notification request with data represented using sr_node_t.
+ * @param [in] dm_ctx DM context.
+ * @param [in] session DM session.
+ * @param [in] notif_xpath XPath of the notification.
+ * @param [in] values Event notification subtree nodes (can be changed inside of the function).
+ * @param [in] values_cnt Number of items inside the values array (can be changed inside of the function).
+ * @return Error code (SR_ERR_OK on success)
+ */
+int dm_validate_event_notif_tree(dm_ctx_t *dm_ctx, dm_session_t *session, const char *notif_xpath, sr_node_t **values, size_t *values_cnt);
 
 /**
  * @brief Locks lyctx_lock and call lyd_get_node.

--- a/src/request_processor.c
+++ b/src/request_processor.c
@@ -1236,7 +1236,9 @@ static int
 rp_rpc_req_process(const rp_ctx_t *rp_ctx, const rp_session_t *session, Sr__Msg *msg)
 {
     char *module_name = NULL;
+    sr_api_variant_t api_variant = SR_API_VALUES;
     sr_val_t *input = NULL;
+    sr_node_t *input_tree = NULL;
     size_t input_cnt = 0;
     np_subscription_t *subscriptions = NULL;
     size_t subscription_cnt = 0;
@@ -1245,51 +1247,81 @@ rp_rpc_req_process(const rp_ctx_t *rp_ctx, const rp_session_t *session, Sr__Msg 
 
     CHECK_NULL_ARG_NORET5(rc, rp_ctx, session, msg, msg->request, msg->request->rpc_req);
     if (SR_ERR_OK != rc) {
-        /* release the message since it won't be released in dispatch */
-        sr__msg__free_unpacked(msg, NULL);
-        return rc;
+        goto finalize;
     }
 
     SR_LOG_DBG_MSG("Processing RPC request.");
 
+    /* parse input arguments */
+    if (msg->request->rpc_req->n_input) {
+        rc = sr_values_gpb_to_sr(msg->request->rpc_req->input,  msg->request->rpc_req->n_input, &input, &input_cnt);
+    } else if (msg->request->rpc_req->n_input_tree) {
+        api_variant = SR_API_TREES;
+        rc = sr_trees_gpb_to_sr(msg->request->rpc_req->input_tree,  msg->request->rpc_req->n_input_tree,
+                                &input_tree, &input_cnt);
+    }
+    if (SR_ERR_OK != rc) {
+        SR_LOG_ERR("Failed to parse RPC (%s) input arguments from GPB message.", msg->request->rpc_req->xpath);
+        goto finalize;
+    }
+
     /* validate RPC request */
-    rc = sr_values_gpb_to_sr(msg->request->rpc_req->input,  msg->request->rpc_req->n_input, &input, &input_cnt);
-    if (SR_ERR_OK == rc) {
-        rc = dm_validate_rpc(rp_ctx->dm_ctx, session->dm_session, msg->request->rpc_req->xpath, &input, &input_cnt, true);
+    if (SR_API_VALUES == api_variant) {
+        rc = dm_validate_rpc(rp_ctx->dm_ctx, session->dm_session, msg->request->rpc_req->xpath,
+                &input, &input_cnt, true);
+    } else {
+        rc = dm_validate_rpc_tree(rp_ctx->dm_ctx, session->dm_session, msg->request->rpc_req->xpath,
+                &input_tree, &input_cnt, true);
+    }
+    if (SR_ERR_OK != rc) {
+        SR_LOG_ERR("Validation of an RPC (%s) message failed.", msg->request->rpc_req->xpath);
+        goto finalize;
     }
 
     /* duplicate msg into req with the new input values */
-    if (SR_ERR_OK == rc) {
-        rc = sr_gpb_req_alloc(SR__OPERATION__RPC, session->id, &req);
+    rc = sr_gpb_req_alloc(SR__OPERATION__RPC, session->id, &req);
+    if (SR_ERR_OK != rc) {
+        SR_LOG_ERR("Failed to duplicate RPC request (%s).", msg->request->rpc_req->xpath);
+        goto finalize;
     }
-    if (SR_ERR_OK == rc) {
-        req->request->rpc_req->xpath = strdup(msg->request->rpc_req->xpath);
-        CHECK_NULL_NOMEM_ERROR(req->request->rpc_req->xpath, rc);
+    req->request->rpc_req->xpath = strdup(msg->request->rpc_req->xpath);
+    CHECK_NULL_NOMEM_ERROR(req->request->rpc_req->xpath, rc);
+    if (SR_ERR_OK != rc) {
+        SR_LOG_ERR("Failed to duplicate RPC request xpath (%s).", msg->request->rpc_req->xpath);
+        goto finalize;
     }
-    if (SR_ERR_OK == rc) {
+
+    if (SR_API_VALUES == api_variant) {
         rc = sr_values_sr_to_gpb(input, input_cnt, &req->request->rpc_req->input, &req->request->rpc_req->n_input);
+    } else {
+        rc = sr_trees_sr_to_gpb(input_tree, input_cnt, &req->request->rpc_req->input_tree, &req->request->rpc_req->n_input_tree);
     }
-    sr_free_values(input, input_cnt);
+    if (SR_ERR_OK != rc ) {
+        SR_LOG_ERR("Failed to duplicate RPC request (%s) input arguments.", msg->request->rpc_req->xpath);
+        goto finalize;
+    }
 
     /* get module name */
-    if (SR_ERR_OK == rc) {
-        rc = sr_copy_first_ns(req->request->rpc_req->xpath, &module_name);
+    rc = sr_copy_first_ns(req->request->rpc_req->xpath, &module_name);
+    if (SR_ERR_OK != rc ) {
+        SR_LOG_ERR("Failed to obtain module name for RPC request (%s).", msg->request->rpc_req->xpath);
+        goto finalize;
     }
 
     /* authorize (write permissions are required to deliver the RPC) */
-    if (SR_ERR_OK == rc) {
-        rc = ac_check_module_permissions(session->ac_session, module_name, AC_OPER_READ_WRITE);
-        if (SR_ERR_OK != rc) {
-            SR_LOG_ERR("Access control check failed for module name '%s'", module_name);
-        }
+    rc = ac_check_module_permissions(session->ac_session, module_name, AC_OPER_READ_WRITE);
+    if (SR_ERR_OK != rc) {
+        SR_LOG_ERR("Access control check failed for module name '%s'", module_name);
+        goto finalize;
     }
 
     /* get RPC subscription */
-    if (SR_ERR_OK == rc) {
-        rc = pm_get_subscriptions(rp_ctx->pm_ctx, module_name, SR__SUBSCRIPTION_TYPE__RPC_SUBS,
-                &subscriptions, &subscription_cnt);
+    rc = pm_get_subscriptions(rp_ctx->pm_ctx, module_name, SR__SUBSCRIPTION_TYPE__RPC_SUBS,
+            &subscriptions, &subscription_cnt);
+    if (SR_ERR_OK != rc) {
+        SR_LOG_ERR("Failed to get subscriptions for RPC request (%s).", msg->request->rpc_req->xpath);
+        goto finalize;
     }
-    free(module_name);
 
     /* fill-in subscription details into the request */
     bool subscription_match = false;
@@ -1304,13 +1336,19 @@ rp_rpc_req_process(const rp_ctx_t *rp_ctx, const rp_session_t *session, Sr__Msg 
             break;
         }
     }
+    if (SR_ERR_OK != rc) {
+        SR_LOG_ERR("Failed to process subscription data for RPC request (%s).", msg->request->rpc_req->xpath);
+        goto finalize;
+    }
 
-    if (SR_ERR_OK == rc && !subscription_match) {
+    if (!subscription_match) {
         /* no subscription for this RPC */
         SR_LOG_ERR("No subscription found for RPC delivery (xpath = '%s').", req->request->rpc_req->xpath);
         rc = SR_ERR_NOT_FOUND;
+        goto finalize;
     }
 
+finalize:
     if (SR_ERR_OK == rc) {
         /* forward the request to the subscriber */
         rc = cm_msg_send(rp_ctx->cm_ctx, req);
@@ -1330,8 +1368,14 @@ rp_rpc_req_process(const rp_ctx_t *rp_ctx, const rp_session_t *session, Sr__Msg 
         }
     }
 
+    free(module_name);
+    if (SR_API_VALUES == api_variant) {
+        sr_free_values(input, input_cnt);
+    } else {
+        sr_free_trees(input_tree, input_cnt);
+    }
+    /* release the message since it won't be released in dispatch */
     sr__msg__free_unpacked(msg, NULL);
-
     return rc;
 }
 
@@ -1388,7 +1432,9 @@ cleanup:
 static int
 rp_rpc_resp_process(const rp_ctx_t *rp_ctx, const rp_session_t *session, Sr__Msg *msg)
 {
+    sr_api_variant_t api_variant = SR_API_VALUES;
     sr_val_t *output = NULL;
+    sr_node_t *output_tree = NULL;
     size_t output_cnt = 0;
     Sr__Msg *resp = NULL;
     int rc = SR_ERR_OK;
@@ -1401,9 +1447,22 @@ rp_rpc_resp_process(const rp_ctx_t *rp_ctx, const rp_session_t *session, Sr__Msg
     }
 
     /* validate the RPC response */
-    rc = sr_values_gpb_to_sr(msg->response->rpc_resp->output,  msg->response->rpc_resp->n_output, &output, &output_cnt);
+    if (msg->response->rpc_resp->n_output) {
+        rc = sr_values_gpb_to_sr(msg->response->rpc_resp->output,  msg->response->rpc_resp->n_output,
+                                 &output, &output_cnt);
+    } else if (msg->response->rpc_resp->n_output_tree) {
+        api_variant = SR_API_TREES;
+        rc = sr_trees_gpb_to_sr(msg->response->rpc_resp->output_tree,  msg->response->rpc_resp->n_output_tree,
+                                &output_tree, &output_cnt);
+    }
     if (SR_ERR_OK == rc) {
-        rc = dm_validate_rpc(rp_ctx->dm_ctx, session->dm_session, msg->response->rpc_resp->xpath, &output, &output_cnt, false);
+        if (SR_API_VALUES == api_variant) {
+            rc = dm_validate_rpc(rp_ctx->dm_ctx, session->dm_session, msg->response->rpc_resp->xpath,
+                    &output, &output_cnt, false);
+        } else {
+            rc = dm_validate_rpc_tree(rp_ctx->dm_ctx, session->dm_session, msg->response->rpc_resp->xpath,
+                    &output_tree, &output_cnt, false);
+        }
     }
 
     /* duplicate msg into resp with the new output values */
@@ -1415,9 +1474,17 @@ rp_rpc_resp_process(const rp_ctx_t *rp_ctx, const rp_session_t *session, Sr__Msg
         CHECK_NULL_NOMEM_ERROR(resp->response->rpc_resp->xpath, rc);
     }
     if (SR_ERR_OK == rc) {
-        rc = sr_values_sr_to_gpb(output, output_cnt, &resp->response->rpc_resp->output, &resp->response->rpc_resp->n_output);
+        if (SR_API_VALUES == api_variant) {
+            rc = sr_values_sr_to_gpb(output, output_cnt, &resp->response->rpc_resp->output, &resp->response->rpc_resp->n_output);
+        } else {
+            rc = sr_trees_sr_to_gpb(output_tree, output_cnt, &resp->response->rpc_resp->output_tree, &resp->response->rpc_resp->n_output_tree);
+        }
     }
-    sr_free_values(output, output_cnt);
+    if (SR_API_VALUES == api_variant) {
+        sr_free_values(output, output_cnt);
+    } else {
+        sr_free_trees(output_tree, output_cnt);
+    }
 
     if ((SR_ERR_OK == rc) || (NULL != resp)) {
         sr__msg__free_unpacked(msg, NULL);

--- a/src/sysrepo.proto
+++ b/src/sysrepo.proto
@@ -75,6 +75,17 @@ message Value {
   optional uint64 uint64_val = 25;
 }
 
+/**
+ * @brief Item stored (or to be stored) in the datastore represented as a tree node
+ * reflecting module schema.
+ * Can be mapped to sr_node_t data structure from sysrepo library API.
+ */
+message Node {
+  required Value value = 1;        /**< Value of the node; member *xpath* is used to store node's name. */
+  required string module_name = 2; /**< Name of the module that defines scheme of this node. */
+  repeated Node children = 3;      /**< Direct descendands of this node. */
+}
+
 message Error {
   optional string message = 1;
   optional string xpath = 2;
@@ -627,6 +638,7 @@ message DataProvideResp {
 message RPCReq {
   required string xpath = 1;
   repeated Value input = 2;
+  repeated Node input_tree = 3;
 
   optional string subscriber_address = 10;
   optional uint32 subscription_id = 11;
@@ -635,6 +647,7 @@ message RPCReq {
 message RPCResp {
   required string xpath = 1;
   repeated Value output = 2;
+  repeated Node output_tree = 3;
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/tests/cl_test.c
+++ b/tests/cl_test.c
@@ -1506,12 +1506,21 @@ test_rpc_cb(const char *xpath, const sr_val_t *input, const size_t input_cnt,
     int *callback_called = (int*)private_ctx;
     *callback_called += 1;
 
-    assert_int_equal(input_cnt, 2);
-
     printf("'Executing' RPC: %s\n", xpath);
     for (size_t i = 0; i < input_cnt; i++) {
         printf("    input parameter[%zu]: %s = %s\n", i, input[i].xpath, input[i].data.string_val);
     }
+
+    /* check input */
+    assert_int_equal(2, input_cnt);
+    assert_string_equal("/test-module:activate-software-image/image-name", input[0].xpath);
+    assert_false(input[0].dflt);
+    assert_int_equal(SR_STRING_T, input[0].type);
+    assert_string_equal("acmefw-2.3", input[0].data.string_val);
+    assert_string_equal("/test-module:activate-software-image/location", input[1].xpath);
+    assert_true(input[1].dflt);
+    assert_int_equal(SR_STRING_T, input[1].type);
+    assert_string_equal("/", input[1].data.string_val);
 
     *output = calloc(2, sizeof(**output));
     (*output)[0].xpath = strdup("/test-module:activate-software-image/status");
@@ -1557,10 +1566,25 @@ cl_rpc_test(void **state)
     rc = sr_rpc_send(session, "/test-module:activate-software-image", &input, 1, &output, &output_cnt);
     assert_int_equal(rc, SR_ERR_OK);
 
-    assert_int_equal(output_cnt, 3);
     for (size_t i = 0; i < output_cnt; i++) {
         printf("RPC output parameter[%zu]: %s = %s\n", i, output[i].xpath, output[i].data.string_val);
     }
+
+    /* check output */
+    assert_int_equal(3, output_cnt);
+    assert_string_equal("/test-module:activate-software-image/status", output[0].xpath);
+    assert_false(output[0].dflt);
+    assert_int_equal(SR_STRING_T, output[0].type);
+    assert_string_equal("The image acmefw-2.3 is being installed.", output[0].data.string_val);
+    assert_string_equal("/test-module:activate-software-image/version", output[1].xpath);
+    assert_false(output[1].dflt);
+    assert_int_equal(SR_STRING_T, output[1].type);
+    assert_string_equal("2.3", output[1].data.string_val);
+    assert_string_equal("/test-module:activate-software-image/location", output[2].xpath);
+    assert_true(output[2].dflt);
+    assert_int_equal(SR_STRING_T, output[2].type);
+    assert_string_equal("/", output[2].data.string_val);
+
     sr_free_values(output, output_cnt);
 
     /* stop the session */

--- a/tests/yang/test-module.yang
+++ b/tests/yang/test-module.yang
@@ -248,6 +248,30 @@ module test-module {
         type string;
         default "/";
       }
+      container init-log {
+        list log-msg {
+          key "msg time";
+          leaf msg {
+            type string;
+          }
+          leaf time {
+            type uint32;
+          }
+          leaf msg-type {
+            type enumeration {
+              enum "error" {
+                value 1;
+              }
+              enum "warning" {
+                value 2;
+              }
+              enum "debug" {
+                value 3;
+              }
+            }
+          }
+        }
+      }
     }
   }
 


### PR DESCRIPTION
The tree variant of API first implemented for RPC. All the necessary conversion functions (from/to libyang/GPB) are in place so it should be relatively quick to do the same for the rest of APIs.

Also, I'm thinking about adding some macros for easier construction of sysrepo data trees as it is quite tiresome to do it from scratch.