### PR TITLE
Cpp code cleanup

### DIFF
--- a/swig/cpp/src/Session.cpp
+++ b/swig/cpp/src/Session.cpp
@@ -463,8 +463,8 @@ Subscribe::~Subscribe()
     }
 }
 
-Callback::Callback() {return;}
-Callback::~Callback() {return;}
+Callback::Callback() {}
+Callback::~Callback() {}
 
 static int module_change_cb(sr_session_ctx_t *session, const char *module_name, sr_notif_event_t event, void *private_ctx) {
     S_Session sess(new Session(session));

--- a/swig/cpp/src/Session.cpp
+++ b/swig/cpp/src/Session.cpp
@@ -262,7 +262,7 @@ S_Trees Session::get_subtrees(const char *xpath, sr_get_subtree_options_t opts)
 
 S_Tree Session::get_child(S_Tree in_tree)
 {
-    sr_node_t *node = sr_node_get_child(_sess, in_tree->tree());
+    sr_node_t *node = sr_node_get_child(_sess, in_tree->_node);
     if (node == NULL) {
         return NULL;
     }
@@ -273,7 +273,7 @@ S_Tree Session::get_child(S_Tree in_tree)
 
 S_Tree Session::get_next_sibling(S_Tree in_tree)
 {
-    sr_node_t *node = sr_node_get_next_sibling(_sess, in_tree->tree());
+    sr_node_t *node = sr_node_get_next_sibling(_sess, in_tree->_node);
     if (node == NULL) {
         return NULL;
     }
@@ -284,7 +284,7 @@ S_Tree Session::get_next_sibling(S_Tree in_tree)
 
 S_Tree Session::get_parent(S_Tree in_tree)
 {
-    sr_node_t *node = sr_node_get_parent(_sess, in_tree->tree());
+    sr_node_t *node = sr_node_get_parent(_sess, in_tree->_node);
     if (node == NULL) {
         return NULL;
     }

--- a/swig/cpp/src/Struct.cpp
+++ b/swig/cpp/src/Struct.cpp
@@ -112,8 +112,7 @@ Val::Val(sr_val_t *val, S_Deleter deleter) {
 }
 Val::Val() {
     _val = NULL;
-    S_Deleter deleter(new Deleter(_val));
-    _deleter = deleter;
+    _deleter = S_Deleter(new Deleter(_val));
 }
 Val::~Val() {return;}
 Val::Val(const char *value, sr_type_t type) {
@@ -138,8 +137,7 @@ Val::Val(const char *value, sr_type_t type) {
     }
 
     _val = val;
-    S_Deleter deleter(new Deleter(val));
-    _deleter = deleter;
+    _deleter = S_Deleter(new Deleter(val));
 }
 Val::Val(bool bool_val, sr_type_t type) {
     sr_val_t *val = NULL;
@@ -155,8 +153,7 @@ Val::Val(bool bool_val, sr_type_t type) {
 
     val->type = type;
     _val = val;
-    S_Deleter deleter(new Deleter(val));
-    _deleter = deleter;
+    _deleter = S_Deleter(new Deleter(val));
 }
 Val::Val(double decimal64_val) {
     sr_val_t *val = NULL;
@@ -169,8 +166,7 @@ Val::Val(double decimal64_val) {
 
     val->type = SR_DECIMAL64_T;
     _val = val;
-    S_Deleter deleter(new Deleter(val));
-    _deleter = deleter;
+    _deleter = S_Deleter(new Deleter(val));
 }
 Val::Val(int8_t int8_val, sr_type_t type) {
     sr_val_t *val = NULL;
@@ -186,8 +182,7 @@ Val::Val(int8_t int8_val, sr_type_t type) {
 
     val->type = type;
     _val = val;
-    S_Deleter deleter(new Deleter(val));
-    _deleter = deleter;
+    _deleter = S_Deleter(new Deleter(val));
 }
 Val::Val(int16_t int16_val, sr_type_t type) {
     sr_val_t *val = NULL;
@@ -203,8 +198,7 @@ Val::Val(int16_t int16_val, sr_type_t type) {
 
     val->type = type;
     _val = val;
-    S_Deleter deleter(new Deleter(val));
-    _deleter = deleter;
+    _deleter = S_Deleter(new Deleter(val));
 }
 Val::Val(int32_t int32_val, sr_type_t type) {
     sr_val_t *val = NULL;
@@ -220,8 +214,7 @@ Val::Val(int32_t int32_val, sr_type_t type) {
 
     val->type = type;
     _val = val;
-    S_Deleter deleter(new Deleter(val));
-    _deleter = deleter;
+    _deleter = S_Deleter(new Deleter(val));
 }
 Val::Val(int64_t int64_val, sr_type_t type) {
     sr_val_t *val = NULL;
@@ -252,8 +245,7 @@ Val::Val(int64_t int64_val, sr_type_t type) {
 
     val->type = type;
     _val = val;
-    S_Deleter deleter(new Deleter(val));
-    _deleter = deleter;
+    _deleter = S_Deleter(new Deleter(val));
 }
 Val::Val(uint8_t uint8_val, sr_type_t type) {
     sr_val_t *val = NULL;
@@ -269,8 +261,7 @@ Val::Val(uint8_t uint8_val, sr_type_t type) {
 
     val->type = type;
     _val = val;
-    S_Deleter deleter(new Deleter(val));
-    _deleter = deleter;
+    _deleter = S_Deleter(new Deleter(val));
 }
 Val::Val(uint16_t uint16_val, sr_type_t type) {
     sr_val_t *val = NULL;
@@ -286,8 +277,7 @@ Val::Val(uint16_t uint16_val, sr_type_t type) {
 
     val->type = type;
     _val = val;
-    S_Deleter deleter(new Deleter(val));
-    _deleter = deleter;
+    _deleter = S_Deleter(new Deleter(val));
 }
 Val::Val(uint32_t uint32_val, sr_type_t type) {
     sr_val_t *val = NULL;
@@ -303,8 +293,7 @@ Val::Val(uint32_t uint32_val, sr_type_t type) {
 
     val->type = type;
     _val = val;
-    S_Deleter deleter(new Deleter(val));
-    _deleter = deleter;
+    _deleter = S_Deleter(new Deleter(val));
 }
 Val::Val(uint64_t uint64_val, sr_type_t type) {
     sr_val_t *val = NULL;
@@ -320,8 +309,7 @@ Val::Val(uint64_t uint64_val, sr_type_t type) {
 
     val->type = type;
     _val = val;
-    S_Deleter deleter(new Deleter(val));
-    _deleter = deleter;
+    _deleter = S_Deleter(new Deleter(val));
 }
 void Val::set(const char *xpath, const char *value, sr_type_t type) {
     int ret = SR_ERR_OK;
@@ -666,8 +654,7 @@ char *Yang_Schema::enabled_features(size_t n) {
 Yang_Schemas::Yang_Schemas() {
     _sch = NULL;
     _cnt = 0;
-    S_Deleter deleter(new Deleter(_sch, _cnt));
-    _deleter = deleter;
+    _deleter = S_Deleter(new Deleter(_sch, _cnt));
 }
 Yang_Schemas::~Yang_Schemas() {return;}
 S_Yang_Schema Yang_Schemas::schema(size_t n) {
@@ -708,11 +695,9 @@ Change::Change() {
     _oper = SR_OP_CREATED;
     _new = NULL;
     _old = NULL;
-    S_Deleter deleter_old(new Deleter(_old));
-    S_Deleter deleter_new(new Deleter(_new));
 
-    _deleter_old = deleter_old;
-    _deleter_new = deleter_new;
+    _deleter_old = S_Deleter(new Deleter(_old));
+    _deleter_new = S_Deleter(new Deleter(_new));
 }
 S_Val Change::new_val() {
     if (_new == NULL) return NULL;

--- a/swig/cpp/src/Struct.cpp
+++ b/swig/cpp/src/Struct.cpp
@@ -37,7 +37,7 @@ using namespace std;
 
 // Data
 Data::Data(sr_data_t data, sr_type_t type, S_Deleter deleter) {_d = data; _t = type; _deleter = deleter;}
-Data::~Data() {return;}
+Data::~Data() {}
 char *Data::get_binary() {
     if (_t != SR_BINARY_T) throw_exception(SR_ERR_DATA_MISSING);
     return _d.binary_val;
@@ -114,7 +114,7 @@ Val::Val() {
     _val = NULL;
     _deleter = S_Deleter(new Deleter(_val));
 }
-Val::~Val() {return;}
+Val::~Val() {}
 Val::Val(const char *value, sr_type_t type) {
     int ret = SR_ERR_OK;
     sr_val_t *val = NULL;
@@ -543,11 +543,8 @@ Vals::Vals(size_t cnt): Vals() {
         _deleter = S_Deleter(new Deleter(_vals, _cnt));
     }
 }
-Vals::Vals(): _cnt(0), _vals(nullptr)
-{
-}
-Vals::~Vals() {
-}
+Vals::Vals(): _cnt(0), _vals(nullptr) {}
+Vals::~Vals() {}
 S_Val Vals::val(size_t n) {
     if (n >= _cnt)
         throw std::out_of_range("Vals::val: index out of range");
@@ -588,24 +585,24 @@ S_Vals Vals_Holder::allocate(size_t n) {
     S_Vals vals(new Vals(p_vals, p_cnt, NULL));
     return vals;
 }
-Vals_Holder::~Vals_Holder() {return;}
+Vals_Holder::~Vals_Holder() {}
 
 // Val_iter
 Val_Iter::Val_Iter(sr_val_iter_t *iter) {_iter = iter;}
-Val_Iter::~Val_Iter() {return;}
+Val_Iter::~Val_Iter() {}
 
 // Change_Iter
 Change_Iter::Change_Iter(sr_change_iter_t *iter) {_iter = iter;}
-Change_Iter::~Change_Iter() {return;}
+Change_Iter::~Change_Iter() {}
 
 // Error
 Error::Error() {_info = NULL;}
 Error::Error(const sr_error_info_t *info) {_info = info;}
-Error::~Error() {return;}
+Error::~Error() {}
 
 // Errors
 Errors::Errors() {_info = NULL; _cnt = 0;}
-Errors::~Errors() {return;}
+Errors::~Errors() {}
 S_Error Errors::error(size_t n) {
     if (n >= _cnt)
         throw std::out_of_range("Errors:error: index out of range");
@@ -616,14 +613,14 @@ S_Error Errors::error(size_t n) {
 
 // Schema_Revision
 Schema_Revision::Schema_Revision(sr_sch_revision_t rev) {_rev = rev;}
-Schema_Revision::~Schema_Revision() {return;}
+Schema_Revision::~Schema_Revision() {}
 
 // Schema_Submodule
 Schema_Submodule::Schema_Submodule(sr_sch_submodule_t sub, S_Deleter deleter) {
     _sub = sub;
     _deleter = deleter;
 }
-Schema_Submodule::~Schema_Submodule() {return;}
+Schema_Submodule::~Schema_Submodule() {}
 S_Schema_Revision Schema_Submodule::revision() {
     S_Schema_Revision rev(new Schema_Revision(_sub.revision));
     return rev;
@@ -631,7 +628,7 @@ S_Schema_Revision Schema_Submodule::revision() {
 
 // Yang_Schema
 Yang_Schema::Yang_Schema(sr_schema_t *sch, S_Deleter deleter) {_sch = sch; _deleter = deleter;}
-Yang_Schema::~Yang_Schema() {return;}
+Yang_Schema::~Yang_Schema() {}
 S_Schema_Revision Yang_Schema::revision() {
     S_Schema_Revision rev(new Schema_Revision(_sch->revision));
     return rev;
@@ -656,7 +653,7 @@ Yang_Schemas::Yang_Schemas() {
     _cnt = 0;
     _deleter = S_Deleter(new Deleter(_sch, _cnt));
 }
-Yang_Schemas::~Yang_Schemas() {return;}
+Yang_Schemas::~Yang_Schemas() {}
 S_Yang_Schema Yang_Schemas::schema(size_t n) {
     if (n >= _cnt)
         throw std::out_of_range("Yang_Schema::schema: index out of range");
@@ -667,11 +664,11 @@ S_Yang_Schema Yang_Schemas::schema(size_t n) {
 
 // Fd_Change
 Fd_Change::Fd_Change(sr_fd_change_t *ch) {_ch = ch;}
-Fd_Change::~Fd_Change() {return;}
+Fd_Change::~Fd_Change() {}
 
 // Fd_Changes
 Fd_Changes::Fd_Changes(sr_fd_change_t *ch, size_t cnt) {_ch = ch; _cnt = cnt;}
-Fd_Changes::~Fd_Changes() {return;}
+Fd_Changes::~Fd_Changes() {}
 S_Fd_Change Fd_Changes::fd_change(size_t n) {
     if (n >= _cnt)
         throw std::out_of_range("Fd_Changes::fd_change: index out of range");

--- a/swig/cpp/src/Struct.cpp
+++ b/swig/cpp/src/Struct.cpp
@@ -608,7 +608,7 @@ Errors::Errors() {_info = NULL; _cnt = 0;}
 Errors::~Errors() {return;}
 S_Error Errors::error(size_t n) {
     if (n >= _cnt)
-        return NULL;
+        throw std::out_of_range("Errors:error: index out of range");
 
     S_Error error(new Error(&_info[n]));
     return error;
@@ -638,14 +638,14 @@ S_Schema_Revision Yang_Schema::revision() {
 }
 S_Schema_Submodule Yang_Schema::submodule(size_t n) {
     if (n >= _sch->submodule_count)
-        return NULL;
+        throw std::out_of_range("Schema_Submodule::submodule: index out of range");
 
     S_Schema_Submodule sub(new Schema_Submodule(_sch->submodules[n], _deleter));
     return sub;
 }
 char *Yang_Schema::enabled_features(size_t n) {
     if (n >= _sch->enabled_feature_cnt)
-        return NULL;
+        throw std::out_of_range("Yang_Schema::enabled_features: index out of range");
 
    return _sch->enabled_features[n];
 }
@@ -659,7 +659,7 @@ Yang_Schemas::Yang_Schemas() {
 Yang_Schemas::~Yang_Schemas() {return;}
 S_Yang_Schema Yang_Schemas::schema(size_t n) {
     if (n >= _cnt)
-        return NULL;
+        throw std::out_of_range("Yang_Schema::schema: index out of range");
 
     S_Yang_Schema rev(new Yang_Schema((sr_schema_t *) &_sch[n], _deleter));
     return rev;
@@ -674,7 +674,7 @@ Fd_Changes::Fd_Changes(sr_fd_change_t *ch, size_t cnt) {_ch = ch; _cnt = cnt;}
 Fd_Changes::~Fd_Changes() {return;}
 S_Fd_Change Fd_Changes::fd_change(size_t n) {
     if (n >= _cnt)
-        return NULL;
+        throw std::out_of_range("Fd_Changes::fd_change: index out of range");
 
     S_Fd_Change change(new Fd_Change(&_ch[n]));
     return change;

--- a/swig/cpp/src/Sysrepo.cpp
+++ b/swig/cpp/src/Sysrepo.cpp
@@ -37,9 +37,7 @@ sysrepo_exception::sysrepo_exception(const sr_error_t error_code)
 {
 }
 
-sysrepo_exception::~sysrepo_exception()
-{
-}
+sysrepo_exception::~sysrepo_exception() {}
 
 sr_error_t sysrepo_exception::error_code() const
 {
@@ -86,8 +84,8 @@ void throw_exception(int error) {
 }
 
 // for consistent swig integration
-Logs::Logs() {return;}
-Logs::~Logs() {return;}
+Logs::Logs() {}
+Logs::~Logs() {}
 
 void Logs::set_stderr(sr_log_level_t log_level)
 {

--- a/swig/cpp/src/Tree.cpp
+++ b/swig/cpp/src/Tree.cpp
@@ -51,9 +51,10 @@ Tree::Tree(sr_node_t *tree, S_Deleter deleter) {
 }
 Tree::~Tree() {return;}
 S_Tree Tree::dup() {
-    sr_node_t *tree_dup = NULL;
-    if (_node == NULL) return NULL;
+    if (!_node)
+        throw std::logic_error("Tree::dup: called on null Tree");
 
+    sr_node_t *tree_dup = NULL;
     int ret = sr_dup_tree(_node, &tree_dup);
     if (ret != SR_ERR_OK) throw_exception(ret);
 
@@ -62,41 +63,52 @@ S_Tree Tree::dup() {
     return dup;
 }
 S_Tree Tree::node() {
-    if (_node == NULL) return NULL;
+    if (!_node)
+        throw std::logic_error("Tree::node: called on null Tree");
 
     S_Tree node(new Tree(_node, _deleter));
     return node;
 }
 S_Tree Tree::parent() {
-    if (_node->parent == NULL)
+    if (!_node)
+        throw std::logic_error("Tree::parent: called on null Tree");
+    if (!_node->parent)
         return NULL;
 
     S_Tree node(new Tree(_node->parent, _deleter));
     return node;
 }
 S_Tree Tree::next() {
-    if (_node->next == NULL)
+    if (!_node)
+        throw std::logic_error("Tree::next: called on null Tree");
+    if (!_node->next)
         return NULL;
 
     S_Tree node(new Tree(_node->next, _deleter));
     return node;
 }
 S_Tree Tree::prev() {
-    if (_node->prev == NULL)
+    if (!_node)
+        throw std::logic_error("Tree::prev: called on null Tree");
+    if (!_node->prev)
         return NULL;
 
     S_Tree node(new Tree(_node->prev, _deleter));
     return node;
 }
 S_Tree Tree::first_child() {
-    if (_node->first_child == NULL)
+    if (!_node)
+        throw std::logic_error("Tree::first_child: called on null Tree");
+    if (!_node->first_child)
         return NULL;
 
     S_Tree node(new Tree(_node->first_child, _deleter));
     return node;
 }
 S_Tree Tree::last_child() {
-    if (_node->last_child == NULL)
+    if (!_node)
+        throw std::logic_error("Tree::last_child: called on null Tree");
+    if (!_node->last_child)
         return NULL;
 
     S_Tree node(new Tree(_node->last_child, _deleter));
@@ -254,18 +266,18 @@ void Tree::set(uint64_t uint64_val, sr_type_t type) {
     _node->type = type;
 }
 
-Trees::Trees() {
-    _trees = NULL;
-    _cnt = 0;
-    _deleter = S_Deleter(new Deleter(_trees, _cnt));
-}
-Trees::Trees(size_t cnt) {
-    int ret = sr_new_trees(cnt, &_trees);
-    if (ret != SR_ERR_OK)
-        throw_exception(ret);
+Trees::Trees(size_t cnt): Trees() {
+    if (cnt) {
+        int ret = sr_new_trees(cnt, &_trees);
+        if (ret != SR_ERR_OK)
+            throw_exception(ret);
 
-    _cnt = cnt;
-    _deleter = S_Deleter(new Deleter(_trees, _cnt));
+        _cnt = cnt;
+        _deleter = S_Deleter(new Deleter(_trees, _cnt));
+    }
+}
+Trees::Trees(): _cnt(0), _trees(nullptr)
+{
 }
 Trees::Trees(sr_node_t **trees, size_t *cnt, S_Deleter deleter) {
     _trees = *trees;
@@ -280,15 +292,22 @@ Trees::Trees(const sr_node_t *trees, const size_t n, S_Deleter deleter) {
 }
 Trees::~Trees() {return;}
 S_Tree Trees::tree(size_t n) {
-    if (_trees == NULL || n >= _cnt) return NULL;
+    if (n >= _cnt)
+        throw std::out_of_range("Trees::tree: index out of range");
+    if (!_trees)
+        throw std::logic_error("Trees::tree: called on null Trees");
+
 
     S_Tree tree(new Tree(&_trees[n], _deleter));
     return tree;
 }
 S_Trees Trees::dup() {
-    sr_node_t *tree_dup = NULL;
-    if (_trees == NULL || _cnt == 0) return NULL;
+    if (_cnt == 0)
+        throw std::out_of_range("Trees::tree: no elements to copy");
+    if (!_trees)
+        throw std::logic_error("Trees::tree: called on null Trees");
 
+    sr_node_t *tree_dup = NULL;
     int ret = sr_dup_trees(_trees, _cnt, &tree_dup);
     if (ret != SR_ERR_OK) throw_exception(ret);
 

--- a/swig/cpp/src/Tree.cpp
+++ b/swig/cpp/src/Tree.cpp
@@ -49,7 +49,7 @@ Tree::Tree(sr_node_t *tree, S_Deleter deleter) {
     _node = tree;
     _deleter = deleter;
 }
-Tree::~Tree() {return;}
+Tree::~Tree() {}
 S_Tree Tree::dup() {
     if (!_node)
         throw std::logic_error("Tree::dup: called on null Tree");
@@ -290,7 +290,7 @@ Trees::Trees(const sr_node_t *trees, const size_t n, S_Deleter deleter) {
 
     _deleter = deleter;
 }
-Trees::~Trees() {return;}
+Trees::~Trees() {}
 S_Tree Trees::tree(size_t n) {
     if (n >= _cnt)
         throw std::out_of_range("Trees::tree: index out of range");
@@ -336,5 +336,5 @@ S_Trees Trees_Holder::allocate(size_t n) {
     S_Trees trees(new Trees(p_trees, p_cnt, NULL));
     return trees;
 }
-Trees_Holder::~Trees_Holder() {return;}
+Trees_Holder::~Trees_Holder() {}
 

--- a/swig/cpp/src/Tree.cpp
+++ b/swig/cpp/src/Tree.cpp
@@ -34,8 +34,7 @@ extern "C" {
 
 Tree::Tree() {
     _node = NULL;
-    S_Deleter deleter(new Deleter(_node));
-    _deleter = deleter;
+    _deleter = S_Deleter(new Deleter(_node));
 }
 Tree::Tree(const char *root_name, const char *root_module_name) {
     sr_node_t *node;
@@ -43,8 +42,7 @@ Tree::Tree(const char *root_name, const char *root_module_name) {
     if (ret != SR_ERR_OK)
         throw_exception(ret);
 
-    S_Deleter deleter(new Deleter(node));
-    _deleter = deleter;
+    _deleter = S_Deleter(new Deleter(node));
     _node = node;
 }
 Tree::Tree(sr_node_t *tree, S_Deleter deleter) {
@@ -259,8 +257,7 @@ void Tree::set(uint64_t uint64_val, sr_type_t type) {
 Trees::Trees() {
     _trees = NULL;
     _cnt = 0;
-    S_Deleter deleter(new Deleter(_trees, _cnt));
-    _deleter = deleter;
+    _deleter = S_Deleter(new Deleter(_trees, _cnt));
 }
 Trees::Trees(size_t cnt) {
     int ret = sr_new_trees(cnt, &_trees);
@@ -268,8 +265,7 @@ Trees::Trees(size_t cnt) {
         throw_exception(ret);
 
     _cnt = cnt;
-    S_Deleter deleter(new Deleter(_trees, _cnt));
-    _deleter = deleter;
+    _deleter = S_Deleter(new Deleter(_trees, _cnt));
 }
 Trees::Trees(sr_node_t **trees, size_t *cnt, S_Deleter deleter) {
     _trees = *trees;

--- a/swig/cpp/src/Tree.h
+++ b/swig/cpp/src/Tree.h
@@ -40,7 +40,6 @@ public:
     Tree(sr_node_t *tree, S_Deleter deleter);
     S_Tree dup();
     S_Tree node();
-    sr_node_t *tree() {return _node;};
     char *name() {return _node->name;};
     sr_type_t type() {return _node->type;};
     bool dflt() {return _node->dflt;};


### PR DESCRIPTION
I implemented some changes that @jktjkt suggested in the pull request #635.

They are:

1) Remove redundant class method with the use of friends.
2) Now methods throw exception if the underlying C struct is NULL.
3) Remove redundant line of code in creating Deleter class instances.
4) Remove "return;" from class destructors

@jktjkt can you take a look at the changes.