### PR TITLE
Module enable can't enable sub nodes with uses statement

### DIFF
--- a/tests/rp_dt_running_test.c
+++ b/tests/rp_dt_running_test.c
@@ -230,6 +230,23 @@ enable_running_for_submodule(void **state)
    rc = dm_enable_module_running(ctx->dm_ctx, session->dm_session, "module-a", NULL);
    assert_int_equal(SR_ERR_OK, rc);
 
+   /* testing the results */
+   sr_val_t val_a = {0,};
+   val_a.type = SR_STRING_T;
+   val_a.data.string_val = strdup("abc");
+   rc = rp_dt_set_item(ctx->dm_ctx, session->dm_session, "/module-a:cont_a/something/a-string", SR_EDIT_DEFAULT, &val_a);
+   
+   /* enable a moudle has grouping/uses, per rfc6020 7.12.1 */
+   rc = dm_enable_module_running(ctx->dm_ctx, session->dm_session, "servers", NULL);
+   assert_int_equal(SR_ERR_OK, rc);
+
+   /* testing the results */
+   sr_val_t val_b = {0,};
+   val_b.type = SR_STRING_T;
+   val_b.data.string_val = strdup("abc");
+   rc = rp_dt_set_item(ctx->dm_ctx, session->dm_session, "/servers:server/name", SR_EDIT_DEFAULT, &val_b);
+   assert_int_equal(SR_ERR_OK, rc);
+
    test_rp_session_cleanup(ctx, session);
 }
 


### PR DESCRIPTION
For RFC6020 section 7.12.1 support, pull request#583 solve the issue of sysrepoctl.
Here is another issue, if the 'uses' statement is directly under a 'module', function dm_enable_module_running will ignore it and the result of this is, nodes under that 'uses' statement will not be enabled, hence can not be edited.