### PR TITLE
Do not leak memory from Session::get_item

### DIFF
--- a/swig/cpp/src/Session.cpp
+++ b/swig/cpp/src/Session.cpp
@@ -154,11 +154,10 @@ S_Schema_Content Session::get_schema(const char *module_name, const char *revisi
 
 S_Val Session::get_item(const char *xpath)
 {
-    S_Val value(new Val());
-    if (value == NULL) throw_exception(SR_ERR_NOMEM);
-
-    int ret = sr_get_item(_sess, xpath, value->p_get());
+    sr_val_t *val;
+    int ret = sr_get_item(_sess, xpath, &val);
     if (SR_ERR_OK == ret) {
+        S_Val value(new Val(val, std::make_shared<Deleter>(val)));
         return value;
     } else if (SR_ERR_NOT_FOUND == ret) {
         return NULL;


### PR DESCRIPTION
As reported by ASAN when disabling custom memory management:
```
  Direct leak of 32 byte(s) in 1 object(s) allocated from:
    #0 0x5041c5 in calloc /var/tmp/portage/sys-devel/llvm-3.9.0/work/llvm-3.9.0.src/projects/compiler-rt/lib/asan/asan_malloc_linux.cc:72
    #1 0x7f81aefd5726 in sr_calloc /home/jkt/work/prog/sysrepo/build/../src/common/sr_mem_mgmt.c:290:16
    #2 0x7f81aefbecdb in sr_dup_gpb_to_val_t /home/jkt/work/prog/sysrepo/build/../src/common/sr_protobuf.c:1486:11
    #3 0x7f81af1b7a72 in sr_get_item /home/jkt/work/prog/sysrepo/build/../src/clientlib/client_library.c:826:10
    #4 0x7f81b0897ef3 in Session::get_item(char const*) /home/jkt/work/prog/sysrepo/build/../swig/cpp/src/Session.cpp:160:15
    #5 0x54e40e in ____C_A_T_C_H____T_E_S_T____17()
```
The old code was creating an empty Val and manipulating its underlying
storage without setting a corresponding deleter. It seems to me that any
code which uses Val::p_get (which is only Session::get_item_next now) is
broken in the same manner. This patch is not touching that part because
I do not use it and therefore have no way of testing it.

The code is complicated because the Lua bindings typedef the S_Val to a
naked, raw Val* rather than the usual std::shared_ptr<Val>. This makes
the code much harder to reason about. It also necessitates that
strangely looking pattern of creating a local variable just to return
it.

This patch also removes a check for operator new returning nullptr. That
never happens on a standard-compliant compiler because allocation
failures are reported as std::bad_alloc. Because the code already relies
on exceptions, I don't see much point in changing each and every
operator new to [1] just to translate from std::bad_alloc to an
exception wraping SR_ERR_NOMEM.

[1] http://en.cppreference.com/w/cpp/memory/new/nothrow