### PR TITLE
tests: Fix a stack buffer overflow

### DIFF
--- a/src/executables/sysrepocfg.c
+++ b/src/executables/sysrepocfg.c
@@ -933,7 +933,7 @@ cleanup:
 static int
 srcfg_prompt(const char *question, const char *positive, const char *negative)
 {
-    char input[PATH_MAX] = { 0, };
+    char input[PATH_MAX + 1] = { 0, };
     int ret = 0;
 
     CHECK_NULL_ARG3(question, positive, negative);


### PR DESCRIPTION
When using the length argument for scanf's %s formatting option, the
target buffer needs to have space for the terminating null character as
well.

This fixes the first part of #551. The underflow, however, is still
there.