### PR TITLE
cmake: Fix protobuf-c invocation once again

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -27,6 +27,7 @@ add_library(HELPERS OBJECT ${TEST_HELPERS_DIR}rp_dt_context_helper.c
             ${TEST_HELPERS_DIR}test_module_helper.c
             ${TEST_HELPERS_DIR}system_helper.c
             ${TEST_HELPERS_DIR}nacm_module_helper.c)
+add_dependencies(HELPERS COMMON)
 
 # create test target with specified options
 macro(ADD_UNIT_TEST_WITH_OPTS TEST_NAME USE_HELPERS USE_VALGRIND WRAP_FUNCTION)
@@ -50,6 +51,7 @@ macro(ADD_UNIT_TEST_WITH_OPTS TEST_NAME USE_HELPERS USE_VALGRIND WRAP_FUNCTION)
             --suppressions=${TEST_HELPERS_DIR}valgrind.supp
             ./${TEST_NAME})
     endif()
+    add_dependencies(${TEST_NAME} COMMON)
 endmacro(ADD_UNIT_TEST_WITH_OPTS)
 
 # create default test target with valgrind is on
@@ -87,7 +89,6 @@ if("${TEST_REPOSITORY_LOC}" STREQUAL "${REPOSITORY_LOC}")
     # global procject's repository location
 
     ADD_UNIT_TEST(cm_test 1)
-    add_dependencies(cm_test COMMON)
     ADD_UNIT_TEST(rp_test 1)
     if(ENABLE_NACM)
         ADD_UNIT_TEST(nacm_test 1)


### PR DESCRIPTION
This builds on top of 1b56f984c70569fa2832451c9716525a7e4b9d40;
apparently, my change was not enough for at least some versions of CMake
and Ninja:
```
  + ninja-build install
  [1/140] cd /home/turbo-hipster/jobs/...
  [2/140] Building C object tests/CMakeFiles/HELPERS.dir/helpers/test_module_helper.c.o
  FAILED: tests/CMakeFiles/HELPERS.dir/helpers/test_module_helper.c.o
  /opt/rh/devtoolset-6/root/usr/bin/cc   -I. -I../inc -I/home/turbo-hipster/target/include -I../src -I../src/clientlib -I../src/common -Isrc/common -I../tests/helpers -Itests/helpers -Wall -Wpedantic -std=gnu11 -Wno-strict-aliasing -g -O0 -MD -MT tests/CMakeFiles/HELPERS.dir/helpers/test_module_helper.c.o -MF tests/CMakeFiles/HELPERS.dir/helpers/test_module_helper.c.o.d -o tests/CMakeFiles/HELPERS.dir/helpers/test_module_helper.c.o   -c ../tests/helpers/test_module_helper.c
  In file included from ../tests/helpers/test_module_helper.h:26:0,
                   from ../tests/helpers/test_module_helper.c:22:
  ../src/data_manager.h:30:26: fatal error: sysrepo.pb-c.h: No such file or directory
   #include "sysrepo.pb-c.h"
                            ^
  compilation terminated.
```
When I tried to fix this, I forgot that the HELPERS also include files such as
the data_manager.h which in turn depend on the generated .h.