### PR TITLE
Fix build with -Wvarargs

### DIFF
--- a/tests/md_test.c
+++ b/tests/md_test.c
@@ -359,7 +359,7 @@ static const char * const md_module_E_rev2_body =
 "  }";
 
 static md_test_dep_t *
-md_test_dep(md_dep_type_t type, bool direct, ...)
+md_test_dep(md_dep_type_t type, int is_direct, ...)
 {
     md_test_dep_t *dep = NULL;
     size_t orig_cnt = 0;
@@ -371,10 +371,10 @@ md_test_dep(md_dep_type_t type, bool direct, ...)
     assert_int_equal(SR_ERR_OK, sr_list_init(&dep->orig_modules));
 
     dep->type = type;
-    dep->direct = direct;
+    dep->direct = is_direct;
 
     if (MD_DEP_DATA == type) {
-        va_start(va, direct);
+        va_start(va, is_direct);
         orig_cnt = va_arg(va, int);
 
         for (int i = 0; i < orig_cnt; ++i) {


### PR DESCRIPTION
va_args is picky about the type of the function argument which gets
passed, and bool gets promoted to int by default, leading to undefined
behavior.

I took the liberty to rename 'direct' to 'is_direct' to keep the
original intention now that the type is int -- feel free to change this
if you disagree.

Here's clang's error message:

  ../tests/md_test.c:377:22: warning: passing an object that undergoes default argument promotion to 'va_start' has undefined behavior [-Wvarargs]
        va_start(va, direct);
                     ^
  ../tests/md_test.c:362:38: note: parameter of type 'bool' is declared here
  md_test_dep(md_dep_type_t type, bool direct, ...)