### PR TITLE
Install the C++ headers

### DIFF
--- a/swig/CMakeLists.txt
+++ b/swig/CMakeLists.txt
@@ -178,6 +178,8 @@ endif()
 
 # install binary
 install(TARGETS Sysrepo-cpp DESTINATION ${LIB_INSTALL_DIR})
+install(DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/cpp/src/" DESTINATION ${INCLUDE_INSTALL_DIR}/sysrepo-cpp
+    FILES_MATCHING PATTERN "*.h")
 
 # Examples
 if(GEN_CPP_BINDINGS AND BUILD_CPP_EXAMPLES)


### PR DESCRIPTION
I'm not installing directly to include/sysrepo because the include setup
is a bit weird. There's an include/sysrepo/*.h and include/sysrepo.h,
and the include paths not necessarily reflect all that.

Long term, I would like the C++ headers to use better include paths,
such as sysrepo/Foo.h, but that would require some shuffling around and
SWIG updates, and it's too late in the evening for them now.