### PR TITLE
Differentiate imported and implemented modules -- enhancement #422

### DIFF
--- a/inc/sysrepo.h
+++ b/inc/sysrepo.h
@@ -573,6 +573,8 @@ typedef struct sr_schema_s {
     const char *module_name;         /**< Name of the module. */
     const char *ns;                  /**< Namespace of the module used in @ref xp_page "XPath". */
     const char *prefix;              /**< Prefix of the module. */
+    bool implemented;                /**< TRUE if the module is implemented (= explicitly installed),
+                                          not just imported. */
 
     sr_sch_revision_t revision;      /**< Revision the module. */
 
@@ -1109,6 +1111,16 @@ typedef enum sr_change_oper_e {
 } sr_change_oper_t;
 
 /**
+ * @brief State of a module as returned by the ::sr_module_install_cb callback.
+ */
+typedef enum sr_module_state_e {
+    SR_MS_UNINSTALLED,  /**< The module is not installed in the sysrepo repository. */
+    SR_MS_IMPORTED,     /**< The module has been implicitly installed into the sysrepo repository
+                             as it is imported by another implemented/imported module. */
+    SR_MS_IMPLEMENTED   /**< The module has been explicitly installed into the sysrepo repository by the user. */
+} sr_module_state_t;
+
+/**
  * @brief Sysrepo subscription context returned from sr_*_subscribe calls,
  * it is supposed to be released by the caller using ::sr_unsubscribe call.
  */
@@ -1155,11 +1167,12 @@ typedef int (*sr_subtree_change_cb)(sr_session_ctx_t *session, const char *xpath
  * @param[in] module_name Name of the newly installed / uinstalled module.
  * @param[in] revision Revision of the newly installed module (if specified
  * within the YANG model).
- * @param[in] installed TRUE if the module has been installed, FALSE if uninstalled.
+ * @param[in] state The new state of the module (uninstalled vs. imported vs. implemented).
  * @param[in] private_ctx Private context opaque to sysrepo, as passed to
  * ::sr_module_install_subscribe call.
  */
-typedef void (*sr_module_install_cb)(const char *module_name, const char *revision, bool installed, void *private_ctx);
+typedef void (*sr_module_install_cb)(const char *module_name, const char *revision, sr_module_state_t state,
+        void *private_ctx);
 
 /**
  * @brief Callback to be called by the event of enabling / disabling of

--- a/src/clientlib/cl_subscription_manager.c
+++ b/src/clientlib/cl_subscription_manager.c
@@ -675,7 +675,7 @@ cl_sm_notif_process(cl_sm_ctx_t *sm_ctx, cl_sm_conn_ctx_t *conn, Sr__Msg *msg)
             subscription->callback.module_install_cb(
                     msg->notification->module_install_notif->module_name,
                     msg->notification->module_install_notif->revision,
-                    msg->notification->module_install_notif->installed,
+                    sr_module_state_gpb_to_sr(msg->notification->module_install_notif->state),
                     subscription->private_ctx);
             break;
         case SR__SUBSCRIPTION_TYPE__FEATURE_ENABLE_SUBS:

--- a/src/common/sr_protobuf.c
+++ b/src/common/sr_protobuf.c
@@ -2158,6 +2158,51 @@ sr_api_variant_gpb_to_sr(Sr__ApiVariant api_variant_gpb)
     }
 }
 
+char *
+sr_module_state_sr_to_str(sr_module_state_t state)
+{
+    switch (state) {
+        case SR_MS_UNINSTALLED:
+            return "uninstalled";
+        case SR_MS_IMPORTED:
+            return "imported";
+        case SR_MS_IMPLEMENTED:
+            return "implemented";
+        default:
+            return "unknown";
+    }
+}
+
+Sr__ModuleState
+sr_module_state_sr_to_gpb(sr_module_state_t state)
+{
+    switch (state) {
+    case SR_MS_UNINSTALLED:
+        return SR__MODULE_STATE__UNINSTALLED;
+    case SR_MS_IMPORTED:
+        return SR__MODULE_STATE__IMPORTED;
+    case SR_MS_IMPLEMENTED:
+        return SR__MODULE_STATE__IMPLEMENTED;
+    default:
+        return SR__MODULE_STATE__UNINSTALLED;
+    }
+}
+
+sr_module_state_t
+sr_module_state_gpb_to_sr(Sr__ModuleState state)
+{
+    switch (state) {
+        case SR__MODULE_STATE__UNINSTALLED:
+            return SR_MS_UNINSTALLED;
+        case SR__MODULE_STATE__IMPORTED:
+            return SR_MS_IMPORTED;
+        case SR__MODULE_STATE__IMPLEMENTED:
+            return SR_MS_IMPLEMENTED;
+        default:
+            return SR_MS_UNINSTALLED;
+    }
+}
+
 int
 sr_schemas_sr_to_gpb(const sr_schema_t *sr_schemas, const size_t schema_cnt, Sr__Schema ***gpb_schemas)
 {

--- a/src/common/sr_protobuf.h
+++ b/src/common/sr_protobuf.h
@@ -365,6 +365,29 @@ Sr__ApiVariant sr_api_variant_sr_to_gpb(sr_api_variant_t api_variant);
 sr_api_variant_t sr_api_variant_gpb_to_sr(Sr__ApiVariant api_variant_gpb);
 
 /**
+ * @brief Converts module state type from sysrepo enum to string representation.
+ *
+ * @param[in] state Sysrepo module state type.
+ * @return Pointer to statically allocated string with the event type name.
+ */
+char *sr_module_state_sr_to_str(sr_module_state_t state);
+
+/**
+ * @brief Converts module state type from sysrepo enum to its GPB enum representation
+ * @param [in] state Syrepo module state type
+ * @return GPB module state type
+ */
+Sr__ModuleState sr_module_state_sr_to_gpb(sr_module_state_t state);
+
+/**
+ * @brief Converts module state type from GPB to sysrepo type.
+ *
+ * @param[in] state GPB module state type.
+ * @return Sysrepo module state type.
+ */
+sr_module_state_t sr_module_state_gpb_to_sr(Sr__ModuleState state);
+
+/**
  * @brief Converts array of sr_schema_t to an array of pointers to GPB schemas.
  *
  * @param [in] sr_schemas Array of sr_schema_t.

--- a/src/data_manager.c
+++ b/src/data_manager.c
@@ -1908,6 +1908,8 @@ dm_list_module(dm_ctx_t *dm_ctx, md_module_t *module, sr_schema_t *schema)
     sr_mem_edit_string(sr_mem, (char **)&schema->prefix, module->prefix);
     CHECK_NULL_NOMEM_GOTO(schema->prefix, rc, cleanup);
 
+    schema->implemented = module->implemented;
+
     rc = dm_list_rev_file(dm_ctx, sr_mem, module->name, module->revision_date, &schema->revision);
     CHECK_RC_LOG_GOTO(rc, cleanup, "List rev file failed module %s", module->name);
 

--- a/src/data_manager.c
+++ b/src/data_manager.c
@@ -3211,9 +3211,10 @@ dm_feature_enable(dm_ctx_t *dm_ctx, const char *module_name, const char *feature
 }
 
 int
-dm_install_module(dm_ctx_t *dm_ctx, const char *module_name, const char *revision, const char *file_name)
+dm_install_module(dm_ctx_t *dm_ctx, const char *module_name, const char *revision, const char *file_name,
+        sr_list_t **implicitly_installed_p)
 {
-    CHECK_NULL_ARG3(dm_ctx, module_name, file_name); /* revision can be NULL */
+    CHECK_NULL_ARG4(dm_ctx, module_name, file_name, implicitly_installed_p); /* revision can be NULL */
 
     int rc = 0;
     md_module_t *module = NULL;
@@ -3221,16 +3222,14 @@ dm_install_module(dm_ctx_t *dm_ctx, const char *module_name, const char *revisio
     sr_llist_node_t *ll_node = NULL;
     dm_schema_info_t *si = NULL, *si_ext = NULL;
     dm_schema_info_t lookup = {0};
+    sr_list_t *implicitly_installed = NULL;
 
     /* insert module into the dependency graph */
     md_ctx_lock(dm_ctx->md_ctx, true);
     pthread_rwlock_wrlock(&dm_ctx->schema_tree_lock);
 
-    rc = md_insert_module(dm_ctx->md_ctx, file_name);
-    if (SR_ERR_DATA_EXISTS == rc) {
-        SR_LOG_WRN("Module '%s' is already installed", file_name);
-        rc = SR_ERR_OK; /*< do not treat as error */
-    }
+    rc = md_insert_module(dm_ctx->md_ctx, file_name, &implicitly_installed);
+    CHECK_RC_MSG_GOTO(rc, cleanup, "Failed to insert module into the dependency graph");
 
     rc = md_get_module_info(dm_ctx->md_ctx, module_name, revision, &module);
     CHECK_RC_LOG_GOTO(rc, cleanup, "Get module %s info failed", module_name);
@@ -3291,15 +3290,26 @@ unlock:
 cleanup:
     pthread_rwlock_unlock(&dm_ctx->schema_tree_lock);
     md_ctx_unlock(dm_ctx->md_ctx);
+    if (SR_ERR_OK == rc) {
+        *implicitly_installed_p = implicitly_installed;
+    } else {
+        md_free_module_key_list(implicitly_installed);
+    }
     return rc;
 }
 
-int
-dm_uninstall_module(dm_ctx_t *dm_ctx, const char *module_name, const char *revision)
+/**
+ * @brief Disables module
+ * @param [in] dm_ctx
+ * @param [in] module_name
+ * @param [in] revision
+ * @return Error code (SR_ERR_OK on success)
+ */
+static int
+dm_uninstall_module_schema(dm_ctx_t *dm_ctx, const char *module_name, const char *revision)
 {
     CHECK_NULL_ARG2(dm_ctx, module_name);
     int rc = SR_ERR_OK;
-    md_module_t *module = NULL;
     dm_schema_info_t lookup = {0};
     dm_schema_info_t *schema_info = NULL;
 
@@ -3330,18 +3340,50 @@ dm_uninstall_module(dm_ctx_t *dm_ctx, const char *module_name, const char *revis
     pthread_rwlock_unlock(&dm_ctx->schema_tree_lock);
 
     CHECK_RC_LOG_RETURN(rc, "Uninstallation of module %s was not successful", module_name);
+    return rc;
+}
+
+int
+dm_uninstall_module(dm_ctx_t *dm_ctx, const char *module_name, const char *revision,
+        sr_list_t **implicitly_removed_p)
+{
+    CHECK_NULL_ARG2(dm_ctx, module_name);
+    int rc = SR_ERR_OK;
+    md_module_t *module = NULL;
+    md_module_key_t *module_key = NULL;
+    sr_list_t *implicitly_removed = NULL;
+
+    /* uninstall context with module schema */
+    rc = dm_uninstall_module_schema(dm_ctx, module_name, revision);
+    if (SR_ERR_OK != rc) {
+        goto cleanup;
+    }
 
     md_ctx_lock(dm_ctx->md_ctx, true);
     rc = md_get_module_info(dm_ctx->md_ctx, module_name, revision, &module);
 
+    /* remove module from the dependency graph */
     if (NULL == module) {
         SR_LOG_ERR("Module %s with revision %s was not found", module_name, revision);
         rc = SR_ERR_NOT_FOUND;
     } else {
-        rc = md_remove_module(dm_ctx->md_ctx, module_name, revision);
+        rc = md_remove_module(dm_ctx->md_ctx, module_name, revision, &implicitly_removed);
+    }
+
+    /* uninstall also modules that were "silently" removed */
+    for (size_t i = 0; rc == SR_ERR_OK && NULL != implicitly_removed && i < implicitly_removed->count; ++i) {
+        module_key = (md_module_key_t *)implicitly_removed->data[i];
+        rc = dm_uninstall_module_schema(dm_ctx, module_key->name, module_key->revision_date);
     }
 
     md_ctx_unlock(dm_ctx->md_ctx);
+
+cleanup:
+    if (SR_ERR_OK == rc) {
+        *implicitly_removed_p = implicitly_removed;
+    } else {
+        md_free_module_key_list(implicitly_removed);
+    }
     return rc;
 }
 

--- a/src/data_manager.h
+++ b/src/data_manager.h
@@ -649,19 +649,23 @@ int dm_feature_enable(dm_ctx_t *dm_ctx, const char *module_name, const char *fea
  * @param [in] module_name
  * @param [in] revision
  * @param [in] file_name Name of the file that should be used for module installation
+ * @param [out] implicitly_installed List of automatically installed modules (import based dependencies).
  * @return Error code (SR_ERR_OK on success), SR_ERR_NOT_FOUND if module
  * is not loaded successfully
  */
-int dm_install_module(dm_ctx_t *dm_ctx, const char *module_name, const char *revision, const char *file_name);
+int dm_install_module(dm_ctx_t *dm_ctx, const char *module_name, const char *revision, const char *file_name,
+        sr_list_t **implicitly_installed);
 
 /**
  * @brief Disables module
  * @param [in] dm_ctx
  * @param [in] module_name
  * @param [in] revision
+ * @param [out] implicitly_removed List of automatically removed modules (import based dependencies).
  * @return Error code (SR_ERR_OK on success)
  */
-int dm_uninstall_module(dm_ctx_t *dm_ctx, const char *module_name, const char *revision);
+int dm_uninstall_module(dm_ctx_t *dm_ctx, const char *module_name, const char *revision,
+        sr_list_t **implicitly_removed);
 
 /**
  * @brief Checks whether the module contains any state data.

--- a/src/module_dependencies.c
+++ b/src/module_dependencies.c
@@ -268,8 +268,10 @@ md_get_module_key(md_module_t *module, md_module_key_t **key_p)
     CHECK_NULL_NOMEM_GOTO(key, rc, cleanup);
     key->name = strdup(module->name);
     CHECK_NULL_NOMEM_GOTO(key->name, rc, cleanup);
-    key->revision_date = strdup(module->revision_date);
-    CHECK_NULL_NOMEM_GOTO(key->revision_date, rc, cleanup);
+    if (0 < strlen(module->revision_date)) {
+        key->revision_date = strdup(module->revision_date);
+        CHECK_NULL_NOMEM_GOTO(key->revision_date, rc, cleanup);
+    }
     key->filepath = strdup(module->filepath);
     CHECK_NULL_NOMEM_GOTO(key->filepath, rc, cleanup);
 

--- a/src/module_dependencies.c
+++ b/src/module_dependencies.c
@@ -254,6 +254,34 @@ md_get_module_fullname(md_module_t *module)
     return module->fullname;
 }
 
+/**
+ * @brief Convert a md_module_t pointer into a string-based reference.
+ */
+static int
+md_get_module_key(md_module_t *module, md_module_key_t **key_p)
+{
+    int rc = SR_ERR_OK;
+    md_module_key_t *key = NULL;
+    CHECK_NULL_ARG2(module, key_p);
+
+    key = calloc(1, sizeof *key);
+    CHECK_NULL_NOMEM_GOTO(key, rc, cleanup);
+    key->name = strdup(module->name);
+    CHECK_NULL_NOMEM_GOTO(key->name, rc, cleanup);
+    key->revision_date = strdup(module->revision_date);
+    CHECK_NULL_NOMEM_GOTO(key->revision_date, rc, cleanup);
+    key->filepath = strdup(module->filepath);
+    CHECK_NULL_NOMEM_GOTO(key->filepath, rc, cleanup);
+
+    *key_p = key;
+
+cleanup:
+    if (SR_ERR_OK != rc) {
+        md_free_module_key(key);
+    }
+    return rc;
+}
+
 /*
  * @brief Compare two module instances.
  */
@@ -453,11 +481,11 @@ md_get_destination_module(md_ctx_t *md_ctx, const struct lys_node *node)
         }
     } while (parent);
 
-    md_module_t module_lkp_key;
-    module_lkp_key.name = (char *)MD_MAIN_MODULE(node)->name;
-    module_lkp_key.revision_date = (char *)md_get_module_revision(MD_MAIN_MODULE(node));
+    md_module_t module_lkp;
+    module_lkp.name = (char *)MD_MAIN_MODULE(node)->name;
+    module_lkp.revision_date = (char *)md_get_module_revision(MD_MAIN_MODULE(node));
 
-    return (md_module_t *)sr_btree_search(md_ctx->modules_btree, &module_lkp_key);
+    return (md_module_t *)sr_btree_search(md_ctx->modules_btree, &module_lkp);
 }
 
 /*
@@ -592,7 +620,7 @@ md_transitive_closure(md_ctx_t *md_ctx)
                      *  (***) For a full validation of module A, the data of module C may be needed to be loaded
                      *        in the same libyang context as A.
                      *
-                     *  -> all scenarios in which there are dependancies between (A,B) and (B,C) but of different
+                     *  -> all scenarios in which there are dependencies between (A,B) and (B,C) but of different
                      *     types, do not create even a potential dependency between (A,C)
                      *  -> A path of extensions implies a path of imports in the opposite direction, hence
                      *     the set of inverses of all extensions is a subgraph of all import dependencies
@@ -626,7 +654,7 @@ md_load_subtree_ref_list(md_ctx_t *md_ctx, const struct lyd_node *source_root, m
 {
     int rc = SR_ERR_INTERNAL;
     const struct lyd_node *node = source_root->child;
-    md_module_t module_lkp_key;
+    md_module_t module_lkp;
     struct lyd_node_leaf_list *leaf = NULL;
     char *xpath = NULL;
     md_subtree_ref_t *subtree_ref = NULL;
@@ -636,8 +664,8 @@ md_load_subtree_ref_list(md_ctx_t *md_ctx, const struct lyd_node *source_root, m
 
     while (node) {
         if (node->schema->name && 0 == strcmp(subtree_name, node->schema->name)) {
-            module_lkp_key.name = NULL;
-            module_lkp_key.revision_date = NULL;
+            module_lkp.name = NULL;
+            module_lkp.revision_date = NULL;
             leaf = (struct lyd_node_leaf_list *)node->child;
             while (leaf) {
                 if (LYS_LEAF & leaf->schema->nodetype) {
@@ -648,20 +676,20 @@ md_load_subtree_ref_list(md_ctx_t *md_ctx, const struct lyd_node *source_root, m
                         xpath = strdup(leaf->value.string);
                         CHECK_NULL_NOMEM_GOTO(xpath, rc, fail);
                     } else if (leaf->schema->name && 0 == strcmp("orig-module-name", leaf->schema->name)) {
-                        module_lkp_key.name = (char *)leaf->value.string;
+                        module_lkp.name = (char *)leaf->value.string;
                     } else if (leaf->schema->name && 0 == strcmp("orig-module-revision", leaf->schema->name)) {
-                        module_lkp_key.revision_date = (char *)leaf->value.string;
+                        module_lkp.revision_date = (char *)leaf->value.string;
                     }
                 }
                 leaf = (struct lyd_node_leaf_list *)leaf->next;
             }
-            if (!xpath || !module_lkp_key.revision_date || !module_lkp_key.name) {
+            if (!xpath || !module_lkp.revision_date || !module_lkp.name) {
                 SR_LOG_ERR("Missing parameter(s) in %s.", subtree_name);
                 goto fail;
             }
-            if (0 != strcmp(dest_module->name, module_lkp_key.name) ||
-                0 != strcmp(dest_module->revision_date, module_lkp_key.revision_date)) {
-                orig_module = (md_module_t *)sr_btree_search(md_ctx->modules_btree, &module_lkp_key);
+            if (0 != strcmp(dest_module->name, module_lkp.name) ||
+                0 != strcmp(dest_module->revision_date, module_lkp.revision_date)) {
+                orig_module = (md_module_t *)sr_btree_search(md_ctx->modules_btree, &module_lkp);
                 if (NULL == orig_module) {
                     SR_LOG_ERR("Failed to resolve origin of %s.", subtree_name);
                     goto fail;
@@ -801,7 +829,7 @@ static int
 md_load_dependency_list(md_ctx_t *md_ctx, const struct lyd_node *source_root, md_module_t *module)
 {
     int rc = SR_ERR_OK;
-    md_module_t module_lkp_key, orig_module_lkp_key;
+    md_module_t module_lkp, orig_module_lkp;
     const struct lyd_node *node = source_root, *child = NULL, *child2 = NULL;
     struct lyd_node_leaf_list *leaf = NULL;
     sr_list_t *orig_modules = NULL;
@@ -817,8 +845,8 @@ md_load_dependency_list(md_ctx_t *md_ctx, const struct lyd_node *source_root, md
     node = node->child;
     while (node) {
         if (node->schema->name && 0 == strcmp("dependency", node->schema->name)) {
-            module_lkp_key.name = NULL;
-            module_lkp_key.revision_date = NULL;
+            module_lkp.name = NULL;
+            module_lkp.revision_date = NULL;
             dep_type = MD_DEP_NONE;
             orig_modules->count = 0; /**< clear the list */
             child = node->child;
@@ -826,9 +854,9 @@ md_load_dependency_list(md_ctx_t *md_ctx, const struct lyd_node *source_root, md
                 if (LYS_LEAF & child->schema->nodetype) {
                     leaf = (struct lyd_node_leaf_list *)child;
                     if (leaf->schema->name && 0 == strcmp("module-name", leaf->schema->name)) {
-                        module_lkp_key.name = (char *)leaf->value.string;
+                        module_lkp.name = (char *)leaf->value.string;
                     } else if (leaf->schema->name && 0 == strcmp("module-revision", leaf->schema->name)) {
-                        module_lkp_key.revision_date = (char *)leaf->value.string;
+                        module_lkp.revision_date = (char *)leaf->value.string;
                     } else if (leaf->schema->name && 0 == strcmp("type", leaf->schema->name)) {
                         dep_type = md_get_dep_type_from_ly(leaf->value.enm);
                     }
@@ -838,24 +866,24 @@ md_load_dependency_list(md_ctx_t *md_ctx, const struct lyd_node *source_root, md
                     child2 = child->child;
                     while (child2) {
                         if (child2->schema->name && 0 == strcmp("orig-module", child2->schema->name)) {
-                            orig_module_lkp_key.name = NULL;
-                            orig_module_lkp_key.revision_date = NULL;
+                            orig_module_lkp.name = NULL;
+                            orig_module_lkp.revision_date = NULL;
                             leaf = (struct lyd_node_leaf_list *)child2->child;
                             while (leaf) {
                                 if (LYS_LEAF & leaf->schema->nodetype) {
                                     if (leaf->schema->name
                                                     && 0 == strcmp("orig-module-name", leaf->schema->name)) {
-                                        orig_module_lkp_key.name = (char *)leaf->value.string;
+                                        orig_module_lkp.name = (char *)leaf->value.string;
                                     } else if (leaf->schema->name
                                                     && 0 == strcmp("orig-module-revision", leaf->schema->name)) {
-                                        orig_module_lkp_key.revision_date = (char *)leaf->value.string;
+                                        orig_module_lkp.revision_date = (char *)leaf->value.string;
                                     }
                                 }
                                 leaf = (struct lyd_node_leaf_list *)leaf->next;
                             }
-                            if (orig_module_lkp_key.name && orig_module_lkp_key.revision_date) {
+                            if (orig_module_lkp.name && orig_module_lkp.revision_date) {
                                 /* resolve dependency originator */
-                                orig_module = (md_module_t *)sr_btree_search(md_ctx->modules_btree, &orig_module_lkp_key);
+                                orig_module = (md_module_t *)sr_btree_search(md_ctx->modules_btree, &orig_module_lkp);
                                 if (NULL == orig_module) {
                                     SR_LOG_ERR_MSG("Failed to resolve dependency originator.");
                                     rc = SR_ERR_INTERNAL;
@@ -870,13 +898,13 @@ md_load_dependency_list(md_ctx_t *md_ctx, const struct lyd_node *source_root, md
                 }
                 child = child->next;
             }
-            if (!module_lkp_key.name || !module_lkp_key.revision_date || MD_DEP_NONE == dep_type) {
+            if (!module_lkp.name || !module_lkp.revision_date || MD_DEP_NONE == dep_type) {
                 SR_LOG_ERR_MSG("Missing parameter of a dependency.");
                 rc = SR_ERR_INTERNAL;
                 goto cleanup;
             }
             /* resolve and insert dependency */
-            dest_module = (md_module_t *)sr_btree_search(md_ctx->modules_btree, &module_lkp_key);
+            dest_module = (md_module_t *)sr_btree_search(md_ctx->modules_btree, &module_lkp);
             if (NULL == dest_module) {
                 SR_LOG_ERR_MSG("Failed to resolve dependency.");
                 rc = SR_ERR_INTERNAL;
@@ -1158,15 +1186,36 @@ md_destroy(md_ctx_t *md_ctx)
     return SR_ERR_OK;
 }
 
+void
+md_free_module_key(md_module_key_t *module_key)
+{
+    if (module_key) {
+        free(module_key->name);
+        free(module_key->revision_date);
+        free(module_key->filepath);
+        free(module_key);
+    }
+}
+
+void
+md_free_module_key_list(sr_list_t *module_key_list)
+{
+    for (size_t i = 0; NULL != module_key_list && i < module_key_list->count; ++i) {
+        md_module_key_t *module_key = (md_module_key_t *)module_key_list->data[i];
+        md_free_module_key(module_key);
+    }
+    sr_list_cleanup(module_key_list);
+}
+
 int
 md_get_module_info(const md_ctx_t *md_ctx, const char *name, const char *revision,
                    md_module_t **module)
 {
-    md_module_t module_lkp_key;
-    module_lkp_key.name = (char *)name;
-    module_lkp_key.revision_date = (char *)revision;
+    md_module_t module_lkp;
+    module_lkp.name = (char *)name;
+    module_lkp.revision_date = (char *)revision;
 
-    *module = (md_module_t *)sr_btree_search(md_ctx->modules_btree, &module_lkp_key);
+    *module = (md_module_t *)sr_btree_search(md_ctx->modules_btree, &module_lkp);
     if (NULL == *module) {
         SR_LOG_ERR("Module '%s@%s' is not present in the dependency graph.",
                    name, revision ? revision : "<latest>");
@@ -1180,21 +1229,21 @@ static md_module_t *
 md_get_imported_module(const md_ctx_t *md_ctx, const struct lys_module *orig_module, const char *name)
 {
     struct lys_module *imp_module = NULL;
-    md_module_t module_lkp_key = { 0, };
+    md_module_t module_lkp = { 0, };
 
     for (size_t i = 0; i < orig_module->imp_size; ++i) {
         imp_module = orig_module->imp[i].module;
         if (0 == strcmp(imp_module->name, name)) {
-            module_lkp_key.name = (char *)imp_module->name;
-            module_lkp_key.revision_date = (char *)md_get_module_revision(imp_module);
+            module_lkp.name = (char *)imp_module->name;
+            module_lkp.revision_date = (char *)md_get_module_revision(imp_module);
             break;
         }
     }
 
-    if (NULL == module_lkp_key.name || NULL == module_lkp_key.revision_date) {
+    if (NULL == module_lkp.name || NULL == module_lkp.revision_date) {
         return NULL;
     }
-    return (md_module_t *)sr_btree_search(md_ctx->modules_btree, &module_lkp_key);
+    return (md_module_t *)sr_btree_search(md_ctx->modules_btree, &module_lkp);
 }
 
 static int
@@ -1560,7 +1609,7 @@ md_traverse_schema_tree(md_ctx_t *md_ctx, md_module_t *module, struct lys_node *
  */
 static int
 md_insert_lys_module(md_ctx_t *md_ctx, const struct lys_module *module_schema, const char *revision, bool dependency,
-                     md_module_t *belongsto)
+                     md_module_t *belongsto, sr_list_t *implicitly_inserted)
 {
     int rc = SR_ERR_INTERNAL, ret = 0;
     bool already_installed = false;
@@ -1570,7 +1619,8 @@ md_insert_lys_module(md_ctx_t *md_ctx, const struct lys_module *module_schema, c
     struct lys_include *inc = NULL;
     struct lys_ident *ident = NULL;
     struct lys_node_augment *augment = NULL;
-    md_module_t module_lkp_key;
+    md_module_t module_lkp = { 0, };
+    md_module_key_t *module_key = NULL;
 
     CHECK_NULL_ARG3(md_ctx, module_schema, revision);
 
@@ -1717,7 +1767,7 @@ dependencies:
             continue;
         }
         rc = md_insert_lys_module(md_ctx, (struct lys_module *)inc->submodule, md_get_inc_revision(inc), true,
-                                  module->submodule ? belongsto : module);
+                                  module->submodule ? belongsto : module, implicitly_inserted);
         if (SR_ERR_OK != rc) {
             goto cleanup;
         }
@@ -1736,7 +1786,7 @@ dependencies:
             /* skip libyang's internal modules */
             continue;
         }
-        rc = md_insert_lys_module(md_ctx, imp->module, md_get_imp_revision(imp), true, NULL);
+        rc = md_insert_lys_module(md_ctx, imp->module, md_get_imp_revision(imp), true, NULL, implicitly_inserted);
         if (SR_ERR_OK != rc) {
             goto cleanup;
         }
@@ -1775,9 +1825,9 @@ dependencies:
             /* skip libyang's internal modules */
             continue;
         }
-        module_lkp_key.name = (char *)imp->module->name;
-        module_lkp_key.revision_date = (char *)md_get_imp_revision(imp);
-        module2 = (md_module_t *)sr_btree_search(md_ctx->modules_btree, &module_lkp_key);
+        module_lkp.name = (char *)imp->module->name;
+        module_lkp.revision_date = (char *)md_get_imp_revision(imp);
+        module2 = (md_module_t *)sr_btree_search(md_ctx->modules_btree, &module_lkp);
         if (NULL == module2) {
             SR_LOG_ERR_MSG("Unable to resolve import dependency.");
             rc = SR_ERR_INTERNAL;
@@ -1804,9 +1854,9 @@ dependencies:
         ident = module_schema->ident + i;
         for (uint8_t b = 0; b < ident->base_size; b++) {
             if (ident->base && module_schema != MD_MAIN_MODULE(ident->base[b])) {
-                module_lkp_key.name = (char *)MD_MAIN_MODULE(ident->base[b])->name;
-                module_lkp_key.revision_date = (char *)md_get_module_revision(MD_MAIN_MODULE(ident->base[b]));
-                module2 = (md_module_t *)sr_btree_search(md_ctx->modules_btree, &module_lkp_key);
+                module_lkp.name = (char *)MD_MAIN_MODULE(ident->base[b])->name;
+                module_lkp.revision_date = (char *)md_get_module_revision(MD_MAIN_MODULE(ident->base[b]));
+                module2 = (md_module_t *)sr_btree_search(md_ctx->modules_btree, &module_lkp);
                 if (NULL == module2) {
                     SR_LOG_ERR_MSG("Unable to resolve dependency induced by a derived identity.");
                     rc = SR_ERR_INTERNAL;
@@ -1835,9 +1885,9 @@ dependencies:
     for (uint32_t i = 0; i < module_schema->augment_size; ++i) {
         augment = module_schema->augment + i;
         if (module_schema != MD_MAIN_MODULE(augment->target)) {
-            module_lkp_key.name = (char *)MD_MAIN_MODULE(augment->target)->name;
-            module_lkp_key.revision_date = (char *)md_get_module_revision(MD_MAIN_MODULE(augment->target));
-            module2 = (md_module_t *)sr_btree_search(md_ctx->modules_btree, &module_lkp_key);
+            module_lkp.name = (char *)MD_MAIN_MODULE(augment->target)->name;
+            module_lkp.revision_date = (char *)md_get_module_revision(MD_MAIN_MODULE(augment->target));
+            module2 = (md_module_t *)sr_btree_search(md_ctx->modules_btree, &module_lkp);
             if (NULL == module2) {
                 SR_LOG_ERR_MSG("Unable to resolve dependency induced by an augment.");
                 rc = SR_ERR_INTERNAL;
@@ -1889,6 +1939,15 @@ dependencies:
         }
     }
 
+    /* inform caller about implicitly installed modules */
+    if (!module->submodule && dependency) {
+        rc = md_get_module_key(module, &module_key);
+        CHECK_RC_MSG_GOTO(rc, cleanup, "md_get_module_key failed");
+        rc = sr_list_add(implicitly_inserted, module_key);
+        CHECK_RC_MSG_GOTO(rc, cleanup, "sr_list_add failed");
+        module_key = NULL;
+    }
+
     if (!already_installed) {
         /* insert the new module into the linked list */
         rc = sr_llist_add_new(md_ctx->modules, module);
@@ -1910,6 +1969,7 @@ dependencies:
     rc = SR_ERR_OK;
 
 cleanup:
+    md_free_module_key(module_key);
     if (!already_installed && module) { /*< not inserted into the btree */
         md_free_module(module);
     }
@@ -1917,11 +1977,15 @@ cleanup:
 }
 
 int
-md_insert_module(md_ctx_t *md_ctx, const char *filepath)
+md_insert_module(md_ctx_t *md_ctx, const char *filepath, sr_list_t **implicitly_inserted_p)
 {
     int rc = SR_ERR_INTERNAL;
     struct ly_ctx *tmp_ly_ctx = NULL;
     const struct lys_module *module_schema = NULL;
+    sr_list_t *implicitly_inserted = NULL;
+
+    rc = sr_list_init(&implicitly_inserted);
+    CHECK_RC_MSG_GOTO(rc, cleanup, "List init failed");
 
     /* Use a separate context for module schema processing */
     tmp_ly_ctx = ly_ctx_new(md_ctx->schema_search_dir);
@@ -1941,7 +2005,8 @@ md_insert_module(md_ctx_t *md_ctx, const char *filepath)
     }
 
     /* insert module into the dependency graph */
-    rc = md_insert_lys_module(md_ctx, module_schema, md_get_module_revision(module_schema), false, NULL);
+    rc = md_insert_lys_module(md_ctx, module_schema, md_get_module_revision(module_schema), false, NULL,
+            implicitly_inserted);
     if (rc != SR_ERR_OK) {
         goto cleanup;
     }
@@ -1952,22 +2017,31 @@ md_insert_module(md_ctx_t *md_ctx, const char *filepath)
         goto cleanup;
     }
 
+    *implicitly_inserted_p = implicitly_inserted;
     rc = SR_ERR_OK;
 
 cleanup:
     if (tmp_ly_ctx) {
         ly_ctx_destroy(tmp_ly_ctx, NULL);
     }
+    if (SR_ERR_OK != rc) {
+        md_free_module_key_list(implicitly_inserted);
+    }
     return rc;
 }
 
-int
-md_remove_module(md_ctx_t *md_ctx, const char *name, const char *revision)
+/**
+ * @brief Try to remove module from the dependency graph and update all the edges.
+ */
+static int
+md_remove_module_internal(md_ctx_t *md_ctx, const char *name, const char *revision, bool force,
+        sr_list_t *implicitly_removed)
 {
     int ret = 0;
     bool submodule = false;
     md_module_t *module = NULL, *module2 = NULL, *latest = NULL, *orig = NULL;
-    md_module_t module_lkp_key;
+    md_module_t module_lkp = { 0, };
+    md_module_key_t *module_key = NULL;
     sr_llist_node_t *module_ll_node = NULL, *tmp_ll_node = NULL;
     sr_llist_node_t *dep_node = NULL, *dep_node2 = NULL, *orig_node = NULL;
     md_dep_t *dep = NULL, *dep2 = NULL;
@@ -1976,12 +2050,13 @@ md_remove_module(md_ctx_t *md_ctx, const char *name, const char *revision)
     const char *dep_name = NULL, *dep_rev = NULL, *orig_name = NULL, *orig_rev = NULL;
     size_t orig_module_cnt = 0;
     md_dep_type_t dep_type = MD_DEP_NONE;
+    int usage_cnt = 0;
     CHECK_NULL_ARG2(md_ctx, name);
 
     /* search for the module */
-    module_lkp_key.name = (char *)name;
-    module_lkp_key.revision_date = (char *)revision;
-    module = (md_module_t *)sr_btree_search(md_ctx->modules_btree, &module_lkp_key);
+    module_lkp.name = (char *)name;
+    module_lkp.revision_date = (char *)revision;
+    module = (md_module_t *)sr_btree_search(md_ctx->modules_btree, &module_lkp);
     if (NULL == module) {
         SR_LOG_ERR("Module '%s@%s' is not present in the dependency graph.",
                    name, revision ? revision : "<latest>");
@@ -1991,7 +2066,7 @@ md_remove_module(md_ctx_t *md_ctx, const char *name, const char *revision)
 
     /* check if this module can be removed */
     dep_node = module->inv_deps->first;
-    while (dep_node) {
+    while (!force && dep_node) {
         dep = (md_dep_t *)dep_node->data;
         if (dep->type == MD_DEP_IMPORT || dep->type == MD_DEP_INCLUDE || dep->type == MD_DEP_DATA) {
             SR_LOG_ERR("Module '%s' cannot be removed as module '%s' depends on it.",
@@ -2025,28 +2100,56 @@ md_remove_module(md_ctx_t *md_ctx, const char *name, const char *revision)
 
     /**
      * Remove all direct edges pointing to this node in the inverse graph.
-     * Also, automatically remove no longer needed submodules.
+     * Also, automatically remove no longer needed (sub)modules.
      */
     dep_node = module->deps->first;
     while (dep_node) {
         dep = (md_dep_t *)dep_node->data;
         if (dep->direct) {
+            usage_cnt = 0;
+            /* get usage count after the removal */
             dep_node2 = dep->dest->inv_deps->first;
             while (dep_node2) {
                 dep2 = (md_dep_t *)dep_node2->data;
-                if (module == dep2->dest) {
-                    sr_llist_cleanup(dep2->orig_modules);
-                    free(dep2);
-                    tmp_ll_node = dep_node2;
-                    dep_node2 = dep_node2->next;
-                    sr_llist_rm(dep->dest->inv_deps, tmp_ll_node);
-                    if (dep->dest->submodule && dep->dest->inv_deps->first == NULL) {
-                        /*no longer needed submodule */
-                        md_remove_module(md_ctx, dep->dest->name, dep->dest->revision_date);
-                    }
-                    continue;
+                if (module != dep2->dest && MD_DEP_EXTENSION != dep2->type) {
+                    ++usage_cnt;
                 }
                 dep_node2 = dep_node2->next;
+            }
+            if (0 == usage_cnt && (dep->dest->submodule || !dep->dest->implemented)) {
+                /* no longer needed (sub)module */
+                if (!dep->dest->submodule) {
+                    ret = md_get_module_key(dep->dest, &module_key);
+                    if (SR_ERR_OK == ret) {
+                        if (SR_ERR_OK != sr_list_add(implicitly_removed, module_key)) {
+                            /* ignore any errors here */
+                            md_free_module_key(module_key);
+                        }
+                    }
+                }
+                md_remove_module_internal(md_ctx, dep->dest->name, dep->dest->revision_date, true,
+                        implicitly_removed);
+                /**
+                 * Restart the iteration. Recursive removal might have invalidated the pointer
+                 * and some successors.
+                 */
+                dep_node = module->deps->first;
+                continue;
+            } else {
+                /* just remove edges pointing to this module */
+                dep_node2 = dep->dest->inv_deps->first;
+                while (dep_node2) {
+                    dep2 = (md_dep_t *)dep_node2->data;
+                    if (module == dep2->dest) {
+                        sr_llist_cleanup(dep2->orig_modules);
+                        free(dep2);
+                        tmp_ll_node = dep_node2;
+                        dep_node2 = dep_node2->next;
+                        sr_llist_rm(dep->dest->inv_deps, tmp_ll_node);
+                        continue;
+                    }
+                    dep_node2 = dep_node2->next;
+                }
             }
         }
         dep_node = dep_node->next;
@@ -2316,6 +2419,26 @@ md_remove_module(md_ctx_t *md_ctx, const char *name, const char *revision)
     }
 
     return SR_ERR_OK;
+}
+
+int
+md_remove_module(md_ctx_t *md_ctx, const char *name, const char *revision, sr_list_t **implicitly_removed_p)
+{
+    int rc = SR_ERR_OK;
+    sr_list_t *implicitly_removed = NULL;
+
+    rc = sr_list_init(&implicitly_removed);
+    CHECK_RC_MSG_RETURN(rc, "List init failed");
+
+    rc = md_remove_module_internal(md_ctx, name, revision, false, implicitly_removed);
+
+    if (SR_ERR_OK == rc) {
+        *implicitly_removed_p = implicitly_removed;
+    } else {
+        md_free_module_key_list(implicitly_removed);
+    }
+
+    return rc;
 }
 
 int

--- a/src/module_dependencies.h
+++ b/src/module_dependencies.h
@@ -98,6 +98,16 @@ typedef struct md_module_s {
     sr_llist_node_t *ll_node;     /**< Pointer to the node in ::md_ctx_t::modules which is used to store this instance. */
 } md_module_t;
 
+/**
+ * brief A string based reference to a module (which may or may not be inserted in the dependency graph),
+ * used by ::md_insert_module and ::md_remove_module.
+ */
+typedef struct md_module_key_s {
+    char *name;
+    char *revision_date;
+    char *filepath;
+} md_module_key_t;
+
 /*
  * @brief Context used to represent complete, transitively-closed, module dependency graph in-memory (using adjacency lists).
  *        If the context is accessed from multiple threads, use ::md_ctx_lock and ::md_ctx_unlock to protect it.
@@ -164,6 +174,20 @@ void md_ctx_unlock(md_ctx_t *md_ctx);
 int md_destroy(md_ctx_t *md_ctx);
 
 /**
+ * @brief Deallocates instance of md_module_key_t structure.
+ *
+ * @param [in] module_key Key to deallocate.
+ */
+void md_free_module_key(md_module_key_t *module_key);
+
+/**
+ * @brief Deallocates a list module keys.
+ *
+ * @param [in] module_key_list List of keys to deallocate.
+ */
+void md_free_module_key_list(sr_list_t *module_key_list);
+
+/**
  * @brief Get dependency-related information for a given (sub)module.
  *        "revision" set to NULL represents the latest revision.
  *
@@ -198,8 +222,10 @@ const char *md_get_module_fullname(md_module_t *module);
  * @param [in] md_ctx Module Dependencies context
  * @param [in] filepath Path leading to the file with the module schema. Should be installed in the repository
  *                      with all its imports.
+ * @param [out] implicitly_inserted A list of modules (not submodules) that were automatically inserted
+ *              (import-based dependencies). Items are pointers to md_module_key_t.
  */
-int md_insert_module(md_ctx_t *md_ctx, const char *filepath);
+int md_insert_module(md_ctx_t *md_ctx, const char *filepath, sr_list_t **implicitly_inserted);
 
 /**
  * @brief Try to remove module from the dependency graph and update all the edges.
@@ -215,8 +241,10 @@ int md_insert_module(md_ctx_t *md_ctx, const char *filepath);
  * @param [in] md_ctx Module Dependencies context
  * @param [in] name Name of the module to remove
  * @param [in] revision Revision of the module to remove, can be empty string
+ * @param [out] implicitly_removed A list of modules (not submodules) that were automatically removed
+ *              (previous import-based dependencies). Items are pointers to md_module_key_t.
  */
-int md_remove_module(md_ctx_t *md_ctx, const char *name, const char *revision);
+int md_remove_module(md_ctx_t *md_ctx, const char *name, const char *revision, sr_list_t **implicitly_removed);
 
 /**
  * @brief Output the in-memory stored dependency graph from the given context into the internal data file

--- a/src/module_dependencies.h
+++ b/src/module_dependencies.h
@@ -181,7 +181,7 @@ int md_destroy(md_ctx_t *md_ctx);
 void md_free_module_key(md_module_key_t *module_key);
 
 /**
- * @brief Deallocates a list module keys.
+ * @brief Deallocates a list of module keys.
  *
  * @param [in] module_key_list List of keys to deallocate.
  */

--- a/src/module_dependencies.h
+++ b/src/module_dependencies.h
@@ -77,6 +77,7 @@ typedef struct md_module_s {
 
     bool latest_revision;         /**< "true" if this is the latest installed revision of this (sub)module. */
     bool submodule;               /**< "true" if this is actually a submodule, "false" in case of a proper module. */
+    bool implemented;             /**< flag if the module is implemented, not just imported */
 
     sr_llist_t *inst_ids;         /**< List of xpaths referencing all instance-identifiers in the module.
                                        Items are of type (md_subtree_ref_t *) (one node subtrees).

--- a/src/notification_processor.c
+++ b/src/notification_processor.c
@@ -590,15 +590,16 @@ cleanup:
 }
 
 int
-np_module_install_notify(np_ctx_t *np_ctx, const char *module_name, const char *revision, bool installed)
+np_module_install_notify(np_ctx_t *np_ctx, const char *module_name, const char *revision,
+        sr_module_state_t state)
 {
     Sr__Msg *notif = NULL;
     int rc = SR_ERR_OK;
 
     CHECK_NULL_ARG2(np_ctx, module_name);
 
-    SR_LOG_DBG("Sending module-install notifications, module_name='%s', revision='%s', installed=%d.",
-            module_name, revision, installed);
+    SR_LOG_DBG("Sending module-install notifications, module_name='%s', revision='%s', state=%s.",
+            module_name, revision, sr_module_state_sr_to_str(state));
 
     pthread_rwlock_rdlock(&np_ctx->lock);
 
@@ -609,7 +610,7 @@ np_module_install_notify(np_ctx_t *np_ctx, const char *module_name, const char *
                     np_ctx->subscriptions[i]->dst_address, np_ctx->subscriptions[i]->dst_id, &notif);
             /* fill-in notification details */
             if (SR_ERR_OK == rc) {
-                notif->notification->module_install_notif->installed = installed;
+                notif->notification->module_install_notif->state = sr_module_state_sr_to_gpb(state);
                 notif->notification->module_install_notif->module_name = strdup(module_name);
                 CHECK_NULL_NOMEM_ERROR(notif->notification->module_install_notif->module_name, rc);
             }

--- a/src/notification_processor.h
+++ b/src/notification_processor.h
@@ -22,6 +22,8 @@
 #ifndef NOTIFICATION_PROCESSOR_H_
 #define NOTIFICATION_PROCESSOR_H_
 
+#include "sysrepo.h"
+
 typedef struct rp_ctx_s rp_ctx_t;          /**< Forward-declaration of Request Processor context. */
 typedef struct rp_session_s rp_session_t;  /**< Forward-declaration of Request Processor session context. */
 typedef struct ac_ucred_s ac_ucred_t;      /**< Forward-declaration of user credentials context. */
@@ -140,11 +142,12 @@ int np_unsubscribe_destination(np_ctx_t *np_ctx, const char *dst_address);
  * @param[in] np_ctx Notification Processor context acquired by ::np_init call.
  * @param[in] module_name Name of the module that has been (un)installed.
  * @param[in] revision Revision of the module that has been (un)installed.
- * @param[in] installed TRUE if the module has been installed, FALSE if uninstalled.
+ * @param[in] state The new state of the module (uninstalled/imported/implemented).
  *
  * @return Error code (SR_ERR_OK on success).
  */
-int np_module_install_notify(np_ctx_t *np_ctx, const char *module_name, const char *revision, bool installed);
+int np_module_install_notify(np_ctx_t *np_ctx, const char *module_name, const char *revision,
+        sr_module_state_t state);
 
 /**
  * @brief Notify all subscribers about the feature enable/disable event.

--- a/src/request_processor.c
+++ b/src/request_processor.c
@@ -256,6 +256,7 @@ rp_module_install_req_process(const rp_ctx_t *rp_ctx, const rp_session_t *sessio
 {
     Sr__Msg *resp = NULL;
     sr_mem_ctx_t *sr_mem = NULL;
+    sr_list_t *implicitly_installed = NULL, *implicitly_removed = NULL;
     int rc = SR_ERR_OK, oper_rc = SR_ERR_OK;
 
     CHECK_NULL_ARG5(rp_ctx, session, msg, msg->request, msg->request->module_install_req);
@@ -284,11 +285,13 @@ rp_module_install_req_process(const rp_ctx_t *rp_ctx, const rp_session_t *sessio
                 dm_install_module(rp_ctx->dm_ctx,
                         msg->request->module_install_req->module_name,
                         msg->request->module_install_req->revision,
-                        msg->request->module_install_req->file_name)
+                        msg->request->module_install_req->file_name,
+                        &implicitly_installed)
                 :
                 dm_uninstall_module(rp_ctx->dm_ctx,
                         msg->request->module_install_req->module_name,
-                        msg->request->module_install_req->revision);
+                        msg->request->module_install_req->revision,
+                        &implicitly_removed);
     }
 
     /* set response code */
@@ -302,6 +305,10 @@ rp_module_install_req_process(const rp_ctx_t *rp_ctx, const rp_session_t *sessio
         rc = np_module_install_notify(rp_ctx->np_ctx, msg->request->module_install_req->module_name,
                 msg->request->module_install_req->revision, msg->request->module_install_req->installed);
     }
+
+    /* cleanup */
+    md_free_module_key_list(implicitly_installed);
+    md_free_module_key_list(implicitly_removed);
 
     return rc;
 }

--- a/src/request_processor.c
+++ b/src/request_processor.c
@@ -256,6 +256,7 @@ rp_module_install_req_process(const rp_ctx_t *rp_ctx, const rp_session_t *sessio
 {
     Sr__Msg *resp = NULL;
     sr_mem_ctx_t *sr_mem = NULL;
+    md_module_key_t *module_key = NULL;
     sr_list_t *implicitly_installed = NULL, *implicitly_removed = NULL;
     int rc = SR_ERR_OK, oper_rc = SR_ERR_OK;
 
@@ -303,7 +304,18 @@ rp_module_install_req_process(const rp_ctx_t *rp_ctx, const rp_session_t *sessio
     /* notify subscribers */
     if (SR_ERR_OK == oper_rc) {
         rc = np_module_install_notify(rp_ctx->np_ctx, msg->request->module_install_req->module_name,
-                msg->request->module_install_req->revision, msg->request->module_install_req->installed);
+                msg->request->module_install_req->revision,
+                msg->request->module_install_req->installed ? SR_MS_IMPLEMENTED : SR_MS_UNINSTALLED);
+        for (size_t i = 0; SR_ERR_OK == rc && NULL != implicitly_installed && i < implicitly_installed->count; ++i) {
+            module_key = (md_module_key_t *)implicitly_installed->data[i];
+            rc = np_module_install_notify(rp_ctx->np_ctx, module_key->name, module_key->revision_date,
+                                          SR_MS_IMPORTED);
+        }
+        for (size_t i = 0; SR_ERR_OK == rc && NULL != implicitly_removed && i < implicitly_removed->count; ++i) {
+            module_key = (md_module_key_t *)implicitly_removed->data[i];
+            rc = np_module_install_notify(rp_ctx->np_ctx, module_key->name, module_key->revision_date,
+                                          SR_MS_UNINSTALLED);
+        }
     }
 
     /* cleanup */

--- a/src/sysrepo.proto
+++ b/src/sysrepo.proto
@@ -592,10 +592,16 @@ message CheckEnabledRunningResp {
   required bool enabled = 1;
 }
 
+enum ModuleState {
+    UNINSTALLED = 1;
+    IMPORTED = 2;
+    IMPLEMENTED = 3;
+}
+
 message ModuleInstallNotification {
   optional string module_name = 1;
   optional string revision = 2;
-  required bool installed = 3;
+  required ModuleState state = 3;
 }
 
 message FeatureEnableNotification {

--- a/swig/cpp/src/Session.cpp
+++ b/swig/cpp/src/Session.cpp
@@ -386,9 +386,9 @@ static int module_change_cb(sr_session_ctx_t *session, const char *module_name, 
     wrap->module_change(sess, module_name, event, wrap->private_ctx["module_change"]);
     return SR_ERR_OK;
 }
-static void module_install_cb(const char *module_name, const char *revision, bool installed, void *private_ctx) {
+static void module_install_cb(const char *module_name, const char *revision, sr_module_state_t state, void *private_ctx) {
     Callback *wrap = (Callback*) private_ctx;
-    return wrap->module_install(module_name, revision, installed, wrap->private_ctx["module_install"]);
+    return wrap->module_install(module_name, revision, state, wrap->private_ctx["module_install"]);
 }
 static void feature_enable_cb(const char *module_name, const char *feature_name, bool enabled, void *private_ctx) {
     Callback *wrap = (Callback*) private_ctx;

--- a/swig/cpp/src/Session.h
+++ b/swig/cpp/src/Session.h
@@ -92,7 +92,7 @@ public:
 
     virtual void module_change(S_Session session, const char *module_name, sr_notif_event_t event, void *private_ctx) {return;};
     virtual void subtree_change(S_Session session, const char *xpath, sr_notif_event_t event, void *private_ctx) {return;};
-    virtual void module_install(const char *module_name, const char *revision, bool installed, void *private_ctx) {return;};
+    virtual void module_install(const char *module_name, const char *revision, sr_module_state_t state, void *private_ctx) {return;};
     virtual void feature_enable(const char *module_name, const char *feature_name, bool enabled, void *private_ctx) {return;};
     virtual void rpc(const char *xpath, S_Vals input, S_Vals_Holder output, void *private_ctx) {return;};
     virtual void rpc_tree(const char *xpath, S_Trees input, S_Trees_Holder output, void *private_ctx) {return;};

--- a/swig/lua51/libsysrepoLua51.i
+++ b/swig/lua51/libsysrepoLua51.i
@@ -68,11 +68,11 @@ public:
         lua_call(fn.L, 4, 0);
     }
 
-    void module_install(const char *module_name, const char *revision, bool installed, void *private_ctx) {
+    void module_install(const char *module_name, const char *revision, sr_module_state_t state, void *private_ctx) {
         swiglua_ref_get(&fn);
         lua_pushstring(fn.L, module_name);
         lua_pushstring(fn.L, revision);
-        lua_pushboolean(fn.L, installed);
+        lua_pushnumber(fn.L, (lua_Number)(int)(state));
         SWIG_NewPointerObj(fn.L, private_ctx, SWIGTYPE_p_void, 0);
         lua_call(fn.L, 4, 0);
     }
@@ -182,10 +182,10 @@ static int g_subtree_change_cb(sr_session_ctx_t *session, const char *xpath, sr_
     return SR_ERR_OK;
 }
 
-static void g_module_install_cb(const char *module_name, const char *revision, bool installed, void *private_ctx)
+static void g_module_install_cb(const char *module_name, const char *revision, sr_module_state_t state, void *private_ctx)
 {
     Wrap_cb *ctx = (Wrap_cb *) private_ctx;
-    ctx->module_install(module_name, revision, installed, ctx->private_ctx);
+    ctx->module_install(module_name, revision, state, ctx->private_ctx);
 }
 
 static void g_feature_enable_cb(const char *module_name, const char *feature_name, bool enabled, void *private_ctx)

--- a/swig/python2/libsysrepoPython2.i
+++ b/swig/python2/libsysrepoPython2.i
@@ -111,10 +111,10 @@ public:
         }
     }
 
-    void module_install(const char *module_name, const char *revision, bool installed, void *private_ctx) {
+    void module_install(const char *module_name, const char *revision, sr_module_state_t state, void *private_ctx) {
         PyObject *arglist;
         PyObject *p =  SWIG_NewPointerObj(private_ctx, SWIGTYPE_p_void, 0);
-        arglist = Py_BuildValue("(ssOO)", module_name, revision, installed ? Py_True: Py_False, p);
+        arglist = Py_BuildValue("(ssOO)", module_name, revision, state, p);
         PyObject *result = PyEval_CallObject(_callback, arglist);
         Py_DECREF(arglist);
         if (result == NULL)
@@ -284,10 +284,10 @@ static int g_subtree_change_cb(sr_session_ctx_t *session, const char *xpath, sr_
     return SR_ERR_OK;
 }
 
-static void g_module_install_cb(const char *module_name, const char *revision, bool installed, void *private_ctx)
+static void g_module_install_cb(const char *module_name, const char *revision, sr_module_state_t state, void *private_ctx)
 {
     Wrap_cb *ctx = (Wrap_cb *) private_ctx;
-    ctx->module_install(module_name, revision, installed, ctx->private_ctx);
+    ctx->module_install(module_name, revision, state, ctx->private_ctx);
 }
 
 static void g_feature_enable_cb(const char *module_name, const char *feature_name, bool enabled, void *private_ctx)

--- a/tests/cl_test.c
+++ b/tests/cl_test.c
@@ -1836,6 +1836,9 @@ cl_notification_test(void **state)
     char file_name[512] = {0};
     snprintf(file_name, 512, "%s%s.yang", SR_SCHEMA_SEARCH_DIR, "example-module");
     /* do some changes */
+    rc = sr_module_install(session, "example-module", NULL, file_name, false);
+    assert_int_equal(rc, SR_ERR_OK);
+
     rc = sr_module_install(session, "example-module", NULL, file_name, true);
     assert_int_equal(rc, SR_ERR_OK);
 

--- a/tests/cl_test.c
+++ b/tests/cl_test.c
@@ -1911,10 +1911,10 @@ cl_notification_test(void **state)
 
     /* wait for all callbacks or timeout after 10 seconds */
     for (size_t i = 0; i < 1000; i++) {
-        if (callback_called >= 7) break;
+        if (callback_called >= 8) break;
         usleep(10000); /* 10 ms */
     }
-    assert_true(callback_called >= 7);
+    assert_true(callback_called == 8);
     callback_called = 0;
 
     /* some negative tests */

--- a/tests/md_test.c
+++ b/tests/md_test.c
@@ -1354,6 +1354,8 @@ md_test_insert_module(void **state)
 {
     int rc;
     md_ctx_t *md_ctx = NULL;
+    md_module_key_t *module_key = NULL;
+    sr_list_t *implicitly_inserted = NULL;
     memset(&inserted, 0, sizeof inserted);
     memset(&implemented, 0, sizeof implemented);
 
@@ -1364,49 +1366,77 @@ md_test_insert_module(void **state)
     validate_context(md_ctx);
 
     /* insert module A */
-    rc = md_insert_module(md_ctx, md_module_A_filepath);
+    rc = md_insert_module(md_ctx, md_module_A_filepath, &implicitly_inserted);
     assert_int_equal(SR_ERR_OK, rc);
     inserted.A = implemented.A = true;
+    assert_int_equal(0, implicitly_inserted->count);
+    sr_list_cleanup(implicitly_inserted);
+    implicitly_inserted = NULL;
     validate_context(md_ctx);
 
     /* try to insert module A again */
-    rc = md_insert_module(md_ctx, md_module_A_filepath);
+    rc = md_insert_module(md_ctx, md_module_A_filepath, &implicitly_inserted);
+    assert_null(implicitly_inserted);
     assert_int_equal(SR_ERR_DATA_EXISTS, rc);
 
     /* insert module B */
-    rc = md_insert_module(md_ctx, md_module_B_filepath);
+    rc = md_insert_module(md_ctx, md_module_B_filepath, &implicitly_inserted);
     assert_int_equal(SR_ERR_OK, rc);
     inserted.B = implemented.B = true;
+    assert_int_equal(0, implicitly_inserted->count);
+    sr_list_cleanup(implicitly_inserted);
+    implicitly_inserted = NULL;
     validate_context(md_ctx);
 
     /* insert module C */
-    rc = md_insert_module(md_ctx, md_module_C_filepath);
+    rc = md_insert_module(md_ctx, md_module_C_filepath, &implicitly_inserted);
     assert_int_equal(SR_ERR_OK, rc);
     inserted.C = implemented.C = true;
+    assert_int_equal(0, implicitly_inserted->count);
+    sr_list_cleanup(implicitly_inserted);
+    implicitly_inserted = NULL;
     validate_context(md_ctx);
 
     /* insert module E-rev1 (D-rev1 should get inserted automatically) */
-    rc = md_insert_module(md_ctx, md_module_E_rev1_filepath);
+    rc = md_insert_module(md_ctx, md_module_E_rev1_filepath, &implicitly_inserted);
     assert_int_equal(SR_ERR_OK, rc);
     inserted.D_rev1 = inserted.E_rev1 = true;
     implemented.E_rev1 = true;
+    assert_int_equal(1, implicitly_inserted->count);
+    module_key = (md_module_key_t *)implicitly_inserted->data[0];
+    assert_string_equal(TEST_MODULE_PREFIX "D", module_key->name);
+    assert_string_equal("2016-06-10", module_key->revision_date);
+    assert_string_equal(md_module_D_rev1_filepath, module_key->filepath);
+    md_free_module_key_list(implicitly_inserted);
+    implicitly_inserted = NULL;
     validate_context(md_ctx);
 
     /* D-rev1 is actually only imported, not implemented */
-    rc = md_insert_module(md_ctx, md_module_D_rev1_filepath);
+    rc = md_insert_module(md_ctx, md_module_D_rev1_filepath, &implicitly_inserted);
     assert_int_equal(SR_ERR_OK, rc);
     implemented.D_rev1 = true;
+    assert_int_equal(0, implicitly_inserted->count);
+    sr_list_cleanup(implicitly_inserted);
+    implicitly_inserted = NULL;
     validate_context(md_ctx);
 
     /* D-rev1 is now really implemented */
-    rc = md_insert_module(md_ctx, md_module_D_rev1_filepath);
+    rc = md_insert_module(md_ctx, md_module_D_rev1_filepath, &implicitly_inserted);
     assert_int_equal(SR_ERR_DATA_EXISTS, rc);
+    assert_null(implicitly_inserted);
 
     /* insert module E-rev2 (D-rev2 should get inserted automatically) */
-    rc = md_insert_module(md_ctx, md_module_E_rev2_filepath);
+    rc = md_insert_module(md_ctx, md_module_E_rev2_filepath, &implicitly_inserted);
     assert_int_equal(SR_ERR_OK, rc);
     inserted.D_rev2 = inserted.E_rev2 = true;
     implemented.E_rev2 = true;
+    assert_int_equal(1, implicitly_inserted->count);
+    module_key = (md_module_key_t *)implicitly_inserted->data[0];
+    assert_string_equal(TEST_MODULE_PREFIX "D", module_key->name);
+    assert_string_equal("2016-06-20", module_key->revision_date);
+    assert_string_equal(md_module_D_rev2_filepath, module_key->filepath);
+    md_free_module_key_list(implicitly_inserted);
+    implicitly_inserted = NULL;
     validate_context(md_ctx);
 
     /* flush changes into the internal data file */
@@ -1438,6 +1468,8 @@ md_test_remove_module(void **state)
 {
     int rc;
     md_ctx_t *md_ctx = NULL;
+    sr_list_t *implicitly_removed = NULL;
+    md_module_key_t *module_key = NULL;
     memset(&inserted, 1, sizeof inserted);
     memset(&implemented, 1, sizeof implemented);
     implemented.D_rev2 = false;
@@ -1449,72 +1481,104 @@ md_test_remove_module(void **state)
     validate_context(md_ctx);
 
     /* there is no module named F */
-    rc = md_remove_module(md_ctx, TEST_MODULE_PREFIX "F", NULL);
+    rc = md_remove_module(md_ctx, TEST_MODULE_PREFIX "F", NULL, &implicitly_removed);
     assert_int_equal(SR_ERR_NOT_FOUND, rc);
+    assert_null(implicitly_removed);
 
     /* initialy only the module E can be removed (both rev1, rev2) */
-    rc = md_remove_module(md_ctx, TEST_MODULE_PREFIX "A", NULL);
+    rc = md_remove_module(md_ctx, TEST_MODULE_PREFIX "A", NULL, &implicitly_removed);
     assert_int_equal(SR_ERR_INVAL_ARG, rc);
-    rc = md_remove_module(md_ctx, TEST_MODULE_PREFIX "B", NULL);
+    assert_null(implicitly_removed);
+    rc = md_remove_module(md_ctx, TEST_MODULE_PREFIX "B", NULL, &implicitly_removed);
     assert_int_equal(SR_ERR_INVAL_ARG, rc);
-    rc = md_remove_module(md_ctx, TEST_MODULE_PREFIX "C", NULL);
+    assert_null(implicitly_removed);
+    rc = md_remove_module(md_ctx, TEST_MODULE_PREFIX "C", NULL, &implicitly_removed);
     assert_int_equal(SR_ERR_INVAL_ARG, rc);
-    rc = md_remove_module(md_ctx, TEST_MODULE_PREFIX "D", "2016-06-10");
+    assert_null(implicitly_removed);
+    rc = md_remove_module(md_ctx, TEST_MODULE_PREFIX "D", "2016-06-10", &implicitly_removed);
     assert_int_equal(SR_ERR_INVAL_ARG, rc);
-    rc = md_remove_module(md_ctx, TEST_MODULE_PREFIX "D", "2016-06-20");
+    assert_null(implicitly_removed);
+    rc = md_remove_module(md_ctx, TEST_MODULE_PREFIX "D", "2016-06-20", &implicitly_removed);
     assert_int_equal(SR_ERR_INVAL_ARG, rc);
+    assert_null(implicitly_removed);
 
-    /* remove module E-rev2 */
-    rc = md_remove_module(md_ctx, TEST_MODULE_PREFIX "E", "2016-06-21");
+    /* remove module E-rev2 (D-rev2 should get removed automatically) */
+    rc = md_remove_module(md_ctx, TEST_MODULE_PREFIX "E", "2016-06-21", &implicitly_removed);
     assert_int_equal(SR_ERR_OK, rc);
     inserted.E_rev2 = implemented.E_rev2 = false;
+    inserted.D_rev2 = false;
+    assert_int_equal(1, implicitly_removed->count);
+    module_key = (md_module_key_t *)implicitly_removed->data[0];
+    assert_string_equal(TEST_MODULE_PREFIX "D", module_key->name);
+    assert_string_equal("2016-06-20", module_key->revision_date);
+    assert_string_equal(md_module_D_rev2_filepath, module_key->filepath);
+    md_free_module_key_list(implicitly_removed);
+    implicitly_removed = NULL;
     validate_context(md_ctx);
 
-    /* remove module D-rev2 */
-    rc = md_remove_module(md_ctx, TEST_MODULE_PREFIX "D", "2016-06-20");
-    assert_int_equal(SR_ERR_OK, rc);
-    inserted.D_rev2 = false;
-    validate_context(md_ctx);
+    /* D-rev2 is already removed */
+    rc = md_remove_module(md_ctx, TEST_MODULE_PREFIX "D", "2016-06-20", &implicitly_removed);
+    assert_int_equal(SR_ERR_NOT_FOUND, rc);
+    assert_null(implicitly_removed);
 
     /* now there are no modules dependent on B, remove it */
-    rc = md_remove_module(md_ctx, TEST_MODULE_PREFIX "B", ""); /*< try "" instead of NULL */
+    rc = md_remove_module(md_ctx, TEST_MODULE_PREFIX "B", "", &implicitly_removed); /*< try "" instead of NULL */
     assert_int_equal(SR_ERR_OK, rc);
+    assert_int_equal(0, implicitly_removed->count);
+    sr_list_cleanup(implicitly_removed);
+    implicitly_removed = NULL;
     inserted.B = implemented.B =false;
     validate_context(md_ctx);
 
     /* still can't remove A, C, D-rev1 */
-    rc = md_remove_module(md_ctx, TEST_MODULE_PREFIX "A", NULL);
+    rc = md_remove_module(md_ctx, TEST_MODULE_PREFIX "A", NULL, &implicitly_removed);
     assert_int_equal(SR_ERR_INVAL_ARG, rc);
-    rc = md_remove_module(md_ctx, TEST_MODULE_PREFIX "C", NULL);
+    assert_null(implicitly_removed);
+    rc = md_remove_module(md_ctx, TEST_MODULE_PREFIX "C", NULL, &implicitly_removed);
     assert_int_equal(SR_ERR_INVAL_ARG, rc);
-    rc = md_remove_module(md_ctx, TEST_MODULE_PREFIX "D", "2016-06-10");
+    assert_null(implicitly_removed);
+    rc = md_remove_module(md_ctx, TEST_MODULE_PREFIX "D", "2016-06-10", &implicitly_removed);
     assert_int_equal(SR_ERR_INVAL_ARG, rc);
+    assert_null(implicitly_removed);
 
     /* B is not present anymore */
-    rc = md_remove_module(md_ctx, TEST_MODULE_PREFIX "B", NULL);
+    rc = md_remove_module(md_ctx, TEST_MODULE_PREFIX "B", NULL, &implicitly_removed);
     assert_int_equal(SR_ERR_NOT_FOUND, rc);
+    assert_null(implicitly_removed);
 
     /* remove module E-rev1 */
-    rc = md_remove_module(md_ctx, TEST_MODULE_PREFIX "E", "2016-06-11");
+    rc = md_remove_module(md_ctx, TEST_MODULE_PREFIX "E", "2016-06-11", &implicitly_removed);
     assert_int_equal(SR_ERR_OK, rc);
+    assert_int_equal(0, implicitly_removed->count);
+    sr_list_cleanup(implicitly_removed);
+    implicitly_removed = NULL;
     inserted.E_rev1 = implemented.E_rev1 = false;
     validate_context(md_ctx);
 
     /* remove module D-rev1 */
-    rc = md_remove_module(md_ctx, TEST_MODULE_PREFIX "D", "2016-06-10");
+    rc = md_remove_module(md_ctx, TEST_MODULE_PREFIX "D", "2016-06-10", &implicitly_removed);
     assert_int_equal(SR_ERR_OK, rc);
+    assert_int_equal(0, implicitly_removed->count);
+    sr_list_cleanup(implicitly_removed);
+    implicitly_removed = NULL;
     inserted.D_rev1 = implemented.D_rev1 = false;
     validate_context(md_ctx);
 
     /* remove module C */
-    rc = md_remove_module(md_ctx, TEST_MODULE_PREFIX "C", NULL);
+    rc = md_remove_module(md_ctx, TEST_MODULE_PREFIX "C", NULL, &implicitly_removed);
     assert_int_equal(SR_ERR_OK, rc);
+    assert_int_equal(0, implicitly_removed->count);
+    sr_list_cleanup(implicitly_removed);
+    implicitly_removed = NULL;
     inserted.C = implemented.C = false;
     validate_context(md_ctx);
 
     /* finally remove module A */
-    rc = md_remove_module(md_ctx, TEST_MODULE_PREFIX "A", NULL);
+    rc = md_remove_module(md_ctx, TEST_MODULE_PREFIX "A", NULL, &implicitly_removed);
     assert_int_equal(SR_ERR_OK, rc);
+    assert_int_equal(0, implicitly_removed->count);
+    sr_list_cleanup(implicitly_removed);
+    implicitly_removed = NULL;
     inserted.A = implemented.A = false;
     validate_context(md_ctx);
 

--- a/tests/md_test.c
+++ b/tests/md_test.c
@@ -39,6 +39,7 @@ typedef struct md_test_inserted_modules_s {
 } md_test_inserted_modules_t;
 
 md_test_inserted_modules_t inserted;
+md_test_inserted_modules_t implemented; /**< inserted AND implemented */
 
 typedef struct md_test_dep_s {
     md_dep_type_t type;
@@ -771,6 +772,11 @@ validate_context(md_ctx_t *md_ctx)
         assert_string_equal("urn:ietf:params:xml:ns:yang:A", module->ns);
         assert_string_equal(md_module_A_filepath, module->filepath);
         assert_true(module->latest_revision);
+        if (implemented.A) {
+            assert_true(module->implemented);
+        } else {
+            assert_false(module->implemented);
+        }
         /* inst_ids */
         check_list_size(module->inst_ids, inserted.B + inserted.D_rev1 + 2*inserted.D_rev2);
         validate_subtree_ref(md_ctx, module->inst_ids,
@@ -852,6 +858,11 @@ validate_context(md_ctx_t *md_ctx)
         assert_string_equal("urn:ietf:params:xml:ns:yang:B", module->ns);
         assert_string_equal(md_module_B_filepath, module->filepath);
         assert_true(module->latest_revision);
+        if (implemented.B) {
+            assert_true(module->implemented);
+        } else {
+            assert_false(module->implemented);
+        }
         /* inst_ids */
         check_list_size(module->inst_ids, 1);
         validate_subtree_ref(md_ctx, module->inst_ids, "/" TEST_MODULE_PREFIX "B:inst-ids/inst-id", "B");
@@ -914,6 +925,11 @@ validate_context(md_ctx_t *md_ctx)
         assert_string_equal("", module->ns);
         assert_string_equal(md_submodule_B_sub1_filepath, module->filepath);
         assert_true(module->latest_revision);
+        if (implemented.B) {
+            assert_true(module->implemented);
+        } else {
+            assert_false(module->implemented);
+        }
         /* inst_ids */
         check_list_size(module->inst_ids, 0);
         /* op_data_subtrees */
@@ -942,6 +958,11 @@ validate_context(md_ctx_t *md_ctx)
         assert_string_equal("", module->ns);
         assert_string_equal(md_submodule_B_sub2_filepath, module->filepath);
         assert_true(module->latest_revision);
+        if (implemented.B) {
+            assert_true(module->implemented);
+        } else {
+            assert_false(module->implemented);
+        }
         /* inst_ids */
         check_list_size(module->inst_ids, 0);
         /* op_data_subtrees */
@@ -970,6 +991,11 @@ validate_context(md_ctx_t *md_ctx)
         assert_string_equal("", module->ns);
         assert_string_equal(md_submodule_B_sub3_filepath, module->filepath);
         assert_true(module->latest_revision);
+        if (implemented.B) {
+            assert_true(module->implemented);
+        } else {
+            assert_false(module->implemented);
+        }
         /* inst_ids */
         check_list_size(module->inst_ids, 0);
         /* op_data_subtrees */
@@ -998,6 +1024,11 @@ validate_context(md_ctx_t *md_ctx)
         assert_string_equal("urn:ietf:params:xml:ns:yang:C", module->ns);
         assert_string_equal(md_module_C_filepath, module->filepath);
         assert_true(module->latest_revision);
+        if (implemented.C) {
+            assert_true(module->implemented);
+        } else {
+            assert_false(module->implemented);
+        }
         /* inst_ids */
         check_list_size(module->inst_ids, 2);
         validate_subtree_ref(md_ctx, module->inst_ids, "/" TEST_MODULE_PREFIX "C:inst-id1", "C");
@@ -1056,6 +1087,11 @@ validate_context(md_ctx_t *md_ctx)
         } else {
             assert_true(module->latest_revision);
         }
+        if (implemented.D_rev1) {
+            assert_true(module->implemented);
+        } else {
+            assert_false(module->implemented);
+        }
         /* inst_ids */
         check_list_size(module->inst_ids, 0);
         /* op_data_subtrees */
@@ -1107,6 +1143,11 @@ validate_context(md_ctx_t *md_ctx)
         assert_string_equal("urn:ietf:params:xml:ns:yang:D", module->ns);
         assert_string_equal(md_module_D_rev2_filepath, module->filepath);
         assert_true(module->latest_revision);
+        if (implemented.D_rev2) {
+            assert_true(module->implemented);
+        } else {
+            assert_false(module->implemented);
+        }
         /* inst_ids */
         check_list_size(module->inst_ids, 0);
         /* op_data_subtrees */
@@ -1154,6 +1195,11 @@ validate_context(md_ctx_t *md_ctx)
         assert_string_equal("", module->ns);
         assert_string_equal(md_submodule_D_common_filepath, module->filepath);
         assert_true(module->latest_revision);
+        if (implemented.D_rev1 || implemented.D_rev2) {
+            assert_true(module->implemented);
+        } else {
+            assert_false(module->implemented);
+        }
         /* inst_ids */
         check_list_size(module->inst_ids, 0);
         /* op_data_subtrees */
@@ -1186,6 +1232,11 @@ validate_context(md_ctx_t *md_ctx)
             assert_false(module->latest_revision);
         } else {
             assert_true(module->latest_revision);
+        }
+        if (implemented.E_rev1) {
+            assert_true(module->implemented);
+        } else {
+            assert_false(module->implemented);
         }
         /* inst_ids */
         check_list_size(module->inst_ids, 1);
@@ -1243,6 +1294,11 @@ validate_context(md_ctx_t *md_ctx)
         assert_string_equal("urn:ietf:params:xml:ns:yang:E", module->ns);
         assert_string_equal(md_module_E_rev2_filepath, module->filepath);
         assert_true(module->latest_revision);
+        if (implemented.E_rev2) {
+            assert_true(module->implemented);
+        } else {
+            assert_false(module->implemented);
+        }
         /* inst_ids */
         check_list_size(module->inst_ids, 1);
         validate_subtree_ref(md_ctx, module->inst_ids, "/" TEST_MODULE_PREFIX "E:inst-id-list/inst-id", "E@2016-06-21");
@@ -1299,6 +1355,7 @@ md_test_insert_module(void **state)
     int rc;
     md_ctx_t *md_ctx = NULL;
     memset(&inserted, 0, sizeof inserted);
+    memset(&implemented, 0, sizeof implemented);
 
     /* initialize context */
     rc = md_init(TEST_SCHEMA_SEARCH_DIR, TEST_SCHEMA_SEARCH_DIR "internal/",
@@ -1309,31 +1366,47 @@ md_test_insert_module(void **state)
     /* insert module A */
     rc = md_insert_module(md_ctx, md_module_A_filepath);
     assert_int_equal(SR_ERR_OK, rc);
-    inserted.A = true;
+    inserted.A = implemented.A = true;
     validate_context(md_ctx);
+
+    /* try to insert module A again */
+    rc = md_insert_module(md_ctx, md_module_A_filepath);
+    assert_int_equal(SR_ERR_DATA_EXISTS, rc);
 
     /* insert module B */
     rc = md_insert_module(md_ctx, md_module_B_filepath);
     assert_int_equal(SR_ERR_OK, rc);
-    inserted.B = true;
+    inserted.B = implemented.B = true;
     validate_context(md_ctx);
 
     /* insert module C */
     rc = md_insert_module(md_ctx, md_module_C_filepath);
     assert_int_equal(SR_ERR_OK, rc);
-    inserted.C = true;
+    inserted.C = implemented.C = true;
     validate_context(md_ctx);
 
     /* insert module E-rev1 (D-rev1 should get inserted automatically) */
     rc = md_insert_module(md_ctx, md_module_E_rev1_filepath);
     assert_int_equal(SR_ERR_OK, rc);
     inserted.D_rev1 = inserted.E_rev1 = true;
+    implemented.E_rev1 = true;
     validate_context(md_ctx);
+
+    /* D-rev1 is actually only imported, not implemented */
+    rc = md_insert_module(md_ctx, md_module_D_rev1_filepath);
+    assert_int_equal(SR_ERR_OK, rc);
+    implemented.D_rev1 = true;
+    validate_context(md_ctx);
+
+    /* D-rev1 is now really implemented */
+    rc = md_insert_module(md_ctx, md_module_D_rev1_filepath);
+    assert_int_equal(SR_ERR_DATA_EXISTS, rc);
 
     /* insert module E-rev2 (D-rev2 should get inserted automatically) */
     rc = md_insert_module(md_ctx, md_module_E_rev2_filepath);
     assert_int_equal(SR_ERR_OK, rc);
     inserted.D_rev2 = inserted.E_rev2 = true;
+    implemented.E_rev2 = true;
     validate_context(md_ctx);
 
     /* flush changes into the internal data file */
@@ -1366,6 +1439,8 @@ md_test_remove_module(void **state)
     int rc;
     md_ctx_t *md_ctx = NULL;
     memset(&inserted, 1, sizeof inserted);
+    memset(&implemented, 1, sizeof implemented);
+    implemented.D_rev2 = false;
 
     /* initialize context */
     rc = md_init(TEST_SCHEMA_SEARCH_DIR, TEST_SCHEMA_SEARCH_DIR "internal/",
@@ -1392,7 +1467,7 @@ md_test_remove_module(void **state)
     /* remove module E-rev2 */
     rc = md_remove_module(md_ctx, TEST_MODULE_PREFIX "E", "2016-06-21");
     assert_int_equal(SR_ERR_OK, rc);
-    inserted.E_rev2 = false;
+    inserted.E_rev2 = implemented.E_rev2 = false;
     validate_context(md_ctx);
 
     /* remove module D-rev2 */
@@ -1404,7 +1479,7 @@ md_test_remove_module(void **state)
     /* now there are no modules dependent on B, remove it */
     rc = md_remove_module(md_ctx, TEST_MODULE_PREFIX "B", ""); /*< try "" instead of NULL */
     assert_int_equal(SR_ERR_OK, rc);
-    inserted.B = false;
+    inserted.B = implemented.B =false;
     validate_context(md_ctx);
 
     /* still can't remove A, C, D-rev1 */
@@ -1422,25 +1497,25 @@ md_test_remove_module(void **state)
     /* remove module E-rev1 */
     rc = md_remove_module(md_ctx, TEST_MODULE_PREFIX "E", "2016-06-11");
     assert_int_equal(SR_ERR_OK, rc);
-    inserted.E_rev1 = false;
+    inserted.E_rev1 = implemented.E_rev1 = false;
     validate_context(md_ctx);
 
     /* remove module D-rev1 */
     rc = md_remove_module(md_ctx, TEST_MODULE_PREFIX "D", "2016-06-10");
     assert_int_equal(SR_ERR_OK, rc);
-    inserted.D_rev1 = false;
+    inserted.D_rev1 = implemented.D_rev1 = false;
     validate_context(md_ctx);
 
     /* remove module C */
     rc = md_remove_module(md_ctx, TEST_MODULE_PREFIX "C", NULL);
     assert_int_equal(SR_ERR_OK, rc);
-    inserted.C = false;
+    inserted.C = implemented.C = false;
     validate_context(md_ctx);
 
     /* finally remove module A */
     rc = md_remove_module(md_ctx, TEST_MODULE_PREFIX "A", NULL);
     assert_int_equal(SR_ERR_OK, rc);
-    inserted.A = false;
+    inserted.A = implemented.A = false;
     validate_context(md_ctx);
 
     /* flush changes into the internal data file */

--- a/tests/sysrepoctl_test.c
+++ b/tests/sysrepoctl_test.c
@@ -263,9 +263,9 @@ sysrepoctl_test_init(void **state)
                                    TEST_SCHEMA_SEARCH_DIR ".ietf-interfaces@2014-05-08.yang.bkp");
     exec_shell_command(buff, ".*", true, 0);
 
-    /* first uninstall ietf-interfaces (and ietf-ip which depends on it) */
+    /* first uninstall ietf-ip (and automatically also ietf-interfaces which was only imported) */
     exec_shell_command("../src/sysrepoctl --uninstall --module=ietf-ip --revision=2014-06-16", ".*", true, 0);
-    exec_shell_command("../src/sysrepoctl --uninstall --module=ietf-interfaces --revision=2014-05-08", ".*", true, 0);
+    test_file_exists(TEST_SCHEMA_SEARCH_DIR "ietf-interfaces@2014-05-08.yang", false);
 
     /* revert the ietf-interfaces schema file */
     snprintf(buff, PATH_MAX, "mv " TEST_SCHEMA_SEARCH_DIR ".ietf-interfaces@2014-05-08.yang.bkp "

--- a/yang/sysrepo-module-dependencies.yang
+++ b/yang/sysrepo-module-dependencies.yang
@@ -61,6 +61,11 @@ module sysrepo-module-dependencies {
         description "TRUE if this is only submodule, FALSE in case of a proper module.";
     }
 
+    leaf implemented {
+        type boolean;
+        description "TRUE if this module is implemented and not just imported.";
+    }
+
     container dependencies {
       description "List of dependencies. Only direct (non-transitive) dependencies are stored in the data file.";
 


### PR DESCRIPTION
Sysrepo now differentiates between explicitly installed modules and modules that were automatically installed as import-based dependencies. A new flag was added to `struct sr_schema_s`: `implemented`, which is set to  `true` only if the module was explicitly installed. `sr_module_install_cb()` now instead of `bool installed` returns enumerated type `sr_module_state_t`, which is one of the `SR_MS_UNINSTALLED`, `SR_MS_IMPORTED` and `SR_MD_IMPLEMENTED`.
Imported module may become implemented using `sysrepoctl --install`. Already implemented module cannot be installed again (sysrepoctl will return error), it needs to be first uninstalled and then installed in order to achieve re-installation.
Also, sysrepoctl will automatically uninstall module which was only imported and (after removal of another module) is no longer used.
Meanwhile, the behaviour of data editing remains the same -- even data of only imported modules can be changed and retrieved. While it is not quite in-sync with libyang, we do not want to confuse users for no added benefits.
