### PR TITLE
cpp: remove exception throwing from class destructors

### DIFF
--- a/swig/cpp/src/Internal.cpp
+++ b/swig/cpp/src/Internal.cpp
@@ -101,7 +101,8 @@ Deleter::~Deleter() {
         if (!v._sess) break;
         int ret = sr_session_stop(v._sess);
         if (ret != SR_ERR_OK) {
-            throw_exception(ret);
+            //this exception can't be catched
+            //throw_exception(ret);
         }
 	v._sess = NULL;
     break;

--- a/swig/cpp/src/Session.cpp
+++ b/swig/cpp/src/Session.cpp
@@ -444,7 +444,8 @@ Subscribe::~Subscribe()
     if (_sub && _sess->_sess) {
         int ret = sr_unsubscribe(_sess->_sess, _sub);
         if (ret != SR_ERR_OK) {
-            throw_exception(ret);
+            //this exception can't be catched
+            //throw_exception(ret);
         }
 	_sub = NULL;
     }


### PR DESCRIPTION
This is a temporary fix for the Coverity bug report of type:
'Error handling issues  (UNCAUGHT_EXCEPT)'

Signed-off-by: Mislav Novakovic <mislav.novakovic@sartura.hr>