### PR TITLE
get-subtree and get-subtrees API calls

### DIFF
--- a/inc/sysrepo.h
+++ b/inc/sysrepo.h
@@ -743,11 +743,11 @@ int sr_get_subtree(sr_session_ctx_t *session, const char *xpath, sr_node_t **sub
  * simplifies the implementation and decreases the cost of this operation. The downside is that
  * the user must choose the XPath carefully. If the subtree selection process results in too many
  * node overlaps, the cost of the operation may easily outshine the benefits. As an example,
- * a common XPath expression "//*" is normally used to select all nodes in a data tree, but for this
+ * a common XPath expression "//." is normally used to select all nodes in a data tree, but for this
  * operation it would result in an excessive duplication of transfered data elements.
  * Since you get all the descendants of each matched node implicitly, you probably should not need
  * to use XPath wildcards deeper than on the top-level.
- * (i.e. "/*" is preferred alternative to "//*" for get-subtrees operation).
+ * (i.e. "/." is preferred alternative to "//." for get-subtrees operation).
  *
  * If the response contains too many elements time out may be exceeded, SR_ERR_TIME_OUT
  * will be returned.

--- a/inc/sysrepo.h
+++ b/inc/sysrepo.h
@@ -643,7 +643,7 @@ int sr_get_item(sr_session_ctx_t *session, const char *xpath, sr_val_t **value);
  *
  * If the user does not have read permission to access certain nodes, these
  * won't be part of the result. SR_ERR_NOT_FOUND will be returned if there are
- * no nodes match xpath in the data tree, or the user does not have read permission to access them.
+ * no nodes matching xpath in the data tree, or the user does not have read permission to access them.
  *
  * If the response contains too many elements time out may be exceeded, SR_ERR_TIME_OUT
  * will be returned, use ::sr_get_items_iter.
@@ -705,6 +705,66 @@ int sr_get_items_iter(sr_session_ctx_t *session, const char *xpath, sr_val_iter_
  * @return Error code (SR_ERR_OK on success).
  */
 int sr_get_item_next(sr_session_ctx_t *session, sr_val_iter_t *iter, sr_val_t **value);
+
+/**
+ * @brief Retrieves a single subtree whose root node is stored under the provided XPath.
+ * If multiple nodes matches the xpath SR_ERR_INVAL_ARG is returned.
+ *
+ * The functions returns values and all associated information stored under the root node and
+ * all its descendants. While the same data can be obtained using ::sr_get_items in combination
+ * with the expressive power of XPath addressing, the recursive nature of the output data type
+ * also preserves the hierarchical relationships between data elements.
+ *
+ * Values of internal nodes of the subtree have no data filled in and their type is set properly
+ * (SR_LIST_T / SR_CONTAINER_T / SR_CONTAINER_PRESENCE_T), whereas leaf nodes are carrying actual
+ * data (apart from SR_LEAF_EMPTY_T).
+ *
+ * @see @ref xp_page "XPath Addressing" documentation, or
+ * https://tools.ietf.org/html/draft-ietf-netmod-yang-json#section-6.11
+ * for XPath syntax used for identification of yang nodes in sysrepo calls.
+ *
+ * @param[in] session Session context acquired with ::sr_session_start call.
+ * @param[in] xpath @ref xp_page "XPath" identifier referencing the root node of the subtree to be retrieved.
+ * @param[out] subtree Nested structure storing all data of the requested subtree
+ * (allocated by the function, it is supposed to be freed by the caller using ::sr_free_tree).
+ *
+ * @return Error code (SR_ERR_OK on success)
+ */
+int sr_get_subtree(sr_session_ctx_t *session, const char *xpath, sr_node_t **subtree);
+
+/**
+ * @brief Retrieves an array of subtrees whose root nodes match the provided XPath.
+ *
+ * If the user does not have read permission to access certain nodes, these together with
+ * their descendants won't be part of the result. SR_ERR_NOT_FOUND will be returned if there are
+ * no nodes matching xpath in the data tree, or the user does not have read permission to access them.
+ *
+ * Subtrees that match the provided XPath are not merged even if they overlap. This significantly
+ * simplifies the implementation and decreases the cost of this operation. The downside is that
+ * the user must choose the XPath carefully. If the subtree selection process results in too many
+ * node overlaps, the cost of the operation may easily outshine the benefits. As an example,
+ * a common XPath expression "//*" is normally used to select all nodes in a data tree, but for this
+ * operation it would result in an excessive duplication of transfered data elements.
+ * Since you get all the descendants of each matched node implicitly, you probably should not need
+ * to use XPath wildcards deeper than on the top-level.
+ * (i.e. "/*" is preferred alternative to "//*" for get-subtrees operation).
+ *
+ * If the response contains too many elements time out may be exceeded, SR_ERR_TIME_OUT
+ * will be returned.
+ *
+ * @see @ref xp_page "XPath Addressing" documentation, or
+ * https://tools.ietf.org/html/draft-ietf-netmod-yang-json#section-6.11
+ * for XPath syntax used for identification of yang nodes in sysrepo calls.
+ *
+ * @param[in] session Session context acquired with ::sr_session_start call.
+ * @param[in] xpath @ref xp_page "XPath" identifier referencing root nodes of subtrees to be retrieved.
+ * @param[out] subtrees Array of nested structures storing all data of the requested subtrees
+ * (allocated by the function, it is supposed to be freed by the caller using ::sr_free_trees).
+ * @param[out] subtree_cnt Number of returned trees in the subtrees array.
+ *
+ * @return Error code (SR_ERR_OK on success).
+ */
+int sr_get_subtrees(sr_session_ctx_t *session, const char *xpath, sr_node_t **subtrees, size_t *subtree_cnt);
 
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/inc/sysrepo.h
+++ b/inc/sysrepo.h
@@ -707,6 +707,35 @@ int sr_get_items_iter(sr_session_ctx_t *session, const char *xpath, sr_val_iter_
 int sr_get_item_next(sr_session_ctx_t *session, sr_val_iter_t *iter, sr_val_t **value);
 
 /**
+ * @brief Flags used to customize the behaviour of ::sr_get_subtree and ::sr_get_subtrees calls.
+ */
+typedef enum sr_get_subtree_flag_e {
+    /**
+     * Default get-subtree(s) behaviour.
+     * All matched subtrees are sent with all their content in one message.
+     */
+    SR_GET_SUBTREE_DEFAULT = 0,
+
+    /**
+     * The iterative get-subtree(s) behaviour.
+     * The matched subtrees are sent in chunks and only as needed while they are iterated
+     * through using functions ::sr_node_get_child, ::sr_node_get_next_sibling and
+     * ::sr_node_get_parent from "sysrepo/trees.h". This behaviour gives much better
+     * performance than the default one if only a small portion of matched subtree(s) is
+     * actually iterated through.
+     * @note It is considered a programming error to access ::next, ::prev, ::parent,
+     * ::first_child and ::last_child data members of sr_node_t on a partially loaded tree.
+     */
+    SR_GET_SUBTREE_ITERATIVE = 1
+} sr_get_subtree_flag_t;
+
+/**
+ * @brief Options for get-subtree and get-subtrees operations.
+ * It is supposed to be bitwise OR-ed value of any ::sr_get_subtree_flag_t flags.
+ */
+typedef uint32_t sr_get_subtree_options_t;
+
+/**
  * @brief Retrieves a single subtree whose root node is stored under the provided XPath.
  * If multiple nodes matches the xpath SR_ERR_INVAL_ARG is returned.
  *
@@ -725,12 +754,14 @@ int sr_get_item_next(sr_session_ctx_t *session, sr_val_iter_t *iter, sr_val_t **
  *
  * @param[in] session Session context acquired with ::sr_session_start call.
  * @param[in] xpath @ref xp_page "XPath" identifier referencing the root node of the subtree to be retrieved.
+ * @param[in] opts Options overriding default behavior of this operation.
  * @param[out] subtree Nested structure storing all data of the requested subtree
  * (allocated by the function, it is supposed to be freed by the caller using ::sr_free_tree).
  *
  * @return Error code (SR_ERR_OK on success)
  */
-int sr_get_subtree(sr_session_ctx_t *session, const char *xpath, sr_node_t **subtree);
+int sr_get_subtree(sr_session_ctx_t *session, const char *xpath, sr_get_subtree_options_t opts,
+        sr_node_t **subtree);
 
 /**
  * @brief Retrieves an array of subtrees whose root nodes match the provided XPath.
@@ -758,13 +789,15 @@ int sr_get_subtree(sr_session_ctx_t *session, const char *xpath, sr_node_t **sub
  *
  * @param[in] session Session context acquired with ::sr_session_start call.
  * @param[in] xpath @ref xp_page "XPath" identifier referencing root nodes of subtrees to be retrieved.
+ * @param[in] opts Options overriding default behavior of this operation.
  * @param[out] subtrees Array of nested structures storing all data of the requested subtrees
  * (allocated by the function, it is supposed to be freed by the caller using ::sr_free_trees).
  * @param[out] subtree_cnt Number of returned trees in the subtrees array.
  *
  * @return Error code (SR_ERR_OK on success).
  */
-int sr_get_subtrees(sr_session_ctx_t *session, const char *xpath, sr_node_t **subtrees, size_t *subtree_cnt);
+int sr_get_subtrees(sr_session_ctx_t *session, const char *xpath, sr_get_subtree_options_t opts,
+        sr_node_t **subtrees, size_t *subtree_cnt);
 
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/inc/sysrepo/trees.h
+++ b/inc/sysrepo/trees.h
@@ -98,4 +98,38 @@ int sr_dup_tree(sr_node_t *tree, sr_node_t **tree_dup);
  */
 int sr_dup_trees(sr_node_t *trees, size_t count, sr_node_t **trees_dup);
 
+/**
+ * @brief Returns pointer to the first child (based on the schema) of a given node.
+ * For a fully loaded tree it is equivalent to "node->first_child". For a partially
+ * loaded tree (@see SR_GET_SUBTREE_ITERATIVE) it may internally issue a sysrepo
+ * get-subtree-chunk request in order to obtain the data of the child
+ * (and the data of some surrounding nodes with it for efficiency).
+ *
+ * @param[in] node Node to get the child of.
+ * @return Pointer to a child node. NULL if there is none or an error occured.
+ */
+sr_node_t *sr_node_get_child(sr_node_t *node);
+
+/**
+ * @brief Returns pointer to the next sibling (based on the schema) of a given node.
+ * For a fully loaded tree it is equivalent to "node->next". For a partially
+ * loaded tree (@see SR_GET_SUBTREE_ITERATIVE) it may internally issue a sysrepo
+ * get-subtree-chunk request in order to obtain the data of the next sibling
+ * (and the data of some surrounding nodes with it for efficiency).
+ *
+ * @param[in] node Node to get the next sibling of.
+ * @return Pointer to the next sibling. NULL if this is the last sibling or an error occured.
+ */
+sr_node_t *sr_node_get_next_sibling(sr_node_t *node);
+
+/**
+ * @brief Get the parent of a given node. It is equivalent to "node->parent", but for
+ * a partially loaded tree it is preferred to use this function rather than to access
+ * the pointer directly just for the sake of code cleanliness.
+ *
+ * @param[in] node Node to get the parent of.
+ * @return Pointer to the node's parent or NULL if the node is a root of a (sub)tree.
+ */
+sr_node_t *sr_node_get_parent(sr_node_t *node);
+
 #endif /* TREES_H_ */

--- a/src/client_library.c
+++ b/src/client_library.c
@@ -1020,7 +1020,8 @@ sr_free_val_iter(sr_val_iter_t *iter){
 }
 
 int
-sr_get_subtree(sr_session_ctx_t *session, const char *xpath, sr_node_t **subtree)
+sr_get_subtree(sr_session_ctx_t *session, const char *xpath, sr_get_subtree_options_t opts,
+        sr_node_t **subtree)
 {
     Sr__Msg *msg_req = NULL, *msg_resp = NULL;
     sr_mem_ctx_t *sr_mem = NULL;
@@ -1067,7 +1068,8 @@ cleanup:
 }
 
 int
-sr_get_subtrees(sr_session_ctx_t *session, const char *xpath, sr_node_t **subtrees, size_t *subtree_cnt)
+sr_get_subtrees(sr_session_ctx_t *session, const char *xpath, sr_get_subtree_options_t opts,
+        sr_node_t **subtrees, size_t *subtree_cnt)
 {
     Sr__Msg *msg_req = NULL, *msg_resp = NULL;
     sr_mem_ctx_t *sr_mem = NULL;
@@ -1106,6 +1108,15 @@ cleanup:
         sr_msg_free(msg_resp);
     }
     return cl_session_return(session, rc);
+}
+
+int
+sr_get_subtree_chunk(sr_session_ctx_t *session, const char *xpath, bool single,
+        size_t offset, size_t child_limit, size_t depth_limit,
+        sr_node_t **chunks, size_t *chunk_cnt);
+{
+    /* TODO */
+    return SR_ERR_OK;
 }
 
 int

--- a/src/client_library.c
+++ b/src/client_library.c
@@ -211,7 +211,7 @@ cl_subscription_close(sr_session_ctx_t *session, cl_sm_subscription_ctx_t *subsc
         CHECK_RC_MSG_GOTO(rc, cleanup, "Failed to create a new Sysrepo memory context.");
         rc = sr_gpb_req_alloc(sr_mem, SR__OPERATION__UNSUBSCRIBE, session->id, &msg_req);
         CHECK_RC_MSG_GOTO(rc, cleanup, "Cannot allocate unsubscribe message.");
-        
+
         msg_req->request->unsubscribe_req->type = subscription->type;
 
         sr_mem_edit_string(sr_mem, &msg_req->request->unsubscribe_req->destination, subscription->delivery_address);
@@ -856,7 +856,7 @@ sr_get_items(sr_session_ctx_t *session, const char *xpath, sr_val_t **values, si
     CHECK_RC_MSG_GOTO(rc, cleanup, "Error by processing of the request.");
 
     /* copy the content of gpb values to sr_val_t */
-    rc = sr_values_gpb_to_sr((sr_mem_ctx_t *)msg_resp->_sysrepo_mem_ctx, msg_resp->response->get_items_resp->values, 
+    rc = sr_values_gpb_to_sr((sr_mem_ctx_t *)msg_resp->_sysrepo_mem_ctx, msg_resp->response->get_items_resp->values,
                              msg_resp->response->get_items_resp->n_values, values, value_cnt);
     CHECK_RC_MSG_GOTO(rc, cleanup, "Error by copying the values from GPB.");
 
@@ -1017,6 +1017,95 @@ sr_free_val_iter(sr_val_iter_t *iter){
         iter->buff_values = NULL;
     }
     free(iter);
+}
+
+int
+sr_get_subtree(sr_session_ctx_t *session, const char *xpath, sr_node_t **subtree)
+{
+    Sr__Msg *msg_req = NULL, *msg_resp = NULL;
+    sr_mem_ctx_t *sr_mem = NULL;
+    int rc = SR_ERR_OK;
+
+    CHECK_NULL_ARG4(session, session->conn_ctx, xpath, subtree);
+
+    cl_session_clear_errors(session);
+
+    /* prepare get_subtree message */
+    rc = sr_mem_new(0, &sr_mem);
+    CHECK_RC_MSG_GOTO(rc, cleanup, "Failed to create a new Sysrepo memory context.");
+    rc = sr_gpb_req_alloc(sr_mem, SR__OPERATION__GET_SUBTREE, session->id, &msg_req);
+    CHECK_RC_MSG_GOTO(rc, cleanup, "Cannot allocate GPB message.");
+
+    /* fill in the path */
+    sr_mem_edit_string(sr_mem, &msg_req->request->get_subtree_req->xpath, xpath);
+    CHECK_NULL_NOMEM_GOTO(msg_req->request->get_subtree_req->xpath, rc, cleanup);
+
+    /* send the request and receive the response */
+    rc = cl_request_process(session, msg_req, &msg_resp, SR__OPERATION__GET_SUBTREE);
+    CHECK_RC_MSG_GOTO(rc, cleanup, "Error by processing of the request.");
+
+    /* duplicate the content of gpb to sr_node_t */
+    rc = sr_dup_gpb_to_tree((sr_mem_ctx_t *)msg_resp->_sysrepo_mem_ctx,
+                             msg_resp->response->get_subtree_resp->tree, subtree);
+    CHECK_RC_MSG_GOTO(rc, cleanup, "Subtree duplication failed.");
+
+    sr_msg_free(msg_req);
+    sr_msg_free(msg_resp);
+
+    return cl_session_return(session, SR_ERR_OK);
+
+cleanup:
+    if (NULL != msg_req) {
+        sr_msg_free(msg_req);
+    } else {
+        sr_mem_free(sr_mem);
+    }
+    if (NULL != msg_resp) {
+        sr_msg_free(msg_resp);
+    }
+    return cl_session_return(session, rc);
+}
+
+int
+sr_get_subtrees(sr_session_ctx_t *session, const char *xpath, sr_node_t **subtrees, size_t *subtree_cnt)
+{
+    Sr__Msg *msg_req = NULL, *msg_resp = NULL;
+    sr_mem_ctx_t *sr_mem = NULL;
+    int rc = SR_ERR_OK;
+
+    CHECK_NULL_ARG5(session, session->conn_ctx, xpath, subtrees, subtree_cnt);
+
+    cl_session_clear_errors(session);
+
+    /* prepare get_subtrees message */
+    rc = sr_mem_new(0, &sr_mem);
+    CHECK_RC_MSG_GOTO(rc, cleanup, "Failed to create a new Sysrepo memory context.");
+    rc = sr_gpb_req_alloc(sr_mem, SR__OPERATION__GET_SUBTREES, session->id, &msg_req);
+    CHECK_RC_MSG_GOTO(rc, cleanup, "Cannot allocate GPB message.");
+
+    /* fill in the path */
+    sr_mem_edit_string(sr_mem, &msg_req->request->get_subtrees_req->xpath, xpath);
+    CHECK_NULL_NOMEM_GOTO(msg_req->request->get_subtrees_req->xpath, rc, cleanup);
+
+    /* send the request and receive the response */
+    rc = cl_request_process(session, msg_req, &msg_resp, SR__OPERATION__GET_SUBTREES);
+    CHECK_RC_MSG_GOTO(rc, cleanup, "Error by processing of the request.");
+
+    /* copy the content of gpb values to sr_val_t */
+    rc = sr_trees_gpb_to_sr((sr_mem_ctx_t *)msg_resp->_sysrepo_mem_ctx, msg_resp->response->get_subtrees_resp->trees,
+                             msg_resp->response->get_subtrees_resp->n_trees, subtrees, subtree_cnt);
+    CHECK_RC_MSG_GOTO(rc, cleanup, "Error by copying the values from GPB.");
+
+cleanup:
+    if (NULL != msg_req) {
+        sr_msg_free(msg_req);
+    } else {
+        sr_mem_free(sr_mem);
+    }
+    if (NULL != msg_resp) {
+        sr_msg_free(msg_resp);
+    }
+    return cl_session_return(session, rc);
 }
 
 int

--- a/src/client_library.c
+++ b/src/client_library.c
@@ -1113,7 +1113,7 @@ cleanup:
 int
 sr_get_subtree_chunk(sr_session_ctx_t *session, const char *xpath, bool single,
         size_t offset, size_t child_limit, size_t depth_limit,
-        sr_node_t **chunks, size_t *chunk_cnt);
+        sr_node_t **chunks, size_t *chunk_cnt)
 {
     /* TODO */
     return SR_ERR_OK;

--- a/src/client_library.h
+++ b/src/client_library.h
@@ -63,4 +63,24 @@ int sr_feature_enable(sr_session_ctx_t *session, const char *module_name, const 
  */
 int sr_check_enabled_running(sr_session_ctx_t *session, const char *module_name, bool *res);
 
+/**
+ * @brief Get the first or a next chunk of gradually downloaded subtree(s).
+ * The first chunk is the upper portion of requested subtree(s), while the following
+ * chunks consist of all the nodes inside a pre-configured diameter in the direction of tree
+ * iteration.
+ *
+ * @param[in] session Session context acquired with ::sr_session_start call.
+ * @param[in] xpath @ref xp_page "XPath" identifier referencing root nodes of subtrees to
+ * partially receive (first chunk) or a starting point for the next chunk.
+ * @param[in] first Set to TRUE if this is the first chunk of data to get.
+ * @param[in] single Set to TRUE if the XPath should reference only a single node.
+ *                   Function returns SR_ERR_INVAL_ARG if that is not the case.
+ * @param[out] chunks Array of chunks (sub-sub-trees) returned by this call.
+ * @param[out] chunk_cnt Number of returned chunks.
+ *
+ * @return Error code (SR_ERR_OK on success).
+ */
+int sr_get_subtree_chunk(sr_session_ctx_t *session, const char *xpath, bool first, bool single,
+        sr_node_t **chunks, size_t *chunk_cnt);
+
 #endif /* CLIENT_LIBRARY_H_ */

--- a/src/client_library.h
+++ b/src/client_library.h
@@ -64,23 +64,29 @@ int sr_feature_enable(sr_session_ctx_t *session, const char *module_name, const 
 int sr_check_enabled_running(sr_session_ctx_t *session, const char *module_name, bool *res);
 
 /**
- * @brief Get the first or a next chunk of gradually downloaded subtree(s).
- * The first chunk is the upper portion of requested subtree(s), while the following
- * chunks consist of all the nodes inside a pre-configured diameter in the direction of tree
- * iteration.
+ * @brief Get first or a next chunk of a gradually downloaded subtree(s).
+ * A subtree chunk is also a tree, where the root node is the node referenced by XPath,
+ * the next level consists of its children skipping the first "offset" nodes and including
+ * at most "child_limit" nodes, while the remaining (depth_limit-2) levels always start with 
+ * the first child (offset is ignored) but also impose the same limiitation on the number 
+ * of transferred children. The chunk consists of at most "depth_limit" levels.
+ * @note Order of child nodes is determined by the schema tree.
  *
  * @param[in] session Session context acquired with ::sr_session_start call.
- * @param[in] xpath @ref xp_page "XPath" identifier referencing root nodes of subtrees to
- * partially receive (first chunk) or a starting point for the next chunk.
- * @param[in] first Set to TRUE if this is the first chunk of data to get.
+ * @param[in] xpath @ref xp_page "XPath" identifier referencing the starting point 
+ *                  for the next chunk.
  * @param[in] single Set to TRUE if the XPath should reference only a single node.
  *                   Function returns SR_ERR_INVAL_ARG if that is not the case.
+ * @param[in] offset Index of the first child to include on the second level of each chunk.
+ * @param[in] child_limit Maximum number of children to include. Applied on each level.
+ * @param[in] depth_limit The maximum number of levels to include in each chunk.
  * @param[out] chunks Array of chunks (sub-sub-trees) returned by this call.
  * @param[out] chunk_cnt Number of returned chunks.
  *
  * @return Error code (SR_ERR_OK on success).
  */
-int sr_get_subtree_chunk(sr_session_ctx_t *session, const char *xpath, bool first, bool single,
+int sr_get_subtree_chunk(sr_session_ctx_t *session, const char *xpath, bool single,
+        size_t offset, size_t child_limit, size_t depth_limit,
         sr_node_t **chunks, size_t *chunk_cnt);
 
 #endif /* CLIENT_LIBRARY_H_ */

--- a/src/common/sr_protobuf.c
+++ b/src/common/sr_protobuf.c
@@ -49,6 +49,10 @@ sr_gpb_operation_name(Sr__Operation operation)
         return "get-item";
     case SR__OPERATION__GET_ITEMS:
         return "get-items";
+    case SR__OPERATION__GET_SUBTREE:
+        return "get-subtree";
+    case SR__OPERATION__GET_SUBTREES:
+        return "get-subtrees";
     case SR__OPERATION__SET_ITEM:
         return "set-item";
     case SR__OPERATION__DELETE_ITEM:
@@ -189,6 +193,18 @@ sr_gpb_req_alloc(sr_mem_ctx_t *sr_mem, const Sr__Operation operation, const uint
             CHECK_NULL_NOMEM_GOTO(sub_msg, rc, error);
             sr__get_items_req__init((Sr__GetItemsReq*)sub_msg);
             req->get_items_req = (Sr__GetItemsReq*)sub_msg;
+            break;
+        case SR__OPERATION__GET_SUBTREE:
+            sub_msg = sr_calloc(sr_mem, 1, sizeof(Sr__GetSubtreeReq));
+            CHECK_NULL_NOMEM_GOTO(sub_msg, rc, error);
+            sr__get_subtree_req__init((Sr__GetSubtreeReq*)sub_msg);
+            req->get_subtree_req = (Sr__GetSubtreeReq*)sub_msg;
+            break;
+        case SR__OPERATION__GET_SUBTREES:
+            sub_msg = sr_calloc(sr_mem, 1, sizeof(Sr__GetSubtreesReq));
+            CHECK_NULL_NOMEM_GOTO(sub_msg, rc, error);
+            sr__get_subtrees_req__init((Sr__GetSubtreesReq*)sub_msg);
+            req->get_subtrees_req = (Sr__GetSubtreesReq*)sub_msg;
             break;
         case SR__OPERATION__SET_ITEM:
             sub_msg = sr_calloc(sr_mem, 1, sizeof(Sr__SetItemReq));
@@ -408,6 +424,18 @@ sr_gpb_resp_alloc(sr_mem_ctx_t *sr_mem, const Sr__Operation operation, const uin
             CHECK_NULL_NOMEM_GOTO(sub_msg, rc, error);
             sr__get_items_resp__init((Sr__GetItemsResp*)sub_msg);
             resp->get_items_resp = (Sr__GetItemsResp*)sub_msg;
+            break;
+        case SR__OPERATION__GET_SUBTREE:
+            sub_msg = sr_calloc(sr_mem, 1, sizeof(Sr__GetSubtreeResp));
+            CHECK_NULL_NOMEM_GOTO(sub_msg, rc, error);
+            sr__get_subtree_resp__init((Sr__GetSubtreeResp*)sub_msg);
+            resp->get_subtree_resp = (Sr__GetSubtreeResp*)sub_msg;
+            break;
+        case SR__OPERATION__GET_SUBTREES:
+            sub_msg = sr_calloc(sr_mem, 1, sizeof(Sr__GetSubtreesResp));
+            CHECK_NULL_NOMEM_GOTO(sub_msg, rc, error);
+            sr__get_subtrees_resp__init((Sr__GetSubtreesResp*)sub_msg);
+            resp->get_subtrees_resp = (Sr__GetSubtreesResp*)sub_msg;
             break;
         case SR__OPERATION__SET_ITEM:
             sub_msg = sr_calloc(sr_mem, 1, sizeof(Sr__SetItemResp));
@@ -787,6 +815,12 @@ sr_gpb_msg_validate(const Sr__Msg *msg, const Sr__Msg__MsgType type, const Sr__O
             case SR__OPERATION__GET_ITEMS:
                 CHECK_NULL_RETURN(msg->request->get_items_req, SR_ERR_MALFORMED_MSG);
                 break;
+            case SR__OPERATION__GET_SUBTREE:
+                CHECK_NULL_RETURN(msg->request->get_subtree_req, SR_ERR_MALFORMED_MSG);
+                break;
+            case SR__OPERATION__GET_SUBTREES:
+                CHECK_NULL_RETURN(msg->request->get_subtrees_req, SR_ERR_MALFORMED_MSG);
+                break;
             case SR__OPERATION__SET_ITEM:
                 CHECK_NULL_RETURN(msg->request->set_item_req, SR_ERR_MALFORMED_MSG);
                 break;
@@ -877,6 +911,12 @@ sr_gpb_msg_validate(const Sr__Msg *msg, const Sr__Msg__MsgType type, const Sr__O
                 break;
             case SR__OPERATION__GET_ITEMS:
                 CHECK_NULL_RETURN(msg->response->get_items_resp, SR_ERR_MALFORMED_MSG);
+                break;
+            case SR__OPERATION__GET_SUBTREE:
+                CHECK_NULL_RETURN(msg->response->get_subtree_resp, SR_ERR_MALFORMED_MSG);
+                break;
+            case SR__OPERATION__GET_SUBTREES:
+                CHECK_NULL_RETURN(msg->response->get_subtrees_resp, SR_ERR_MALFORMED_MSG);
                 break;
             case SR__OPERATION__SET_ITEM:
                 CHECK_NULL_RETURN(msg->response->set_item_resp, SR_ERR_MALFORMED_MSG);

--- a/src/common/sr_utils.c
+++ b/src/common/sr_utils.c
@@ -1036,14 +1036,13 @@ sr_api_variant_from_str(const char *api_variant_str)
 /**
  * @brief Copy and convert content of a libyang node and its descendands into a sysrepo tree.
  *
- * @param [in] ly_ctx libyang context
  * @param [in] parent Parent node.
  * @param [in] child Child node.
  * @param [in] node libyang node.
  * @param [out] sr_tree Returned sysrepo tree.
  */
 static int
-sr_copy_node_to_tree_internal(struct ly_ctx *ly_ctx, const struct lyd_node *parent, const struct lyd_node *node,
+sr_copy_node_to_tree_internal(const struct lyd_node *parent, const struct lyd_node *node,
         sr_node_t *sr_tree)
 {
     int rc = SR_ERR_OK;
@@ -1052,7 +1051,7 @@ sr_copy_node_to_tree_internal(struct ly_ctx *ly_ctx, const struct lyd_node *pare
     const struct lyd_node *child = NULL;
     sr_node_t *sr_subtree = NULL;
 
-    CHECK_NULL_ARG3(ly_ctx, node, sr_tree);
+    CHECK_NULL_ARG2(node, sr_tree);
 
     /* copy node name */
     rc = sr_node_set_name(sr_tree, node->schema->name);
@@ -1100,7 +1099,7 @@ sr_copy_node_to_tree_internal(struct ly_ctx *ly_ctx, const struct lyd_node *pare
             if (SR_ERR_OK != rc) {
                 goto cleanup;
             }
-            rc = sr_copy_node_to_tree_internal(ly_ctx, node, child, sr_subtree);
+            rc = sr_copy_node_to_tree_internal(node, child, sr_subtree);
             if (SR_ERR_OK != rc) {
                 goto cleanup;
             }
@@ -1116,20 +1115,20 @@ cleanup:
 }
 
 int
-sr_copy_node_to_tree(struct ly_ctx *ly_ctx, const struct lyd_node *node, sr_node_t *sr_tree)
+sr_copy_node_to_tree(const struct lyd_node *node, sr_node_t *sr_tree)
 {
-    return sr_copy_node_to_tree_internal(ly_ctx, NULL, node, sr_tree);
+    return sr_copy_node_to_tree_internal(NULL, node, sr_tree);
 }
 
 int
-sr_nodes_to_trees(struct ly_ctx *ly_ctx, struct ly_set *nodes, sr_mem_ctx_t *sr_mem, sr_node_t **sr_trees, size_t *count)
+sr_nodes_to_trees(struct ly_set *nodes, sr_mem_ctx_t *sr_mem, sr_node_t **sr_trees, size_t *count)
 {
     int rc = SR_ERR_OK;
     sr_node_t *trees = NULL;
     sr_mem_snapshot_t snapshot = { 0, };
     size_t i = 0;
 
-    CHECK_NULL_ARG4(ly_ctx, nodes, sr_trees, count);
+    CHECK_NULL_ARG3(nodes, sr_trees, count);
 
     if (0 == nodes->number) {
         *sr_trees = NULL;
@@ -1149,7 +1148,7 @@ sr_nodes_to_trees(struct ly_ctx *ly_ctx, struct ly_set *nodes, sr_mem_ctx_t *sr_
 
     for (i = 0; i < nodes->number && 0 == rc; ++i) {
         trees[i]._sr_mem = sr_mem;
-        rc = sr_copy_node_to_tree(ly_ctx, nodes->set.d[i], trees + i);
+        rc = sr_copy_node_to_tree(nodes->set.d[i], trees + i);
     }
 
     if (SR_ERR_OK == rc) {

--- a/src/common/sr_utils.h
+++ b/src/common/sr_utils.h
@@ -328,11 +328,10 @@ sr_api_variant_t sr_api_variant_from_str(const char *api_variant_str);
 /**
  * @brief Copy and convert content of a libyang node and its descendands into a sysrepo tree.
  *
- * @param [in] ly_ctx libyang context
  * @param [in] node libyang node.
  * @param [out] sr_tree Returned sysrepo tree.
  */
-int sr_copy_node_to_tree(struct ly_ctx *ly_ctx, const struct lyd_node *node, sr_node_t *sr_tree);
+int sr_copy_node_to_tree(const struct lyd_node *node, sr_node_t *sr_tree);
 
 /**
  * @brief Convert a set of libyang nodes into an array of sysrepo trees. For each node a corresponding
@@ -340,13 +339,12 @@ int sr_copy_node_to_tree(struct ly_ctx *ly_ctx, const struct lyd_node *node, sr_
  * of each other! With this assumption the links between the output trees does not need to be considered which
  * significantly decreses the cost of this operation.
  *
- * @param [in] ly_ctx libyang context
  * @param [in] nodes A set of libyang nodes.
  * @param [in] sr_mem Sysrepo memory context to use for memory allocation. Can be NULL.
  * @param [out] sr_trees Returned array of sysrepo trees.
  * @param [out] count Number of returned trees.
  */
-int sr_nodes_to_trees(struct ly_ctx *ly_ctx, struct ly_set *nodes, sr_mem_ctx_t *sr_mem, sr_node_t **sr_trees, size_t *count);
+int sr_nodes_to_trees(struct ly_set *nodes, sr_mem_ctx_t *sr_mem, sr_node_t **sr_trees, size_t *count);
 
 /**
  * @brief Convert a sysrepo tree into a libyang data tree.

--- a/src/data_manager.c
+++ b/src/data_manager.c
@@ -3652,7 +3652,7 @@ dm_validate_procedure(dm_ctx_t *dm_ctx, dm_session_t *session, dm_procedure_t ty
                 strcat(tmp_xpath, "*");
                 nodeset = lyd_get_node(data_tree, tmp_xpath);
                 if (NULL != nodeset) {
-                    rc = sr_nodes_to_trees(schema_info->ly_ctx, nodeset, sr_mem, with_def_tree, with_def_tree_cnt);
+                    rc = sr_nodes_to_trees(nodeset, sr_mem, with_def_tree, with_def_tree_cnt);
                 } else {
                     SR_LOG_ERR("No matching nodes returned for xpath '%s'.", tmp_xpath);
                     rc = SR_ERR_INTERNAL;

--- a/src/request_processor.c
+++ b/src/request_processor.c
@@ -110,6 +110,10 @@ rp_check_notif_session(rp_ctx_t *rp_ctx, rp_session_t *session, Sr__Msg *msg)
         xpath = msg->request->get_items_req->xpath;
     } else if (SR__OPERATION__GET_CHANGES == msg->request->operation) {
         xpath = msg->request->get_changes_req->xpath;
+    } else if (SR__OPERATION__GET_SUBTREE == msg->request->operation) {
+        xpath = msg->request->get_subtree_req->xpath;
+    } else if (SR__OPERATION__GET_SUBTREES == msg->request->operation) {
+        xpath = msg->request->get_subtrees_req->xpath;
     } else {
         SR_LOG_WRN_MSG("Check notif session called for unknown operation");
     }
@@ -519,6 +523,7 @@ rp_get_items_req_process(rp_ctx_t *rp_ctx, rp_session_t *session, Sr__Msg *msg, 
         *skip_msg_cleanup = true;
         /* setup timeout */
         rc = rp_set_oper_request_timeout(rp_ctx, session, msg, RP_OPER_DATA_REQ_TIMEOUT);
+        sr_free_values(values, count);
         sr_msg_free(resp);
         pthread_mutex_unlock(&session->cur_req_mutex);
         return rc;
@@ -548,6 +553,192 @@ cleanup:
     return rc;
 }
 
+/**
+ * @brief Processes a get_subtree request.
+ */
+static int
+rp_get_subtree_req_process(rp_ctx_t *rp_ctx, rp_session_t *session, Sr__Msg *msg, bool *skip_msg_cleanup)
+{
+    int rc = SR_ERR_OK;
+
+    CHECK_NULL_ARG5(rp_ctx, session, msg, msg->request, msg->request->get_subtree_req);
+
+    SR_LOG_DBG_MSG("Processing get_subtree request.");
+
+    Sr__Msg *resp = NULL;
+    sr_mem_ctx_t *sr_mem = NULL;
+
+    rc = sr_mem_new(0, &sr_mem);
+    CHECK_RC_MSG_RETURN(rc, "Failed to create a new Sysrepo memory context.");
+    rc = sr_gpb_resp_alloc(sr_mem, SR__OPERATION__GET_SUBTREE, session->id, &resp);
+    if (SR_ERR_OK != rc) {
+        sr_mem_free(sr_mem);
+        SR_LOG_ERR_MSG("Gpb response allocation failed");
+        return rc;
+    }
+
+    sr_node_t *tree = NULL;
+    char *xpath = msg->request->get_subtree_req->xpath;
+
+    if (session->options & SR__SESSION_FLAGS__SESS_NOTIFICATION) {
+        rc = rp_check_notif_session(rp_ctx, session, msg);
+        CHECK_RC_MSG_GOTO(rc, cleanup, "Check notif session failed");
+    }
+
+    MUTEX_LOCK_TIMED_CHECK_GOTO(&session->cur_req_mutex, rc, cleanup);
+    if (RP_REQ_FINISHED == session->state) {
+        session->state = RP_REQ_NEW;
+    } else if (RP_REQ_WAITING_FOR_DATA == session->state) {
+        if (msg == session->req) {
+            SR_LOG_ERR("Time out waiting for operational data expired before all responses have been received, session id = %u", session->id);
+            session->state = RP_REQ_DATA_LOADED;
+        } else {
+            SR_LOG_ERR("A request was not processed, probably invalid state, session id = %u", session->id);
+            sr_msg_free(session->req);
+            session->state = RP_REQ_NEW;
+        }
+    }
+    /* store current request to session */
+    session->req = msg;
+
+    /* get value from data manager */
+    rc = rp_dt_get_subtree_wrapper(rp_ctx, session, sr_mem, xpath, &tree);
+    if (SR_ERR_OK != rc && SR_ERR_NOT_FOUND != rc) {
+        SR_LOG_ERR("Get subtree failed for '%s', session id=%"PRIu32".", xpath, session->id);
+    }
+
+    if (RP_REQ_WAITING_FOR_DATA == session->state) {
+        SR_LOG_DBG_MSG("Request paused, waiting for data");
+        /* we are waiting for operational data do not free the request */
+        *skip_msg_cleanup = true;
+        /* setup timeout */
+        rc = rp_set_oper_request_timeout(rp_ctx, session, msg, RP_OPER_DATA_REQ_TIMEOUT);
+        sr_free_tree(tree);
+        sr_msg_free(resp);
+        pthread_mutex_unlock(&session->cur_req_mutex);
+        return rc;
+    }
+
+    pthread_mutex_unlock(&session->cur_req_mutex);
+
+    /* copy value to gpb */
+    if (SR_ERR_OK == rc) {
+        rc = sr_dup_tree_to_gpb(tree, &resp->response->get_subtree_resp->tree);
+        if (SR_ERR_OK != rc) {
+            SR_LOG_ERR("Copying sr_node_t to gpb failed for xpath '%s'", xpath);
+        }
+    }
+
+cleanup:
+    session->req = NULL;
+    /* set response code */
+    resp->response->result = rc;
+
+    rc = rp_resp_fill_errors(resp, session->dm_session);
+    if (SR_ERR_OK != rc) {
+        SR_LOG_ERR_MSG("Copying errors to gpb failed");
+    }
+
+    sr_free_tree(tree);
+    rc = cm_msg_send(rp_ctx->cm_ctx, resp);
+
+    return rc;
+}
+
+/**
+ * @brief Processes a get_subtrees request.
+ */
+static int
+rp_get_subtrees_req_process(rp_ctx_t *rp_ctx, rp_session_t *session, Sr__Msg *msg, bool *skip_msg_cleanup)
+{
+    sr_node_t *trees = NULL;
+    size_t count = 0;
+    char *xpath = NULL;
+    int rc = SR_ERR_OK;
+
+    CHECK_NULL_ARG5(rp_ctx, session, msg, msg->request, msg->request->get_subtrees_req);
+
+    SR_LOG_DBG_MSG("Processing get_subtrees request.");
+
+    Sr__Msg *resp = NULL;
+    sr_mem_ctx_t *sr_mem = NULL;
+
+    rc = sr_mem_new(0, &sr_mem);
+    CHECK_RC_MSG_RETURN(rc, "Failed to create a new Sysrepo memory context.");
+    rc = sr_gpb_resp_alloc(sr_mem, SR__OPERATION__GET_SUBTREES, session->id, &resp);
+    if (SR_ERR_OK != rc) {
+        sr_mem_free(sr_mem);
+        SR_LOG_ERR_MSG("Gpb response allocation failed");
+        return rc;
+    }
+
+    if (session->options & SR__SESSION_FLAGS__SESS_NOTIFICATION) {
+        rc = rp_check_notif_session(rp_ctx, session, msg);
+        CHECK_RC_MSG_GOTO(rc, cleanup, "Check notif session failed");
+    }
+
+    MUTEX_LOCK_TIMED_CHECK_GOTO(&session->cur_req_mutex, rc, cleanup);
+    if (RP_REQ_FINISHED == session->state) {
+        session->state = RP_REQ_NEW;
+    } else if (RP_REQ_WAITING_FOR_DATA == session->state) {
+        if (msg == session->req) {
+            SR_LOG_ERR("Time out waiting for operational data expired before all responses have been received, session id = %u", session->id);
+            session->state = RP_REQ_DATA_LOADED;
+        } else {
+            SR_LOG_ERR("A request was not processed, probably invalid state, session id = %u", session->id);
+            sr_msg_free(session->req);
+            session->state = RP_REQ_NEW;
+        }
+    }
+    /* store current request to session */
+    session->req = msg;
+
+    xpath = msg->request->get_subtrees_req->xpath;
+    rc = rp_dt_get_subtrees_wrapper(rp_ctx, session, sr_mem, xpath, &trees, &count);
+
+    if (SR_ERR_OK != rc) {
+        if (SR_ERR_NOT_FOUND != rc) {
+            SR_LOG_ERR("Get subtrees failed for '%s', session id=%"PRIu32".", xpath, session->id);
+        }
+        pthread_mutex_unlock(&session->cur_req_mutex);
+        goto cleanup;
+    }
+
+    if (RP_REQ_WAITING_FOR_DATA == session->state) {
+        SR_LOG_DBG_MSG("Request paused, waiting for data");
+        /* we are waiting for operational data do not free the request */
+        *skip_msg_cleanup = true;
+        /* setup timeout */
+        rc = rp_set_oper_request_timeout(rp_ctx, session, msg, RP_OPER_DATA_REQ_TIMEOUT);
+        sr_free_trees(trees, count);
+        sr_msg_free(resp);
+        pthread_mutex_unlock(&session->cur_req_mutex);
+        return rc;
+    }
+
+    SR_LOG_DBG("%zu subtrees found for '%s', session id=%"PRIu32".", count, xpath, session->id);
+    pthread_mutex_unlock(&session->cur_req_mutex);
+
+    /* copy subtrees to gpb */
+    rc = sr_trees_sr_to_gpb(trees, count, &resp->response->get_subtrees_resp->trees, &resp->response->get_subtrees_resp->n_trees);
+    CHECK_RC_MSG_GOTO(rc, cleanup, "Copying values to GPB failed.");
+
+cleanup:
+    session->req = NULL;
+
+    /* set response code */
+    resp->response->result = rc;
+
+    rc = rp_resp_fill_errors(resp, session->dm_session);
+    if (SR_ERR_OK != rc) {
+        SR_LOG_ERR_MSG("Copying errors to gpb failed");
+    }
+
+    sr_free_trees(trees, count);
+    rc = cm_msg_send(rp_ctx->cm_ctx, resp);
+
+    return rc;
+}
 /**
  * @brief Processes a set_item request.
  */
@@ -1878,6 +2069,8 @@ rp_req_dispatch(rp_ctx_t *rp_ctx, rp_session_t *session, Sr__Msg *msg, bool *ski
     switch (msg->request->operation) {
         case SR__OPERATION__GET_ITEM:
         case SR__OPERATION__GET_ITEMS:
+        case SR__OPERATION__GET_SUBTREE:
+        case SR__OPERATION__GET_SUBTREES:
         case SR__OPERATION__SET_ITEM:
         case SR__OPERATION__DELETE_ITEM:
         case SR__OPERATION__MOVE_ITEM:
@@ -1915,6 +2108,12 @@ rp_req_dispatch(rp_ctx_t *rp_ctx, rp_session_t *session, Sr__Msg *msg, bool *ski
             break;
         case SR__OPERATION__GET_ITEMS:
             rc = rp_get_items_req_process(rp_ctx, session, msg, skip_msg_cleanup);
+            break;
+        case SR__OPERATION__GET_SUBTREE:
+            rc = rp_get_subtree_req_process(rp_ctx, session, msg, skip_msg_cleanup);
+            break;
+        case SR__OPERATION__GET_SUBTREES:
+            rc = rp_get_subtrees_req_process(rp_ctx, session, msg, skip_msg_cleanup);
             break;
         case SR__OPERATION__SET_ITEM:
             rc = rp_set_item_req_process(rp_ctx, session, msg);
@@ -1977,6 +2176,8 @@ rp_req_dispatch(rp_ctx_t *rp_ctx, rp_session_t *session, Sr__Msg *msg, bool *ski
     switch (msg->request->operation) {
         case SR__OPERATION__GET_ITEM:
         case SR__OPERATION__GET_ITEMS:
+        case SR__OPERATION__GET_SUBTREE:
+        case SR__OPERATION__GET_SUBTREES:
         case SR__OPERATION__SET_ITEM:
         case SR__OPERATION__DELETE_ITEM:
         case SR__OPERATION__MOVE_ITEM:
@@ -2076,7 +2277,9 @@ rp_msg_dispatch(rp_ctx_t *rp_ctx, rp_session_t *session, Sr__Msg *msg)
                 (SR__OPERATION__GET_ITEMS != msg->request->operation) &&
                 (SR__OPERATION__SESSION_REFRESH != msg->request->operation) &&
                 (SR__OPERATION__GET_CHANGES != msg->request->operation) &&
-                (SR__OPERATION__UNSUBSCRIBE != msg->request->operation)) {
+                (SR__OPERATION__UNSUBSCRIBE != msg->request->operation) &&
+                (SR__OPERATION__GET_SUBTREE != msg->request->operation) &&
+                (SR__OPERATION__GET_SUBTREES != msg->request->operation)) {
             SR_LOG_ERR("Unsupported operation for notification session (session id=%"PRIu32", operation=%d).",
                     session->id, msg->request->operation);
             sr_msg_free(msg);

--- a/src/rp_dt_get.h
+++ b/src/rp_dt_get.h
@@ -108,6 +108,56 @@ int rp_dt_get_values_wrapper_with_opts(rp_ctx_t *rp_ctx, rp_session_t *rp_sessio
 int rp_dt_get_values_from_nodes(sr_mem_ctx_t *sr_mem, struct ly_set *nodes, sr_val_t **values, size_t *value_cnt);
 
 /**
+ * @brief Returns subtree with the root node at the specified xpath. If more than one node matching xpath,
+ * SR_ERR_INVAL_ARG is returned.
+ * @param [in] dm_ctx
+ * @param [in] data_tree
+ * @param [in] sr_mem
+ * @param [in] xpath
+ * @param [in] check_enable
+ * @param [out] value
+ * @return Error code (SR_ERR_OK on success)
+ */
+int rp_dt_get_subtree(const dm_ctx_t *dm_ctx, struct lyd_node *data_tree, sr_mem_ctx_t *sr_mem, const char *xpath, bool check_enable, sr_node_t **subtree);
+
+/**
+ * @brief Retrieves all subtrees with root nodes matching the specified xpath.
+ * @param [in] dm_ctx
+ * @param [in] data_tree
+ * @param [in] sr_mem
+ * @param [in] xpath
+ * @param [in] check_enable
+ * @param [out] values
+ * @param [out] count
+ * @return Error code (SR_ERR_OK on success)
+ */
+int rp_dt_get_subtrees(const dm_ctx_t *dm_ctx, struct lyd_node *data_tree, sr_mem_ctx_t *sr_mem, const char *xpath, bool check_enable,
+        sr_node_t **subtrees, size_t *count);
+
+/**
+ * @brief Returns the subtree whose root node is referenced by the specified xpath.
+ * @param [in] rp_ctx
+ * @param [in] rp_session
+ * @param [in] sr_mem
+ * @param [in] xpath
+ * @param [out] subtree
+ * @return Error code (SR_ERR_OK on success), SR_ERR_NOT_FOUND, SR_ERR_UNKNOWN_MODEL, SR_ERR_BAD_ELEMENT
+ */
+int rp_dt_get_subtree_wrapper(rp_ctx_t *rp_ctx, rp_session_t *rp_session, sr_mem_ctx_t *sr_mem, const char *xpath, sr_node_t **subtree);
+
+/**
+ * @brief Retrieves all subtrees with root nodes matching the specified xpath.
+ * @param [in] rp_ctx
+ * @param [in] rp_session
+ * @param [in] sr_mem
+ * @param [in] xpath
+ * @param [out] subtrees
+ * @param [out] count
+ * @return Error code (SR_ERR_OK on success), SR_ERR_NOT_FOUND, SR_ERR_UNKNOWN_MODEL, SR_ERR_BAD_ELEMENT
+ */
+int rp_dt_get_subtrees_wrapper(rp_ctx_t *rp_ctx, rp_session_t *rp_session, sr_mem_ctx_t *sr_mem, const char *xpath, sr_node_t **subtrees, size_t *count);
+
+/**
  * @brief Transforms difflist to the set of changes
  * @param [in] difflist
  * @param [out] changes

--- a/src/sysrepo.proto
+++ b/src/sysrepo.proto
@@ -301,6 +301,35 @@ message GetItemsResp {
   repeated Value values = 1;
 }
 
+/**
+ * @brief Retrieves a single subtree whose root is stored under provided path.
+ * Sent by sr_get_subtree API call.
+ */
+message GetSubtreeReq {
+  required string xpath = 1;
+}
+
+/**
+ * @brief Response to sr_get_subtree request.
+ */
+message GetSubtreeResp {
+  optional Node tree = 1;
+}
+
+/**
+ * @brief Retrieves an array of subtrees whose root nodes match provided path.
+ * Sent by sr_get_subtrees API call.
+ */
+message GetSubtreesReq {
+  required string xpath = 1;
+}
+
+/**
+ * @brief Response to sr_get_subtrees request.
+ */
+message GetSubtreesResp {
+  repeated Node trees = 1;
+}
 
 ////////////////////////////////////////////////////////////////////////////////
 // Data Manipulation API (edit-config functionality)
@@ -731,6 +760,9 @@ enum Operation {
   GET_ITEM = 30;
   GET_ITEMS = 31;
 
+  GET_SUBTREE = 32;
+  GET_SUBTREES = 33;
+
   SET_ITEM = 40;
   DELETE_ITEM = 41;
   MOVE_ITEM = 42;
@@ -777,6 +809,9 @@ message Request {
   optional GetItemReq get_item_req = 30;
   optional GetItemsReq get_items_req = 31;
 
+  optional GetSubtreeReq get_subtree_req = 32;
+  optional GetSubtreesReq get_subtrees_req = 33;
+
   optional SetItemReq set_item_req = 40;
   optional DeleteItemReq delete_item_req = 41;
   optional MoveItemReq move_item_req = 42;
@@ -820,6 +855,9 @@ message Response {
 
   optional GetItemResp get_item_resp = 30;
   optional GetItemsResp get_items_resp = 31;
+
+  optional GetSubtreeResp get_subtree_resp = 32;
+  optional GetSubtreesResp get_subtrees_resp = 33;
 
   optional SetItemResp set_item_resp = 40;
   optional DeleteItemResp delete_item_resp = 41;

--- a/src/utils/trees.c
+++ b/src/utils/trees.c
@@ -312,3 +312,23 @@ sr_dup_trees(sr_node_t *trees, size_t count, sr_node_t **trees_dup_p)
 {
     return sr_dup_trees_ctx(trees, count, NULL, trees_dup_p);
 }
+
+sr_node_t *
+sr_node_get_child(sr_node_t *node)
+{
+    /* TODO */
+    return node->first_child;
+}
+
+sr_node_t *
+sr_node_get_next_sibling(sr_node_t *node)
+{
+    /* TODO */
+    return node->next;
+}
+
+sr_node_t *
+sr_node_get_parent(sr_node_t *node)
+{
+    return node->parent;
+}

--- a/tests/cl_notifications_test.c
+++ b/tests/cl_notifications_test.c
@@ -145,7 +145,7 @@ cl_get_changes_create_test(void **state)
     rc = sr_get_item(session, xpath, &val);
     assert_int_equal(rc, SR_ERR_NOT_FOUND);
 
-    rc = sr_get_subtree(session, xpath, &tree);
+    rc = sr_get_subtree(session, xpath, 0, &tree);
     assert_int_equal(rc, SR_ERR_NOT_FOUND);
 
     /* create the list instance */
@@ -220,7 +220,7 @@ cl_get_changes_modified_test(void **state)
     rc = sr_get_item(session, xpath, &val);
     assert_int_equal(rc, SR_ERR_OK);
 
-    rc = sr_get_subtree(session, xpath, &tree);
+    rc = sr_get_subtree(session, xpath, 0, &tree);
     assert_int_equal(rc, SR_ERR_OK);
 
     sr_val_t new_val = {0};

--- a/tests/cl_notifications_test.c
+++ b/tests/cl_notifications_test.c
@@ -128,6 +128,7 @@ cl_get_changes_create_test(void **state)
     struct timespec ts;
 
     sr_val_t *val = NULL;
+    sr_node_t *tree = NULL;
     const char *xpath = NULL;
     int rc = SR_ERR_OK;
     xpath = "/example-module:container/list[key1='abc'][key2='def']";
@@ -144,6 +145,8 @@ cl_get_changes_create_test(void **state)
     rc = sr_get_item(session, xpath, &val);
     assert_int_equal(rc, SR_ERR_NOT_FOUND);
 
+    rc = sr_get_subtree(session, xpath, &tree);
+    assert_int_equal(rc, SR_ERR_NOT_FOUND);
 
     /* create the list instance */
     rc = sr_set_item(session, xpath, NULL, SR_EDIT_DEFAULT);
@@ -200,6 +203,7 @@ cl_get_changes_modified_test(void **state)
     struct timespec ts;
 
     sr_val_t *val = NULL;
+    sr_node_t *tree = NULL;
     const char *xpath = NULL;
     int rc = SR_ERR_OK;
     xpath = "/example-module:container/list[key1='key1'][key2='key2']/leaf";
@@ -214,6 +218,9 @@ cl_get_changes_modified_test(void **state)
 
     /* check the list presence in candidate */
     rc = sr_get_item(session, xpath, &val);
+    assert_int_equal(rc, SR_ERR_OK);
+
+    rc = sr_get_subtree(session, xpath, &tree);
     assert_int_equal(rc, SR_ERR_OK);
 
     sr_val_t new_val = {0};
@@ -238,6 +245,7 @@ cl_get_changes_modified_test(void **state)
     assert_non_null(changes.new_values[0]);
     assert_non_null(changes.old_values[0]);
     assert_string_equal(val->data.string_val, changes.old_values[0]->data.string_val);
+    assert_string_equal(tree->data.string_val, changes.old_values[0]->data.string_val);
     assert_string_equal(new_val.data.string_val, changes.new_values[0]->data.string_val);
 
     for (size_t i = 0; i < changes.cnt; i++) {
@@ -246,6 +254,7 @@ cl_get_changes_modified_test(void **state)
     }
 
     sr_free_val(val);
+    sr_free_tree(tree);
     pthread_mutex_unlock(&changes.mutex);
 
     rc = sr_unsubscribe(NULL, subscription);

--- a/tests/cl_state_data_test.c
+++ b/tests/cl_state_data_test.c
@@ -442,7 +442,7 @@ cl_parent_subscription_tree(void **state)
     assert_int_equal(rc, SR_ERR_OK);
 
     /* retrieve data using the tree API */
-    rc = sr_get_subtree(session, "/state-module:bus", &tree);
+    rc = sr_get_subtree(session, "/state-module:bus", 0, &tree);
     assert_int_equal(rc, SR_ERR_OK);
 
     /* check data */
@@ -591,7 +591,7 @@ cl_exact_match_subscription_tree(void **state)
     assert_int_equal(rc, SR_ERR_OK);
 
     /* retrieve data using the tree API */
-    rc = sr_get_subtree(session, "/state-module:bus", &tree);
+    rc = sr_get_subtree(session, "/state-module:bus", 0, &tree);
     assert_int_equal(rc, SR_ERR_OK);
 
     /* check data */
@@ -723,7 +723,7 @@ cl_partialy_covered_by_subscription_tree(void **state)
     assert_int_equal(rc, SR_ERR_OK);
 
     /* retrieve data */
-    rc = sr_get_subtree(session, "/state-module:bus", &tree);
+    rc = sr_get_subtree(session, "/state-module:bus", 0, &tree);
     assert_int_equal(rc, SR_ERR_OK);
 
     /* check data */
@@ -839,7 +839,7 @@ cl_incorrect_data_subscription_tree(void **state)
     assert_int_equal(rc, SR_ERR_OK);
 
     /* retrieve data */
-    rc = sr_get_subtree(session, "/state-module:bus", &tree);
+    rc = sr_get_subtree(session, "/state-module:bus/gps_located", 0, &tree);
     assert_int_equal(rc, SR_ERR_NOT_FOUND);
 
     /* check data */
@@ -942,7 +942,7 @@ cl_missing_subscription_tree(void **state)
     assert_int_equal(rc, SR_ERR_OK);
 
     /* retrieve data */
-    rc = sr_get_subtree(session, "/state-module:cpu_load", &tree);
+    rc = sr_get_subtree(session, "/state-module:cpu_load", 0, &tree);
     assert_int_equal(rc, SR_ERR_NOT_FOUND);
 
     /* check data */
@@ -1078,7 +1078,7 @@ cl_nested_data_subscription_tree(void **state)
     assert_int_equal(rc, SR_ERR_OK);
 
     /* retrieve data */
-    rc = sr_get_subtree(session, "/state-module:traffic_stats", &tree);
+    rc = sr_get_subtree(session, "/state-module:traffic_stats", 0, &tree);
     assert_int_equal(rc, SR_ERR_OK);
 
     /* check data */
@@ -1542,13 +1542,13 @@ cl_nested_data_subscription2_tree(void **state)
     assert_int_equal(rc, SR_ERR_OK);
 
     /* retrieve data */
-    rc = sr_get_subtree(session, "/state-module:traffic_stats/cross_road[id='0']/advanced_info", &tree);
+    rc = sr_get_subtree(session, "/state-module:traffic_stats/cross_road[id='0']/advanced_info", 0, &tree);
     assert_int_equal(rc, SR_ERR_OK);
 
     /* check data */
     assert_non_null(tree);
     // advanced info
-    node = node->parent->next;
+    node = tree;
     assert_string_equal("advanced_info", node->name);
     assert_string_equal("state-module", node->module_name);
     assert_false(node->dflt);

--- a/tests/cl_state_data_test.c
+++ b/tests/cl_state_data_test.c
@@ -37,6 +37,26 @@
 #include "sysrepo/xpath_utils.h"
 #include "sysrepo/values.h"
 
+#define CHECK_LIST_OF_STRINGS(list, expected)                           \
+    do {                                                                \
+        size_t exp_cnt = sizeof(expected) / sizeof(*expected);          \
+        assert_int_equal(exp_cnt, list->count);                         \
+        for (size_t i = 0; i < exp_cnt; i++) {                          \
+            bool match = false;                                         \
+            for (size_t j = 0; list->count; j++) {                      \
+                if (0 == strcmp(expected[i], (char *)list->data[j])) {  \
+                    match = true;                                       \
+                    break;                                              \
+                }                                                       \
+            }                                                           \
+            if (!match) {                                               \
+                /* assert string that can not be found */               \
+                assert_string_equal("", expected[i]);                   \
+            }                                                           \
+        }                                                               \
+    } while (0)
+
+
 static int
 sysrepo_setup(void **state)
 {
@@ -383,22 +403,82 @@ cl_parent_subscription(void **state)
         "/state-module:bus/gps_located",
         "/state-module:bus/distance_travelled"
     };
-    size_t expected_xp_cnt = sizeof(xpath_expected_to_be_loaded) / sizeof(*xpath_expected_to_be_loaded);
-    assert_int_equal(expected_xp_cnt, xpath_retrieved->count);
+    CHECK_LIST_OF_STRINGS(xpath_retrieved, xpath_expected_to_be_loaded);
 
-    for (size_t i = 0; i < expected_xp_cnt; i++) {
-        bool match = false;
-        for (size_t j = 0; xpath_retrieved->count; j++) {
-            if (0 == strcmp(xpath_expected_to_be_loaded[i], (char *) xpath_retrieved->data[j])) {
-                match = true;
-                break;
-            }
-        }
-        if (!match) {
-            /* assert xpath that can not be found */
-            assert_string_equal("", xpath_expected_to_be_loaded[i]);
-        }
+    /* cleanup */
+    sr_unsubscribe(session, subscription);
+    sr_session_stop(session);
+
+    for (size_t i = 0; i < xpath_retrieved->count; i++) {
+        free(xpath_retrieved->data[i]);
     }
+    sr_list_cleanup(xpath_retrieved);
+}
+
+static void
+cl_parent_subscription_tree(void **state)
+{
+    sr_conn_ctx_t *conn = *state;
+    assert_non_null(conn);
+    sr_session_ctx_t *session = NULL;
+    sr_subscription_ctx_t *subscription = NULL;
+    sr_list_t *xpath_retrieved = NULL;
+    sr_node_t *tree = NULL, *node = NULL;
+    int rc = SR_ERR_OK;
+
+    rc = sr_list_init(&xpath_retrieved);
+    assert_int_equal(rc, SR_ERR_OK);
+
+    /* start session */
+    rc = sr_session_start(conn, SR_DS_RUNNING, SR_SESS_DEFAULT, &session);
+    assert_int_equal(rc, SR_ERR_OK);
+
+    rc = sr_module_change_subscribe(session, "state-module", cl_whole_module_cb, NULL,
+            0, SR_SUBSCR_DEFAULT, &subscription);
+    assert_int_equal(rc, SR_ERR_OK);
+
+    /* subscribe data providers */
+    rc = sr_dp_get_items_subscribe(session, "/state-module:bus", cl_dp_bus, xpath_retrieved, SR_SUBSCR_CTX_REUSE, &subscription);
+    assert_int_equal(rc, SR_ERR_OK);
+
+    /* retrieve data using the tree API */
+    rc = sr_get_subtree(session, "/state-module:bus", &tree);
+    assert_int_equal(rc, SR_ERR_OK);
+
+    /* check data */
+    assert_non_null(tree);
+    assert_string_equal("bus", tree->name);
+    assert_string_equal("state-module", tree->module_name);
+    assert_false(tree->dflt);
+    assert_int_equal(SR_CONTAINER_T, tree->type);
+    // gps located
+    node = tree->first_child;
+    assert_non_null(node);
+    assert_string_equal("gps_located", node->name);
+    assert_null(node->module_name);
+    assert_false(node->dflt);
+    assert_int_equal(SR_BOOL_T, node->type);
+    assert_false(node->data.bool_val);
+    assert_null(node->first_child);
+    // distance travelled
+    node = node->next;
+    assert_non_null(node);
+    assert_string_equal("distance_travelled", node->name);
+    assert_null(node->module_name);
+    assert_false(node->dflt);
+    assert_int_equal(SR_UINT32_T, node->type);
+    assert_int_equal(999, node->data.uint32_val);
+    assert_null(node->first_child);
+    assert_null(node->next);
+
+    sr_free_tree(tree);
+
+    /* check xpath that were retrieved */
+    const char *xpath_expected_to_be_loaded [] = {
+        "/state-module:bus/gps_located",
+        "/state-module:bus/distance_travelled"
+    };
+    CHECK_LIST_OF_STRINGS(xpath_retrieved, xpath_expected_to_be_loaded);
 
     /* cleanup */
     sr_unsubscribe(session, subscription);
@@ -466,22 +546,88 @@ cl_exact_match_subscription(void **state)
         "/state-module:bus/gps_located",
         "/state-module:bus/distance_travelled"
     };
-    size_t expected_xp_cnt = sizeof(xpath_expected_to_be_loaded) / sizeof(*xpath_expected_to_be_loaded);
-    assert_int_equal(expected_xp_cnt, xpath_retrieved->count);
+    CHECK_LIST_OF_STRINGS(xpath_retrieved, xpath_expected_to_be_loaded);
 
-    for (size_t i = 0; i < expected_xp_cnt; i++) {
-        bool match = false;
-        for (size_t j = 0; xpath_retrieved->count; j++) {
-            if (0 == strcmp(xpath_expected_to_be_loaded[i], (char *) xpath_retrieved->data[j])) {
-                match = true;
-                break;
-            }
-        }
-        if (!match) {
-            /* assert xpath that can not be found */
-            assert_string_equal("", xpath_expected_to_be_loaded[i]);
-        }
+    /* cleanup */
+    sr_unsubscribe(session, subscription);
+    sr_session_stop(session);
+
+    for (size_t i = 0; i < xpath_retrieved->count; i++) {
+        free(xpath_retrieved->data[i]);
     }
+    sr_list_cleanup(xpath_retrieved);
+}
+
+static void
+cl_exact_match_subscription_tree(void **state)
+{
+    sr_conn_ctx_t *conn = *state;
+    assert_non_null(conn);
+    sr_session_ctx_t *session = NULL;
+    sr_subscription_ctx_t *subscription = NULL;
+    sr_list_t *xpath_retrieved = NULL;
+    sr_node_t *tree = NULL, *node = NULL;
+    int rc = SR_ERR_OK;
+
+    rc = sr_list_init(&xpath_retrieved);
+    assert_int_equal(rc, SR_ERR_OK);
+
+    /* start session */
+    rc = sr_session_start(conn, SR_DS_RUNNING, SR_SESS_DEFAULT, &session);
+    assert_int_equal(rc, SR_ERR_OK);
+
+    rc = sr_module_change_subscribe(session, "state-module", cl_whole_module_cb, NULL,
+            0, SR_SUBSCR_DEFAULT, &subscription);
+    assert_int_equal(rc, SR_ERR_OK);
+
+    /* subscribe data providers */
+    rc = sr_dp_get_items_subscribe(session, "/state-module:bus/distance_travelled", cl_dp_distance_travelled, xpath_retrieved, SR_SUBSCR_CTX_REUSE, &subscription);
+    assert_int_equal(rc, SR_ERR_OK);
+
+    rc = sr_dp_get_items_subscribe(session, "/state-module:bus/gps_located", cl_dp_gps_located, xpath_retrieved, SR_SUBSCR_CTX_REUSE, &subscription);
+    assert_int_equal(rc, SR_ERR_OK);
+
+    rc = sr_dp_get_items_subscribe(session, "/state-module:cpu_load", cl_dp_cpu_load, xpath_retrieved, SR_SUBSCR_CTX_REUSE, &subscription);
+    assert_int_equal(rc, SR_ERR_OK);
+
+    /* retrieve data using the tree API */
+    rc = sr_get_subtree(session, "/state-module:bus", &tree);
+    assert_int_equal(rc, SR_ERR_OK);
+
+    /* check data */
+    assert_non_null(tree);
+    assert_string_equal("bus", tree->name);
+    assert_string_equal("state-module", tree->module_name);
+    assert_false(tree->dflt);
+    assert_int_equal(SR_CONTAINER_T, tree->type);
+    // gps located
+    node = tree->first_child;
+    assert_non_null(node);
+    assert_string_equal("gps_located", node->name);
+    assert_null(node->module_name);
+    assert_false(node->dflt);
+    assert_int_equal(SR_BOOL_T, node->type);
+    assert_false(node->data.bool_val);
+    assert_null(node->first_child);
+    // distance travelled
+    node = node->next;
+    assert_non_null(node);
+    assert_string_equal("distance_travelled", node->name);
+    assert_null(node->module_name);
+    assert_false(node->dflt);
+    assert_int_equal(SR_UINT32_T, node->type);
+    assert_int_equal(999, node->data.uint32_val);
+    assert_null(node->first_child);
+    assert_null(node->next);
+
+    sr_free_tree(tree);
+
+    /* check xpath that were retrieved */
+    const char *xpath_expected_to_be_loaded [] = {
+        "/state-module:bus/gps_located",
+        "/state-module:bus/distance_travelled"
+    };
+    CHECK_LIST_OF_STRINGS(xpath_retrieved, xpath_expected_to_be_loaded);
 
     /* cleanup */
     sr_unsubscribe(session, subscription);
@@ -538,22 +684,72 @@ cl_partialy_covered_by_subscription(void **state)
     const char *xpath_expected_to_be_loaded [] = {
         "/state-module:bus/gps_located",
     };
-    size_t expected_xp_cnt = sizeof(xpath_expected_to_be_loaded) / sizeof(*xpath_expected_to_be_loaded);
-    assert_int_equal(expected_xp_cnt, xpath_retrieved->count);
+    CHECK_LIST_OF_STRINGS(xpath_retrieved, xpath_expected_to_be_loaded);
 
-    for (size_t i = 0; i < expected_xp_cnt; i++) {
-        bool match = false;
-        for (size_t j = 0; xpath_retrieved->count; j++) {
-            if (0 == strcmp(xpath_expected_to_be_loaded[i], (char *) xpath_retrieved->data[j])) {
-                match = true;
-                break;
-            }
-        }
-        if (!match) {
-            /* assert xpath that can not be found */
-            assert_string_equal("", xpath_expected_to_be_loaded[i]);
-        }
+    /* cleanup */
+    sr_unsubscribe(session, subscription);
+    sr_session_stop(session);
+
+    for (size_t i = 0; i < xpath_retrieved->count; i++) {
+        free(xpath_retrieved->data[i]);
     }
+    sr_list_cleanup(xpath_retrieved);
+}
+
+static void
+cl_partialy_covered_by_subscription_tree(void **state)
+{
+    sr_conn_ctx_t *conn = *state;
+    assert_non_null(conn);
+    sr_session_ctx_t *session = NULL;
+    sr_subscription_ctx_t *subscription = NULL;
+    sr_list_t *xpath_retrieved = NULL;
+    sr_node_t *tree = NULL, *node = NULL;
+    int rc = SR_ERR_OK;
+
+    rc = sr_list_init(&xpath_retrieved);
+    assert_int_equal(rc, SR_ERR_OK);
+
+    /* start session */
+    rc = sr_session_start(conn, SR_DS_RUNNING, SR_SESS_DEFAULT, &session);
+    assert_int_equal(rc, SR_ERR_OK);
+
+    rc = sr_module_change_subscribe(session, "state-module", cl_whole_module_cb, NULL,
+            0, SR_SUBSCR_DEFAULT, &subscription);
+    assert_int_equal(rc, SR_ERR_OK);
+
+    /* subscribe data providers - provider for distance_travelled is missing */
+    rc = sr_dp_get_items_subscribe(session, "/state-module:bus/gps_located", cl_dp_gps_located, xpath_retrieved, SR_SUBSCR_CTX_REUSE, &subscription);
+    assert_int_equal(rc, SR_ERR_OK);
+
+    /* retrieve data */
+    rc = sr_get_subtree(session, "/state-module:bus", &tree);
+    assert_int_equal(rc, SR_ERR_OK);
+
+    /* check data */
+    assert_non_null(tree);
+    assert_string_equal("bus", tree->name);
+    assert_string_equal("state-module", tree->module_name);
+    assert_false(tree->dflt);
+    assert_int_equal(SR_CONTAINER_T, tree->type);
+    // gps located
+    node = tree->first_child;
+    assert_non_null(node);
+    assert_string_equal("gps_located", node->name);
+    assert_null(node->module_name);
+    assert_false(node->dflt);
+    assert_int_equal(SR_BOOL_T, node->type);
+    assert_false(node->data.bool_val);
+    assert_null(node->first_child);
+    assert_null(node->next);
+
+    sr_free_tree(tree);
+
+    /* check xpath that were retrieved */
+    const char *xpath_expected_to_be_loaded [] = {
+        "/state-module:bus/gps_located",
+    };
+    CHECK_LIST_OF_STRINGS(xpath_retrieved, xpath_expected_to_be_loaded);
 
     /* cleanup */
     sr_unsubscribe(session, subscription);
@@ -604,22 +800,56 @@ cl_incorrect_data_subscription(void **state)
     const char *xpath_expected_to_be_loaded [] = {
         "/state-module:bus/gps_located",
     };
-    size_t expected_xp_cnt = sizeof(xpath_expected_to_be_loaded) / sizeof(*xpath_expected_to_be_loaded);
-    assert_int_equal(expected_xp_cnt, xpath_retrieved->count);
+    CHECK_LIST_OF_STRINGS(xpath_retrieved, xpath_expected_to_be_loaded);
 
-    for (size_t i = 0; i < expected_xp_cnt; i++) {
-        bool match = false;
-        for (size_t j = 0; xpath_retrieved->count; j++) {
-            if (0 == strcmp(xpath_expected_to_be_loaded[i], (char *) xpath_retrieved->data[j])) {
-                match = true;
-                break;
-            }
-        }
-        if (!match) {
-            /* assert xpath that can not be found */
-            assert_string_equal("", xpath_expected_to_be_loaded[i]);
-        }
+    /* cleanup */
+    sr_unsubscribe(session, subscription);
+    sr_session_stop(session);
+
+    for (size_t i = 0; i < xpath_retrieved->count; i++) {
+        free(xpath_retrieved->data[i]);
     }
+    sr_list_cleanup(xpath_retrieved);
+}
+
+static void
+cl_incorrect_data_subscription_tree(void **state)
+{
+    sr_conn_ctx_t *conn = *state;
+    assert_non_null(conn);
+    sr_session_ctx_t *session = NULL;
+    sr_subscription_ctx_t *subscription = NULL;
+    sr_list_t *xpath_retrieved = NULL;
+    sr_node_t *tree = NULL;
+    int rc = SR_ERR_OK;
+
+    rc = sr_list_init(&xpath_retrieved);
+    assert_int_equal(rc, SR_ERR_OK);
+
+    /* start session */
+    rc = sr_session_start(conn, SR_DS_RUNNING, SR_SESS_DEFAULT, &session);
+    assert_int_equal(rc, SR_ERR_OK);
+
+    rc = sr_module_change_subscribe(session, "state-module", cl_whole_module_cb, NULL,
+            0, SR_SUBSCR_DEFAULT, &subscription);
+    assert_int_equal(rc, SR_ERR_OK);
+
+    /* subscribe data providers - data subscriber will try to provide config data */
+    rc = sr_dp_get_items_subscribe(session, "/state-module:bus/gps_located", cl_dp_incorrect_data, xpath_retrieved, SR_SUBSCR_CTX_REUSE, &subscription);
+    assert_int_equal(rc, SR_ERR_OK);
+
+    /* retrieve data */
+    rc = sr_get_subtree(session, "/state-module:bus", &tree);
+    assert_int_equal(rc, SR_ERR_NOT_FOUND);
+
+    /* check data */
+    assert_null(tree);
+
+    /* check xpath that were retrieved */
+    const char *xpath_expected_to_be_loaded [] = {
+        "/state-module:bus/gps_located",
+    };
+    CHECK_LIST_OF_STRINGS(xpath_retrieved, xpath_expected_to_be_loaded);
 
     /* cleanup */
     sr_unsubscribe(session, subscription);
@@ -654,7 +884,7 @@ cl_missing_subscription(void **state)
             0, SR_SUBSCR_DEFAULT, &subscription);
     assert_int_equal(rc, SR_ERR_OK);
 
-    /* subscribe data providers - provider for distance_travelled is missing */
+    /* subscribe data providers - provider for cpu_load is missing */
     rc = sr_dp_get_items_subscribe(session, "/state-module:bus/gps_located", cl_dp_gps_located, xpath_retrieved, SR_SUBSCR_CTX_REUSE, &subscription);
     assert_int_equal(rc, SR_ERR_OK);
 
@@ -668,6 +898,55 @@ cl_missing_subscription(void **state)
     /* check data */
     assert_null(values);
     assert_int_equal(0, cnt);
+
+    /* check xpath that were retrieved */
+    assert_int_equal(0, xpath_retrieved->count);
+
+    /* cleanup */
+    sr_unsubscribe(session, subscription);
+    sr_session_stop(session);
+
+    for (size_t i = 0; i < xpath_retrieved->count; i++) {
+        free(xpath_retrieved->data[i]);
+    }
+    sr_list_cleanup(xpath_retrieved);
+}
+
+static void
+cl_missing_subscription_tree(void **state)
+{
+    sr_conn_ctx_t *conn = *state;
+    assert_non_null(conn);
+    sr_session_ctx_t *session = NULL;
+    sr_subscription_ctx_t *subscription = NULL;
+    sr_list_t *xpath_retrieved = NULL;
+    sr_node_t *tree = NULL;
+    int rc = SR_ERR_OK;
+
+    rc = sr_list_init(&xpath_retrieved);
+    assert_int_equal(rc, SR_ERR_OK);
+
+    /* start session */
+    rc = sr_session_start(conn, SR_DS_RUNNING, SR_SESS_DEFAULT, &session);
+    assert_int_equal(rc, SR_ERR_OK);
+
+    rc = sr_module_change_subscribe(session, "state-module", cl_whole_module_cb, NULL,
+            0, SR_SUBSCR_DEFAULT, &subscription);
+    assert_int_equal(rc, SR_ERR_OK);
+
+    /* subscribe data providers - provider for cpu_load is missing */
+    rc = sr_dp_get_items_subscribe(session, "/state-module:bus/gps_located", cl_dp_gps_located, xpath_retrieved, SR_SUBSCR_CTX_REUSE, &subscription);
+    assert_int_equal(rc, SR_ERR_OK);
+
+    rc = sr_dp_get_items_subscribe(session, "/state-module:bus/distance_travelled", cl_dp_distance_travelled, xpath_retrieved, SR_SUBSCR_CTX_REUSE, &subscription);
+    assert_int_equal(rc, SR_ERR_OK);
+
+    /* retrieve data */
+    rc = sr_get_subtree(session, "/state-module:cpu_load", &tree);
+    assert_int_equal(rc, SR_ERR_NOT_FOUND);
+
+    /* check data */
+    assert_null(tree);
 
     /* check xpath that were retrieved */
     assert_int_equal(0, xpath_retrieved->count);
@@ -760,22 +1039,397 @@ cl_nested_data_subscription(void **state)
         "/state-module:traffic_stats/cross_road[id='2']/traffic_light",
         "/state-module:traffic_stats/cross_road[id='2']/advanced_info",
     };
-    size_t expected_xp_cnt = sizeof(xpath_expected_to_be_loaded) / sizeof(*xpath_expected_to_be_loaded);
-    assert_int_equal(expected_xp_cnt, xpath_retrieved->count);
+    CHECK_LIST_OF_STRINGS(xpath_retrieved, xpath_expected_to_be_loaded);
 
-    for (size_t i = 0; i < expected_xp_cnt; i++) {
-        bool match = false;
-        for (size_t j = 0; xpath_retrieved->count; j++) {
-            if (0 == strcmp(xpath_expected_to_be_loaded[i], (char *) xpath_retrieved->data[j])) {
-                match = true;
-                break;
-            }
-        }
-        if (!match) {
-            /* assert xpath that can not be found */
-            assert_string_equal("", xpath_expected_to_be_loaded[i]);
-        }
+    /* cleanup */
+    sr_unsubscribe(session, subscription);
+    sr_session_stop(session);
+
+    for (size_t i = 0; i < xpath_retrieved->count; i++) {
+        free(xpath_retrieved->data[i]);
     }
+    sr_list_cleanup(xpath_retrieved);
+}
+
+static void
+cl_nested_data_subscription_tree(void **state)
+{
+    sr_conn_ctx_t *conn = *state;
+    assert_non_null(conn);
+    sr_session_ctx_t *session = NULL;
+    sr_subscription_ctx_t *subscription = NULL;
+    sr_list_t *xpath_retrieved = NULL;
+    sr_node_t *tree = NULL, *node = NULL;
+    int rc = SR_ERR_OK;
+
+    rc = sr_list_init(&xpath_retrieved);
+    assert_int_equal(rc, SR_ERR_OK);
+
+    /* start session */
+    rc = sr_session_start(conn, SR_DS_RUNNING, SR_SESS_DEFAULT, &session);
+    assert_int_equal(rc, SR_ERR_OK);
+
+    rc = sr_module_change_subscribe(session, "state-module", cl_whole_module_cb, NULL,
+            0, SR_SUBSCR_DEFAULT, &subscription);
+    assert_int_equal(rc, SR_ERR_OK);
+
+    /* subscribe data provider */
+    rc = sr_dp_get_items_subscribe(session, "/state-module:traffic_stats", cl_dp_traffic_stats, xpath_retrieved, SR_SUBSCR_CTX_REUSE, &subscription);
+    assert_int_equal(rc, SR_ERR_OK);
+
+    /* retrieve data */
+    rc = sr_get_subtree(session, "/state-module:traffic_stats", &tree);
+    assert_int_equal(rc, SR_ERR_OK);
+
+    /* check data */
+    // traffic stats
+    node = tree;
+    assert_non_null(node);
+    assert_string_equal("traffic_stats", node->name);
+    assert_string_equal("state-module", node->module_name);
+    assert_false(node->dflt);
+    assert_int_equal(SR_CONTAINER_T, node->type);
+    assert_null(node->next);
+    // num. of accidents
+    node = node->first_child;
+    assert_string_equal("number_of_accidents", node->name);
+    assert_null(node->module_name);
+    assert_false(node->dflt);
+    assert_int_equal(SR_UINT8_T, node->type);
+    assert_int_equal(2, node->data.uint8_val);
+    assert_null(node->first_child);
+    // cross roads offline count
+    node = node->next;
+    assert_string_equal("cross_roads_offline_count", node->name);
+    assert_null(node->module_name);
+    assert_false(node->dflt);
+    assert_int_equal(SR_UINT8_T, node->type);
+    assert_int_equal(9, node->data.uint8_val);
+    assert_null(node->first_child);
+    // cross road, id=0
+    node = node->next;
+    assert_string_equal("cross_road", node->name);
+    assert_null(node->module_name);
+    assert_false(node->dflt);
+    assert_int_equal(SR_LIST_T, node->type);
+    // id
+    node = node->first_child;
+    assert_string_equal("id", node->name);
+    assert_null(node->module_name);
+    assert_false(node->dflt);
+    assert_int_equal(SR_UINT32_T, node->type);
+    assert_int_equal(0, node->data.uint32_val);
+    assert_null(node->first_child);
+    // status
+    node = node->next;
+    assert_string_equal("status", node->name);
+    assert_null(node->module_name);
+    assert_false(node->dflt);
+    assert_int_equal(SR_ENUM_T, node->type);
+    assert_string_equal("manual", node->data.enum_val);
+    assert_null(node->first_child);
+    // traffic light, name = a
+    node = node->next;
+    assert_string_equal("traffic_light", node->name);
+    assert_null(node->module_name);
+    assert_false(node->dflt);
+    assert_int_equal(SR_LIST_T, node->type);
+    // traffic light, name
+    node = node->first_child;
+    assert_string_equal("name", node->name);
+    assert_null(node->module_name);
+    assert_false(node->dflt);
+    assert_int_equal(SR_STRING_T, node->type);
+    assert_string_equal("a", node->data.enum_val);
+    assert_null(node->first_child);
+    // traffic light, color
+    node = node->next;
+    assert_string_equal("color", node->name);
+    assert_null(node->module_name);
+    assert_false(node->dflt);
+    assert_int_equal(SR_ENUM_T, node->type);
+    assert_string_equal("red", node->data.enum_val);
+    assert_null(node->first_child);
+    assert_null(node->next);
+    // traffic light, name = b
+    node = node->parent->next;
+    assert_string_equal("traffic_light", node->name);
+    assert_null(node->module_name);
+    assert_false(node->dflt);
+    assert_int_equal(SR_LIST_T, node->type);
+    // traffic light, name
+    node = node->first_child;
+    assert_string_equal("name", node->name);
+    assert_null(node->module_name);
+    assert_false(node->dflt);
+    assert_int_equal(SR_STRING_T, node->type);
+    assert_string_equal("b", node->data.enum_val);
+    assert_null(node->first_child);
+    // traffic light, color
+    node = node->next;
+    assert_string_equal("color", node->name);
+    assert_null(node->module_name);
+    assert_false(node->dflt);
+    assert_int_equal(SR_ENUM_T, node->type);
+    assert_string_equal("orange", node->data.enum_val);
+    assert_null(node->first_child);
+    assert_null(node->next);
+    // traffic light, name = c
+    node = node->parent->next;
+    assert_string_equal("traffic_light", node->name);
+    assert_null(node->module_name);
+    assert_false(node->dflt);
+    assert_int_equal(SR_LIST_T, node->type);
+    // traffic light, name
+    node = node->first_child;
+    assert_string_equal("name", node->name);
+    assert_null(node->module_name);
+    assert_false(node->dflt);
+    assert_int_equal(SR_STRING_T, node->type);
+    assert_string_equal("c", node->data.enum_val);
+    assert_null(node->first_child);
+    // traffic light, color
+    node = node->next;
+    assert_string_equal("color", node->name);
+    assert_null(node->module_name);
+    assert_false(node->dflt);
+    assert_int_equal(SR_ENUM_T, node->type);
+    assert_string_equal("green", node->data.enum_val);
+    assert_null(node->first_child);
+    assert_null(node->next);
+    // advanced info
+    node = node->parent->next;
+    assert_string_equal("advanced_info", node->name);
+    assert_null(node->module_name);
+    assert_false(node->dflt);
+    assert_int_equal(SR_CONTAINER_T, node->type);
+    // latitude
+    node = node->first_child;
+    assert_string_equal("latitude", node->name);
+    assert_null(node->module_name);
+    assert_false(node->dflt);
+    assert_int_equal(SR_STRING_T, node->type);
+    assert_string_equal("48.729885N", node->data.string_val);
+    // longitude
+    node = node->next;
+    assert_string_equal("longitude", node->name);
+    assert_null(node->module_name);
+    assert_false(node->dflt);
+    assert_int_equal(SR_STRING_T, node->type);
+    assert_string_equal("19.137425E", node->data.string_val);
+    assert_null(node->next);
+    assert_null(node->parent->next);
+    // cross road, id=1
+    node = node->parent->parent->next;
+    assert_string_equal("cross_road", node->name);
+    assert_null(node->module_name);
+    assert_false(node->dflt);
+    assert_int_equal(SR_LIST_T, node->type);
+    // id
+    node = node->first_child;
+    assert_string_equal("id", node->name);
+    assert_null(node->module_name);
+    assert_false(node->dflt);
+    assert_int_equal(SR_UINT32_T, node->type);
+    assert_int_equal(1, node->data.uint32_val);
+    assert_null(node->first_child);
+    // status
+    node = node->next;
+    assert_string_equal("status", node->name);
+    assert_null(node->module_name);
+    assert_false(node->dflt);
+    assert_int_equal(SR_ENUM_T, node->type);
+    assert_string_equal("automatic", node->data.enum_val);
+    assert_null(node->first_child);
+    // traffic light, name = a
+    node = node->next;
+    assert_string_equal("traffic_light", node->name);
+    assert_null(node->module_name);
+    assert_false(node->dflt);
+    assert_int_equal(SR_LIST_T, node->type);
+    // traffic light, name
+    node = node->first_child;
+    assert_string_equal("name", node->name);
+    assert_null(node->module_name);
+    assert_false(node->dflt);
+    assert_int_equal(SR_STRING_T, node->type);
+    assert_string_equal("a", node->data.enum_val);
+    assert_null(node->first_child);
+    // traffic light, color
+    node = node->next;
+    assert_string_equal("color", node->name);
+    assert_null(node->module_name);
+    assert_false(node->dflt);
+    assert_int_equal(SR_ENUM_T, node->type);
+    assert_string_equal("orange", node->data.enum_val);
+    assert_null(node->first_child);
+    assert_null(node->next);
+    // traffic light, name = b
+    node = node->parent->next;
+    assert_string_equal("traffic_light", node->name);
+    assert_null(node->module_name);
+    assert_false(node->dflt);
+    assert_int_equal(SR_LIST_T, node->type);
+    // traffic light, name
+    node = node->first_child;
+    assert_string_equal("name", node->name);
+    assert_null(node->module_name);
+    assert_false(node->dflt);
+    assert_int_equal(SR_STRING_T, node->type);
+    assert_string_equal("b", node->data.enum_val);
+    assert_null(node->first_child);
+    // traffic light, color
+    node = node->next;
+    assert_string_equal("color", node->name);
+    assert_null(node->module_name);
+    assert_false(node->dflt);
+    assert_int_equal(SR_ENUM_T, node->type);
+    assert_string_equal("green", node->data.enum_val);
+    assert_null(node->first_child);
+    assert_null(node->next);
+    // traffic light, name = c
+    node = node->parent->next;
+    assert_string_equal("traffic_light", node->name);
+    assert_null(node->module_name);
+    assert_false(node->dflt);
+    assert_int_equal(SR_LIST_T, node->type);
+    // traffic light, name
+    node = node->first_child;
+    assert_string_equal("name", node->name);
+    assert_null(node->module_name);
+    assert_false(node->dflt);
+    assert_int_equal(SR_STRING_T, node->type);
+    assert_string_equal("c", node->data.enum_val);
+    assert_null(node->first_child);
+    // traffic light, color
+    node = node->next;
+    assert_string_equal("color", node->name);
+    assert_null(node->module_name);
+    assert_false(node->dflt);
+    assert_int_equal(SR_ENUM_T, node->type);
+    assert_string_equal("red", node->data.enum_val);
+    assert_null(node->first_child);
+    assert_null(node->next);
+    // no advanced info
+    assert_null(node->parent->next);
+    // cross road, id=1
+    node = node->parent->parent->next;
+    assert_string_equal("cross_road", node->name);
+    assert_null(node->module_name);
+    assert_false(node->dflt);
+    assert_int_equal(SR_LIST_T, node->type);
+    // id
+    node = node->first_child;
+    assert_string_equal("id", node->name);
+    assert_null(node->module_name);
+    assert_false(node->dflt);
+    assert_int_equal(SR_UINT32_T, node->type);
+    assert_int_equal(2, node->data.uint32_val);
+    assert_null(node->first_child);
+    // status
+    node = node->next;
+    assert_string_equal("status", node->name);
+    assert_null(node->module_name);
+    assert_false(node->dflt);
+    assert_int_equal(SR_ENUM_T, node->type);
+    assert_string_equal("automatic", node->data.enum_val);
+    assert_null(node->first_child);
+    // average wait time
+    node = node->next;
+    assert_string_equal("average_wait_time", node->name);
+    assert_null(node->module_name);
+    assert_false(node->dflt);
+    assert_int_equal(SR_UINT32_T, node->type);
+    assert_int_equal(15, node->data.uint32_val);
+    assert_null(node->first_child);
+    // traffic light, name = a
+    node = node->next;
+    assert_string_equal("traffic_light", node->name);
+    assert_null(node->module_name);
+    assert_false(node->dflt);
+    assert_int_equal(SR_LIST_T, node->type);
+    // traffic light, name
+    node = node->first_child;
+    assert_string_equal("name", node->name);
+    assert_null(node->module_name);
+    assert_false(node->dflt);
+    assert_int_equal(SR_STRING_T, node->type);
+    assert_string_equal("a", node->data.enum_val);
+    assert_null(node->first_child);
+    // traffic light, color
+    node = node->next;
+    assert_string_equal("color", node->name);
+    assert_null(node->module_name);
+    assert_false(node->dflt);
+    assert_int_equal(SR_ENUM_T, node->type);
+    assert_string_equal("green", node->data.enum_val);
+    assert_null(node->first_child);
+    assert_null(node->next);
+    // traffic light, name = b
+    node = node->parent->next;
+    assert_string_equal("traffic_light", node->name);
+    assert_null(node->module_name);
+    assert_false(node->dflt);
+    assert_int_equal(SR_LIST_T, node->type);
+    // traffic light, name
+    node = node->first_child;
+    assert_string_equal("name", node->name);
+    assert_null(node->module_name);
+    assert_false(node->dflt);
+    assert_int_equal(SR_STRING_T, node->type);
+    assert_string_equal("b", node->data.enum_val);
+    assert_null(node->first_child);
+    // traffic light, color
+    node = node->next;
+    assert_string_equal("color", node->name);
+    assert_null(node->module_name);
+    assert_false(node->dflt);
+    assert_int_equal(SR_ENUM_T, node->type);
+    assert_string_equal("red", node->data.enum_val);
+    assert_null(node->first_child);
+    assert_null(node->next);
+    // traffic light, name = c
+    node = node->parent->next;
+    assert_string_equal("traffic_light", node->name);
+    assert_null(node->module_name);
+    assert_false(node->dflt);
+    assert_int_equal(SR_LIST_T, node->type);
+    // traffic light, name
+    node = node->first_child;
+    assert_string_equal("name", node->name);
+    assert_null(node->module_name);
+    assert_false(node->dflt);
+    assert_int_equal(SR_STRING_T, node->type);
+    assert_string_equal("c", node->data.enum_val);
+    assert_null(node->first_child);
+    // traffic light, color
+    node = node->next;
+    assert_string_equal("color", node->name);
+    assert_null(node->module_name);
+    assert_false(node->dflt);
+    assert_int_equal(SR_ENUM_T, node->type);
+    assert_string_equal("orange", node->data.enum_val);
+    assert_null(node->first_child);
+    assert_null(node->next);
+    // no advanced info
+    assert_null(node->parent->next);
+    // no more cross roads
+    assert_null(node->parent->parent->next);
+
+    sr_free_tree(tree);
+
+    /* check xpath that were retrieved */
+    const char *xpath_expected_to_be_loaded [] = {
+        "/state-module:traffic_stats",
+        "/state-module:traffic_stats/cross_road",
+        "/state-module:traffic_stats/cross_road[id='0']/traffic_light",
+        "/state-module:traffic_stats/cross_road[id='0']/advanced_info",
+        "/state-module:traffic_stats/cross_road[id='1']/traffic_light",
+        "/state-module:traffic_stats/cross_road[id='1']/advanced_info",
+        "/state-module:traffic_stats/cross_road[id='2']/traffic_light",
+        "/state-module:traffic_stats/cross_road[id='2']/advanced_info",
+    };
+    CHECK_LIST_OF_STRINGS(xpath_retrieved, xpath_expected_to_be_loaded);
 
     /* cleanup */
     sr_unsubscribe(session, subscription);
@@ -846,22 +1500,90 @@ cl_nested_data_subscription2(void **state)
         "/state-module:traffic_stats/cross_road[id='2']/traffic_light",
         "/state-module:traffic_stats/cross_road[id='2']/advanced_info",
     };
-    size_t expected_xp_cnt = sizeof(xpath_expected_to_be_loaded) / sizeof(*xpath_expected_to_be_loaded);
-    assert_int_equal(expected_xp_cnt, xpath_retrieved->count);
+    CHECK_LIST_OF_STRINGS(xpath_retrieved, xpath_expected_to_be_loaded);
 
-    for (size_t i = 0; i < expected_xp_cnt; i++) {
-        bool match = false;
-        for (size_t j = 0; xpath_retrieved->count; j++) {
-            if (0 == strcmp(xpath_expected_to_be_loaded[i], (char *) xpath_retrieved->data[j])) {
-                match = true;
-                break;
-            }
-        }
-        if (!match) {
-            /* assert xpath that can not be found */
-            assert_string_equal("", xpath_expected_to_be_loaded[i]);
-        }
+    /* cleanup */
+    sr_unsubscribe(session, subscription);
+    sr_session_stop(session);
+
+    for (size_t i = 0; i < xpath_retrieved->count; i++) {
+        free(xpath_retrieved->data[i]);
     }
+    sr_list_cleanup(xpath_retrieved);
+}
+
+static void
+cl_nested_data_subscription2_tree(void **state)
+{
+    sr_conn_ctx_t *conn = *state;
+    assert_non_null(conn);
+    sr_session_ctx_t *session = NULL;
+    sr_subscription_ctx_t *subscription = NULL;
+    sr_list_t *xpath_retrieved = NULL;
+    sr_node_t *tree = NULL, *node = NULL;
+    int rc = SR_ERR_OK;
+
+    rc = sr_list_init(&xpath_retrieved);
+    assert_int_equal(rc, SR_ERR_OK);
+
+    /* start session */
+    rc = sr_session_start(conn, SR_DS_RUNNING, SR_SESS_DEFAULT, &session);
+    assert_int_equal(rc, SR_ERR_OK);
+
+    rc = sr_module_change_subscribe(session, "state-module", cl_whole_module_cb, NULL,
+            0, SR_SUBSCR_DEFAULT, &subscription);
+    assert_int_equal(rc, SR_ERR_OK);
+
+    /* subscribe data providers */
+    rc = sr_dp_get_items_subscribe(session, "/state-module:bus", cl_dp_bus, xpath_retrieved, SR_SUBSCR_CTX_REUSE, &subscription);
+    assert_int_equal(rc, SR_ERR_OK);
+
+    rc = sr_dp_get_items_subscribe(session, "/state-module:traffic_stats", cl_dp_traffic_stats, xpath_retrieved, SR_SUBSCR_CTX_REUSE, &subscription);
+    assert_int_equal(rc, SR_ERR_OK);
+
+    /* retrieve data */
+    rc = sr_get_subtree(session, "/state-module:traffic_stats/cross_road[id='0']/advanced_info", &tree);
+    assert_int_equal(rc, SR_ERR_OK);
+
+    /* check data */
+    assert_non_null(tree);
+    // advanced info
+    node = node->parent->next;
+    assert_string_equal("advanced_info", node->name);
+    assert_string_equal("state-module", node->module_name);
+    assert_false(node->dflt);
+    assert_int_equal(SR_CONTAINER_T, node->type);
+    // latitude
+    node = node->first_child;
+    assert_string_equal("latitude", node->name);
+    assert_null(node->module_name);
+    assert_false(node->dflt);
+    assert_int_equal(SR_STRING_T, node->type);
+    assert_string_equal("48.729885N", node->data.string_val);
+    // longitude
+    node = node->next;
+    assert_string_equal("longitude", node->name);
+    assert_null(node->module_name);
+    assert_false(node->dflt);
+    assert_int_equal(SR_STRING_T, node->type);
+    assert_string_equal("19.137425E", node->data.string_val);
+    assert_null(node->next);
+    assert_null(node->parent->next);
+
+    sr_free_tree(tree);
+
+    /* check xpath that were retrieved */
+    const char *xpath_expected_to_be_loaded [] = {
+        "/state-module:traffic_stats",
+        "/state-module:traffic_stats/cross_road",
+        "/state-module:traffic_stats/cross_road[id='0']/traffic_light",
+        "/state-module:traffic_stats/cross_road[id='0']/advanced_info",
+        "/state-module:traffic_stats/cross_road[id='1']/traffic_light",
+        "/state-module:traffic_stats/cross_road[id='1']/advanced_info",
+        "/state-module:traffic_stats/cross_road[id='2']/traffic_light",
+        "/state-module:traffic_stats/cross_road[id='2']/advanced_info",
+    };
+    CHECK_LIST_OF_STRINGS(xpath_retrieved, xpath_expected_to_be_loaded);
 
     /* cleanup */
     sr_unsubscribe(session, subscription);
@@ -878,13 +1600,20 @@ main()
 {
     const struct CMUnitTest tests[] = {
         cmocka_unit_test_setup_teardown(cl_exact_match_subscription, sysrepo_setup, sysrepo_teardown),
+        cmocka_unit_test_setup_teardown(cl_exact_match_subscription_tree, sysrepo_setup, sysrepo_teardown),
         cmocka_unit_test_setup_teardown(cl_parent_subscription, sysrepo_setup, sysrepo_teardown),
+        cmocka_unit_test_setup_teardown(cl_parent_subscription_tree, sysrepo_setup, sysrepo_teardown),
         cmocka_unit_test_setup_teardown(cl_partialy_covered_by_subscription, sysrepo_setup, sysrepo_teardown),
+        cmocka_unit_test_setup_teardown(cl_partialy_covered_by_subscription_tree, sysrepo_setup, sysrepo_teardown),
         cmocka_unit_test_setup_teardown(cl_missing_subscription, sysrepo_setup, sysrepo_teardown),
+        cmocka_unit_test_setup_teardown(cl_missing_subscription_tree, sysrepo_setup, sysrepo_teardown),
         cmocka_unit_test_setup_teardown(cl_incorrect_data_subscription, sysrepo_setup, sysrepo_teardown),
+        cmocka_unit_test_setup_teardown(cl_incorrect_data_subscription_tree, sysrepo_setup, sysrepo_teardown),
         cmocka_unit_test_setup_teardown(cl_dp_neg_subscription, sysrepo_setup, sysrepo_teardown),
         cmocka_unit_test_setup_teardown(cl_nested_data_subscription, sysrepo_setup, sysrepo_teardown),
+        cmocka_unit_test_setup_teardown(cl_nested_data_subscription_tree, sysrepo_setup, sysrepo_teardown),
         cmocka_unit_test_setup_teardown(cl_nested_data_subscription2, sysrepo_setup, sysrepo_teardown),
+        cmocka_unit_test_setup_teardown(cl_nested_data_subscription2_tree, sysrepo_setup, sysrepo_teardown),
     };
 
     return cmocka_run_group_tests(tests, NULL, NULL);

--- a/tests/common_test.c
+++ b/tests/common_test.c
@@ -542,7 +542,7 @@ sr_node_t_test(void **state)
     assert_non_null(nodeset);
     assert_int_equal(4, nodeset->number);
 
-    assert_int_equal(SR_ERR_OK, sr_nodes_to_trees(ly_ctx, nodeset, NULL, &trees, &tree_cnt));
+    assert_int_equal(SR_ERR_OK, sr_nodes_to_trees(nodeset, NULL, &trees, &tree_cnt));
     assert_non_null(trees);
     assert_int_equal(4, tree_cnt);
 
@@ -698,7 +698,7 @@ sr_node_t_with_augments_test(void **state)
     assert_non_null(nodeset);
     assert_int_equal(2, nodeset->number);
 
-    assert_int_equal(SR_ERR_OK, sr_nodes_to_trees(ly_ctx, nodeset, NULL, &trees, &tree_cnt));
+    assert_int_equal(SR_ERR_OK, sr_nodes_to_trees(nodeset, NULL, &trees, &tree_cnt));
     assert_non_null(trees);
     assert_int_equal(2, tree_cnt);
 
@@ -798,7 +798,7 @@ sr_node_t_rpc_input_test(void **state)
     assert_non_null(nodeset);
     assert_int_equal(2, nodeset->number);
 
-    assert_int_equal(SR_ERR_OK, sr_nodes_to_trees(ly_ctx, nodeset, NULL, &trees, &tree_cnt));
+    assert_int_equal(SR_ERR_OK, sr_nodes_to_trees(nodeset, NULL, &trees, &tree_cnt));
     assert_non_null(trees);
     assert_int_equal(2, tree_cnt);
 
@@ -888,7 +888,7 @@ sr_node_t_rpc_output_test(void **state)
     assert_non_null(nodeset);
     assert_int_equal(3, nodeset->number);
 
-    assert_int_equal(SR_ERR_OK, sr_nodes_to_trees(ly_ctx, nodeset, NULL, &trees, &tree_cnt));
+    assert_int_equal(SR_ERR_OK, sr_nodes_to_trees(nodeset, NULL, &trees, &tree_cnt));
     assert_non_null(trees);
     assert_int_equal(3, tree_cnt);
 

--- a/tests/concurr_test.c
+++ b/tests/concurr_test.c
@@ -84,7 +84,7 @@ test_execute_in_session(sr_session_ctx_t *session)
         assert_non_null(value);
         assert_int_equal(SR_STRING_T, value->type);
         sr_free_val(value);
-        rc = sr_get_subtree(session, "/example-module:container/list[key1='key1'][key2='key2']/leaf", &tree);
+        rc = sr_get_subtree(session, "/example-module:container/list[key1='key1'][key2='key2']/leaf", 0, &tree);
         assert_int_equal(rc, SR_ERR_OK);
         assert_non_null(tree);
         assert_int_equal(SR_STRING_T, tree->type);

--- a/tests/concurr_test.c
+++ b/tests/concurr_test.c
@@ -74,15 +74,21 @@ test_execute_in_session(sr_session_ctx_t *session)
 {
     int rc = 0;
     sr_val_t *value = NULL;
+    sr_node_t *tree = NULL;
 
     /* perform get-item requests */
-    for (size_t i = 0; i<1000; i++) {
+    for (size_t i = 0; i<500; i++) {
         /* existing leaf */
         rc = sr_get_item(session, "/example-module:container/list[key1='key1'][key2='key2']/leaf", &value);
         assert_int_equal(rc, SR_ERR_OK);
         assert_non_null(value);
         assert_int_equal(SR_STRING_T, value->type);
         sr_free_val(value);
+        rc = sr_get_subtree(session, "/example-module:container/list[key1='key1'][key2='key2']/leaf", &tree);
+        assert_int_equal(rc, SR_ERR_OK);
+        assert_non_null(tree);
+        assert_int_equal(SR_STRING_T, tree->type);
+        sr_free_tree(tree);
     }
 }
 

--- a/tests/measure_performance.c
+++ b/tests/measure_performance.c
@@ -378,7 +378,7 @@ perf_get_subtree_test(void **state, int op_num, int *items) {
     /* perform a get-item request */
     for (size_t i = 0; i<op_num; i++){
         /* existing leaf */
-        rc = sr_get_subtree(session, "/example-module:container/list[key1='key1'][key2='key2']/leaf", &tree);
+        rc = sr_get_subtree(session, "/example-module:container/list[key1='key1'][key2='key2']/leaf", 0, &tree);
         assert_int_equal(rc, SR_ERR_OK);
         assert_non_null(tree);
         assert_int_equal(SR_STRING_T, tree->type);
@@ -407,7 +407,7 @@ perf_get_subtree_with_data_load_test(void **state, int op_num, int *items) {
         assert_int_equal(rc, SR_ERR_OK);
 
         /* existing leaf */
-        rc = sr_get_subtree(session, "/example-module:container/list[key1='key1'][key2='key2']/leaf", &tree);
+        rc = sr_get_subtree(session, "/example-module:container/list[key1='key1'][key2='key2']/leaf", 0, &tree);
         assert_int_equal(rc, SR_ERR_OK);
         assert_non_null(tree);
         assert_int_equal(SR_STRING_T, tree->type);
@@ -438,7 +438,7 @@ perf_get_subtrees_test(void **state, int op_num, int *items) {
     /* perform a get-subtrees request */
     for (size_t i = 0; i<op_num; i++){
         /* existing leaf */
-        rc = sr_get_subtrees(session, "/example-module:container/list/leaf", &trees, &count);
+        rc = sr_get_subtrees(session, "/example-module:container/list/leaf", 0, &trees, &count);
         assert_int_equal(SR_ERR_OK, rc);
         assert_null(trees[0].first_child);
         sr_free_trees(trees, count);
@@ -497,7 +497,7 @@ perf_get_ietf_intefaces_tree_test(void **state, int op_num, int *items) {
 
     /* perform a get-subtrees request */
     for (size_t i = 0; i<op_num; i++){
-        rc = sr_get_subtrees(session, "/ietf-interfaces:interfaces/.", &trees, &count);
+        rc = sr_get_subtrees(session, "/ietf-interfaces:interfaces/.", 0, &trees, &count);
         assert_int_equal(rc, SR_ERR_OK);
         if (0 == i) {
             total_cnt = get_nodes_cnt(trees, count);

--- a/tests/measure_performance.c
+++ b/tests/measure_performance.c
@@ -79,7 +79,7 @@ typedef struct test_s{
 void
 print_measure_header(const char *title){
     printf("\n\n\t\t%s", title);
-    printf("\n%-30s| %-11s| %-10s| %-12s | %-20s\n",
+    printf("\n%-32s| %-11s| %-10s| %-12s | %-20s\n",
             "Operation", "ops/sec", "items/op", "op performed", "test time");
     printf("------------------------------------------------------------------------------------");
 }
@@ -120,7 +120,7 @@ measure(void (*func)(void **, int, int *), const char *name, int op_count, void 
     timeval_subtract(&diff, &tv2, &tv1);
 
     seconds = diff.tv_sec + 0.000001*diff.tv_usec;
-    printf("\n%-30s| %11.2f| %10d| %12d | %11.6f",
+    printf("\n%-32s| %11.2f| %10d| %12d | %11.6f",
             name, ((double) op_count)/ seconds, items, op_count, seconds);
 
 }
@@ -363,6 +363,155 @@ perf_get_ietf_intefaces_test(void **state, int op_num, int *items) {
 }
 
 static void
+perf_get_subtree_test(void **state, int op_num, int *items) {
+    sr_conn_ctx_t *conn = *state;
+    assert_non_null(conn);
+
+    sr_session_ctx_t *session = NULL;
+    sr_node_t *tree = NULL;
+    int rc = 0;
+
+    /* start a session */
+    rc = sr_session_start(conn, SR_DS_STARTUP, SR_SESS_DEFAULT, &session);
+    assert_int_equal(rc, SR_ERR_OK);
+
+    /* perform a get-item request */
+    for (size_t i = 0; i<op_num; i++){
+        /* existing leaf */
+        rc = sr_get_subtree(session, "/example-module:container/list[key1='key1'][key2='key2']/leaf", &tree);
+        assert_int_equal(rc, SR_ERR_OK);
+        assert_non_null(tree);
+        assert_int_equal(SR_STRING_T, tree->type);
+        sr_free_tree(tree);
+    }
+
+    /* stop the session */
+    rc = sr_session_stop(session);
+    assert_int_equal(rc, SR_ERR_OK);
+    *items = 1;
+}
+
+static void
+perf_get_subtree_with_data_load_test(void **state, int op_num, int *items) {
+    sr_conn_ctx_t *conn = *state;
+    assert_non_null(conn);
+
+    sr_session_ctx_t *session = NULL;
+    sr_node_t *tree = NULL;
+    int rc = 0;
+
+    /* perform session_start, get-item, session-stop requests */
+    for (size_t i = 0; i<op_num; i++){
+        /* start a session */
+        rc = sr_session_start(conn, SR_DS_STARTUP, SR_SESS_DEFAULT, &session);
+        assert_int_equal(rc, SR_ERR_OK);
+
+        /* existing leaf */
+        rc = sr_get_subtree(session, "/example-module:container/list[key1='key1'][key2='key2']/leaf", &tree);
+        assert_int_equal(rc, SR_ERR_OK);
+        assert_non_null(tree);
+        assert_int_equal(SR_STRING_T, tree->type);
+        sr_free_tree(tree);
+
+        /* stop the session */
+        rc = sr_session_stop(session);
+        assert_int_equal(rc, SR_ERR_OK);
+    }
+
+    *items = 1;
+}
+
+static void
+perf_get_subtrees_test(void **state, int op_num, int *items) {
+    sr_conn_ctx_t *conn = *state;
+    assert_non_null(conn);
+
+    sr_session_ctx_t *session = NULL;
+    sr_node_t *trees = NULL;
+    size_t count = 0;
+    int rc = 0;
+
+    /* start a session */
+    rc = sr_session_start(conn, SR_DS_STARTUP, SR_SESS_DEFAULT, &session);
+    assert_int_equal(rc, SR_ERR_OK);
+
+    /* perform a get-subtrees request */
+    for (size_t i = 0; i<op_num; i++){
+        /* existing leaf */
+        rc = sr_get_subtrees(session, "/example-module:container/list/leaf", &trees, &count);
+        assert_int_equal(SR_ERR_OK, rc);
+        assert_null(trees[0].first_child);
+        sr_free_trees(trees, count);
+    }
+
+    /* stop the session */
+    rc = sr_session_stop(session);
+    assert_int_equal(rc, SR_ERR_OK);
+    *items = count;
+}
+
+static size_t
+get_nodes_cnt(sr_node_t *trees, size_t tree_cnt)
+{
+    sr_node_t *node = NULL;
+    bool count_children = true;
+    size_t count = 0;
+
+    for (size_t i = 0; i < tree_cnt; ++i) {
+        node = trees+i;
+        count_children = true;
+        do {
+            if (count_children) {
+                while (node->first_child) {
+                    node = node->first_child;
+                }
+            }
+            ++count;
+            if (node->next) {
+                node = node->next;
+                count_children = true;
+            } else {
+                node = node->parent;
+                count_children = false;
+            }
+        } while(node);
+    }
+
+    return count;
+}
+
+static void
+perf_get_ietf_intefaces_tree_test(void **state, int op_num, int *items) {
+    sr_conn_ctx_t *conn = *state;
+    assert_non_null(conn);
+
+    sr_session_ctx_t *session = NULL;
+    sr_node_t *trees = NULL;
+    size_t count = 0;
+    size_t total_cnt;
+    int rc = 0;
+
+    /* start a session */
+    rc = sr_session_start(conn, SR_DS_STARTUP, SR_SESS_DEFAULT, &session);
+    assert_int_equal(rc, SR_ERR_OK);
+
+    /* perform a get-subtrees request */
+    for (size_t i = 0; i<op_num; i++){
+        rc = sr_get_subtrees(session, "/ietf-interfaces:interfaces/.", &trees, &count);
+        assert_int_equal(rc, SR_ERR_OK);
+        if (0 == i) {
+            total_cnt = get_nodes_cnt(trees, count);
+        }
+        sr_free_trees(trees, count);
+    }
+
+    /* stop the session */
+    rc = sr_session_stop(session);
+    assert_int_equal(rc, SR_ERR_OK);
+    *items = total_cnt;
+}
+
+static void
 perf_commit_test(void **state, int op_num, int *items) {
     sr_conn_ctx_t *conn = *state;
     assert_non_null(conn);
@@ -463,6 +612,10 @@ main (int argc, char **argv)
         {perf_get_items_test, "Get items all list", OP_COUNT, sysrepo_setup, sysrepo_teardown},
         {perf_get_items_iter_test, "Get items iter all list", OP_COUNT, sysrepo_setup, sysrepo_teardown},
         {perf_get_ietf_intefaces_test, "Get items ietf-if config", OP_COUNT, sysrepo_setup, sysrepo_teardown},
+        {perf_get_subtree_test, "Get subtree one leaf", OP_COUNT, sysrepo_setup, sysrepo_teardown},
+        {perf_get_subtree_with_data_load_test, "Get subtree incl session start", OP_COUNT, sysrepo_setup, sysrepo_teardown},
+        {perf_get_subtrees_test, "Get subtrees all list", OP_COUNT, sysrepo_setup, sysrepo_teardown},
+        {perf_get_ietf_intefaces_tree_test, "Get subtrees ietf-if config", OP_COUNT, sysrepo_setup, sysrepo_teardown},
         {perf_commit_test, "Commit one leaf change", OP_COUNT_COMMIT, sysrepo_setup, sysrepo_teardown},
         {perf_libyang_get_node, "Libyang get one node", OP_COUNT, libyang_setup, libyang_teardown},
         {perf_libyang_get_all_list, "Libyang get all list", OP_COUNT, libyang_setup, libyang_teardown},

--- a/tests/perf_test.c
+++ b/tests/perf_test.c
@@ -109,7 +109,7 @@ perf_get_subtree_test(void **state) {
     for (size_t i = 0; i<100000; i++){
 
         /* existing leaf */
-        rc = sr_get_subtree(session, "/example-module:container/list[key1='key1'][key2='key2']/leaf", &tree);
+        rc = sr_get_subtree(session, "/example-module:container/list[key1='key1'][key2='key2']/leaf", 0, &tree);
         assert_int_equal(rc, SR_ERR_OK);
         assert_non_null(tree);
         assert_int_equal(SR_STRING_T, tree->type);

--- a/tests/perf_test.c
+++ b/tests/perf_test.c
@@ -91,12 +91,41 @@ perf_get_item_test(void **state) {
     assert_int_equal(rc, SR_ERR_OK);
 }
 
+static void
+perf_get_subtree_test(void **state) {
+    sr_conn_ctx_t *conn = *state;
+    assert_non_null(conn);
 
+    sr_session_ctx_t *session = NULL;
+    sr_node_t *tree = NULL;
+    int rc = 0;
+
+    /* start a session */
+    rc = sr_session_start(conn, SR_DS_STARTUP, SR_SESS_DEFAULT, &session);
+    assert_int_equal(rc, SR_ERR_OK);
+
+    /* perform a get-subtree request */
+
+    for (size_t i = 0; i<100000; i++){
+
+        /* existing leaf */
+        rc = sr_get_subtree(session, "/example-module:container/list[key1='key1'][key2='key2']/leaf", &tree);
+        assert_int_equal(rc, SR_ERR_OK);
+        assert_non_null(tree);
+        assert_int_equal(SR_STRING_T, tree->type);
+        sr_free_tree(tree);
+    }
+
+    /* stop the session */
+    rc = sr_session_stop(session);
+    assert_int_equal(rc, SR_ERR_OK);
+}
 
 int
 main() {
     const struct CMUnitTest tests[] = {
             cmocka_unit_test_setup_teardown(perf_get_item_test, sysrepo_setup, sysrepo_teardown),
+            cmocka_unit_test_setup_teardown(perf_get_subtree_test, sysrepo_setup, sysrepo_teardown),
     };
 
     return cmocka_run_group_tests(tests, NULL, NULL);

--- a/tests/rp_datatree_test.c
+++ b/tests/rp_datatree_test.c
@@ -1179,37 +1179,6 @@ void get_value_wrapper_test(void **state){
     test_rp_sesssion_create(ctx, SR_DS_STARTUP, &ses_ctx);
 
     /* unknown model*/
-    sr_node_t *tree = NULL;
-    rc = rp_dt_get_subtree_wrapper(ctx, ses_ctx, NULL, "/non-existing:abc", &tree);
-    assert_int_equal(SR_ERR_UNKNOWN_MODEL, rc);
-
-    /* whole model xpath*/
-
-    ses_ctx->state = RP_REQ_NEW;
-    tree = NULL;
-    rc = rp_dt_get_subtree_wrapper(ctx, ses_ctx, NULL, "/test-module:*", &tree);
-    assert_int_equal(SR_ERR_INVAL_ARG, rc);
-
-    /* not existing data tree*/
-    ses_ctx->state = RP_REQ_NEW;
-    rc = rp_dt_get_subtree_wrapper(ctx, ses_ctx, NULL, "/small-module:item", &tree);
-    assert_int_equal(SR_ERR_NOT_FOUND, rc);
-
-    /* not exisiting now in existing data tree*/
-    ses_ctx->state = RP_REQ_NEW;
-    rc = rp_dt_get_subtree_wrapper(ctx, ses_ctx, NULL, "/example-module:container/list[key1='abc'][key2='def']", &tree);
-    assert_int_equal(SR_ERR_NOT_FOUND, rc);
-
-    test_rp_session_cleanup(ctx, ses_ctx);
-}
-
-void get_tree_wrapper_test(void **state){
-    int rc = 0;
-    rp_ctx_t *ctx = *state;
-    rp_session_t *ses_ctx = NULL;
-    test_rp_sesssion_create(ctx, SR_DS_STARTUP, &ses_ctx);
-
-    /* unknown model*/
     sr_val_t *value = NULL;
     rc = rp_dt_get_value_wrapper(ctx, ses_ctx, NULL, "/non-existing:abc", &value);
     assert_int_equal(SR_ERR_UNKNOWN_MODEL, rc);
@@ -1235,6 +1204,43 @@ void get_tree_wrapper_test(void **state){
     /* not exisiting now in existing data tree*/
     ses_ctx->state = RP_REQ_NEW;
     rc = rp_dt_get_value_wrapper(ctx, ses_ctx, NULL, "/example-module:container/list[key1='abc'][key2='def']", &value);
+    assert_int_equal(SR_ERR_NOT_FOUND, rc);
+
+    test_rp_session_cleanup(ctx, ses_ctx);
+}
+
+void get_tree_wrapper_test(void **state){
+    int rc = 0;
+    rp_ctx_t *ctx = *state;
+    rp_session_t *ses_ctx = NULL;
+    test_rp_sesssion_create(ctx, SR_DS_STARTUP, &ses_ctx);
+
+    /* unknown model*/
+    sr_node_t *tree = NULL;
+    rc = rp_dt_get_subtree_wrapper(ctx, ses_ctx, NULL, "/non-existing:abc", &tree);
+    assert_int_equal(SR_ERR_UNKNOWN_MODEL, rc);
+
+    /* whole model xpath*/
+
+    ses_ctx->state = RP_REQ_NEW;
+    tree = NULL;
+    rc = rp_dt_get_subtree_wrapper(ctx, ses_ctx, NULL, "/test-module:*", &tree);
+    assert_int_equal(SR_ERR_INVAL_ARG, rc);
+
+    /* since yang 1.1 empty container might be present */
+    ses_ctx->state = RP_REQ_NEW;
+    rc = rp_dt_get_subtree_wrapper(ctx, ses_ctx, NULL, "/small-module:item", &tree);
+    assert_int_equal(SR_ERR_OK, rc);
+    assert_non_null(tree);
+    assert_string_equal("item", tree->name);
+    assert_int_equal(SR_CONTAINER_T, tree->type);
+    assert_true(tree->dflt);
+    sr_free_tree(tree);
+    tree = NULL;
+
+    /* not exisiting now in existing data tree*/
+    ses_ctx->state = RP_REQ_NEW;
+    rc = rp_dt_get_subtree_wrapper(ctx, ses_ctx, NULL, "/example-module:container/list[key1='abc'][key2='def']", &tree);
     assert_int_equal(SR_ERR_NOT_FOUND, rc);
 
     test_rp_session_cleanup(ctx, ses_ctx);

--- a/tests/rp_datatree_test.c
+++ b/tests/rp_datatree_test.c
@@ -140,7 +140,6 @@ void check_ietf_interfaces_ipv4_values(sr_val_t *values, size_t count){
      }
 }
 
-
 /**
  * Function expects the values under xpath
  * /ietf-interfaces:interfaces/interface[name='eth0']/ietf-ip:ipv4/address[ip='192.168.2.100']
@@ -158,6 +157,181 @@ void check_ietf_interfaces_addr_values(sr_val_t *values, size_t count){
         }
     }
 }
+
+/**
+ * @brief Retrieve child of a parent node by an index.
+ */
+static sr_node_t *
+get_child_by_index(sr_node_t *parent, int index)
+{
+    assert_non_null(parent->first_child);
+    sr_node_t *child = parent->first_child;
+
+    while (index) {
+        child = child->next;
+        assert_non_null(child);
+        --index;
+    }
+    return child;
+}
+
+/**
+ * @brief Get number of children of a parent node.
+ */
+static size_t
+get_child_cnt(sr_node_t *parent)
+{
+    size_t cnt = 0;
+    sr_node_t *child = parent->first_child;
+    while (child) {
+        ++cnt;
+        child = child->next;
+    }
+    return cnt;
+}
+
+/**
+ * Function expects a tree with root's xpath
+ * /ietf-interfaces:interfaces/interface[name='<based on index>']/ietf-ip:ipv4/address[ip='192.168.2.100']
+ */
+void check_ietf_interfaces_addr_tree(sr_node_t *tree, size_t index, bool top)
+{
+    sr_node_t *node = NULL;
+    const char * const addresses[] = {"192.168.2.100", "10.10.1.5"};
+    int8_t prefix_lengths[] = {24, 16};
+
+    assert_true(index < 2);
+
+    // address
+    assert_string_equal("address", tree->name);
+    assert_int_equal(SR_LIST_T, tree->type);
+    if (top) {
+        assert_string_equal("ietf-ip", tree->module_name);
+    } else {
+        assert_null(tree->module_name);
+    }
+    assert_false(tree->dflt);
+    assert_int_equal(2, get_child_cnt(tree));
+    // ip
+    node = get_child_by_index(tree, 0);
+    assert_string_equal("ip", node->name);
+    assert_int_equal(SR_STRING_T, node->type);
+    assert_string_equal(addresses[index], node->data.string_val);
+    assert_null(node->module_name);
+    assert_false(node->dflt);
+    assert_int_equal(0, get_child_cnt(node));
+    // prefix-length
+    node = get_child_by_index(tree, 1);
+    assert_string_equal("prefix-length", node->name);
+    assert_int_equal(SR_UINT8_T, node->type);
+    assert_int_equal(prefix_lengths[index], node->data.uint8_val);
+    assert_null(node->module_name);
+    assert_false(node->dflt);
+    assert_int_equal(0, get_child_cnt(node));
+}
+
+/**
+ * Function expect a tree with root's xpath
+ * /ietf-interfaces:interfaces/interface[name=<based on index>]/ietf-ip:ipv4
+ */
+void check_ietf_interfaces_ipv4_tree(sr_node_t *tree, size_t index)
+{
+    sr_node_t *node = NULL;
+    assert_true(index < 2);
+
+    // ipv4
+    assert_string_equal("ipv4", tree->name);
+    assert_int_equal(SR_CONTAINER_PRESENCE_T, tree->type);
+    assert_string_equal("ietf-ip", tree->module_name);
+    assert_false(tree->dflt);
+    assert_int_equal(4, get_child_cnt(tree));
+    // enabled
+    node = get_child_by_index(tree, 0);
+    assert_string_equal("enabled", node->name);
+    assert_int_equal(SR_BOOL_T, node->type);
+    assert_true(node->data.bool_val);
+    assert_null(node->module_name);
+    assert_false(node->dflt);
+    assert_int_equal(0, get_child_cnt(node));
+    // mtu
+    node = get_child_by_index(tree, 1);
+    assert_string_equal("mtu", node->name);
+    assert_int_equal(SR_UINT16_T, node->type);
+    assert_int_equal(1500, node->data.uint16_val);
+    assert_null(node->module_name);
+    assert_false(node->dflt);
+    assert_int_equal(0, get_child_cnt(node));
+    // address
+    node = get_child_by_index(tree, 2);
+    check_ietf_interfaces_addr_tree(node, index, false);
+    // forwarding
+    node = get_child_by_index(tree, 3);
+    assert_string_equal("forwarding", node->name);
+    assert_int_equal(SR_BOOL_T, node->type);
+    assert_false(node->data.bool_val);
+    assert_null(node->module_name);
+    assert_true(node->dflt);
+    assert_int_equal(0, get_child_cnt(node));
+}
+
+/**
+ * Function expects a tree with root's xpath
+ * "/ietf-interfaces:interfaces/interface[name=<based on index>]"
+ */
+void check_ietf_interfaces_int_tree(sr_node_t *tree, size_t index)
+{
+    sr_node_t *node = NULL;
+    const char * const names[] = {"eth0", "eth1", "gigaeth0"};
+    const char * const descriptions[] = {"Ethernet 0", "Ethernet 1", "GigabitEthernet 0"};
+    bool enabled[] = {true, true, false};
+
+    assert_true(index < 3);
+
+    // interface
+    assert_string_equal("interface", tree->name);
+    assert_int_equal(SR_LIST_T, tree->type);
+    assert_string_equal("ietf-interfaces", tree->module_name);
+    assert_false(tree->dflt);
+    assert_int_equal(index < 2 ? 5 : 4, get_child_cnt(tree));
+    // name
+    node = get_child_by_index(tree, 0);
+    assert_string_equal("name", node->name);
+    assert_int_equal(SR_STRING_T, node->type);
+    assert_string_equal(names[index], node->data.string_val);
+    assert_null(node->module_name);
+    assert_false(node->dflt);
+    assert_int_equal(0, get_child_cnt(node));
+    // description
+    node = get_child_by_index(tree, 1);
+    assert_string_equal("description", node->name);
+    assert_int_equal(SR_STRING_T, node->type);
+    assert_string_equal(descriptions[index], node->data.string_val);
+    assert_null(node->module_name);
+    assert_false(node->dflt);
+    assert_int_equal(0, get_child_cnt(node));
+    // type
+    node = get_child_by_index(tree, 2);
+    assert_string_equal("type", node->name);
+    assert_int_equal(SR_IDENTITYREF_T, node->type);
+    assert_string_equal("ethernetCsmacd", node->data.identityref_val);
+    assert_null(node->module_name);
+    assert_false(node->dflt);
+    assert_int_equal(0, get_child_cnt(node));
+    // enabled
+    node = get_child_by_index(tree, 3);
+    assert_string_equal("enabled", node->name);
+    assert_int_equal(SR_BOOL_T, node->type);
+    assert_true(enabled[index] == node->data.bool_val);
+    assert_null(node->module_name);
+    assert_false(node->dflt);
+    assert_int_equal(0, get_child_cnt(node));
+    // ipv4
+    if (index < 2) {
+        node = get_child_by_index(tree, 4);
+        check_ietf_interfaces_ipv4_tree(node, index);
+    }
+}
+
 
 void ietf_interfaces_test(void **state){
     int rc = 0;
@@ -216,6 +390,83 @@ void ietf_interfaces_test(void **state){
     dm_session_stop(ctx, ses_ctx);
 }
 
+void ietf_interfaces_tree_test(void **state){
+    int rc = 0;
+    rp_ctx_t *rp_ctx = *state;
+    dm_ctx_t *ctx = rp_ctx->dm_ctx;
+    dm_session_t *ses_ctx = NULL;
+    struct lyd_node *root = NULL;
+    createDataTreeIETFinterfacesModule();
+    dm_session_start(ctx, NULL, SR_DS_STARTUP, &ses_ctx);
+    rc = dm_get_datatree(ctx, ses_ctx, "ietf-interfaces", &root);
+    assert_int_equal(SR_ERR_OK, rc);
+
+    sr_node_t *trees = NULL;
+    sr_node_t *tree = NULL;
+    size_t count = 0;
+
+#define INTERFACES "/ietf-interfaces:interfaces/*"
+    rc = rp_dt_get_subtrees(ctx, root, NULL, INTERFACES, false, &trees, &count);
+    assert_int_equal(SR_ERR_OK, rc);
+    assert_int_equal(3, count);
+    for (size_t i = 0; i < count; i++) {
+        assert_null(trees[i].parent);
+        check_ietf_interfaces_int_tree(&trees[i], i);
+    }
+    sr_free_trees(trees, count);
+
+#define INTERFACE_ETH0 "/ietf-interfaces:interfaces/interface[name='eth0']"
+    rc = rp_dt_get_subtree(ctx, root, NULL, INTERFACE_ETH0, false, &tree);
+    assert_int_equal(SR_ERR_OK, rc);
+    check_ietf_interfaces_int_tree(tree, 0);
+    sr_free_tree(tree);
+
+#define INTERFACE_ETH1 "/ietf-interfaces:interfaces/interface[name='eth1']"
+    rc = rp_dt_get_subtree(ctx, root, NULL, INTERFACE_ETH1, false, &tree);
+    assert_int_equal(SR_ERR_OK, rc);
+    check_ietf_interfaces_int_tree(tree, 1);
+    sr_free_tree(tree);
+
+#define INTERFACE_GIGAETH0 "/ietf-interfaces:interfaces/interface[name='gigaeth0']"
+    rc = rp_dt_get_subtree(ctx, root, NULL, INTERFACE_GIGAETH0, false, &tree);
+    assert_int_equal(SR_ERR_OK, rc);
+    check_ietf_interfaces_int_tree(tree, 2);
+    sr_free_tree(tree);
+
+#define INTERFACE_ETH0_IPV4 "/ietf-interfaces:interfaces/interface[name='eth0']/ietf-ip:ipv4"
+    rc = rp_dt_get_subtree(ctx, root, NULL, INTERFACE_ETH0_IPV4, false, &tree);
+    assert_int_equal(SR_ERR_OK, rc);
+    check_ietf_interfaces_ipv4_tree(tree, 0);
+    sr_free_tree(tree);
+
+#define INTERFACE_ETH1_IPV4 "/ietf-interfaces:interfaces/interface[name='eth1']/ietf-ip:ipv4"
+    rc = rp_dt_get_subtree(ctx, root, NULL, INTERFACE_ETH1_IPV4, false, &tree);
+    assert_int_equal(SR_ERR_OK, rc);
+    check_ietf_interfaces_ipv4_tree(tree, 1);
+    sr_free_tree(tree);
+
+#define INTERFACE_GIGAETH0_IPV4 "/ietf-interfaces:interfaces/interface[name='gigaeth0']/ietf-ip:ipv4"
+    rc = rp_dt_get_subtree(ctx, root, NULL, INTERFACE_GIGAETH0_IPV4, false, &tree);
+    assert_int_equal(SR_ERR_NOT_FOUND, rc);
+
+#define INTERFACE_ETH0_IPV4_IP "/ietf-interfaces:interfaces/interface[name='eth0']/ietf-ip:ipv4/address[ip='192.168.2.100']"
+    rc = rp_dt_get_subtree(ctx, root, NULL, INTERFACE_ETH0_IPV4_IP, false, &tree);
+    assert_int_equal(SR_ERR_OK, rc);
+    check_ietf_interfaces_addr_tree(tree, 0, true);
+    sr_free_tree(tree);
+
+#define INTERFACE_ETH1_IPV4_IP "/ietf-interfaces:interfaces/interface[name='eth1']/ietf-ip:ipv4/address[ip='10.10.1.5']"
+    rc = rp_dt_get_subtree(ctx, root, NULL, INTERFACE_ETH1_IPV4_IP, false, &tree);
+    assert_int_equal(SR_ERR_OK, rc);
+    check_ietf_interfaces_addr_tree(tree, 1, true);
+    sr_free_tree(tree);
+
+#define INTERFACE_GIGAETH0_IPV4_IP "/ietf-interfaces:interfaces/interface[name='gigaeth0']/ietf-ip:ipv4/address"
+    rc = rp_dt_get_subtree(ctx, root, NULL, INTERFACE_GIGAETH0_IPV4_IP, false, &tree);
+    assert_int_equal(SR_ERR_NOT_FOUND, rc);
+
+    dm_session_stop(ctx, ses_ctx);
+}
 
 void get_values_test_module_test(void **state){
     int rc = 0;
@@ -271,7 +522,84 @@ void get_values_test_module_test(void **state){
     dm_session_stop(ctx, ses_ctx);
 }
 
+void get_tree_test_module_test(void **state)
+{
+    int rc = 0;
+    rp_ctx_t *rp_ctx = *state;
+    dm_ctx_t *ctx = rp_ctx->dm_ctx;
+    dm_session_t *ses_ctx = NULL;
+    dm_session_start(ctx, NULL, SR_DS_STARTUP, &ses_ctx);
 
+    struct lyd_node *root = NULL;
+    createDataTreeTestModule();
+    dm_get_datatree(ctx, ses_ctx, "test-module", &root);
+    assert_non_null(root);
+
+    sr_node_t *tree = NULL;
+
+    /* enum leaf */
+    rc = rp_dt_get_subtree(ctx, root, NULL, XP_TEST_MODULE_ENUM, false, &tree);
+    assert_int_equal(SR_ERR_OK, rc);
+    assert_string_equal("enum", tree->name);
+    assert_string_equal("test-module", tree->module_name);
+    assert_int_equal(SR_ENUM_T, tree->type);
+    assert_string_equal(XP_TEST_MODULE_ENUM_VALUE, tree->data.enum_val);
+    assert_false(tree->dflt);
+    assert_null(tree->parent);
+    assert_null(tree->first_child);
+    assert_null(tree->next);
+    assert_null(tree->prev);
+
+    sr_free_tree(tree);
+
+    /* binary leaf*/
+    rc = rp_dt_get_subtree(ctx, root, NULL, XP_TEST_MODULE_RAW, false, &tree);
+    assert_int_equal(SR_ERR_OK, rc);
+    assert_string_equal("raw", tree->name);
+    assert_string_equal("test-module", tree->module_name);
+    assert_int_equal(SR_BINARY_T, tree->type);
+    assert_string_equal(XP_TEST_MODULE_RAW_VALUE, tree->data.binary_val);
+    assert_false(tree->dflt);
+    assert_null(tree->parent);
+    assert_null(tree->first_child);
+    assert_null(tree->next);
+    assert_null(tree->prev);
+
+    sr_free_tree(tree);
+
+    /*bits leaf*/
+    rc = rp_dt_get_subtree(ctx, root, NULL, XP_TEST_MODULE_BITS, false, &tree);
+    assert_int_equal(SR_ERR_OK, rc);
+    assert_string_equal("options", tree->name);
+    assert_string_equal("test-module", tree->module_name);
+    assert_int_equal(SR_BITS_T, tree->type);
+    assert_string_equal(XP_TEST_MODULE_BITS_VALUE, tree->data.bits_val);
+    assert_false(tree->dflt);
+    assert_null(tree->parent);
+    assert_null(tree->first_child);
+    assert_null(tree->next);
+    assert_null(tree->prev);
+
+    sr_free_tree(tree);
+
+    /* leafref */
+#define LEAFREF_XP "/test-module:university/classes/class[title='CCNA']/student[name='nameB']/age"
+    rc = rp_dt_get_subtree(ctx, root, NULL, LEAFREF_XP, false, &tree);
+    assert_int_equal(SR_ERR_OK, rc);
+    assert_string_equal("age", tree->name);
+    assert_string_equal("test-module", tree->module_name);
+    assert_int_equal(SR_UINT8_T, tree->type);
+    assert_int_equal(17, tree->data.uint8_val);
+    assert_false(tree->dflt);
+    assert_null(tree->parent);
+    assert_null(tree->first_child);
+    assert_null(tree->next);
+    assert_null(tree->prev);
+
+    sr_free_tree(tree);
+
+    dm_session_stop(ctx, ses_ctx);
+}
 
 void get_values_test(void **state){
     int rc = 0;
@@ -328,9 +656,9 @@ void get_values_test(void **state){
     sr_free_values(values, count);
 
 #define XP_CONTAINER "/example-module:container"
-    rc = rp_dt_get_values(ctx, root, NULL, XP_LIST_WITHOUT_KEYS, false, &values, &count);
+    rc = rp_dt_get_values(ctx, root, NULL, XP_CONTAINER, false, &values, &count);
     assert_int_equal(SR_ERR_OK, rc);
-    assert_int_equal(2, count);
+    assert_int_equal(1, count);
     for (size_t i = 0; i < count; i++) {
         assert_int_equal(0, strncmp(XP_CONTAINER, values[i].xpath, strlen(XP_CONTAINER)));
     }
@@ -351,6 +679,151 @@ void get_values_test(void **state){
     dm_session_stop(ctx, ses_ctx);
 }
 
+void get_trees_test(void **state){
+    int rc = 0;
+    rp_ctx_t *rp_ctx = *state;
+    dm_ctx_t *ctx = rp_ctx->dm_ctx;
+    dm_session_t *ses_ctx = NULL;
+    struct lyd_node *data_tree = NULL;
+    dm_session_start(ctx, NULL, SR_DS_STARTUP, &ses_ctx);
+    rc = dm_get_datatree(ctx, ses_ctx, "example-module", &data_tree);
+    assert_int_equal(SR_ERR_OK, rc);
+
+    struct lyd_node *root = NULL;
+    createDataTree(data_tree->schema->module->ctx, &root);
+    assert_non_null(root);
+
+    sr_node_t *trees = NULL;
+    size_t count = 0;
+
+    #define XP_MODULE "/example-module:*"
+    rc = rp_dt_get_subtrees(ctx, root, NULL, XP_MODULE, false, &trees, &count);
+    assert_int_equal(SR_ERR_OK, rc);
+    assert_int_equal(4, count); /*container + 3 leaf-list instances */
+    // container
+    assert_string_equal("container", trees[0].name);
+    assert_string_equal("example-module", trees[0].module_name);
+    assert_int_equal(SR_CONTAINER_T, trees[0].type);
+    assert_false(trees[0].dflt);
+    assert_int_equal(2, get_child_cnt(&trees[0]));
+    // number - 2
+    assert_string_equal("number", trees[1].name);
+    assert_string_equal("example-module", trees[1].module_name);
+    assert_int_equal(SR_UINT16_T, trees[1].type);
+    assert_int_equal(2, trees[1].data.uint16_val);
+    assert_false(trees[1].dflt);
+    assert_int_equal(0, get_child_cnt(&trees[1]));
+    // number - 1
+    assert_string_equal("number", trees[2].name);
+    assert_string_equal("example-module", trees[2].module_name);
+    assert_int_equal(SR_UINT16_T, trees[2].type);
+    assert_int_equal(1, trees[2].data.uint16_val);
+    assert_false(trees[2].dflt);
+    assert_int_equal(0, get_child_cnt(&trees[2]));
+    // number - 42
+    assert_string_equal("number", trees[3].name);
+    assert_string_equal("example-module", trees[3].module_name);
+    assert_int_equal(SR_UINT16_T, trees[3].type);
+    assert_int_equal(42, trees[3].data.uint16_val);
+    assert_false(trees[3].dflt);
+    assert_int_equal(0, get_child_cnt(&trees[3]));
+
+    sr_free_trees(trees, count);
+
+#define XP_LEAF "/example-module:container/list[key1='key1'][key2='key2']/leaf"
+    rc = rp_dt_get_subtrees(ctx, root, NULL, XP_LEAF, false, &trees, &count);
+    assert_int_equal(SR_ERR_OK, rc);
+    assert_int_equal(1, count);
+    assert_string_equal("leaf", trees[0].name);
+    assert_string_equal("example-module", trees[0].module_name);
+    assert_int_equal(SR_STRING_T, trees[0].type);
+    assert_string_equal(LEAF_VALUE, trees[0].data.string_val);
+    assert_false(trees[0].dflt);
+    assert_int_equal(0, get_child_cnt(&trees[0]));
+    sr_free_trees(trees, count);
+
+#define XP_LIST_WITH_KEYS "/example-module:container/list[key1='key1'][key2='key2']/*"
+    rc = rp_dt_get_subtrees(ctx, root, NULL, XP_LIST_WITH_KEYS, false, &trees, &count);
+    assert_int_equal(SR_ERR_OK, rc);
+    assert_int_equal(3, count);
+    // key1
+    assert_string_equal("key1", trees[0].name);
+    assert_string_equal("example-module", trees[0].module_name);
+    assert_int_equal(SR_STRING_T, trees[0].type);
+    assert_string_equal("key1", trees[0].data.string_val);
+    assert_false(trees[0].dflt);
+    assert_int_equal(0, get_child_cnt(&trees[0]));
+    // key2
+    assert_string_equal("key2", trees[1].name);
+    assert_string_equal("example-module", trees[1].module_name);
+    assert_int_equal(SR_STRING_T, trees[1].type);
+    assert_string_equal("key2", trees[1].data.string_val);
+    assert_false(trees[1].dflt);
+    assert_int_equal(0, get_child_cnt(&trees[1]));
+    // leaf
+    assert_string_equal("leaf", trees[2].name);
+    assert_string_equal("example-module", trees[2].module_name);
+    assert_int_equal(SR_STRING_T, trees[2].type);
+    assert_string_equal(LEAF_VALUE, trees[2].data.string_val);
+    assert_false(trees[2].dflt);
+    assert_int_equal(0, get_child_cnt(&trees[2]));
+    sr_free_trees(trees, count);
+
+#define XP_LIST_WITHOUT_KEYS "/example-module:container/list"
+    rc = rp_dt_get_subtrees(ctx, root, NULL, XP_LIST_WITHOUT_KEYS, false, &trees, &count);
+    assert_int_equal(SR_ERR_OK, rc);
+    assert_int_equal(2, count);
+    for (count = 0; count < 2; ++count) {
+        assert_string_equal("list", trees[count].name);
+        assert_string_equal("example-module", trees[count].module_name);
+        assert_int_equal(SR_LIST_T, trees[count].type);
+        assert_false(trees[count].dflt);
+        assert_int_equal(3, get_child_cnt(&trees[count]));
+    }
+    sr_free_trees(trees, count);
+
+#define XP_CONTAINER "/example-module:container"
+    rc = rp_dt_get_subtrees(ctx, root, NULL, XP_CONTAINER, false, &trees, &count);
+    assert_int_equal(SR_ERR_OK, rc);
+    assert_int_equal(1, count);
+    assert_string_equal("container", trees[0].name);
+    assert_string_equal("example-module", trees[0].module_name);
+    assert_int_equal(SR_CONTAINER_T, trees[0].type);
+    assert_false(trees[0].dflt);
+    assert_int_equal(2, get_child_cnt(&trees[0]));
+    sr_free_trees(trees, count);
+
+#define XP_LEAFLIST "/example-module:number"
+    rc = rp_dt_get_subtrees(ctx, root, NULL, XP_LEAFLIST, false, &trees, &count);
+    assert_int_equal(SR_ERR_OK, rc);
+    assert_int_equal(3, count);
+    // number - 2
+    assert_string_equal("number", trees[0].name);
+    assert_string_equal("example-module", trees[0].module_name);
+    assert_int_equal(SR_UINT16_T, trees[0].type);
+    assert_int_equal(2, trees[0].data.uint16_val);
+    assert_false(trees[0].dflt);
+    assert_int_equal(0, get_child_cnt(&trees[0]));
+    // number - 1
+    assert_string_equal("number", trees[1].name);
+    assert_string_equal("example-module", trees[1].module_name);
+    assert_int_equal(SR_UINT16_T, trees[1].type);
+    assert_int_equal(1, trees[1].data.uint16_val);
+    assert_false(trees[1].dflt);
+    assert_int_equal(0, get_child_cnt(&trees[1]));
+    // number - 42
+    assert_string_equal("number", trees[2].name);
+    assert_string_equal("example-module", trees[2].module_name);
+    assert_int_equal(SR_UINT16_T, trees[2].type);
+    assert_int_equal(42, trees[2].data.uint16_val);
+    assert_false(trees[2].dflt);
+    assert_int_equal(0, get_child_cnt(&trees[2]));
+    sr_free_trees(trees, count);
+
+    lyd_free_withsiblings(root);
+
+    dm_session_stop(ctx, ses_ctx);
+}
 
 void get_values_opts_test(void **state) {
     int rc = 0;
@@ -440,7 +913,47 @@ void get_values_with_augments_test(void **state){
     dm_session_stop(ctx, ses_ctx);
 }
 
-void get_value_test(void **state){
+void get_trees_with_augments_test(void **state){
+    int rc = 0;
+    rp_ctx_t *rp_ctx = *state;
+    dm_ctx_t *ctx = rp_ctx->dm_ctx;
+    dm_session_t *ses_ctx = NULL;
+    struct lyd_node *data_tree = NULL;
+    struct lyd_node *root = NULL;
+    size_t count = 0;
+    sr_node_t *trees = NULL;
+    dm_session_start(ctx, NULL, SR_DS_STARTUP, &ses_ctx);
+
+    rc = dm_get_datatree(ctx, ses_ctx, "example-module", &data_tree);
+    assert_int_equal(SR_ERR_OK, rc);
+    createDataTreeWithAugments(data_tree->schema->module->ctx, &root);
+    assert_non_null(root);
+#define SM_MODULE "/small-module:item/*"
+    rc = rp_dt_get_subtrees(ctx, root, NULL, SM_MODULE, false, &trees, &count);
+    assert_int_equal(SR_ERR_OK, rc);
+    assert_int_equal(2, count);
+    // name
+    assert_string_equal("name", trees[0].name);
+    assert_string_equal("small-module", trees[0].module_name);
+    assert_int_equal(SR_STRING_T, trees[0].type);
+    assert_string_equal("hey hou", trees[0].data.string_val);
+    assert_false(trees[0].dflt);
+    assert_int_equal(0, get_child_cnt(&trees[0]));
+    // info
+    assert_string_equal("info", trees[1].name);
+    assert_string_equal("info-module", trees[1].module_name);
+    assert_int_equal(SR_STRING_T, trees[1].type);
+    assert_string_equal("info 123", trees[1].data.string_val);
+    assert_false(trees[1].dflt);
+    assert_int_equal(0, get_child_cnt(&trees[1]));
+    sr_free_trees(trees, count);
+
+    lyd_free_withsiblings(root);
+    dm_session_stop(ctx, ses_ctx);
+}
+
+void get_value_test(void **state)
+{
     int rc = 0;
     rp_ctx_t *rp_ctx = *state;
     dm_ctx_t *ctx = rp_ctx->dm_ctx;
@@ -480,6 +993,62 @@ void get_value_test(void **state){
     assert_int_equal(SR_CONTAINER_T, value->type);
     assert_string_equal(XPATH_FOR_CONTAINER, value->xpath);
     sr_free_val(value);
+
+    dm_session_stop(ctx, ses_ctx);
+}
+
+void get_tree_test(void **state)
+{
+    int rc = 0;
+    rp_ctx_t *rp_ctx = *state;
+    dm_ctx_t *ctx = rp_ctx->dm_ctx;
+    dm_session_t *ses_ctx = NULL;
+    struct lyd_node *data_tree = NULL;
+    dm_session_start(ctx, NULL, SR_DS_STARTUP, &ses_ctx);
+
+    /* Load from file */
+    rc = dm_get_datatree(ctx, ses_ctx, "example-module", &data_tree);
+    assert_int_equal(SR_ERR_OK, rc);
+    sr_node_t *tree = NULL;
+
+    assert_int_equal(SR_ERR_INVAL_ARG, rp_dt_get_subtree(ctx, data_tree, NULL, "/example-module:", false, &tree));
+
+    /*leaf*/
+#define XPATH_FOR_VALUE "/example-module:container/list[key1='key1'][key2='key2']/leaf"
+    assert_int_equal(SR_ERR_OK, rp_dt_get_subtree(ctx, data_tree, NULL, XPATH_FOR_VALUE, false, &tree));
+
+    assert_string_equal("leaf", tree->name);
+    assert_string_equal("example-module", tree->module_name);
+    assert_int_equal(SR_STRING_T, tree->type);
+    assert_string_equal("Leaf value", tree->data.string_val);
+    assert_false(tree->dflt);
+    assert_int_equal(0, get_child_cnt(tree));
+
+    sr_free_tree(tree);
+
+    /*list*/
+#define XPATH_FOR_LIST "/example-module:container/list[key1='key1'][key2='key2']"
+    assert_int_equal(SR_ERR_OK, rp_dt_get_subtree(ctx, data_tree, NULL, XPATH_FOR_LIST, false, &tree));
+
+    assert_string_equal("list", tree->name);
+    assert_string_equal("example-module", tree->module_name);
+    assert_int_equal(SR_LIST_T, tree->type);
+    assert_false(tree->dflt);
+    assert_int_equal(3, get_child_cnt(tree));
+
+    sr_free_tree(tree);
+
+    /*container*/
+#define XPATH_FOR_CONTAINER "/example-module:container"
+    assert_int_equal(SR_ERR_OK, rp_dt_get_subtree(ctx, data_tree, NULL, "/example-module:container", false, &tree));
+
+    assert_string_equal("container", tree->name);
+    assert_string_equal("example-module", tree->module_name);
+    assert_int_equal(SR_CONTAINER_T, tree->type);
+    assert_false(tree->dflt);
+    assert_int_equal(1, get_child_cnt(tree));
+
+    sr_free_tree(tree);
 
     dm_session_stop(ctx, ses_ctx);
 }
@@ -610,6 +1179,37 @@ void get_value_wrapper_test(void **state){
     test_rp_sesssion_create(ctx, SR_DS_STARTUP, &ses_ctx);
 
     /* unknown model*/
+    sr_node_t *tree = NULL;
+    rc = rp_dt_get_subtree_wrapper(ctx, ses_ctx, NULL, "/non-existing:abc", &tree);
+    assert_int_equal(SR_ERR_UNKNOWN_MODEL, rc);
+
+    /* whole model xpath*/
+
+    ses_ctx->state = RP_REQ_NEW;
+    tree = NULL;
+    rc = rp_dt_get_subtree_wrapper(ctx, ses_ctx, NULL, "/test-module:*", &tree);
+    assert_int_equal(SR_ERR_INVAL_ARG, rc);
+
+    /* not existing data tree*/
+    ses_ctx->state = RP_REQ_NEW;
+    rc = rp_dt_get_subtree_wrapper(ctx, ses_ctx, NULL, "/small-module:item", &tree);
+    assert_int_equal(SR_ERR_NOT_FOUND, rc);
+
+    /* not exisiting now in existing data tree*/
+    ses_ctx->state = RP_REQ_NEW;
+    rc = rp_dt_get_subtree_wrapper(ctx, ses_ctx, NULL, "/example-module:container/list[key1='abc'][key2='def']", &tree);
+    assert_int_equal(SR_ERR_NOT_FOUND, rc);
+
+    test_rp_session_cleanup(ctx, ses_ctx);
+}
+
+void get_tree_wrapper_test(void **state){
+    int rc = 0;
+    rp_ctx_t *ctx = *state;
+    rp_session_t *ses_ctx = NULL;
+    test_rp_sesssion_create(ctx, SR_DS_STARTUP, &ses_ctx);
+
+    /* unknown model*/
     sr_val_t *value = NULL;
     rc = rp_dt_get_value_wrapper(ctx, ses_ctx, NULL, "/non-existing:abc", &value);
     assert_int_equal(SR_ERR_UNKNOWN_MODEL, rc);
@@ -681,6 +1281,7 @@ default_nodes_test(void **state)
 
     test_rp_sesssion_create(ctx, SR_DS_STARTUP, &ses_ctx);
     sr_val_t *val = NULL;
+    sr_node_t *tree = NULL;
     sr_error_info_t *errors = NULL;
     size_t e_cnt = 0;
 
@@ -698,6 +1299,13 @@ default_nodes_test(void **state)
     assert_false(val->dflt);
     sr_free_val(val);
 
+    ses_ctx->state = RP_REQ_NEW;
+    rc = rp_dt_get_subtree_wrapper(ctx, ses_ctx, NULL, "/test-module:main/string", &tree);
+    assert_int_equal(SR_ERR_OK, rc);
+    assert_non_null(tree);
+    assert_false(tree->dflt);
+    sr_free_tree(tree);
+
     /* list with default value */
     rc = rp_dt_set_item_wrapper(ctx, ses_ctx, "/test-module:with_def[name='withdef']", NULL, SR_EDIT_DEFAULT);
     assert_int_equal(SR_ERR_OK, rc);
@@ -705,6 +1313,10 @@ default_nodes_test(void **state)
     ses_ctx->state = RP_REQ_NEW;
     /* due to recent changes in libyang, default nodes are added during validate/commit only */
     rc = rp_dt_get_value_wrapper(ctx, ses_ctx, NULL, "/test-module:with_def[name='withdef']/num", &val);
+    assert_int_equal(SR_ERR_NOT_FOUND, rc);
+
+    ses_ctx->state = RP_REQ_NEW;
+    rc = rp_dt_get_subtree_wrapper(ctx, ses_ctx, NULL, "/test-module:with_def[name='withdef']/num", &tree);
     assert_int_equal(SR_ERR_NOT_FOUND, rc);
 
     /* set default value with strict */
@@ -725,6 +1337,13 @@ default_nodes_test(void **state)
     assert_false(val->dflt);
     sr_free_val(val);
 
+    ses_ctx->state = RP_REQ_NEW;
+    rc = rp_dt_get_subtree_wrapper(ctx, ses_ctx, NULL, "/test-module:with_def[name='createWithStrict']/num", &tree);
+    assert_int_equal(SR_ERR_OK, rc);
+    assert_non_null(tree);
+    assert_int_equal(99, tree->data.int8_val);
+    assert_false(tree->dflt);
+    sr_free_tree(tree);
 
     /* overwrite default value with strict */
     v = NULL;
@@ -746,6 +1365,14 @@ default_nodes_test(void **state)
     assert_int_equal(42, val->data.int8_val);
     assert_false(val->dflt);
     sr_free_val(val);
+
+    ses_ctx->state = RP_REQ_NEW;
+    rc = rp_dt_get_subtree_wrapper(ctx, ses_ctx, NULL, "/test-module:with_def[name='overwrite']/num", &tree);
+    assert_int_equal(SR_ERR_OK, rc);
+    assert_non_null(tree);
+    assert_int_equal(42, tree->data.int8_val);
+    assert_false(tree->dflt);
+    sr_free_tree(tree);
 
     /* once the leaf contains non-default value SR_EDIT_STRICT failed */
     v = NULL;
@@ -775,6 +1402,14 @@ default_nodes_test(void **state)
     assert_false(val->dflt);
     sr_free_val(val);
 
+    ses_ctx->state = RP_REQ_NEW;
+    rc = rp_dt_get_subtree_wrapper(ctx, ses_ctx, NULL, "/test-module:with_def[name='withother']/num", &tree);
+    assert_int_equal(SR_ERR_OK, rc);
+    assert_non_null(tree);
+    assert_int_equal(9, tree->data.int8_val);
+    assert_false(tree->dflt);
+    sr_free_tree(tree);
+
     /* list with explicitly set default value */
     v = NULL;
     v = calloc(1, sizeof(*v));
@@ -791,6 +1426,13 @@ default_nodes_test(void **state)
     assert_non_null(val);
     assert_false(val->dflt);
     sr_free_val(val);
+
+    ses_ctx->state = RP_REQ_NEW;
+    rc = rp_dt_get_subtree_wrapper(ctx, ses_ctx, NULL, "/test-module:with_def[name='withexpl']/num", &tree);
+    assert_int_equal(SR_ERR_OK, rc);
+    assert_non_null(tree);
+    assert_false(tree->dflt);
+    sr_free_tree(tree);
 
     /* list with default value later overwritten with a non-default one */
     rc = rp_dt_set_item_wrapper(ctx, ses_ctx, "/test-module:with_def[name='withmodifdef']", NULL, SR_EDIT_DEFAULT);
@@ -813,6 +1455,14 @@ default_nodes_test(void **state)
     assert_false(val->dflt);
     sr_free_val(val);
 
+    ses_ctx->state = RP_REQ_NEW;
+    rc = rp_dt_get_subtree_wrapper(ctx, ses_ctx, NULL, "/test-module:with_def[name='withmodifdef']/num", &tree);
+    assert_int_equal(SR_ERR_OK, rc);
+    assert_non_null(tree);
+    assert_int_equal(9, tree->data.int8_val);
+    assert_false(tree->dflt);
+    sr_free_tree(tree);
+
     rc = rp_dt_commit(ctx, ses_ctx, &errors, &e_cnt);
     assert_int_equal(SR_ERR_OK, rc);
 
@@ -825,12 +1475,27 @@ default_nodes_test(void **state)
     sr_free_val(val);
 
     ses_ctx->state = RP_REQ_NEW;
+    rc = rp_dt_get_subtree_wrapper(ctx, ses_ctx, NULL, "/test-module:with_def[name='withdef']/num", &tree);
+    assert_int_equal(SR_ERR_OK, rc);
+    assert_non_null(tree);
+    assert_true(tree->dflt);
+    sr_free_tree(tree);
+
+    ses_ctx->state = RP_REQ_NEW;
     rc = rp_dt_get_value_wrapper(ctx, ses_ctx, NULL, "/test-module:with_def[name='withother']/num", &val);
     assert_int_equal(SR_ERR_OK, rc);
     assert_non_null(val);
     assert_int_equal(9, val->data.int8_val);
     assert_false(val->dflt);
     sr_free_val(val);
+
+    ses_ctx->state = RP_REQ_NEW;
+    rc = rp_dt_get_subtree_wrapper(ctx, ses_ctx, NULL, "/test-module:with_def[name='withother']/num", &tree);
+    assert_int_equal(SR_ERR_OK, rc);
+    assert_non_null(tree);
+    assert_int_equal(9, tree->data.int8_val);
+    assert_false(tree->dflt);
+    sr_free_tree(tree);
 
     ses_ctx->state = RP_REQ_NEW;
     rc = rp_dt_get_value_wrapper(ctx, ses_ctx, NULL, "/test-module:with_def[name='withexpl']/num", &val);
@@ -840,12 +1505,27 @@ default_nodes_test(void **state)
     sr_free_val(val);
 
     ses_ctx->state = RP_REQ_NEW;
+    rc = rp_dt_get_subtree_wrapper(ctx, ses_ctx, NULL, "/test-module:with_def[name='withexpl']/num", &tree);
+    assert_int_equal(SR_ERR_OK, rc);
+    assert_non_null(tree);
+    assert_false(tree->dflt);
+    sr_free_tree(tree);
+
+    ses_ctx->state = RP_REQ_NEW;
     rc = rp_dt_get_value_wrapper(ctx, ses_ctx, NULL, "/test-module:with_def[name='withmodifdef']/num", &val);
     assert_int_equal(SR_ERR_OK, rc);
     assert_non_null(val);
     assert_int_equal(9, val->data.int8_val);
     assert_false(val->dflt);
     sr_free_val(val);
+
+    ses_ctx->state = RP_REQ_NEW;
+    rc = rp_dt_get_subtree_wrapper(ctx, ses_ctx, NULL, "/test-module:with_def[name='withmodifdef']/num", &tree);
+    assert_int_equal(SR_ERR_OK, rc);
+    assert_non_null(tree);
+    assert_int_equal(9, tree->data.int8_val);
+    assert_false(tree->dflt);
+    sr_free_tree(tree);
 
     /* explicitly overwrite default*/
     v = NULL;
@@ -863,6 +1543,13 @@ default_nodes_test(void **state)
     assert_non_null(val);
     assert_false(val->dflt);
     sr_free_val(val);
+
+    ses_ctx->state = RP_REQ_NEW;
+    rc = rp_dt_get_subtree_wrapper(ctx, ses_ctx, NULL, "/test-module:with_def[name='withdef']/num", &tree);
+    assert_int_equal(SR_ERR_OK, rc);
+    assert_non_null(tree);
+    assert_false(tree->dflt);
+    sr_free_tree(tree);
 
     /* clean up*/
     rc = rp_dt_delete_item_wrapper(ctx, ses_ctx, "/test-module:with_def", SR_EDIT_DEFAULT);
@@ -933,13 +1620,19 @@ int main(){
             cmocka_unit_test(get_node_test_found),
             cmocka_unit_test(get_node_test_not_found),
             cmocka_unit_test(get_value_test),
+            cmocka_unit_test(get_tree_test),
             cmocka_unit_test(get_values_test),
+            cmocka_unit_test(get_trees_test),
             cmocka_unit_test(get_values_with_augments_test),
+            cmocka_unit_test(get_trees_with_augments_test),
             cmocka_unit_test(ietf_interfaces_test),
+            cmocka_unit_test(ietf_interfaces_tree_test),
             cmocka_unit_test(get_values_test_module_test),
+            cmocka_unit_test(get_tree_test_module_test),
             cmocka_unit_test(get_nodes_test),
             cmocka_unit_test(get_values_opts_test),
             cmocka_unit_test(get_value_wrapper_test),
+            cmocka_unit_test(get_tree_wrapper_test),
             cmocka_unit_test(get_nodes_with_opts_cache_missed_test),
             cmocka_unit_test(default_nodes_test),
             cmocka_unit_test(default_nodes_toplevel_test)


### PR DESCRIPTION
The implementation for the iterative tree loading is still in progress, but I would merge at least the basic functionality in order to avoid any future merge conflicts (that I would have to fix myself :) )

The support for trees on the side of operational data providers is also planned. I will do it as a separate task.

Set-subtree op is not going to be implemented unless CESNET guys find use for it in their NETCONF server.