### PR TITLE
cpp: Ensure that Trees::tree reuses our reference counter

### DIFF
--- a/swig/cpp/src/Tree.cpp
+++ b/swig/cpp/src/Tree.cpp
@@ -304,8 +304,7 @@ Trees::~Trees() {return;}
 S_Tree Trees::tree(size_t n) {
     if (_trees == NULL || n >= _cnt) return NULL;
 
-    S_Counter counter(new Counter(&_trees[n]));
-    S_Tree tree(new Tree(&_trees[n], counter));
+    S_Tree tree(new Tree(&_trees[n], _counter));
     return tree;
 }
 S_Trees Trees::dup() {


### PR DESCRIPTION
The code uses Counter instances to work around the std::shared_ptr API
design where one cannot really manipulate the reference count from
outside. In this context, we however need to ensure that a
shared_ptr<Tree> created from within a Trees context reuses the same
counter, and that the underlying data structure only gets deleted when
the enclosing Trees structure is destroyed.

@mislavn , please check issue #366 and ensure that this patch doesn't make the situation worse.