### PR TITLE
cmake: RelWithDebugInfo is not a debug build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,8 +42,14 @@ endif()
 
 set(PLUGINS_DIR "${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}/sysrepo/plugins/" CACHE PATH "Sysrepo plugins directory.")
 
+if(CMAKE_BUILD_TYPE_LOWER MATCHES "debug" AND NOT CMAKE_BUILD_TYPE_LOWER MATCHES "^rel")
+    set(IS_DEBUG_BUILD true)
+else()
+    set(IS_DEBUG_BUILD false)
+endif()
+
 # set build-type specific settings
-if(CMAKE_BUILD_TYPE_LOWER MATCHES "debug")
+if(${IS_DEBUG_BUILD})
     MESSAGE(STATUS "Preparing debug build of sysrepo v. ${SYSREPO_VERSION}")
     set(DAEMON_PID_FILE "/tmp/sysrepod.pid" CACHE PATH "Sysrepo daemon PID file.")
     set(DAEMON_SOCKET "/tmp/sysrepod.sock" CACHE PATH "Sysrepo deamon server socket path.")
@@ -58,7 +64,7 @@ else()
 endif()
 
 # location of system repository
-if(CMAKE_BUILD_TYPE_LOWER MATCHES "debug")
+if(${IS_DEBUG_BUILD})
     set(REPOSITORY_LOC "${CMAKE_BINARY_DIR}/repository" CACHE PATH "System repository location, contains configuration schema and data files.")
 else()
     set(REPOSITORY_LOC "/etc/sysrepo" CACHE PATH "System repository location, contains configuration schema and data files.")


### PR DESCRIPTION
The RelWithDebugInfo mode is intended to produce a release binary with
all optimizations, but with the debug info still present (maybe to be
moved to a -dbg package by Linux distros). This means that these build
configurations should use global, systemwide /etc/sysrepo/ for repo
storage.

A simple regex match for "debug" matches RelWithDebugInfo, too.

Testing:
- no extra options -> debug due to manual override earlier in
  CMakeLists.txt
- RelWithDebugInfo -> release
- Debug -> debug