### PR TITLE
Comment on trees and values + propagate some more errors after failed sr_commit

### DIFF
--- a/inc/sysrepo/trees.h
+++ b/inc/sysrepo/trees.h
@@ -27,7 +27,20 @@
  * @defgroup trees Tree Manipulation Utilities
  * @{
  *
- *  @brief TODO
+ *  @brief Set of functions facilitating simplified manipulation and traversal
+ *  of Sysrepo trees. As there are many connections between the tree nodes
+ *  and also some internal attributes associated with each node, it is actually
+ *  recommended to use these function rather than to allocate and initialize trees
+ *  manually, which is very likely to lead to time-wasting and hard-to-debug programming
+ *  errors.
+ *  Iterative tree loading (@see SR_GET_SUBTREE_ITERATIVE) even requires to use
+ *  designated functions for tree traversal -- ::sr_node_get_child and ::sr_node_get_next_sibling.
+ *
+ *  Another added benefit of using these function is that the trees created using
+ *  ::sr_new_tree and ::sr_new_trees will be allocated using the Sysrepo's own memory management
+ *  (if enabled) which was proven to be more efficient for larger data sets
+ *  (far less copying, quicker conversion to/from google protocol buffer messages,
+ *  stable memory footprint, etc.).
  */
 
 /**

--- a/inc/sysrepo/values.h
+++ b/inc/sysrepo/values.h
@@ -27,7 +27,24 @@
  * @defgroup values Value Manipulation Utilities
  * @{
  *
- *  @brief TODO
+ *  @brief Set of functions facilitating simplified manipulation with sysrepo
+ *  values. It is not necessary to use these functions in any scenario, values
+ *  can be allocated and initialized manually (just remember to set all uninitialized
+ *  members to zero!).
+ *
+ *  Using these utilities, however, has several benefits. Firstly, all the memory
+ *  allocations associated with creating values and setting their attributes get
+ *  hidden behind these functions. The "old-way" was (and still is) to set xpath
+ *  and string values using strdup, which may repeat in applications communicating
+ *  with sysrepo very often and becomes very annoying to write.
+ *  Secondly, the programmer may actually forget to copy or give-up on the ownership
+ *  of a string passed to sysrepo value which will then get unexpectedly deallocated
+ *  in ::sr_free_value or ::sr_free_values.
+ *  The third benefit is that the values created using ::sr_new_value
+ *  and ::sr_new_values will be allocated using the Sysrepo's own memory management
+ *  (if enabled) which was proven to be more efficient for larger data sets
+ *  (far less copying, quicker conversion to/from google protocol buffer messages,
+ *  stable memory footprint, etc.).
  */
 
 /**

--- a/src/common/sr_utils.h
+++ b/src/common/sr_utils.h
@@ -440,6 +440,17 @@ void sr_free_tree_content(sr_node_t *tree);
 void sr_free_node(sr_node_t *node);
 
 /**
+ * @brief Add error into the array of detailed error information.
+ *
+ * @param[in, out] sr_errors Array of detailed error information.
+ * @param[in, out] sr_error_cnt Number of errors in the sr_errors array.
+ * @param[in] xpath Xpath to the node where the error has been discovered.
+ * @param[in] msg_fmt Error message format string.
+ */
+int sr_add_error(sr_error_info_t **sr_errors, size_t *sr_error_cnt, const char *xpath,
+        const char *msg_fmt, ...);
+
+/**
  * @brief Frees an array of detailed error information.
  *
  * @param[in] sr_errors Array of detailed error information.

--- a/src/data_manager.h
+++ b/src/data_manager.h
@@ -418,9 +418,12 @@ int dm_commit_prepare_context(dm_ctx_t *dm_ctx, dm_session_t *session, dm_commit
  * @param [in] dm_ctx
  * @param [in] session
  * @param [in] c_ctx - commit context
+ * @param [out] errors
+ * @param [out] err_cnt
  * @return Error code (SR_ERR_OK on success)
  */
-int dm_commit_load_modified_models(dm_ctx_t *dm_ctx, const dm_session_t *session, dm_commit_context_t *c_ctx);
+int dm_commit_load_modified_models(dm_ctx_t *dm_ctx, const dm_session_t *session, dm_commit_context_t *c_ctx,
+        sr_error_info_t **errors, size_t *err_cnt);
 
 /**
  * @brief Writes the data trees from commit session stored in commit context into the files.

--- a/src/rp_dt_edit.c
+++ b/src/rp_dt_edit.c
@@ -699,7 +699,8 @@ rp_dt_commit(rp_ctx_t *rp_ctx, rp_session_t *session, dm_commit_context_t *c_ctx
                 return SR_ERR_OK;
             }
             /* open all files */
-            rc = dm_commit_load_modified_models(rp_ctx->dm_ctx, session->dm_session, commit_ctx);
+            rc = dm_commit_load_modified_models(rp_ctx->dm_ctx, session->dm_session, commit_ctx,
+                    errors, err_cnt);
             CHECK_RC_MSG_GOTO(rc, cleanup, "Loading of modified models failed");
             SR_LOG_DBG_MSG("Commit (3/7): all modified models loaded successfully");
             state = DM_COMMIT_REPLAY_OPS;


### PR DESCRIPTION
The issue with non-descriptive failed sr_commit due to disabled nodes present in the running datastore is not yet fully fixed, some work needs to be done also on the Netopeer side:

https://github.com/CESNET/Netopeer2/issues/38