### PR TITLE
Remove C ODR violation

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -98,24 +98,16 @@ if (NOT ${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
 endif()
 
 # sysrepo library
-add_library(sysrepo SHARED $<TARGET_OBJECTS:COMMON> $<TARGET_OBJECTS:SR_SRC>)
-add_library(sysrepo_a $<TARGET_OBJECTS:COMMON> $<TARGET_OBJECTS:SR_SRC>)
+add_library(sysrepo SHARED $<TARGET_OBJECTS:COMMON> $<TARGET_OBJECTS:SR_ENGINE> $<TARGET_OBJECTS:SR_SRC>)
+add_library(sysrepo_a $<TARGET_OBJECTS:COMMON> $<TARGET_OBJECTS:SR_ENGINE> $<TARGET_OBJECTS:SR_SRC>)
 SET_TARGET_PROPERTIES(sysrepo_a PROPERTIES
               OUTPUT_NAME sysrepo CLEAN_DIRECT_OUTPUT 1)
-target_link_libraries(sysrepo ${LINK_LIBRARIES} sysrepo-engine)
-target_link_libraries(sysrepo_a ${LINK_LIBRARIES} sysrepo-engine_a)
-
-# sysrepo-engine library
-add_library(sysrepo-engine SHARED $<TARGET_OBJECTS:COMMON> $<TARGET_OBJECTS:SR_ENGINE>)
-add_library(sysrepo-engine_a $<TARGET_OBJECTS:COMMON> $<TARGET_OBJECTS:SR_ENGINE>)
-SET_TARGET_PROPERTIES(sysrepo-engine_a PROPERTIES
-              OUTPUT_NAME sysrepo-engine CLEAN_DIRECT_OUTPUT 1)
-target_link_libraries(sysrepo-engine_a ${LINK_LIBRARIES})
-target_link_libraries(sysrepo-engine ${LINK_LIBRARIES})
+target_link_libraries(sysrepo ${LINK_LIBRARIES})
+target_link_libraries(sysrepo_a ${LINK_LIBRARIES})
 
 # sysrepo daemon
 add_executable(sysrepod ${EXECUTABLES_DIR}/sysrepod.c)
-target_link_libraries(sysrepod sysrepo-engine)
+target_link_libraries(sysrepod sysrepo)
 
 # sysrepo plugin daemon
 add_executable(sysrepo-plugind ${EXECUTABLES_DIR}/sysrepo-plugind.c)
@@ -131,8 +123,6 @@ target_link_libraries(sysrepocfg sysrepo ${YANG_LIBRARIES})
 
 install(TARGETS sysrepo DESTINATION ${LIB_INSTALL_DIR})
 install(TARGETS sysrepo_a DESTINATION ${LIB_INSTALL_DIR})
-install(TARGETS sysrepo-engine DESTINATION ${LIB_INSTALL_DIR})
-install(TARGETS sysrepo-engine_a DESTINATION ${LIB_INSTALL_DIR})
 install(TARGETS sysrepod DESTINATION ${BIN_INSTALL_DIR})
 install(TARGETS sysrepo-plugind DESTINATION ${BIN_INSTALL_DIR})
 install(TARGETS sysrepoctl DESTINATION ${BIN_INSTALL_DIR})

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -40,7 +40,7 @@ macro(ADD_UNIT_TEST_WITH_OPTS TEST_NAME USE_HELPERS USE_VALGRIND WRAP_FUNCTION)
         add_executable(${TEST_NAME} ${TEST_NAME}.c)
     endif()
 
-    target_link_libraries(${TEST_NAME} ${CMOCKA_LIBRARIES} sysrepo_a sysrepo-engine_a ${test_link_flags})
+    target_link_libraries(${TEST_NAME} ${CMOCKA_LIBRARIES} sysrepo_a ${test_link_flags})
     add_test(${TEST_NAME} ${TEST_NAME})
     if(valgrind_FOUND)
        if(${USE_VALGRIND})


### PR DESCRIPTION
Because both libsysrepo.so and libsysrepo-engine.so were linking objects
from COMMON, the protobuf-c's sr__value__descriptor variable was present
twice in the resulting program. That's forbidden.

Thanks to ASAN for showing this:

```
  =================================================================
  ==31698==ERROR: AddressSanitizer: odr-violation (0x7ffbf3b588a0):
    [1] size=120 'sr__value__descriptor' src/common/sysrepo.pb-c.c:3772:34
    [2] size=120 'sr__value__descriptor' src/common/sysrepo.pb-c.c:3772:34
  These globals were registered at these points:
    [1]:
      #0 0x42b18d in __asan_register_globals.part.14 /var/tmp/portage/sys-devel/llvm-3.9.0/work/llvm-3.9.0.src/projects/compiler-rt/lib/asan/asan_globals.cc:309
      #1 0x7ffbf381997d in asan.module_ctor (/opt/libnetconf/lib/libsysrepo.so+0x8097d)
      #2 0x7ffbf3bb111b in call_init /var/tmp/portage/sys-libs/glibc-2.22-r4/work/glibc-2.22/elf/dl-init.c:30
      #3 0x7ffbf3bb111b in _dl_init /var/tmp/portage/sys-libs/glibc-2.22-r4/work/glibc-2.22/elf/dl-init.c:120
      #4 0x7ffbf3ba1cb9  (/lib64/ld-linux-x86-64.so.2+0xcb9)

    [2]:
      #0 0x42b18d in __asan_register_globals.part.14 /var/tmp/portage/sys-devel/llvm-3.9.0/work/llvm-3.9.0.src/projects/compiler-rt/lib/asan/asan_globals.cc:309
      #1 0x7ffbf2d7218d in asan.module_ctor (/opt/libnetconf/lib/libsysrepo-engine.so+0xcd18d)
      #2 0x7ffbf3bb111b in call_init /var/tmp/portage/sys-libs/glibc-2.22-r4/work/glibc-2.22/elf/dl-init.c:30
      #3 0x7ffbf3bb111b in _dl_init /var/tmp/portage/sys-libs/glibc-2.22-r4/work/glibc-2.22/elf/dl-init.c:120
      #4 0x7ffbf3ba1cb9  (/lib64/ld-linux-x86-64.so.2+0xcb9)

  ==31698==HINT: if you don't care about these errors you may set ASAN_OPTIONS=detect_odr_violation=0
  SUMMARY: AddressSanitizer: odr-violation: global 'sr__value__descriptor' at src/common/sysrepo.pb-c.c:3772:34
  ==31698==ABORTING
```