### PR TITLE
fix crash when sr_module_change_subscribe failed in a special condition

### DIFF
--- a/src/clientlib/client_library.c
+++ b/src/clientlib/client_library.c
@@ -2389,7 +2389,9 @@ sr_subtree_change_subscribe(sr_session_ctx_t *session, const char *xpath, sr_sub
     /* Initialize the subscription */
     if (opts & SR_SUBSCR_CTX_REUSE) {
         sr_subscription = *subscription_p;
-        sm_subscription_cnt = sr_subscription->sm_subscription_cnt;
+        if (sr_subscription) {
+            sm_subscription_cnt = sr_subscription->sm_subscription_cnt;
+        }
     }
     rc = cl_subscription_init(session, SR__SUBSCRIPTION_TYPE__SUBTREE_CHANGE_SUBS, module_name, SR_API_VALUES,
             private_ctx, &sr_subscription, &sm_subscription, &msg_req);

--- a/src/clientlib/client_library.c
+++ b/src/clientlib/client_library.c
@@ -2429,6 +2429,9 @@ cleanup:
     cl_subscription_close(session, sm_subscription);
     if (NULL != sr_subscription && sr_subscription->sm_subscription_cnt > sm_subscription_cnt) {
         cl_sr_subscription_remove_one(sr_subscription);
+        if (0 == sm_subscription_cnt) {
+            *subscription_p = NULL;
+        }
     }
     if (NULL != msg_req) {
         sr_msg_free(msg_req);

--- a/src/clientlib/client_library.c
+++ b/src/clientlib/client_library.c
@@ -2376,6 +2376,7 @@ sr_subtree_change_subscribe(sr_session_ctx_t *session, const char *xpath, sr_sub
     cl_sm_subscription_ctx_t *sm_subscription = NULL;
     char *module_name = NULL;
     int rc = SR_ERR_OK;
+    size_t sm_subscription_cnt = 0;
 
     CHECK_NULL_ARG4(session, xpath, callback, subscription_p);
 
@@ -2388,6 +2389,7 @@ sr_subtree_change_subscribe(sr_session_ctx_t *session, const char *xpath, sr_sub
     /* Initialize the subscription */
     if (opts & SR_SUBSCR_CTX_REUSE) {
         sr_subscription = *subscription_p;
+        sm_subscription_cnt = sr_subscription->sm_subscription_cnt;
     }
     rc = cl_subscription_init(session, SR__SUBSCRIPTION_TYPE__SUBTREE_CHANGE_SUBS, module_name, SR_API_VALUES,
             private_ctx, &sr_subscription, &sm_subscription, &msg_req);
@@ -2425,7 +2427,9 @@ sr_subtree_change_subscribe(sr_session_ctx_t *session, const char *xpath, sr_sub
 
 cleanup:
     cl_subscription_close(session, sm_subscription);
-    cl_sr_subscription_remove_one(sr_subscription);
+    if (NULL != sr_subscription && sr_subscription->sm_subscription_cnt > sm_subscription_cnt) {
+        cl_sr_subscription_remove_one(sr_subscription);
+    }
     if (NULL != msg_req) {
         sr_msg_free(msg_req);
     }


### PR DESCRIPTION
Hi,
it will crash when `sr_module_change_subscribe` with `SR_SUBSCR_CTX_REUSE` failed in a special condition:
first, do a successful subscribe.
second, do a failed subscribe, then `sr_subscription->sm_subscription_cnt` becomes 0.
third, do another failed subscribe, then `sr_subscription` is freed. but the pointer of *subscription_p is not set to null. user's program will crash when he used the pointer later.
it looks like `cl_subscription_init` does not add new `cl_sm_subscription_ctx_t` but `cl_sr_subscription_remove_one` delete one.