### PR TITLE
Fix build when older version of sysrepo is in CMAKE_INSTALL_PREFIX

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -77,6 +77,7 @@ MESSAGE(STATUS "sysrepo repository location: ${REPOSITORY_LOC}")
 # include custom Modules
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/CMakeModules/")
 include_directories(${CMAKE_CURRENT_BINARY_DIR})
+include_directories("${CMAKE_CURRENT_SOURCE_DIR}/inc")
 
 # find required libraries
 find_package(EV REQUIRED)


### PR DESCRIPTION
With the current version of Sysrepo from the master branch in
/opt/libnetconf, building the deve branch fails. This is caused by
the obsolete /opt/libnetconf/include/sysrepo.h taking precedence over
the desired inc/libnetconf.