### PR TITLE
cpp: add print value function for nodes

### DIFF
--- a/swig/cpp/src/Tree.cpp
+++ b/swig/cpp/src/Tree.cpp
@@ -30,6 +30,7 @@ using namespace std;
 extern "C" {
 #include "sysrepo.h"
 #include "sysrepo/trees.h"
+#include "sysrepo/values.h"
 }
 
 Tree::Tree() {
@@ -108,6 +109,27 @@ S_String Tree::to_string(int depth_limit) {
     char *mem = NULL;
 
     int ret = sr_print_tree_mem(&mem, _node, depth_limit);
+    if (SR_ERR_OK == ret) {
+        if (mem == NULL)
+            return NULL;
+        S_String string_val = mem;
+        free(mem);
+        return string_val;
+    } else if (SR_ERR_NOT_FOUND == ret) {
+        return NULL;
+    } else {
+        throw_exception(ret);
+        return NULL;
+    }
+}
+S_String Tree::value_to_string() {
+    char *mem = NULL;
+
+    if (_node == NULL) throw_exception(SR_ERR_DATA_MISSING);
+
+    sr_val_t *val = (sr_val_t *) _node;
+
+    int ret = sr_print_val_mem(&mem, val);
     if (SR_ERR_OK == ret) {
         if (mem == NULL)
             return NULL;

--- a/swig/cpp/src/Tree.h
+++ b/swig/cpp/src/Tree.h
@@ -52,6 +52,7 @@ public:
     S_Tree first_child();
     S_Tree last_child();
     S_String to_string(int depth_limit);
+    S_String value_to_string();
     void set_name(const char *name);
     void set_module(const char *module_name);
     void set_str_data(sr_type_t type, const char *string_val);


### PR DESCRIPTION
I add a Tree class method for printing only the value of the Tree (sr_node_t).

@rastislavszabo I am not sure about the name of the class method. Because to_string is used for sr_print_tree(), the method is called value_to_string().

Do you wan't to change the API?
