### PR TITLE
cpp: remove set_type class method

### DIFF
--- a/swig/cpp/src/Struct.cpp
+++ b/swig/cpp/src/Struct.cpp
@@ -131,7 +131,8 @@ Val::Val(const char *value, sr_type_t type) {
         ret = sr_val_set_string(val, value);
         if (ret != SR_ERR_OK)
             throw_exception(ret);
-    } else {
+    } else if (value != NULL && ( type != SR_LIST_T && type != SR_CONTAINER_T && type != SR_CONTAINER_PRESENCE_T &&\
+        type != SR_UNKNOWN_T && type != SR_LEAF_EMPTY_T)) {
         free(val);
         throw_exception(SR_ERR_INVAL_ARG);
     }
@@ -336,7 +337,8 @@ void Val::set(const char *xpath, const char *value, sr_type_t type) {
         ret = sr_val_set_string(_val, value);
         if (ret != SR_ERR_OK)
             throw_exception(ret);
-    } else {
+    } else if (value != NULL && ( type != SR_LIST_T && type != SR_CONTAINER_T && type != SR_CONTAINER_PRESENCE_T &&\
+        type != SR_UNKNOWN_T && type != SR_LEAF_EMPTY_T)) {
         throw_exception(SR_ERR_INVAL_ARG);
     }
 }
@@ -486,19 +488,6 @@ void Val::set(const char *xpath, uint64_t uint64_val, sr_type_t type) {
     if (type == SR_UINT64_T) {
 	    _val->data.uint64_val = uint64_val;
     } else {
-        throw_exception(SR_ERR_INVAL_ARG);
-    }
-
-    _val->type = type;
-}
-void Val::set_type(const char *xpath, sr_type_t type) {
-    if (_val == NULL) throw_exception(SR_ERR_OPERATION_FAILED);
-
-    int ret = sr_val_set_xpath(_val, xpath);
-    if (ret != SR_ERR_OK) throw_exception(ret);
-
-    if (type != SR_LIST_T && type != SR_CONTAINER_T && type != SR_CONTAINER_PRESENCE_T &&\
-        type != SR_UNKNOWN_T && type != SR_LEAF_EMPTY_T) {
         throw_exception(SR_ERR_INVAL_ARG);
     }
 

--- a/swig/cpp/src/Struct.h
+++ b/swig/cpp/src/Struct.h
@@ -91,7 +91,6 @@ public:
     void set(const char *xpath, uint16_t uint16_val, sr_type_t type);
     void set(const char *xpath, uint32_t uint32_val, sr_type_t type);
     void set(const char *xpath, uint64_t uint64_val, sr_type_t type);
-    void set_type(const char *xpath, sr_type_t type);
     char *xpath() {return _val->xpath;};
     void xpath_set(char *data) {_val->xpath = data;};
     sr_type_t type() {return _val->type;};

--- a/swig/cpp/src/Tree.cpp
+++ b/swig/cpp/src/Tree.cpp
@@ -134,7 +134,8 @@ void Tree::set(const char *value, sr_type_t type) {
         ret = sr_node_set_string(_node, value);
         if (ret != SR_ERR_OK)
             throw_exception(ret);
-    } else {
+    } else if (value != NULL && ( type != SR_LIST_T && type != SR_CONTAINER_T && type != SR_CONTAINER_PRESENCE_T &&\
+        type != SR_UNKNOWN_T && type != SR_LEAF_EMPTY_T)) {
         throw_exception(SR_ERR_INVAL_ARG);
     }
 }
@@ -232,14 +233,6 @@ void Tree::set(uint64_t uint64_val, sr_type_t type) {
     if (type == SR_UINT64_T) {
 	    _node->data.uint64_val = uint64_val;
     } else {
-        throw_exception(SR_ERR_INVAL_ARG);
-    }
-
-    _node->type = type;
-}
-void Tree::set_type(sr_type_t type) {
-    if (type != SR_LIST_T && type != SR_CONTAINER_T && type != SR_CONTAINER_PRESENCE_T &&\
-        type != SR_UNKNOWN_T && type != SR_LEAF_EMPTY_T) {
         throw_exception(SR_ERR_INVAL_ARG);
     }
 

--- a/swig/cpp/src/Tree.h
+++ b/swig/cpp/src/Tree.h
@@ -67,7 +67,6 @@ public:
     void set(uint16_t uint16_val, sr_type_t type);
     void set(uint32_t uint32_val, sr_type_t type);
     void set(uint64_t uint64_val, sr_type_t type);
-    void set_type(sr_type_t type);
     ~Tree();
 
 private:


### PR DESCRIPTION
Based on the input from @jktjkt I removed the class method set_type and moved that logic to the functions and constructors which handle strings in values and trees.

Now you cane set empty leafs with:

Val value = new Val(NULL, SR_LEAF_EMPTY_T)

or in Python

value = sr.Val(None, SR_LEAF_EMPTY_T)