### PR TITLE
Ensure that `sysrepod` doesn't pretend to be `sysrepo-plugind`

### DIFF
--- a/src/executables/sysrepod.c
+++ b/src/executables/sysrepod.c
@@ -109,7 +109,7 @@ main(int argc, char* argv[])
     }
 
     /* init logger */
-    sr_logger_init("sysrepo-plugind");
+    sr_logger_init("sysrepod");
 
     /* daemonize the process */
     parent_pid = sr_daemonize(debug_mode, log_level, SR_DAEMON_PID_FILE, &pidfile_fd);


### PR DESCRIPTION
...in case anyone else wonders why exactly the logs show ``sysrepo-plugind`` without that daemon running :).