### PR TITLE
add default nodes into empty data trees if empty data can be validated.

### DIFF
--- a/tests/cl_test.c
+++ b/tests/cl_test.c
@@ -426,7 +426,7 @@ cl_get_item_test(void **state)
     assert_null(value);
 
     /* empty data tree */
-    rc = sr_get_item(session, "/small-module:item", &value);
+    rc = sr_get_item(session, "/small-module:item/name", &value);
     assert_int_equal(SR_ERR_NOT_FOUND, rc);
 
     /* bad element in existing module returns SR_ERR_NOT_FOUND instead of SR_ERR_BAD_ELEMENT*/
@@ -506,7 +506,7 @@ cl_get_subtree_test(void **state)
     assert_null(tree);
 
     /* empty data tree */
-    rc = sr_get_subtree(session, "/small-module:item", 0, &tree);
+    rc = sr_get_subtree(session, "/small-module:item/name", 0, &tree);
     assert_int_equal(SR_ERR_NOT_FOUND, rc);
 
     /* bad element in existing module returns SR_ERR_NOT_FOUND instead of SR_ERR_BAD_ELEMENT*/
@@ -659,7 +659,7 @@ cl_get_items_test(void **state)
     assert_int_equal(SR_ERR_UNKNOWN_MODEL, rc);
 
     /* empty data tree */
-    rc = sr_get_items(session, "/small-module:item", &values, &values_cnt);
+    rc = sr_get_items(session, "/small-module:item/name", &values, &values_cnt);
     assert_int_equal(SR_ERR_NOT_FOUND, rc);
 
     /* bad element in existing module produces SR_ERR_NOT_FOUND instead of SR_ERR_BAD_ELEMENT */
@@ -729,7 +729,7 @@ cl_get_subtrees_test(void **state)
     assert_int_equal(SR_ERR_UNKNOWN_MODEL, rc);
 
     /* empty data tree */
-    rc = sr_get_subtrees(session, "/small-module:item", 0, &trees, &tree_cnt);
+    rc = sr_get_subtrees(session, "/small-module:item/name", 0, &trees, &tree_cnt);
     assert_int_equal(SR_ERR_NOT_FOUND, rc);
 
     /* bad element in existing module produces SR_ERR_NOT_FOUND instead of SR_ERR_BAD_ELEMENT */
@@ -795,7 +795,7 @@ cl_get_items_iter_test(void **state)
     assert_null(it);
 
     /* empty data tree */
-    rc = sr_get_items_iter(session, "/small-module:item", &it);
+    rc = sr_get_items_iter(session, "/small-module:item/name", &it);
     assert_int_equal(SR_ERR_OK, rc);
     assert_non_null(it);
 

--- a/tests/dm_test.c
+++ b/tests/dm_test.c
@@ -98,7 +98,7 @@ void dm_get_data_tree(void **state)
     /* Get from avl tree */
     assert_int_equal(SR_ERR_OK, dm_get_datatree(ctx, ses_ctx ,"example-module", &data_tree));
     /* Module without data */
-    assert_int_equal(SR_ERR_NOT_FOUND, dm_get_datatree(ctx, ses_ctx ,"small-module", &data_tree));
+    assert_int_equal(SR_ERR_OK, dm_get_datatree(ctx, ses_ctx ,"small-module", &data_tree));
     /* Not existing module should return an error*/
     assert_int_equal(SR_ERR_UNKNOWN_MODEL, dm_get_datatree(ctx, ses_ctx ,"not-existing-module", &data_tree));
 

--- a/tests/rp_datatree_test.c
+++ b/tests/rp_datatree_test.c
@@ -1406,7 +1406,7 @@ void get_value_wrapper_test(void **state){
     /* empty data tree */
     ses_ctx->state = RP_REQ_NEW;
     rc = rp_dt_get_value_wrapper(ctx, ses_ctx, NULL, "/small-module:item", &value);
-    assert_int_equal(SR_ERR_NOT_FOUND, rc);
+    assert_int_equal(SR_ERR_OK, rc);
 
     /* not exisiting now in existing data tree*/
     ses_ctx->state = RP_REQ_NEW;
@@ -1437,7 +1437,7 @@ void get_tree_wrapper_test(void **state){
     /* empty data tree */
     ses_ctx->state = RP_REQ_NEW;
     rc = rp_dt_get_subtree_wrapper(ctx, ses_ctx, NULL, "/small-module:item", &tree);
-    assert_int_equal(SR_ERR_NOT_FOUND, rc);
+    assert_int_equal(SR_ERR_OK, rc);
     tree = NULL;
 
     /* not exisiting now in existing data tree*/

--- a/tests/rp_datatree_test.c
+++ b/tests/rp_datatree_test.c
@@ -1407,6 +1407,8 @@ void get_value_wrapper_test(void **state){
     ses_ctx->state = RP_REQ_NEW;
     rc = rp_dt_get_value_wrapper(ctx, ses_ctx, NULL, "/small-module:item", &value);
     assert_int_equal(SR_ERR_OK, rc);
+    sr_free_val(value);
+    value = NULL;
 
     /* not exisiting now in existing data tree*/
     ses_ctx->state = RP_REQ_NEW;
@@ -1438,6 +1440,7 @@ void get_tree_wrapper_test(void **state){
     ses_ctx->state = RP_REQ_NEW;
     rc = rp_dt_get_subtree_wrapper(ctx, ses_ctx, NULL, "/small-module:item", &tree);
     assert_int_equal(SR_ERR_OK, rc);
+    sr_free_tree(tree);
     tree = NULL;
 
     /* not exisiting now in existing data tree*/


### PR DESCRIPTION
Hi, 
This request is used to fix #335 only when empty data can be validated (now, even if the empty data can be validated, get-config with 'report-all' still returns empty).