### PR TITLE
cmake: Use correct dependencies for the protobuf-c invocation

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -30,8 +30,6 @@ add_custom_command(
    COMMENT "Running C protocol buffer compiler on ${PROTO_FILE}"
    VERBATIM )
 
-add_custom_target(proto DEPENDS "${GENERATED_PROTO_C}" "${GENERATED_PROTO_H}")
-
 configure_file("${COMMON_DIR}/sr_constants.h.in" "${COMMON_BIN_DIR}/sr_constants.h" ESCAPE_QUOTES @ONLY)
 
 # common sources
@@ -84,7 +82,6 @@ set_property(TARGET SR_SRC PROPERTY COMPILE_FLAGS "-fPIC")
 add_library(SR_ENGINE OBJECT  ${SYSREPO_ENGINE_SOURCES})
 set_property(TARGET SR_ENGINE PROPERTY COMPILE_FLAGS "-fPIC")
 
-add_dependencies(COMMON proto)
 add_dependencies(SR_SRC COMMON)
 add_dependencies(SR_ENGINE COMMON)
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -87,6 +87,7 @@ if("${TEST_REPOSITORY_LOC}" STREQUAL "${REPOSITORY_LOC}")
     # global procject's repository location
 
     ADD_UNIT_TEST(cm_test 1)
+    add_dependencies(cm_test COMMON)
     ADD_UNIT_TEST(rp_test 1)
     if(ENABLE_NACM)
         ADD_UNIT_TEST(nacm_test 1)


### PR DESCRIPTION
The build was failing every now and then on a 12-CPU build VM (which
results in 18 jobs in Ninja AFAIK):
```
  + ninja-build install
  [1/175] cd /home/turbo-hipster/jobs/bf5a7557514d/44/44/2/check/check-czechlight-devtoolset6-el7/0363a8d/sysrepo/sysrepo/build/tests && mkdir -p /home/turbo-hipster/jobs/bf5a7557514d/44/44/2/check/check-czechlight-devtoolset6-el7/0363a8d/sysrepo/sysrepo/build/repository/yang/ /home/turbo-hipster/jobs/bf5a7557514d/44/44/2/check/check-czechlight-devtoolset6-el7/0363a8d/sysrepo/sysrepo/build/repository/data/ /home/turbo-hipster/jobs/bf5a7557514d/44/44/2/check/check-czechlight-devtoolset6-el7/0363a8d/sysrepo/sysrepo/build/repository/yang/internal/ /home/turbo-hipster/jobs/bf5a7557514d/44/44/2/check/check-czechlight-devtoolset6-el7/0363a8d/sysrepo/sysrepo/build/repository/data/internal/ && cp /home/turbo-hipster/jobs/bf5a7557514d/44/44/2/check/check-czechlight-devtoolset6-el7/0363a8d/sysrepo/sysrepo/yang/sysrepo-persistent-data.yang /home/turbo-hipster/jobs/bf5a7557514d/44/44/2/check/check-czechlight-devtoolset6-el7/0363a8d/sysrepo/sysrepo/build/repository/yang/internal/ && cp /home/turbo-hipster/jobs/bf5a7557514d/44/44/2/check/check-czechlight-devtoolset6-el7/0363a8d/sysrepo/sysrepo/yang/sysrepo-module-dependencies.yang /home/turbo-hipster/jobs/bf5a7557514d/44/44/2/check/check-czechlight-devtoolset6-el7/0363a8d/sysrepo/sysrepo/build/repository/yang/internal/ && cp /home/turbo-hipster/jobs/bf5a7557514d/44/44/2/check/check-czechlight-devtoolset6-el7/0363a8d/sysrepo/sysrepo/yang/sysrepo-notification-store.yang /home/turbo-hipster/jobs/bf5a7557514d/44/44/2/check/check-czechlight-devtoolset6-el7/0363a8d/sysrepo/sysrepo/build/repository/yang/internal/
  [2/175] Building C object tests/CMakeFiles/HELPERS.dir/helpers/test_module_helper.c.o
  FAILED: tests/CMakeFiles/HELPERS.dir/helpers/test_module_helper.c.o
  /opt/rh/devtoolset-6/root/usr/bin/cc   -I. -I../inc -I/home/turbo-hipster/jobs/bf5a7557514d/44/44/2/check/check-czechlight-devtoolset6-el7/0363a8d/dest/include -I../src -I../src/clientlib -I../src/common -Isrc/common -I../tests/helpers -Itests/helpers -Wall -Wpedantic -std=gnu11 -Wno-strict-aliasing -g -O0 -MD -MT tests/CMakeFiles/HELPERS.dir/helpers/test_module_helper.c.o -MF tests/CMakeFiles/HELPERS.dir/helpers/test_module_helper.c.o.d -o tests/CMakeFiles/HELPERS.dir/helpers/test_module_helper.c.o   -c ../tests/helpers/test_module_helper.c
  In file included from ../tests/helpers/test_module_helper.h:26:0,
                   from ../tests/helpers/test_module_helper.c:22:
  ../src/data_manager.h:30:26: fatal error: sysrepo.pb-c.h: No such file or directory
   #include "sysrepo.pb-c.h"
                            ^
  compilation terminated.
  [3/175] Running C protocol buffer compiler on /home/turbo-hipster/jobs/bf5a7557514d/44/44/2/check/check-czechlight-devtoolset6-el7/0363a8d/sysrepo/sysrepo/src/sysrepo.proto
  [4/175] Building C object tests/CMakeFiles/HELPERS.dir/helpers/nacm_module_helper.c.o
  [5/175] Building C object tests/CMakeFiles/HELPERS.dir/helpers/system_helper.c.o
  [6/175] Building C object tests/CMakeFiles/HELPERS.dir/helpers/rp_dt_context_helper.c.o
  ninja: build stopped: subcommand failed.
```
It runs out that CMake's docs explain that one cannot use these
generated files as inputs in more than one target:

>  Do not list the output in more than one independent target that may
>  build in parallel or the two instances of the rule may conflict
>  (instead use add_custom_target to drive the command and make the other
>  targets depend on that one).

Nils Gladitz (ngladitz on #cmake) explained that to me:
```
  12:26 <+ngladitz> jkt: looks like you might have more than one issue there
  12:27 <+ngladitz> you should not have more than one target directly depending on a custom command output in the same scope (you seem to have two)
  12:27 <+ngladitz> and the HELPERS target might be missing a dependency on "proto"
  12:29 < jkt> ngladitz: I'm sorry, what's the second one? I see the `add_custom_target(proto ...)`
  12:29 <+ngladitz> add_library(COMMON OBJECT ${COMMON_SOURCES}) where COMMON_SOURCES contains ${GENERATED_PROTO_C} ...
  [...]
  12:46 < jkt> ngladitz: because I'm afraid I don't know how I can create just one target which depends on the generated files given that the .h is used in several  libraries (but not listed in the input files for these libs)
  12:47 <+ngladitz> that is fine ... it just shouldn't be explicitly listed as a file dependency in the same directory scope more than once
  12:48 <+ngladitz> other targets that also depend on the header can depend on COMMON instead
```
This fix removes that explicit dependency attempt in favor of just
listing the generated files as an input to one target ("COMMON"). All
but one users of the generated .h file are defined in src/CMakeLists.txt
in COMMON or in targets which already depend on COMMON. The only
exception is cm_test which therefore needs that explicit dependency (or
maybe it doesn't, but it definitely doesn't hurt).

I've tested this by nuking the build dir and running the build with
`ninja -j666`. The order of deps looks sane. We could possible get more
parallelism if we split COMMON into several targets, but that doesn't
look like a terrific improvement.