### PR TITLE
Refactoring of C++'s logging with one SR change

### DIFF
--- a/src/data_manager.c
+++ b/src/data_manager.c
@@ -3110,7 +3110,7 @@ dm_commit_notify(dm_ctx_t *dm_ctx, dm_session_t *session, sr_notif_event_t ev, d
         }
 
         /* Log changes */
-        if (NULL != diff && (SR_LL_DBG == sr_ll_stderr || SR_LL_DBG == sr_ll_syslog)) {
+        if (NULL != diff && (SR_LL_DBG == sr_ll_stderr || SR_LL_DBG == sr_ll_syslog || sr_log_callback)) {
             while (LYD_DIFF_END != diff->type[d_cnt]) {
                 char *path = dm_get_notification_changed_xpath(diff, d_cnt);
                 SR_LOG_DBG("%s: %s", dm_get_diff_type_to_string(diff->type[d_cnt]), path);

--- a/swig/cpp/examples/get_item_example.cpp
+++ b/swig/cpp/examples/get_item_example.cpp
@@ -30,7 +30,10 @@ int
 main(int argc, char **argv)
 {
     try {
-        Logs::set_stderr(SR_LL_DBG);
+        Logs::set_stderr(SR_LL_NONE);
+        Logs::setCallback([](const sr_log_level_t logLevel, const std::string &message) {
+            std::cerr << "sysrepo log (" << logLevel << "): " << message << std::endl;
+        });
 
 	S_Connection conn(new Connection("app1"));
 

--- a/swig/cpp/examples/get_item_example.cpp
+++ b/swig/cpp/examples/get_item_example.cpp
@@ -30,8 +30,7 @@ int
 main(int argc, char **argv)
 {
     try {
-        Logs log;
-        log.set_stderr(SR_LL_DBG);
+        Logs::set_stderr(SR_LL_DBG);
 
 	S_Connection conn(new Connection("app1"));
 

--- a/swig/cpp/examples/set_item_example.cpp
+++ b/swig/cpp/examples/set_item_example.cpp
@@ -29,8 +29,7 @@ int
 main(int argc, char **argv)
 {
     try {
-        Logs log;
-        log.set_stderr(SR_LL_DBG);
+        Logs::set_stderr(SR_LL_DBG);
 
 	S_Connection conn(new Connection("app3"));
 

--- a/swig/cpp/src/Sysrepo.cpp
+++ b/swig/cpp/src/Sysrepo.cpp
@@ -81,6 +81,23 @@ void Logs::set_syslog(const sr_log_level_t log_level)
     sr_log_stderr(log_level);
 }
 
+#ifdef SR_SWIG_SUPPORTS_STD_FUNCTION
+Logs::Callback Logs::log_callback;
+
+void sr_cpp_log_callback(sr_log_level_t level, const char *message)
+{
+    if (Logs::log_callback) {
+        Logs::log_callback(level, std::string(message));
+    }
+}
+
+void Logs::setCallback(Callback cb)
+{
+    Logs::log_callback = cb;
+    sr_log_set_cb(sr_cpp_log_callback);
+}
+#endif
+
 Schema_Content::Schema_Content(char *con)
 {
     _con = con;

--- a/swig/cpp/src/Sysrepo.cpp
+++ b/swig/cpp/src/Sysrepo.cpp
@@ -71,12 +71,6 @@ void throw_exception(int error) {
     }
 }
 
-Logs::Logs()
-{
-    // for consistent swig integration
-    return;
-}
-
 void Logs::set_stderr(const sr_log_level_t log_level)
 {
     sr_log_stderr(log_level);

--- a/swig/cpp/src/Sysrepo.cpp
+++ b/swig/cpp/src/Sysrepo.cpp
@@ -77,12 +77,12 @@ Logs::Logs()
     return;
 }
 
-void Logs::set_stderr(sr_log_level_t log_level)
+void Logs::set_stderr(const sr_log_level_t log_level)
 {
     sr_log_stderr(log_level);
 }
 
-void Logs::set_syslog(sr_log_level_t log_level)
+void Logs::set_syslog(const sr_log_level_t log_level)
 {
     sr_log_stderr(log_level);
 }

--- a/swig/cpp/src/Sysrepo.h
+++ b/swig/cpp/src/Sysrepo.h
@@ -103,7 +103,7 @@ void throw_exception(int error);
 class Logs
 {
 public:
-    Logs();
+    Logs() = delete;
     static void set_stderr(const sr_log_level_t log_level);
     static void set_syslog(const sr_log_level_t log_level);
 };

--- a/swig/cpp/src/Sysrepo.h
+++ b/swig/cpp/src/Sysrepo.h
@@ -89,10 +89,15 @@
 #define GET_SUBTREE_DEFAULT 0
 #define SUBSCR_DEFAULT 0
 
+#include <functional>
 #include <iostream>
 #include <stdexcept>
 
 #include "Internal.h"
+
+#if !defined(SWIGPYTHON) && !defined(SWIGLUA) && !defined(SWIGJAVA)
+#  define SR_SWIG_SUPPORTS_STD_FUNCTION
+#endif
 
 extern "C" {
 #include "sysrepo.h"
@@ -106,6 +111,13 @@ public:
     Logs() = delete;
     static void set_stderr(const sr_log_level_t log_level);
     static void set_syslog(const sr_log_level_t log_level);
+#ifdef SR_SWIG_SUPPORTS_STD_FUNCTION
+    using Callback = std::function<void(const sr_log_level_t, const std::string &)>;
+    static void setCallback(Callback cb);
+private:
+    static Callback log_callback;
+    friend void sr_cpp_log_callback(sr_log_level_t, const char *);
+#endif
 };
 
 class Schemas

--- a/swig/cpp/src/Sysrepo.h
+++ b/swig/cpp/src/Sysrepo.h
@@ -104,8 +104,8 @@ class Logs
 {
 public:
     Logs();
-    void set_stderr(sr_log_level_t log_level);
-    void set_syslog(sr_log_level_t log_level);
+    static void set_stderr(const sr_log_level_t log_level);
+    static void set_syslog(const sr_log_level_t log_level);
 };
 
 class Schemas


### PR DESCRIPTION
This series:
- switches the C++ code to static methods (please read the commit messages),
- adds logging callbacks for C++,
- changes core SR to not skip expensive computation when a custom CB is active (see the last commit).

I have no idea whether you want the last commit or not; please feel free to remove that one.

Ccing @mislavn for the C++ part.
