### PR TITLE
Module enable can't enable sub nodes with uses statement

### DIFF
--- a/src/data_manager.c
+++ b/src/data_manager.c
@@ -368,26 +368,28 @@ dm_enable_module_running_internal(dm_ctx_t *ctx, dm_session_t *session, dm_schem
     CHECK_NULL_ARG3(ctx, schema_info, module_name); /* session can be NULL */
     char xpath[PATH_MAX] = {0,};
     int rc = SR_ERR_OK;
-    struct lys_node *node = NULL;
+    const struct lys_node *node = NULL;
 
     /* enable each subtree within the module */
     const struct lys_module *module = ly_ctx_get_module(schema_info->ly_ctx, module_name, NULL);
     if (NULL != module) {
-        node = module->data;
+        /* Use lys_getnext to get real nodes, for rfc6020 7.12.1 support */
+        while (NULL != (node = lys_getnext(node, NULL, module, 0)))
+        {
+            if ((LYS_CONTAINER | LYS_LIST | LYS_LEAF | LYS_LEAFLIST) & node->nodetype) {
+                snprintf(xpath, PATH_MAX, "/%s:%s", module->name, node->name);
+                rc = rp_dt_enable_xpath(ctx, session, schema_info, xpath);
+                if (SR_ERR_OK != rc) {
+                    break;
+                }
+            }
+ 
+        }
     } else {
         SR_LOG_ERR("Module %s not found in provided context", module_name);
         rc = SR_ERR_UNKNOWN_MODEL;
     }
-    while (NULL != node) {
-        if ((LYS_CONTAINER | LYS_LIST | LYS_LEAF | LYS_LEAFLIST) & node->nodetype) {
-            snprintf(xpath, PATH_MAX, "/%s:%s", module->name, node->name);
-            rc = rp_dt_enable_xpath(ctx, session, schema_info, xpath);
-            if (SR_ERR_OK != rc) {
-                break;
-            }
-        }
-        node = node->next;
-    }
+
 
     return rc;
 }

--- a/tests/rp_dt_running_test.c
+++ b/tests/rp_dt_running_test.c
@@ -230,6 +230,22 @@ enable_running_for_submodule(void **state)
    rc = dm_enable_module_running(ctx->dm_ctx, session->dm_session, "module-a", NULL);
    assert_int_equal(SR_ERR_OK, rc);
 
+   /* testing the results */
+   sr_val_t val = {0,};
+   val.type = SR_STRING_T;
+   val.data.string_val = strdup("abc");
+   rc = rp_dt_set_item(ctx->dm_ctx, session->dm_session, "/module-a:cont_a/something/a-string", SR_EDIT_DEFAULT, &val);
+   assert_int_equal(SR_ERR_OK, rc);
+   
+   /* enable a moudle has grouping/uses, per rfc6020 7.12.1 */
+   rc = dm_enable_module_running(ctx->dm_ctx, session->dm_session, "servers", NULL);
+   assert_int_equal(SR_ERR_OK, rc);
+
+   /* testing the results */
+   rc = rp_dt_set_item(ctx->dm_ctx, session->dm_session, "/servers:server/name", SR_EDIT_DEFAULT, &val);
+   assert_int_equal(SR_ERR_OK, rc);
+
+   sr_free_val_content(&val);
    test_rp_session_cleanup(ctx, session);
 }
 


### PR DESCRIPTION
For RFC6020 section 7.12.1 support, pull request#583 solve the issue of sysrepoctl.
Here is another issue, if the 'uses' statement is directly under a 'module', function dm_enable_module_running will ignore it and the result of this is, nodes under that 'uses' statement will not be enabled, hence can not be edited.