### PR TITLE
Remove unused entries from .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,9 +3,6 @@
 *.pyc
 build/
 doc/
-src/common/sr_constants.h
-src/common/*.pb-c.*
-tests/helpers/test_data.h
 .idea/
 nbproject/
 CMakeCache.txt


### PR DESCRIPTION
Now that out-of-tree build doesn't touch the source tree (seems that
71dd25d and 95928ab are relevant), remove these entries from .gitignore.
This is intended as a hint to developers that they might need to clean
their tree to prevent build failures in future. Bad stuff will happen
otherwise because these generated files are now obsolete and won't be
updated anymore, and there order of the include paths is always fun to
debug.