### PR TITLE
cmake: Fix example module registration at install time

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -22,14 +22,21 @@ target_link_libraries(application_example sysrepo)
 target_link_libraries(application_changes_example sysrepo)
 target_link_libraries(application_fd_watcher_example sysrepo)
 
+macro(EXEC_AT_INSTALL_TIME CMD)
+    install(CODE "message(STATUS \"Exec: ${CMD}\")
+        execute_process(COMMAND ${CMD} OUTPUT_QUIET RESULT_VARIABLE ret)
+        if (NOT \${ret} EQUAL 0)
+          message(FATAL_ERROR \"Error: \${ret}\")
+        endif()"
+        )
+endmacro()
+
 macro(INSTALL_EXAMPLE_YANG MODULE_NAME REVISION)
     # install the YANG module
-    set(CMD "${CMAKE_BINARY_DIR}/src/sysrepoctl --install --yang=${CMAKE_CURRENT_SOURCE_DIR}/yang/${MODULE_NAME}${REVISION}.yang --permissions=666")
-    install(CODE "execute_process(COMMAND ${CMD} OUTPUT_QUIET)")
+    EXEC_AT_INSTALL_TIME("${CMAKE_BINARY_DIR}/src/sysrepoctl --install --yang=${CMAKE_CURRENT_SOURCE_DIR}/yang/${MODULE_NAME}${REVISION}.yang --permissions=666")
     if (EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/yang/${MODULE_NAME}.data.xml)
         # import data into module
-        set(CMD "${CMAKE_BINARY_DIR}/src/sysrepocfg --import=${CMAKE_CURRENT_SOURCE_DIR}/yang/${MODULE_NAME}.data.xml --datastore=startup --format=xml --level=0 ${MODULE_NAME}")
-        install(CODE "execute_process(COMMAND ${CMD} OUTPUT_QUIET)")
+        EXEC_AT_INSTALL_TIME("${CMAKE_BINARY_DIR}/src/sysrepocfg --import=${CMAKE_CURRENT_SOURCE_DIR}/yang/${MODULE_NAME}.data.xml --datastore=startup --format=xml --level=0 ${MODULE_NAME}")
     endif()
 endmacro(INSTALL_EXAMPLE_YANG)
 

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -26,9 +26,11 @@ macro(INSTALL_EXAMPLE_YANG MODULE_NAME REVISION)
     # install the YANG module
     set(CMD "${CMAKE_BINARY_DIR}/src/sysrepoctl --install --yang=${CMAKE_CURRENT_SOURCE_DIR}/yang/${MODULE_NAME}${REVISION}.yang --permissions=666")
     install(CODE "execute_process(COMMAND ${CMD} OUTPUT_QUIET)")
-    # import data into module
-    set(CMD "${CMAKE_BINARY_DIR}/src/sysrepocfg --import=${CMAKE_CURRENT_SOURCE_DIR}/yang/${MODULE_NAME}.data.xml --datastore=startup --format=xml --level=0 ${MODULE_NAME}")
-    install(CODE "execute_process(COMMAND ${CMD} OUTPUT_QUIET)")
+    if (EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/yang/${MODULE_NAME}.data.xml)
+        # import data into module
+        set(CMD "${CMAKE_BINARY_DIR}/src/sysrepocfg --import=${CMAKE_CURRENT_SOURCE_DIR}/yang/${MODULE_NAME}.data.xml --datastore=startup --format=xml --level=0 ${MODULE_NAME}")
+        install(CODE "execute_process(COMMAND ${CMD} OUTPUT_QUIET)")
+    endif()
 endmacro(INSTALL_EXAMPLE_YANG)
 
 INSTALL_EXAMPLE_YANG("turing-machine" "")


### PR DESCRIPTION
There was no feedback when any of these commands actually failed (at least for me, CMake 3.6.2, Ninja 1.6.0). This patch series ensures that failures are reported (and fatal), and that data imports are disabled for non-existing data files.