### PR TITLE
tests: Disable valgrind when any sanitizer is active

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -56,7 +56,12 @@ endmacro(ADD_UNIT_TEST_WITH_OPTS)
 
 # create default test target with valgrind is on
 macro(ADD_UNIT_TEST TEST_NAME USE_HELPERS)
-    ADD_UNIT_TEST_WITH_OPTS(${TEST_NAME} ${USE_HELPERS} 1 "")
+    if (${CMAKE_C_FLAGS} MATCHES "-fsanitize=")
+        set(tests_with_valgrind 0)
+    else()
+        set(tests_with_valgrind 1)
+    endif()
+    ADD_UNIT_TEST_WITH_OPTS(${TEST_NAME} ${USE_HELPERS} ${tests_with_valgrind} "")
 endmacro(ADD_UNIT_TEST)
 
 


### PR DESCRIPTION
These tools do not really play well with each other, so let's save our
developers a few keystrokes and do the right thing out-of-box.

This won't catch special cases like forcing these sanitizers through the
compiler's built-in specs; I don't think that is a problem.