### PR TITLE
Add support to sysrepo for rfc6020 uses statement

### DIFF
--- a/src/common/sr_utils.c
+++ b/src/common/sr_utils.c
@@ -2175,7 +2175,7 @@ sr_lys_module_has_data(const struct lys_module *module)
     /* iterate through top-level nodes */
     LY_TREE_FOR(module->data, iter) {
         if (((LYS_CONFIG_R & iter->flags) /* operational data */ ||
-             ((LYS_CONTAINER | LYS_LIST | LYS_LEAF | LYS_LEAFLIST | LYS_CHOICE | LYS_RPC | LYS_NOTIF | LYS_ACTION) & iter->nodetype))) {
+             ((LYS_CONTAINER | LYS_LIST | LYS_LEAF | LYS_LEAFLIST | LYS_CHOICE | LYS_RPC | LYS_NOTIF | LYS_ACTION | LYS_USES) & iter->nodetype))) {
             /* data-carrying */
             return true;
         }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -155,6 +155,7 @@ INSTALL_YANG_MODULE("top-level-mandatory")
 INSTALL_YANG_MODULE("referenced-data")
 INSTALL_YANG_MODULE("cross-module")
 INSTALL_YANG_MODULE("turing-machine")
+INSTALL_YANG_MODULE("servers")
 
 # dummy testing plugins
 add_library(dummy-plugin-1 SHARED ${TEST_HELPERS_DIR}dummy_plugin.c)

--- a/tests/md_test.c
+++ b/tests/md_test.c
@@ -1878,6 +1878,7 @@ md_test_has_data(void **state)
     rc = md_get_module_info(md_ctx, "top-level-mandatory", NULL, &module);
     assert_int_equal(SR_ERR_OK, rc);
     assert_true(module->has_data);
+    /*If top-level node is an USES node, it's data-carrying*/
     rc = md_get_module_info(md_ctx, "servers", NULL, &module);
     assert_int_equal(SR_ERR_OK, rc);
     assert_true(module->has_data);

--- a/tests/md_test.c
+++ b/tests/md_test.c
@@ -1878,6 +1878,9 @@ md_test_has_data(void **state)
     rc = md_get_module_info(md_ctx, "top-level-mandatory", NULL, &module);
     assert_int_equal(SR_ERR_OK, rc);
     assert_true(module->has_data);
+    rc = md_get_module_info(md_ctx, "servers", NULL, &module);
+    assert_int_equal(SR_ERR_OK, rc);
+    assert_true(module->has_data);
 
     /* destroy context */
     md_destroy(md_ctx);

--- a/tests/yang/servers.yang
+++ b/tests/yang/servers.yang
@@ -1,0 +1,14 @@
+module servers {
+    namespace "http://example.com/ns/servers";
+    prefix servers;
+
+    grouping servers{
+        container server {
+            leaf name {
+                type string;
+            }
+        }
+    }
+
+    uses servers;
+}


### PR DESCRIPTION
Provide support for the uses statement which is used to reference a “grouping” definition.  See https://tools.ietf.org/html/rfc6020#section-7.12 for more details.