### PR TITLE
C++: Use an extra class for all sysrepo exceptions

### DIFF
--- a/swig/cpp/src/Sysrepo.cpp
+++ b/swig/cpp/src/Sysrepo.cpp
@@ -20,7 +20,6 @@
  */
 
 #include <iostream>
-#include <stdexcept>
 #include <stdlib.h>
 
 #include "Struct.h"
@@ -32,42 +31,57 @@ extern "C" {
 
 using namespace std;
 
+sysrepo_exception::sysrepo_exception(const sr_error_t error_code)
+    : std::runtime_error(sr_strerror(error_code))
+    , m_error_code(error_code)
+{
+}
+
+sysrepo_exception::~sysrepo_exception()
+{
+}
+
+sr_error_t sysrepo_exception::error_code() const
+{
+    return m_error_code;
+}
+
 void throw_exception(int error) {
     switch(error) {
     case(SR_ERR_INVAL_ARG):
-        throw runtime_error(sr_strerror(SR_ERR_INVAL_ARG));
+        throw sysrepo_exception(SR_ERR_INVAL_ARG);
     case(SR_ERR_NOMEM):
-        throw runtime_error(sr_strerror(SR_ERR_NOMEM));
+        throw sysrepo_exception(SR_ERR_NOMEM);
     case(SR_ERR_NOT_FOUND):
-        throw runtime_error(sr_strerror(SR_ERR_NOT_FOUND));
+        throw sysrepo_exception(SR_ERR_NOT_FOUND);
     case(SR_ERR_INTERNAL):
-        throw runtime_error(sr_strerror(SR_ERR_INTERNAL));
+        throw sysrepo_exception(SR_ERR_INTERNAL);
     case(SR_ERR_INIT_FAILED):
-        throw runtime_error(sr_strerror(SR_ERR_INIT_FAILED));
+        throw sysrepo_exception(SR_ERR_INIT_FAILED);
     case(SR_ERR_IO):
-        throw runtime_error(sr_strerror(SR_ERR_IO));
+        throw sysrepo_exception(SR_ERR_IO);
     case(SR_ERR_DISCONNECT):
-        throw runtime_error(sr_strerror(SR_ERR_DISCONNECT));
+        throw sysrepo_exception(SR_ERR_DISCONNECT);
     case(SR_ERR_MALFORMED_MSG):
-        throw runtime_error(sr_strerror(SR_ERR_MALFORMED_MSG));
+        throw sysrepo_exception(SR_ERR_MALFORMED_MSG);
     case(SR_ERR_UNSUPPORTED):
-        throw runtime_error(sr_strerror(SR_ERR_UNSUPPORTED));
+        throw sysrepo_exception(SR_ERR_UNSUPPORTED);
     case(SR_ERR_UNKNOWN_MODEL):
-        throw runtime_error(sr_strerror(SR_ERR_UNKNOWN_MODEL));
+        throw sysrepo_exception(SR_ERR_UNKNOWN_MODEL);
     case(SR_ERR_BAD_ELEMENT):
-        throw runtime_error(sr_strerror(SR_ERR_BAD_ELEMENT));
+        throw sysrepo_exception(SR_ERR_BAD_ELEMENT);
     case(SR_ERR_VALIDATION_FAILED):
-        throw runtime_error(sr_strerror(SR_ERR_VALIDATION_FAILED));
+        throw sysrepo_exception(SR_ERR_VALIDATION_FAILED);
     case(SR_ERR_DATA_EXISTS):
-        throw runtime_error(sr_strerror(SR_ERR_DATA_EXISTS));
+        throw sysrepo_exception(SR_ERR_DATA_EXISTS);
     case(SR_ERR_DATA_MISSING):
-        throw runtime_error(sr_strerror(SR_ERR_DATA_MISSING));
+        throw sysrepo_exception(SR_ERR_DATA_MISSING);
     case(SR_ERR_UNAUTHORIZED):
-        throw runtime_error(sr_strerror(SR_ERR_UNAUTHORIZED));
+        throw sysrepo_exception(SR_ERR_UNAUTHORIZED);
     case(SR_ERR_LOCKED):
-        throw runtime_error(sr_strerror(SR_ERR_LOCKED));
+        throw sysrepo_exception(SR_ERR_LOCKED);
     case(SR_ERR_TIME_OUT):
-        throw runtime_error(sr_strerror(SR_ERR_TIME_OUT));
+        throw sysrepo_exception(SR_ERR_TIME_OUT);
     }
 }
 

--- a/swig/cpp/src/Sysrepo.h
+++ b/swig/cpp/src/Sysrepo.h
@@ -100,6 +100,16 @@ extern "C" {
 
 void throw_exception(int error);
 
+class sysrepo_exception : public std::runtime_error
+{
+public:
+    explicit sysrepo_exception(const sr_error_t error_code);
+    virtual ~sysrepo_exception() override;
+    sr_error_t error_code() const;
+private:
+    sr_error_t m_error_code;
+};
+
 class Logs
 {
 public:


### PR DESCRIPTION
There is value in knowing that a given exception originated within the sysrepo -- especially in users' exception handlers which might get ``std::runtime_error`` instances from both SR and some unrelated libraries. And because of the way how the RTTI works in C++, the destructor has to
be out-of-line in a separate translation unit.

With the captured error_code, one could override ``std::exception::what`` and construct the string in that context. However, I chose not to do so because a ``std::runtime_error`` has no default constructor anyway, and I would have to come up with some string just to throw it away later.