### PR TITLE
cpp: remove sr_session_stop from the Session destructor

### DIFF
--- a/swig/cpp/src/Session.cpp
+++ b/swig/cpp/src/Session.cpp
@@ -413,16 +413,7 @@ S_Change Session::get_change_next(S_Iter_Change iter)
     }
 }
 
-Session::~Session()
-{
-    if (_sess) {
-        int ret = sr_session_stop(_sess);
-        if (ret != SR_ERR_OK) {
-            throw_exception(ret);
-        }
-	_sess = NULL;
-    }
-}
+Session::~Session() {}
 
 void Session::copy_config(const char *module_name, sr_datastore_t src_datastore, sr_datastore_t dst_datastore)
 {


### PR DESCRIPTION
sr_session_stop should be called only from the Deleter class and the
Deleter class is created only when a new Session class was created
from the user.

Signed-off-by: Mislav Novakovic <mislav.novakovic@sartura.hr>