### PR TITLE
Let C++ callbacks also have reture values

### DIFF
--- a/swig/cpp/examples/cpp_application_changes_example.cpp
+++ b/swig/cpp/examples/cpp_application_changes_example.cpp
@@ -172,7 +172,7 @@ const char *ev_to_str(sr_notif_event_t ev) {
 class My_Callback:public Callback {
     public:
     /* Function to be called for subscribed client of given session whenever configuration changes. */
-    void module_change(S_Session sess, const char *module_name, sr_notif_event_t event, void *private_ctx)
+    int module_change(S_Session sess, const char *module_name, sr_notif_event_t event, void *private_ctx)
     {
         char change_path[MAX_LEN];
 
@@ -199,6 +199,7 @@ class My_Callback:public Callback {
         } catch( const std::exception& e ) {
             cout << e.what() << endl;
         }
+        return SR_ERR_OK;
     }
 };
 

--- a/swig/cpp/examples/cpp_application_example.cpp
+++ b/swig/cpp/examples/cpp_application_example.cpp
@@ -122,11 +122,12 @@ print_current_config(S_Session session, const char *module_name)
 class My_Callback:public Callback {
     public:
     /* Function to be called for subscribed client of given session whenever configuration changes. */
-    void module_change(S_Session sess, const char *module_name, sr_notif_event_t event, void *private_ctx)
+    int module_change(S_Session sess, const char *module_name, sr_notif_event_t event, void *private_ctx)
     {
         cout << "\n\n ========== CONFIG HAS CHANGED, CURRENT RUNNING CONFIG: ==========\n" << endl;
 
         print_current_config(sess, module_name);
+        return SR_ERR_OK;
     }
 };
 

--- a/swig/cpp/examples/cpp_rpc_example.cpp
+++ b/swig/cpp/examples/cpp_rpc_example.cpp
@@ -1,3 +1,4 @@
+
 /**
  * @file application_changes_example.cpp
  * @author Mislav Novakovic <mislav.novakovic@sartura.hr>
@@ -161,7 +162,7 @@ print_value(S_Val value)
 }
 
 class My_Callback:public Callback {
-    void rpc(const char *xpath, const S_Vals in_vals, S_Vals_Holder holder, void *private_ctx) {
+    int rpc(const char *xpath, const S_Vals in_vals, S_Vals_Holder holder, void *private_ctx) {
         cout << "\n ========== RPC CALLED ==========\n" << endl;
 
         auto out_vals = holder->allocate(3);
@@ -178,9 +179,10 @@ class My_Callback:public Callback {
         out_vals->val(2)->set("/test-module:activate-software-image/location",\
                             "/root/",\
                             SR_STRING_T);
+        return SR_ERR_OK;
     }
 
-    void rpc_tree(const char *xpath, S_Trees in_trees, S_Trees_Holder holder, void *private_ctx) {
+    int rpc_tree(const char *xpath, S_Trees in_trees, S_Trees_Holder holder, void *private_ctx) {
         cout << "\n ========== RPC TREE CALLED ==========\n" << endl;
 
         auto out_trees = holder->allocate(3);
@@ -194,6 +196,7 @@ class My_Callback:public Callback {
         out_trees->tree(1)->set("2.3", SR_STRING_T);
         out_trees->tree(2)->set_name("location");
         out_trees->tree(2)->set("/root/", SR_STRING_T);
+        return SR_ERR_OK;
     }
 };
 

--- a/swig/cpp/src/Session.cpp
+++ b/swig/cpp/src/Session.cpp
@@ -384,8 +384,7 @@ Callback::~Callback() {return;}
 static int module_change_cb(sr_session_ctx_t *session, const char *module_name, sr_notif_event_t event, void *private_ctx) {
     S_Session sess(new Session(session));
     Callback *wrap = (Callback*) private_ctx;
-    wrap->module_change(sess, module_name, event, wrap->private_ctx["module_change"]);
-    return SR_ERR_OK;
+    return wrap->module_change(sess, module_name, event, wrap->private_ctx["module_change"]);
 }
 static void module_install_cb(const char *module_name, const char *revision, sr_module_state_t state, void *private_ctx) {
     Callback *wrap = (Callback*) private_ctx;
@@ -398,22 +397,19 @@ static void feature_enable_cb(const char *module_name, const char *feature_name,
 static int subtree_change_cb(sr_session_ctx_t *session, const char *xpath, sr_notif_event_t event, void *private_ctx) {
     S_Session sess(new Session(session));
     Callback *wrap = (Callback*) private_ctx;
-    wrap->subtree_change(sess, xpath, event, wrap->private_ctx["subtree_change"]);
-    return SR_ERR_OK;
+    return wrap->subtree_change(sess, xpath, event, wrap->private_ctx["subtree_change"]);
 }
 static int rpc_cb(const char *xpath, const sr_val_t *input, const size_t input_cnt, sr_val_t **output, size_t *output_cnt, void *private_ctx) {
     S_Vals in_vals(new Vals(input, input_cnt, NULL));
     S_Vals_Holder out_vals(new Vals_Holder(output, output_cnt));
     Callback *wrap = (Callback*) private_ctx;
-    wrap->rpc(xpath, in_vals, out_vals, wrap->private_ctx["rpc_cb"]);
-    return SR_ERR_OK;
+    return wrap->rpc(xpath, in_vals, out_vals, wrap->private_ctx["rpc_cb"]);
 }
 static int rpc_tree_cb(const char *xpath, const sr_node_t *input, const size_t input_cnt, sr_node_t **output, size_t *output_cnt, void *private_ctx) {
     S_Trees in_tree(new Trees(input, input_cnt, NULL));
     S_Trees_Holder out_tree(new Trees_Holder(output, output_cnt));
     Callback *wrap = (Callback*) private_ctx;
-    wrap->rpc_tree(xpath, in_tree, out_tree, wrap->private_ctx["rpc_tree"]);
-    return SR_ERR_OK;
+    return wrap->rpc_tree(xpath, in_tree, out_tree, wrap->private_ctx["rpc_tree"]);
 }
 static void event_notif_cb(const char *xpath, const sr_val_t *values, const size_t values_cnt, void *private_ctx) {
     S_Vals vals(new Vals(values, values_cnt, NULL));
@@ -428,8 +424,7 @@ static void event_notif_tree_cb(const char *xpath, const sr_node_t *trees, const
 static int dp_get_items_cb(const char *xpath, sr_val_t **values, size_t *values_cnt, void *private_ctx) {
     S_Vals_Holder vals(new Vals_Holder(values, values_cnt));
     Callback *wrap = (Callback*) private_ctx;
-    wrap->dp_get_items(xpath, vals, wrap->private_ctx["dp_get_items"]);
-    return SR_ERR_OK;
+    return wrap->dp_get_items(xpath, vals, wrap->private_ctx["dp_get_items"]);
 }
 
 void Subscribe::module_change_subscribe(const char *module_name, S_Callback callback, \

--- a/swig/cpp/src/Session.h
+++ b/swig/cpp/src/Session.h
@@ -90,13 +90,13 @@ public:
     Callback();
     virtual ~Callback();
 
-    virtual void module_change(S_Session session, const char *module_name, sr_notif_event_t event, void *private_ctx) {return;};
-    virtual void subtree_change(S_Session session, const char *xpath, sr_notif_event_t event, void *private_ctx) {return;};
+    virtual int module_change(S_Session session, const char *module_name, sr_notif_event_t event, void *private_ctx) {return SR_ERR_OK;};
+    virtual int subtree_change(S_Session session, const char *xpath, sr_notif_event_t event, void *private_ctx) {return SR_ERR_OK;};
     virtual void module_install(const char *module_name, const char *revision, sr_module_state_t state, void *private_ctx) {return;};
     virtual void feature_enable(const char *module_name, const char *feature_name, bool enabled, void *private_ctx) {return;};
-    virtual void rpc(const char *xpath, S_Vals input, S_Vals_Holder output, void *private_ctx) {return;};
-    virtual void rpc_tree(const char *xpath, S_Trees input, S_Trees_Holder output, void *private_ctx) {return;};
-    virtual void dp_get_items(const char *xpath, S_Vals_Holder vals, void *private_ctx) {return;};
+    virtual int rpc(const char *xpath, S_Vals input, S_Vals_Holder output, void *private_ctx) {return SR_ERR_OK;};
+    virtual int rpc_tree(const char *xpath, S_Trees input, S_Trees_Holder output, void *private_ctx) {return SR_ERR_OK;};
+    virtual int dp_get_items(const char *xpath, S_Vals_Holder vals, void *private_ctx) {return SR_ERR_OK;};
     virtual void event_notif(const char *xpath, S_Vals vals, void *private_ctx) {return;};
     virtual void event_notif_tree(const char *xpath, S_Trees trees, void *private_ctx) {return;};
     Callback *get() {return this;};


### PR DESCRIPTION
We are using Sysrepo C++ interface, in which, those c++ callbacks cannot take any return values, it would be better that callbacks could also return OK/Failed to all the change events, especially on 'Verify' event.