### PR TITLE
Python fix

### DIFF
--- a/swig/CMakeLists.txt
+++ b/swig/CMakeLists.txt
@@ -138,6 +138,11 @@ if(PYTHONLIBS_FOUND AND PYTHONINTERP_FOUND AND ${GEN_PYTHON_VERSION} STREQUAL "3
 
         file(COPY "python3/examples" DESTINATION "${CMAKE_CURRENT_BINARY_DIR}/python3")
 
+        execute_process(COMMAND
+            ${PYTHON_EXECUTABLE} -c
+            "from distutils.sysconfig import get_python_lib; print(get_python_lib())"
+        OUTPUT_VARIABLE PYTHON_MODULE_PATH OUTPUT_STRIP_TRAILING_WHITESPACE)
+
         install( FILES "${CMAKE_CURRENT_BINARY_DIR}/_${PYTHON_SWIG_BINDING_3}.so" DESTINATION ${PYTHON_MODULE_PATH} )
         install( FILES "${CMAKE_BINARY_DIR}/${PYTHON_SWIG_BINDING_3}.py" DESTINATION ${PYTHON_MODULE_PATH} )
 endif()

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -108,10 +108,12 @@ if("${TEST_REPOSITORY_LOC}" STREQUAL "${REPOSITORY_LOC}")
         VERBATIM
     )
 
-    # Python tests
-    FIND_PACKAGE(PythonInterp)
-    FIND_PACKAGE(SWIG)
-    FIND_PACKAGE(PythonLibs 2)
+    if(GEN_LANGUAGE_BINDINGS AND GEN_PYTHON_BINDINGS AND ${GEN_PYTHON_VERSION} STREQUAL "2")
+        # Python tests
+        FIND_PACKAGE(PythonInterp)
+        FIND_PACKAGE(SWIG)
+        FIND_PACKAGE(PythonLibs 2)
+    endif()
 
     if (SWIG_FOUND AND PYTHONLIBS_FOUND AND PYTHONINTERP_FOUND)
         macro(ADD_PYTHON_TEST TEST_NAME)


### PR DESCRIPTION
Hi Rastislav,

I fixed the problem with python3 in the cmake files, the problem was that python2 was included in the tests without the check of GEN_PYTHON_VERSION.

Also I had to add a custom command for finding PYTHON_MODULE_PATH for python3.

Regards,
Mislav