### PR TITLE
Enable returning operational values from C++ callbacks

### DIFF
--- a/swig/cpp/src/Session.cpp
+++ b/swig/cpp/src/Session.cpp
@@ -424,7 +424,7 @@ static void event_notif_tree_cb(const char *xpath, const sr_node_t *trees, const
     return wrap->event_notif_tree(xpath, vals, wrap->private_ctx["event_notif_tree"]);
 }
 static int dp_get_items_cb(const char *xpath, sr_val_t **values, size_t *values_cnt, void *private_ctx) {
-    S_Vals vals(new Vals(values, values_cnt, NULL));
+    S_Vals_Holder vals(new Vals_Holder(values, values_cnt));
     Callback *wrap = (Callback*) private_ctx;
     wrap->dp_get_items(xpath, vals, wrap->private_ctx["dp_get_items"]);
     return SR_ERR_OK;

--- a/swig/cpp/src/Session.h
+++ b/swig/cpp/src/Session.h
@@ -96,7 +96,7 @@ public:
     virtual void feature_enable(const char *module_name, const char *feature_name, bool enabled, void *private_ctx) {return;};
     virtual void rpc(const char *xpath, S_Vals input, S_Vals_Holder output, void *private_ctx) {return;};
     virtual void rpc_tree(const char *xpath, S_Trees input, S_Trees_Holder output, void *private_ctx) {return;};
-    virtual void dp_get_items(const char *xpath, S_Vals vals, void *private_ctx) {return;};
+    virtual void dp_get_items(const char *xpath, S_Vals_Holder vals, void *private_ctx) {return;};
     virtual void event_notif(const char *xpath, S_Vals vals, void *private_ctx) {return;};
     virtual void event_notif_tree(const char *xpath, S_Trees trees, void *private_ctx) {return;};
     Callback *get() {return this;};


### PR DESCRIPTION
``Vals`` doesn't allow its users from adding any data; we need to use
``Vals_Holder`` in this context, similar to what the RPC code is doing with
``out_vals``.