### PR TITLE
Do not log error when client requests a node with no value and no default

### DIFF
--- a/src/clientlib/client_library.c
+++ b/src/clientlib/client_library.c
@@ -820,6 +820,10 @@ sr_get_item(sr_session_ctx_t *session, const char *xpath, sr_val_t **value)
 
     /* send the request and receive the response */
     rc = cl_request_process(session, msg_req, &msg_resp, NULL, SR__OPERATION__GET_ITEM);
+    if (SR_ERR_NOT_FOUND == rc) {
+        /* not an error, so no logging, but we still need to clean up and we won't be copying values */
+        goto cleanup;
+    }
     CHECK_RC_MSG_GOTO(rc, cleanup, "Error by processing of the request.");
 
     /* duplicate the content of gpb to sr_val_t */
@@ -867,6 +871,10 @@ sr_get_items(sr_session_ctx_t *session, const char *xpath, sr_val_t **values, si
 
     /* send the request and receive the response */
     rc = cl_request_process(session, msg_req, &msg_resp, NULL, SR__OPERATION__GET_ITEMS);
+    if (SR_ERR_NOT_FOUND == rc) {
+        /* not an error, so no logging, but we still need to clean up and we won't be copying values */
+        goto cleanup;
+    }
     CHECK_RC_MSG_GOTO(rc, cleanup, "Error by processing of the request.");
 
     /* copy the content of gpb values to sr_val_t */


### PR DESCRIPTION
I was debugging sr-netopeer2 interaction, and I got sidetracked by the
error messages in the log when I start `sysrepo-plugind` with the
sysrepo-plugin-ietf-system:
```
  sysrepo-sysrepo-plugind[16932]: plugin initialized successfully
  sysrepo-sysrepo-plugind[16932]: *** retrieve_current_config: calling sr_get_item
  sysrepo-sysrepo-plugind[16932]: [DBG] (cl_request_process:416) Sending get-item request.
  sysrepo-sysrepo-plugind[16932]: [DBG] (cl_request_process:438) get-item request sent, waiting for response.
  sysrepod[16854]: [DBG] (cm_conn_read_cb:1059) fd 7 readable
  sysrepod[16854]: [DBG] (cm_conn_read_cb:1072) 55 bytes of data received on fd 7
  sysrepod[16854]: [DBG] (cm_conn_read_cb:1082) fd 7 would block
  sysrepod[16854]: [DBG] (cm_conn_in_buff_process:1011) New message of size 51 bytes received.
  sysrepod[16854]: [DBG] (sr_cbuff_enqueue:461) Circular buffer enqueue to position=8, current count=1.
  sysrepod[16854]: [DBG] (rp_msg_process:3300) Threads: active=1/4, 1 requests in queue
  sysrepod[16854]: [DBG] (np_hello_notify:693) Sending HELLO notification to '/var/run/sysrepo-subscriptions/ietf-system/16932.rcDfpt.sock' @ 242249669.
  sysrepod[16854]: [DBG] (sr_cbuff_enqueue:461) Circular buffer enqueue to position=3, current count=1.
  sysrepod[16854]: [DBG] (cm_msg_enqueue_cb:1668) New message enqueued into CM message queue.
  sysrepod[16854]: [DBG] (sr_cbuff_dequeue:477) Circular buffer dequeue, new buffer head=4, count=0.
  sysrepod[16854]: [DBG] (cm_out_notif_process:1330) Sending a notification to '/var/run/sysrepo-subscriptions/ietf-system/16932.rcDfpt.sock'.
  sysrepod[16854]: [DBG] (cm_out_notif_process:1342) Reusing existing connection on fd=8 for the notification destination '/var/run/sysrepo-subscriptions/ietf-system/16932.rcDfpt.sock'
  sysrepod[16854]: [DBG] (cm_conn_out_buff_flush:505) Sending 110 bytes of data.
  sysrepod[16854]: [DBG] (cm_conn_out_buff_flush:511) 110 bytes of data sent.
  sysrepo-sysrepo-plugind[16932]: [DBG] (cl_sm_fd_read_data:1133) fd 11 readable
  sysrepo-sysrepo-plugind[16932]: [DBG] (cl_sm_fd_read_data:1147) 110 bytes of data received on fd 11
  sysrepo-sysrepo-plugind[16932]: [DBG] (cl_sm_fd_read_data:1157) fd 11 would block
  sysrepo-sysrepo-plugind[16932]: [DBG] (cl_sm_conn_in_buff_process:1083) New message of size 106 bytes received.
  sysrepo-sysrepo-plugind[16932]: [DBG] (cl_sm_notif_process:638) Received a notification for subscription id=242249669 (source address='/var/run/sysrepod.sock').
  sysrepo-sysrepo-plugind[16932]: [DBG] (cl_sm_notif_process:708) HELLO notification received on subscription id=242249669.
  sysrepod[16854]: [DBG] (sr_cbuff_dequeue:477) Circular buffer dequeue, new buffer head=9, count=0.
  sysrepod[16854]: [DBG] (rp_get_item_req_process:542) Processing get_item request.
  sysrepod[16854]: [INF] (rp_dt_get_value_wrapper:875) Get item request startup datastore, xpath: /ietf-system:system/hostname
  sysrepod[16854]: [DBG] (dm_load_data_tree_file:695) Loaded module ietf-system: mtime sec=1480004134 nsec=427130768
  sysrepod[16854]: [DBG] (dm_load_data_tree_file:722) Usage count ietf-system incremented (value=1)
  sysrepod[16854]: [INF] (dm_load_data_tree_file:726) Data file /etc/sysrepo/data/ietf-system.startup is empty
  sysrepod[16854]: [DBG] (dm_get_data_info:1772) Module ietf-system has been loaded
  sysrepod[16854]: [DBG] (sr_cbuff_enqueue:461) Circular buffer enqueue to position=4, current count=1.
  sysrepod[16854]: [DBG] (cm_msg_enqueue_cb:1668) New message enqueued into CM message queue.
  sysrepod[16854]: [DBG] (sr_cbuff_dequeue:477) Circular buffer dequeue, new buffer head=5, count=0.
  sysrepod[16854]: [DBG] (cm_conn_out_buff_flush:505) Sending 30 bytes of data.
  sysrepod[16854]: [DBG] (cm_conn_out_buff_flush:511) 30 bytes of data sent.
  sysrepo-sysrepo-plugind[16932]: [DBG] (cl_request_process:460) get-item response received, processing.
> sysrepo-sysrepo-plugind[16932]: [ERR] (sr_get_item:823) Error by processing of the request.
  sysrepo-sysrepo-plugind[16932]: sr_get_item res 3
  sysrepo-sysrepo-plugind[16932]: Setting hostname to default
  sysrepo-sysrepo-plugind[16932]: [INF] (main:461) Sysrepo plugin daemon initialized successfully.
  sysrepod[16854]: [DBG] (rp_worker_thread_execute:3016) Thread id=139787621705472 will wait.
  sysrepod[16854]: [DBG] (sr_cbuff_enqueue:461) Circular buffer enqueue to position=9, current count=1.
  sysrepod[16854]: [DBG] (rp_msg_process:3300) Threads: active=0/4, 1 requests in queue
  sysrepod[16854]: [DBG] (cm_delayed_request_cb:293) Delayed request sent to the Request Processor.
  sysrepod[16854]: [DBG] (rp_worker_thread_execute:3028) Thread id=139787630098176 signaled.
  sysrepod[16854]: [DBG] (sr_cbuff_dequeue:477) Circular buffer dequeue, new buffer head=0, count=0.
  sysrepod[16854]: [DBG] (rp_unsubscribe_destination_req_process:2412) Processing unsubscribe destination request.
  sysrepod[16854]: [DBG] (rp_worker_thread_execute:3016) Thread id=139787630098176 will wait.
```
It is an XPath that points to a valid node, but that node is not set by
the data to any value. Here's how the plugin accesses it:
```
  rc = sr_get_item(session, "/ietf-system:system/hostname", &value);
```
Compare that to what happens when the code accesses an invalid (as in
"doesn't exist in the model" at all) node:
```
  sysrepo-sysrepo-plugind[16910]: plugin initialized successfully
  sysrepo-sysrepo-plugind[16910]: *** retrieve_current_config: calling sr_get_item
  sysrepo-sysrepo-plugind[16910]: [DBG] (cl_request_process:416) Sending get-item request.
  sysrepo-sysrepo-plugind[16910]: [DBG] (cl_request_process:438) get-item request sent, waiting for response.
  sysrepo-sysrepo-plugind[16910]: [DBG] (cl_sm_fd_read_data:1133) fd 11 readable
  sysrepo-sysrepo-plugind[16910]: [DBG] (cl_sm_fd_read_data:1147) 110 bytes of data received on fd 11
  sysrepo-sysrepo-plugind[16910]: [DBG] (cl_sm_fd_read_data:1157) fd 11 would block
  sysrepo-sysrepo-plugind[16910]: [DBG] (cl_sm_conn_in_buff_process:1083) New message of size 106 bytes received.
  sysrepo-sysrepo-plugind[16910]: [DBG] (cl_sm_notif_process:638) Received a notification for subscription id=196539111 (source address='/var/run/sysrepod.sock').
  sysrepo-sysrepo-plugind[16910]: [DBG] (cl_sm_notif_process:708) HELLO notification received on subscription id=196539111.
  sysrepod[16854]: [DBG] (cm_conn_read_cb:1059) fd 7 readable
  sysrepod[16854]: [DBG] (cm_conn_read_cb:1072) 59 bytes of data received on fd 7
  sysrepod[16854]: [DBG] (cm_conn_read_cb:1082) fd 7 would block
  sysrepod[16854]: [DBG] (cm_conn_in_buff_process:1011) New message of size 55 bytes received.
  sysrepod[16854]: [DBG] (sr_cbuff_enqueue:461) Circular buffer enqueue to position=8, current count=1.
  sysrepod[16854]: [DBG] (rp_msg_process:3300) Threads: active=0/4, 1 requests in queue
  sysrepod[16854]: [DBG] (rp_worker_thread_execute:3028) Thread id=139787630098176 signaled.
  sysrepod[16854]: [DBG] (sr_cbuff_dequeue:477) Circular buffer dequeue, new buffer head=9, count=0.
  sysrepod[16854]: [DBG] (rp_get_item_req_process:542) Processing get_item request.
  sysrepod[16854]: [INF] (rp_dt_get_value_wrapper:875) Get item request startup datastore, xpath: /ietf-system:system/hostname/XXXX
  sysrepod[16854]: [DBG] (dm_load_data_tree_file:695) Loaded module ietf-system: mtime sec=1480004134 nsec=427130768
  sysrepod[16854]: [DBG] (dm_load_data_tree_file:722) Usage count ietf-system incremented (value=1)
  sysrepod[16854]: [INF] (dm_load_data_tree_file:726) Data file /etc/sysrepo/data/ietf-system.startup is empty
  sysrepod[16854]: [DBG] (dm_get_data_info:1772) Module ietf-system has been loaded
  sysrepod[16854]: [DBG] (dm_ly_log_cb:851) libyang error: Schema node "XXXX" not found (/ietf-system:system/hostname/XXXX).
  sysrepod[16854]: [DBG] (dm_ly_log_cb:851) libyang error: Resolving XPath expression "/ietf-system:system/hostname/XXXX" failed.
  sysrepod[16854]: [WRN] (rp_dt_get_value_wrapper:898) Validation of xpath /ietf-system:system/hostname/XXXX was not successful
  sysrepod[16854]: [DBG] (sr_cbuff_enqueue:461) Circular buffer enqueue to position=6, current count=1.
  sysrepod[16854]: [DBG] (rp_worker_thread_execute:3016) Thread id=139787630098176 will wait.
  sysrepod[16854]: [DBG] (cm_msg_enqueue_cb:1668) New message enqueued into CM message queue.
  sysrepod[16854]: [DBG] (sr_cbuff_dequeue:477) Circular buffer dequeue, new buffer head=7, count=0.
  sysrepod[16854]: [DBG] (cm_conn_out_buff_flush:505) Sending 135 bytes of data.
  sysrepod[16854]: [DBG] (cm_conn_out_buff_flush:511) 135 bytes of data sent.
  sysrepo-sysrepo-plugind[16910]: [DBG] (cl_request_process:460) get-item response received, processing.
  sysrepo-sysrepo-plugind[16910]: [ERR] (sr_get_item:823) Error by processing of the request.
  sysrepo-sysrepo-plugind[16910]: sr_get_item res 3
  sysrepo-sysrepo-plugind[16910]: Setting hostname to default
  sysrepo-sysrepo-plugind[16910]: [INF] (main:461) Sysrepo plugin daemon initialized successfully.
  sysrepod[16854]: [DBG] (sr_cbuff_enqueue:461) Circular buffer enqueue to position=9, current count=1.
  sysrepod[16854]: [DBG] (rp_msg_process:3300) Threads: active=0/4, 1 requests in queue
  sysrepod[16854]: [DBG] (cm_delayed_request_cb:293) Delayed request sent to the Request Processor.
  sysrepod[16854]: [DBG] (rp_worker_thread_execute:3028) Thread id=139787638490880 signaled.
  sysrepod[16854]: [DBG] (sr_cbuff_dequeue:477) Circular buffer dequeue, new buffer head=0, count=0.
  sysrepod[16854]: [DBG] (rp_unsubscribe_destination_req_process:2412) Processing unsubscribe destination request.
  sysrepod[16854]: [DBG] (rp_worker_thread_execute:3016) Thread id=139787638490880 will wait.
```
...where the relevant error messages, as reported by libyang, are only
shown as warnings.

This change at least makes the error message in case the node is valid,
but without any data, go away.

The log level of messages obtained by libyang should probably be
increased.