### PR TITLE
Improving build stability and Travis debugging support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,6 +37,7 @@ before_script:
 script:
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then mkdir build ; cd build ; cmake -DCMAKE_BUILD_TYPE=Debug -DCMAKE_PREFIX_PATH=$HOME/local -DCMAKE_C_FLAGS="-Werror -coverage" -DLOG_THREAD_ID=ON -DUSE_SR_MEM_MGMT=${USE_SR_MEM_MGMT:-ON} .. && make -j2; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then mkdir build ; cd build ; cmake -DGEN_LANGUAGE_BINDINGS=0 -DCMAKE_BUILD_TYPE=Debug -DCMAKE_PREFIX_PATH=$HOME/local -DCMAKE_C_FLAGS="-Werror -coverage" -DLOG_THREAD_ID=ON .. && make -j2; fi
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then ( sudo sh ../deploy/travis/watch-bt.sh & ); fi
   - ctest --output-on-failure
   - sudo ctest --output-on-failure --tests-regex ac_test
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo sh ../deploy/travis/install-test-users.sh; fi

--- a/deploy/travis/install-libs.sh
+++ b/deploy/travis/install-libs.sh
@@ -8,7 +8,7 @@ sudo apt-get install --reinstall ca-certificates
 sudo apt-get install software-properties-common # add-apt-repository tool
 sudo add-apt-repository --yes ppa:stefanklug/swig
 sudo apt-get update -qq
-sudo apt-get install -y --force-yes libavl-dev libev-dev valgrind timeout swig3.0 python-dev gdb
+sudo apt-get install -y --force-yes libavl-dev libev-dev valgrind coreutils swig3.0 python-dev gdb
 pip install --user codecov
 echo -n | openssl s_client -connect scan.coverity.com:443 | sed -ne '/-BEGIN CERTIFICATE-/,/-END CERTIFICATE-/p' | sudo tee -a /etc/ssl/certs/ca-certificates.crt
 

--- a/deploy/travis/install-libs.sh
+++ b/deploy/travis/install-libs.sh
@@ -8,7 +8,7 @@ sudo apt-get install --reinstall ca-certificates
 sudo apt-get install software-properties-common # add-apt-repository tool
 sudo add-apt-repository --yes ppa:stefanklug/swig
 sudo apt-get update -qq
-sudo apt-get install -y --force-yes libavl-dev libev-dev valgrind swig3.0 python-dev gdb
+sudo apt-get install -y --force-yes libavl-dev libev-dev valgrind timeout swig3.0 python-dev gdb
 pip install --user codecov
 echo -n | openssl s_client -connect scan.coverity.com:443 | sed -ne '/-BEGIN CERTIFICATE-/,/-END CERTIFICATE-/p' | sudo tee -a /etc/ssl/certs/ca-certificates.crt
 

--- a/deploy/travis/watch-bt.sh
+++ b/deploy/travis/watch-bt.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+
+while true;
+do
+        sleep 60;
+        TEST=$(ps -ef | grep _test | grep -v "grep\|valgrind\|defunct\|gdb\|ctest\|timeout")
+        PID=$(echo ${TEST} | awk '{ print $2 }')
+        EXE=$(echo ${TEST} | awk '{ print $8 }')
+        if [ ! -z "$PID" ];
+        then
+            echo; echo "Backtrace for ${EXE} (pid=${PID}):";
+            (cd tests; gdb -ex "attach ${PID}" -ex "thread apply all bt" -batch --args ${EXE} </dev/null)
+        fi
+done

--- a/src/nacm.c
+++ b/src/nacm.c
@@ -1127,6 +1127,7 @@ unlock_all:
         /* update stats */
         pthread_rwlock_wrlock(&nacm_ctx->stats.lock);
         ++nacm_ctx->stats.denied_rpc;
+        SR_LOG_DBG("Increasing NACM counter denied-rpc to: %d", nacm_ctx->stats.denied_rpc);
         pthread_rwlock_unlock(&nacm_ctx->stats.lock);
     }
     pthread_rwlock_unlock(&nacm_ctx->lock);
@@ -1316,6 +1317,7 @@ unlock_all:
         /* update stats */
         pthread_rwlock_wrlock(&nacm_ctx->stats.lock);
         ++nacm_ctx->stats.denied_event_notif;
+        SR_LOG_DBG("Increasing NACM counter denied-event-notif to: %d", nacm_ctx->stats.denied_event_notif);
         pthread_rwlock_unlock(&nacm_ctx->stats.lock);
     }
     pthread_rwlock_unlock(&nacm_ctx->lock);
@@ -1712,6 +1714,7 @@ nacm_stats_add_denied_data_write(nacm_ctx_t *nacm_ctx)
 
     pthread_rwlock_wrlock(&nacm_ctx->stats.lock);
     ++nacm_ctx->stats.denied_data_write;
+    SR_LOG_DBG("Increasing NACM counter denied-data-write to: %d", nacm_ctx->stats.denied_data_write);
     pthread_rwlock_unlock(&nacm_ctx->stats.lock);
     return SR_ERR_OK;
 }

--- a/src/notification_processor.c
+++ b/src/notification_processor.c
@@ -1385,7 +1385,7 @@ np_data_provider_request(np_ctx_t *np_ctx, np_subscription_t *subscription, rp_s
             req->request->data_provide_req->subscriber_address = strdup(subscription->dst_address);
             CHECK_NULL_NOMEM_ERROR(req->request->data_provide_req->subscriber_address, rc);
             /* identification of the request that asked for data */
-            req->request->data_provide_req->request_id = (uint64_t) session->req;
+            req->request->data_provide_req->request_id = session->req->request->_id;
         }
     }
 

--- a/src/request_processor.c
+++ b/src/request_processor.c
@@ -680,7 +680,7 @@ rp_get_item_req_process(rp_ctx_t *rp_ctx, rp_session_t *session, Sr__Msg *msg, b
 
     CHECK_NULL_ARG5(rp_ctx, session, msg, msg->request, msg->request->get_item_req);
 
-    SR_LOG_DBG("Processing get_item request (id=%lu).", msg->request->_id);
+    SR_LOG_DBG("Processing get_item request (id=%" PRIu64 ").", msg->request->_id);
 
     Sr__Msg *resp = NULL;
     sr_mem_ctx_t *sr_mem = NULL;
@@ -707,11 +707,11 @@ rp_get_item_req_process(rp_ctx_t *rp_ctx, rp_session_t *session, Sr__Msg *msg, b
         session->state = RP_REQ_NEW;
     } else if (RP_REQ_WAITING_FOR_DATA == session->state) {
         if (msg->request->_id == session->req->request->_id) {
-            SR_LOG_ERR("Time out waiting for operational data expired before all responses have been received, session id = %u, req = %lu",
-                    session->id, session->req->request->_id);
+            SR_LOG_ERR("Time out waiting for operational data expired before all responses have been received, "
+                    "session id = %u, req = %" PRIu64, session->id, session->req->request->_id);
             session->state = RP_REQ_DATA_LOADED;
         } else {
-            SR_LOG_ERR("A request was not processed, probably invalid state, session id = %u, req = %lu",
+            SR_LOG_ERR("A request was not processed, probably invalid state, session id = %u, req = %" PRIu64,
                     session->id, session->req->request->_id);
             sr_msg_free(session->req);
             session->state = RP_REQ_NEW;
@@ -2522,7 +2522,8 @@ rp_data_provide_resp_process(rp_ctx_t *rp_ctx, rp_session_t *session, Sr__Msg *m
     MUTEX_LOCK_TIMED_CHECK_GOTO(&session->cur_req_mutex, rc, cleanup);
     if (RP_REQ_WAITING_FOR_DATA != session->state || NULL == session->req
             ||  msg->response->data_provide_resp->request_id != session->req->request->_id ) {
-        SR_LOG_ERR("State data arrived after timeout expiration or session id=%u is invalid (msg=%lu, session->req=%lu).",
+        SR_LOG_ERR("State data arrived after timeout expiration or session id=%u is invalid "
+                "(msg=%" PRIu64 ", session->req=%" PRIu64 ").",
                 session->id, msg->response->data_provide_resp->request_id, session->req ? session->req->request->_id : 0);
         goto error;
     }
@@ -2558,8 +2559,8 @@ finish:
         //TODO validate data
         rp_dt_free_state_data_ctx_content(&session->state_data_ctx);
         if (RP_REQ_WAITING_FOR_DATA == session->state) {
-            SR_LOG_DBG("All data from data providers has been received session id = %u, reenque the request id = %lu",
-                    session->id, session->req->request->_id);
+            SR_LOG_DBG("All data from data providers has been received session id = %u, "
+                    "reenque the request id = %" PRIu64, session->id, session->req->request->_id);
             session->state = RP_REQ_DATA_LOADED;
             rp_msg_process(rp_ctx, session, session->req);
             session->req = NULL;
@@ -2738,8 +2739,8 @@ rp_oper_data_timeout_req_process(rp_ctx_t *rp_ctx, rp_session_t *session, Sr__Ms
     MUTEX_LOCK_TIMED_CHECK_RETURN(&session->cur_req_mutex);
     if (RP_REQ_WAITING_FOR_DATA == session->state &&
         session->req && session->req->request->_id == msg->internal_request->oper_data_timeout_req->request_id) {
-        SR_LOG_DBG("Time out expired for operational data to be loaded. Request (id=%lu) processing continue, session id = %u",
-                session->req->request->_id, session->id);
+        SR_LOG_DBG("Time out expired for operational data to be loaded. Request (id=%" PRIu64 ") processing continue, "
+                "session id = %u", session->req->request->_id, session->id);
         rp_msg_process(rp_ctx, session, session->req);
         session->state = RP_REQ_DATA_LOADED;
     }
@@ -2762,7 +2763,7 @@ rp_internal_state_data_req_process(rp_ctx_t *rp_ctx, rp_session_t *session, Sr__
     uint64_t orig_req_id = msg->internal_request->internal_state_data_req->request_id;
     nacm_stats.type = SR_UINT32_T;
 
-    SR_LOG_INF("Internal request for state data at xpath %s, orig-req id = %lu", xpath, orig_req_id);
+    SR_LOG_INF("Internal request for state data at xpath %s, orig-req id = %" PRIu64, xpath, orig_req_id);
 
     MUTEX_LOCK_TIMED_CHECK_GOTO(&session->cur_req_mutex, rc, cleanup);
     if (RP_REQ_WAITING_FOR_DATA != session->state || NULL == session->req || orig_req_id != session->req->request->_id) {
@@ -2816,8 +2817,8 @@ cleanup:
     if (0 == session->dp_req_waiting) {
         rp_dt_free_state_data_ctx_content(&session->state_data_ctx);
         if (RP_REQ_WAITING_FOR_DATA == session->state) {
-            SR_LOG_DBG("All data from data providers has been received session id = %u, reenque the request (id=%lu)",
-                    session->id, session->req->request->_id);
+            SR_LOG_DBG("All data from data providers has been received session id = %u, "
+                    "reenque the request (id=%" PRIu64 ")", session->id, session->req->request->_id);
             session->state = RP_REQ_DATA_LOADED;
             rp_msg_process(rp_ctx, session, session->req);
             session->req = NULL;

--- a/src/request_processor.c
+++ b/src/request_processor.c
@@ -2523,7 +2523,7 @@ finish:
         rp_dt_free_state_data_ctx_content(&session->state_data_ctx);
         if (RP_REQ_WAITING_FOR_DATA == session->state) {
             SR_LOG_DBG("All data from data providers has been received session id = %u, "
-                    "reenque the request id = %" PRIu64, session->id, session->req->request->_id);
+                    "re-enqueue the request id = %" PRIu64, session->id, session->req->request->_id);
             session->state = RP_REQ_DATA_LOADED;
             rp_msg_process(rp_ctx, session, session->req);
             session->req = NULL;
@@ -2781,7 +2781,7 @@ cleanup:
         rp_dt_free_state_data_ctx_content(&session->state_data_ctx);
         if (RP_REQ_WAITING_FOR_DATA == session->state) {
             SR_LOG_DBG("All data from data providers has been received session id = %u, "
-                    "reenque the request (id=%" PRIu64 ")", session->id, session->req->request->_id);
+                    "re-enqueue the request (id=%" PRIu64 ")", session->id, session->req->request->_id);
             session->state = RP_REQ_DATA_LOADED;
             rp_msg_process(rp_ctx, session, session->req);
             session->req = NULL;

--- a/src/rp_dt_get.c
+++ b/src/rp_dt_get.c
@@ -21,6 +21,7 @@
 
 #include <libyang/libyang.h>
 #include <pthread.h>
+#include <inttypes.h>
 #include "sysrepo.h"
 #include "sr_common.h"
 

--- a/src/rp_dt_get.c
+++ b/src/rp_dt_get.c
@@ -1114,6 +1114,7 @@ rp_dt_send_first_set_of_dp_requests(rp_ctx_t *rp_ctx, rp_session_t *rp_session)
                     CHECK_RC_MSG_GOTO(rc, cleanup, "Failed to set string");
 
                     rc = rp_msg_process(rp_ctx, rp_session, req);
+                    SR_LOG_DBG("Enqueued an internal message to obtain state data for request: %lu", (intptr_t)rp_session->req);
                     req = NULL;
                     CHECK_RC_MSG_GOTO(rc, cleanup, "Failed to enqueue message");
 

--- a/src/rp_dt_get.c
+++ b/src/rp_dt_get.c
@@ -1110,11 +1110,13 @@ rp_dt_send_first_set_of_dp_requests(rp_ctx_t *rp_ctx, rp_session_t *rp_session)
 
                     req->internal_request->internal_state_data_req->request_id = rp_session->req->request->_id;
 
-                    rc = sr_mem_edit_string((sr_mem_ctx_t *)req->_sysrepo_mem_ctx, &req->internal_request->internal_state_data_req->xpath, subtree);
+                    rc = sr_mem_edit_string((sr_mem_ctx_t *)req->_sysrepo_mem_ctx,
+                            &req->internal_request->internal_state_data_req->xpath, subtree);
                     CHECK_RC_MSG_GOTO(rc, cleanup, "Failed to set string");
 
                     rc = rp_msg_process(rp_ctx, rp_session, req);
-                    SR_LOG_DBG("Enqueued an internal message to obtain state data for request: %lu", rp_session->req->request->_id);
+                    SR_LOG_DBG("Enqueued an internal message to obtain state data for request: %" PRIu64,
+                            rp_session->req->request->_id);
                     req = NULL;
                     CHECK_RC_MSG_GOTO(rc, cleanup, "Failed to enqueue message");
 

--- a/src/rp_dt_get.c
+++ b/src/rp_dt_get.c
@@ -1108,13 +1108,13 @@ rp_dt_send_first_set_of_dp_requests(rp_ctx_t *rp_ctx, rp_session_t *rp_session)
                     rc = sr_gpb_internal_req_alloc(NULL, SR__OPERATION__INTERNAL_STATE_DATA, &req);
                     CHECK_RC_MSG_GOTO(rc, cleanup, "Failed to allocate internal message");
 
-                    req->internal_request->internal_state_data_req->request_id = (intptr_t) rp_session->req;
+                    req->internal_request->internal_state_data_req->request_id = rp_session->req->request->_id;
 
                     rc = sr_mem_edit_string((sr_mem_ctx_t *)req->_sysrepo_mem_ctx, &req->internal_request->internal_state_data_req->xpath, subtree);
                     CHECK_RC_MSG_GOTO(rc, cleanup, "Failed to set string");
 
                     rc = rp_msg_process(rp_ctx, rp_session, req);
-                    SR_LOG_DBG("Enqueued an internal message to obtain state data for request: %lu", (intptr_t)rp_session->req);
+                    SR_LOG_DBG("Enqueued an internal message to obtain state data for request: %lu", rp_session->req->request->_id);
                     req = NULL;
                     CHECK_RC_MSG_GOTO(rc, cleanup, "Failed to enqueue message");
 

--- a/src/rp_internal.h
+++ b/src/rp_internal.h
@@ -120,6 +120,10 @@ typedef struct rp_session_s {
     rp_dt_get_items_ctx_t get_items_ctx; /**< Context for get_items_iter calls. */
     rp_dt_change_ctx_t change_ctx;       /**< Context for iteration over the changes */
 
+    /* request ID generator */
+    uint64_t total_req_cnt;              /**< Total number of received requests for this session. */
+    pthread_mutex_t total_req_cnt_mutex; /**< Mutex protecting total_req_cnt. */
+
     /* current request - used for data retrieval calls which may need state data */
     rp_request_state_t state;            /**< the state of the request processing used if the operational data are requested */
     size_t dp_req_waiting;               /**< number of waiting request to operational data providers */

--- a/src/sysrepo.proto
+++ b/src/sysrepo.proto
@@ -990,7 +990,8 @@ enum Operation {
  * @brief Request for an operation.
  */
 message Request {
-  required Operation operation = 1;
+  required uint64 _id = 1; /* Request ID used internally by sysrepo */
+  required Operation operation = 2;
 
   optional SessionStartReq session_start_req = 10;
   optional SessionStopReq session_stop_req = 11;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -22,6 +22,7 @@ include_directories (
 )
 
 find_program(valgrind_FOUND valgrind)
+find_program(timeout_FOUND timeout)
 
 add_library(HELPERS OBJECT ${TEST_HELPERS_DIR}rp_dt_context_helper.c
             ${TEST_HELPERS_DIR}test_module_helper.c
@@ -42,7 +43,13 @@ macro(ADD_UNIT_TEST_WITH_OPTS TEST_NAME USE_HELPERS USE_VALGRIND WRAP_FUNCTION)
     endif()
 
     target_link_libraries(${TEST_NAME} ${CMOCKA_LIBRARIES} sysrepo_a ${test_link_flags})
-    add_test(${TEST_NAME} ${TEST_NAME})
+    if(timeout_FOUND AND NOT ${CMAKE_C_FLAGS} MATCHES "-fsanitize")
+        add_test(${TEST_NAME} timeout
+            --signal=6 360
+            ./${TEST_NAME})
+    else()
+        add_test(${TEST_NAME} ${TEST_NAME})
+    endif()
     if(valgrind_FOUND AND ${USE_VALGRIND} AND NOT ${CMAKE_C_FLAGS} MATCHES "-fsanitize")
         add_test(${TEST_NAME}_valgrind valgrind
             --error-exitcode=1 --read-var-info=yes

--- a/tests/cl_test.c
+++ b/tests/cl_test.c
@@ -116,7 +116,7 @@ sr_node_t_get_child(const sr_node_t *node, size_t index)
         ++i;
         child = child->next;
     }
-    assert_true(false && "index out of range");
+    assert_true_bt(false && "index out of range");
     return NULL;
 }
 

--- a/tests/helpers/system_helper.c
+++ b/tests/helpers/system_helper.c
@@ -209,7 +209,7 @@ print_backtrace()
 #endif
 }
 
-static void
+void
 assert_non_null_bt(void *arg)
 {
     if (NULL == arg) {
@@ -218,7 +218,16 @@ assert_non_null_bt(void *arg)
     assert_non_null(arg);
 }
 
-static void
+void
+assert_null_bt(void *arg)
+{
+    if (NULL != arg) {
+        print_backtrace();
+    }
+    assert_null(arg);
+}
+
+void
 assert_true_bt(bool arg)
 {
     if (!arg) {
@@ -227,7 +236,16 @@ assert_true_bt(bool arg)
     assert_true(arg);
 }
 
-static void
+void
+assert_false_bt(bool arg)
+{
+    if (arg) {
+        print_backtrace();
+    }
+    assert_false(arg);
+}
+
+void
 assert_string_equal_bt(const char *a, const char *b)
 {
     if (!a || !b || 0 != strcmp(a, b)) {
@@ -236,8 +254,17 @@ assert_string_equal_bt(const char *a, const char *b)
     assert_string_equal(a, b);
 }
 
-static void
+void
 assert_int_equal_bt(int a, int b)
+{
+    if (a != b) {
+        print_backtrace();
+    }
+    assert_int_equal(a, b);
+}
+
+void
+assert_int_not_equal_bt(int a, int b)
 {
     if (a != b) {
         print_backtrace();

--- a/tests/helpers/system_helper.c
+++ b/tests/helpers/system_helper.c
@@ -266,10 +266,10 @@ assert_int_equal_bt(int a, int b)
 void
 assert_int_not_equal_bt(int a, int b)
 {
-    if (a != b) {
+    if (a == b) {
         print_backtrace();
     }
-    assert_int_equal(a, b);
+    assert_int_not_equal(a, b);
 }
 
 void

--- a/tests/helpers/system_helper.h
+++ b/tests/helpers/system_helper.h
@@ -39,6 +39,48 @@ pid_t sr_popen(const char *command, int *stdin_p, int *stdout_p, int *stderr_p);
 void print_backtrace();
 
 /**
+ * @brief Assert that the given pointer is non-NULL.
+ * In case of failed assertion, print current backtrace to stderr.
+ */
+void assert_non_null_bt(void *arg);
+
+/**
+ * @brief Assert that the given pointer is NULL.
+ * In case of failed assertion, print current backtrace to stderr.
+ */
+void assert_null_bt(void *arg);
+
+/**
+ * @brief Assert that the given argument is true.
+ * In case of failed assertion, print current backtrace to stderr.
+ */
+void assert_true_bt(bool arg);
+
+/**
+ * @brief Assert that the given argument is false.
+ * In case of failed assertion, print current backtrace to stderr.
+ */
+void assert_false_bt(bool arg);
+
+/**
+ * @brief Assert that the two given strings are equal.
+ * In case of failed assertion, print current backtrace to stderr.
+ */
+void assert_string_equal_bt(const char *a, const char *b);
+
+/**
+ * @brief Assert that the two given integers are equal.
+ * In case of failed assertion, print current backtrace to stderr.
+ */
+void assert_int_equal_bt(int a, int b);
+
+/**
+ * @brief Assert that the two given integers are not equal.
+ * In case of failed assertion, print current backtrace to stderr.
+ */
+void assert_int_not_equal_bt(int a, int b);
+
+/**
  * @brief Reads an entire line from a file, storing the address of the buffer
  * containing the text into *line_p. The buffer is null-terminated and includes
  * the newline character, if one was found.

--- a/tests/md_test.c
+++ b/tests/md_test.c
@@ -534,8 +534,8 @@ md_test_dep(md_dep_type_t type, int is_direct, ...)
     va_list va;
 
     dep = calloc(1, sizeof *dep);
-    assert_non_null(dep);
-    assert_int_equal(SR_ERR_OK, sr_list_init(&dep->orig_modules));
+    assert_non_null_bt(dep);
+    assert_int_equal_bt(SR_ERR_OK, sr_list_init(&dep->orig_modules));
 
     dep->type = type;
     dep->direct = is_direct;
@@ -546,8 +546,8 @@ md_test_dep(md_dep_type_t type, int is_direct, ...)
 
         for (int i = 0; i < orig_cnt; ++i) {
             orig = va_arg(va, const char *);
-            assert_non_null(orig);
-            assert_int_equal(SR_ERR_OK, sr_list_add(dep->orig_modules, (void *)orig));
+            assert_non_null_bt((void *)orig);
+            assert_int_equal_bt(SR_ERR_OK, sr_list_add(dep->orig_modules, (void *)orig));
         }
 
         va_end(va);
@@ -616,7 +616,7 @@ create_module_yang_schema(const char *name, const char *destpath, const char *bo
     FILE *fp = NULL;
 
     fp = fopen(destpath, "w");
-    assert_non_null(fp);
+    assert_non_null_bt(fp);
     fprintf(fp,
             "module " TEST_MODULE_PREFIX "%s {\n"
             "  namespace \"urn:ietf:params:xml:ns:yang:%s\";\n"
@@ -647,7 +647,7 @@ create_submodule_yang_schema(const char *name, const char *belongsto, const char
     FILE *fp = NULL;
 
     fp = fopen(destpath, "w");
-    assert_non_null(fp);
+    assert_non_null_bt(fp);
     fprintf(fp,
             "submodule " TEST_SUBMODULE_PREFIX "%s {\n"
             "  belongs-to " TEST_MODULE_PREFIX "%s {\n"
@@ -784,7 +784,7 @@ check_list_size(sr_llist_t *list, size_t expected)
         ++size;
         node = node->next;
     }
-    assert_int_equal(expected, size);
+    assert_int_equal_bt(expected, size);
 }
 
 static void
@@ -805,12 +805,12 @@ compare_orig_modules(sr_llist_t *orig_modules, sr_list_t *expected)
                 if (0 == strcmp(md_get_module_fullname(orig_module)
                                        + (orig_module->submodule ? strlen(TEST_SUBMODULE_PREFIX) : strlen(TEST_MODULE_PREFIX)),
                                 expected->data[i])) {
-                    assert_false(found);
+                    assert_false_bt(found);
                     found = true;
                 }
                 node = node->next;
             }
-            assert_true(found);
+            assert_true_bt(found);
         }
     }
     check_list_size(orig_modules, expected_cnt);
@@ -843,8 +843,8 @@ validate_dependency(const sr_llist_t *deps, const char *module_name, int count, 
             if (0 == strcmp(md_get_module_fullname(dep->dest)
                                 + (dep->dest->submodule ? strlen(TEST_SUBMODULE_PREFIX) : strlen(TEST_MODULE_PREFIX)),
                             module_name) && dep->type == test_dep->type) {
-                assert_true(in);
-                assert_false(found);
+                assert_true_bt(in);
+                assert_false_bt(found);
                 found = true;
                 assert_int_equal(test_dep->direct, dep->direct);
                 if (MD_DEP_DATA == test_dep->type) {
@@ -854,7 +854,7 @@ validate_dependency(const sr_llist_t *deps, const char *module_name, int count, 
             dep_node = dep_node->next;
         }
         if (!found) {
-            assert_false(in);
+            assert_false_bt(in);
         }
         /* release the expected dependency */
         sr_list_cleanup(test_dep->orig_modules);
@@ -874,7 +874,7 @@ validate_dependency(const sr_llist_t *deps, const char *module_name, int count, 
         }
         dep_node = dep_node->next;
     }
-    assert_int_equal(0, in_cnt);
+    assert_int_equal_bt(0, in_cnt);
 }
 
 /**
@@ -905,16 +905,16 @@ validate_subtree_ref(md_ctx_t *md_ctx, sr_llist_t *list, const char *xpath,
     while (node) {
         subtree_ref = (md_subtree_ref_t *)node->data;
         if (0 == strcmp(subtree_ref->xpath, xpath)) {
-            assert_string_equal(subtree_ref->orig->name, full_module_name);
+            assert_string_equal_bt(subtree_ref->orig->name, full_module_name);
             if (0 == strcmp(subtree_ref->orig->revision_date, at)) {
-                assert_int_equal(SR_ERR_OK, rc);
+                assert_int_equal_bt(SR_ERR_OK, rc);
                 free(orig_name_cpy);
                 return;
             }
         }
         node = node->next;
     }
-    assert_int_equal(SR_ERR_NOT_FOUND, rc);
+    assert_int_equal_bt(SR_ERR_NOT_FOUND, rc);
     free(orig_name_cpy);
 }
 
@@ -930,21 +930,21 @@ validate_context(md_ctx_t *md_ctx)
     /* validate module A */
     rc = md_get_module_info(md_ctx, TEST_MODULE_PREFIX "A", NULL, &module);
     if (inserted.A) {
-        assert_int_equal(SR_ERR_OK, rc);
-        assert_non_null(module);
-        assert_string_equal(TEST_MODULE_PREFIX "A", module->name);
-        assert_string_equal("", module->revision_date);
-        assert_string_equal(TEST_MODULE_PREFIX "A", md_get_module_fullname(module));
-        assert_string_equal("A", module->prefix);
-        assert_string_equal("urn:ietf:params:xml:ns:yang:A", module->ns);
-        assert_string_equal(md_module_A_filepath, module->filepath);
+        assert_int_equal_bt(SR_ERR_OK, rc);
+        assert_non_null_bt(module);
+        assert_string_equal_bt(TEST_MODULE_PREFIX "A", module->name);
+        assert_string_equal_bt("", module->revision_date);
+        assert_string_equal_bt(TEST_MODULE_PREFIX "A", md_get_module_fullname(module));
+        assert_string_equal_bt("A", module->prefix);
+        assert_string_equal_bt("urn:ietf:params:xml:ns:yang:A", module->ns);
+        assert_string_equal_bt(md_module_A_filepath, module->filepath);
         assert_true(module->latest_revision);
         if (implemented.A) {
-            assert_true(module->implemented);
+            assert_true_bt(module->implemented);
         } else {
-            assert_false(module->implemented);
+            assert_false_bt(module->implemented);
         }
-        assert_true(module->has_data);
+        assert_true_bt(module->has_data);
         /* inst_ids */
         check_list_size(module->inst_ids, inserted.B + inserted.D_rev1 + 2*inserted.D_rev2);
         validate_subtree_ref(md_ctx, module->inst_ids,
@@ -982,8 +982,8 @@ validate_context(md_ctx_t *md_ctx)
                                      "/" TEST_MODULE_PREFIX "C:C-ext-container"
                                      "/" TEST_MODULE_PREFIX "D:D-ext-op-data2", "D@2016-06-20");
         /* outside references */
-        assert_non_null(module->ly_data);
-        assert_non_null(module->ll_node);
+        assert_non_null_bt(module->ly_data);
+        assert_non_null_bt(module->ll_node);
         /* dependencies */
         validate_dependency(module->deps, "A", 0);
         validate_dependency(module->deps, "B", 2, md_test_dep(MD_DEP_EXTENSION, true), md_test_dep(MD_DEP_DATA, true, 1, "D@2016-06-20"));
@@ -1008,28 +1008,28 @@ validate_context(md_ctx_t *md_ctx)
         validate_dependency(module->inv_deps, "E@2016-06-11", 2, md_test_dep(MD_DEP_IMPORT, false), md_test_dep(MD_DEP_DATA, false, 0));
         validate_dependency(module->inv_deps, "E@2016-06-21", 2, md_test_dep(MD_DEP_IMPORT, false), md_test_dep(MD_DEP_DATA, false, 0));
     } else {
-        assert_int_equal(SR_ERR_NOT_FOUND, rc);
-        assert_null(module);
+        assert_int_equal_bt(SR_ERR_NOT_FOUND, rc);
+        assert_null_bt(module);
     }
 
     /* validate module B */
     rc = md_get_module_info(md_ctx, TEST_MODULE_PREFIX "B", NULL, &module);
     if (inserted.B) {
-        assert_int_equal(SR_ERR_OK, rc);
-        assert_non_null(module);
-        assert_string_equal(TEST_MODULE_PREFIX "B", module->name);
-        assert_string_equal("", module->revision_date);
-        assert_string_equal(TEST_MODULE_PREFIX "B", md_get_module_fullname(module));
-        assert_string_equal("B", module->prefix);
-        assert_string_equal("urn:ietf:params:xml:ns:yang:B", module->ns);
-        assert_string_equal(md_module_B_filepath, module->filepath);
-        assert_true(module->latest_revision);
+        assert_int_equal_bt(SR_ERR_OK, rc);
+        assert_non_null_bt(module);
+        assert_string_equal_bt(TEST_MODULE_PREFIX "B", module->name);
+        assert_string_equal_bt("", module->revision_date);
+        assert_string_equal_bt(TEST_MODULE_PREFIX "B", md_get_module_fullname(module));
+        assert_string_equal_bt("B", module->prefix);
+        assert_string_equal_bt("urn:ietf:params:xml:ns:yang:B", module->ns);
+        assert_string_equal_bt(md_module_B_filepath, module->filepath);
+        assert_true_bt(module->latest_revision);
         if (implemented.B) {
-            assert_true(module->implemented);
+            assert_true_bt(module->implemented);
         } else {
-            assert_false(module->implemented);
+            assert_false_bt(module->implemented);
         }
-        assert_true(module->has_data);
+        assert_true_bt(module->has_data);
         /* inst_ids */
         check_list_size(module->inst_ids, 1);
         validate_subtree_ref(md_ctx, module->inst_ids, "/" TEST_MODULE_PREFIX "B:inst-ids/inst-id", "B");
@@ -1037,8 +1037,8 @@ validate_context(md_ctx_t *md_ctx)
         check_list_size(module->op_data_subtrees, 1);
         validate_subtree_ref(md_ctx, module->op_data_subtrees, "/" TEST_MODULE_PREFIX "B:op-data", "B");
         /* outside references */
-        assert_non_null(module->ly_data);
-        assert_non_null(module->ll_node);
+        assert_non_null_bt(module->ly_data);
+        assert_non_null_bt(module->ll_node);
         /* dependencies */
         validate_dependency(module->deps, "A", 2, md_test_dep(MD_DEP_IMPORT, true), md_test_dep(MD_DEP_DATA, true, 1, "B"));
         validate_dependency(module->deps, "B", 0);
@@ -1076,130 +1076,130 @@ validate_context(md_ctx_t *md_ctx)
             validate_dependency(module->inv_deps, "E@2016-06-21", 1, md_test_dep(MD_DEP_IMPORT, false));
         }
     } else {
-        assert_int_equal(SR_ERR_NOT_FOUND, rc);
-        assert_null(module);
+        assert_int_equal_bt(SR_ERR_NOT_FOUND, rc);
+        assert_null_bt(module);
     }
 
     /* validate submodule Bs1 */
     rc = md_get_module_info(md_ctx, TEST_SUBMODULE_PREFIX "Bs1", NULL, &module);
     if (inserted.B) {
-        assert_int_equal(SR_ERR_OK, rc);
-        assert_non_null(module);
-        assert_string_equal(TEST_SUBMODULE_PREFIX "Bs1", module->name);
-        assert_string_equal("", module->revision_date);
-        assert_string_equal(TEST_SUBMODULE_PREFIX "Bs1", md_get_module_fullname(module));
-        assert_string_equal("", module->prefix);
-        assert_string_equal("", module->ns);
-        assert_string_equal(md_submodule_B_sub1_filepath, module->filepath);
+        assert_int_equal_bt(SR_ERR_OK, rc);
+        assert_non_null_bt(module);
+        assert_string_equal_bt(TEST_SUBMODULE_PREFIX "Bs1", module->name);
+        assert_string_equal_bt("", module->revision_date);
+        assert_string_equal_bt(TEST_SUBMODULE_PREFIX "Bs1", md_get_module_fullname(module));
+        assert_string_equal_bt("", module->prefix);
+        assert_string_equal_bt("", module->ns);
+        assert_string_equal_bt(md_submodule_B_sub1_filepath, module->filepath);
         assert_true(module->latest_revision);
         if (implemented.B) {
-            assert_true(module->implemented);
+            assert_true_bt(module->implemented);
         } else {
-            assert_false(module->implemented);
+            assert_false_bt(module->implemented);
         }
-        assert_false(module->has_data);
+        assert_false_bt(module->has_data);
         /* inst_ids */
         check_list_size(module->inst_ids, 0);
         /* op_data_subtrees */
         check_list_size(module->op_data_subtrees, 0);
         /* outside references */
-        assert_non_null(module->ly_data);
-        assert_non_null(module->ll_node);
+        assert_non_null_bt(module->ly_data);
+        assert_non_null_bt(module->ll_node);
         /* dependencies */
         check_list_size(module->deps, 0);
         check_list_size(module->inv_deps, 1);
         validate_dependency(module->inv_deps, "B", 1, md_test_dep(MD_DEP_INCLUDE, true));
     } else {
-        assert_int_equal(SR_ERR_NOT_FOUND, rc);
-        assert_null(module);
+        assert_int_equal_bt(SR_ERR_NOT_FOUND, rc);
+        assert_null_bt(module);
     }
 
     /* validate submodule Bs2 */
     rc = md_get_module_info(md_ctx, TEST_SUBMODULE_PREFIX "Bs2", NULL, &module);
     if (inserted.B) {
-        assert_int_equal(SR_ERR_OK, rc);
-        assert_non_null(module);
-        assert_string_equal(TEST_SUBMODULE_PREFIX "Bs2", module->name);
-        assert_string_equal("", module->revision_date);
-        assert_string_equal(TEST_SUBMODULE_PREFIX "Bs2", md_get_module_fullname(module));
-        assert_string_equal("", module->prefix);
-        assert_string_equal("", module->ns);
-        assert_string_equal(md_submodule_B_sub2_filepath, module->filepath);
-        assert_true(module->latest_revision);
+        assert_int_equal_bt(SR_ERR_OK, rc);
+        assert_non_null_bt(module);
+        assert_string_equal_bt(TEST_SUBMODULE_PREFIX "Bs2", module->name);
+        assert_string_equal_bt("", module->revision_date);
+        assert_string_equal_bt(TEST_SUBMODULE_PREFIX "Bs2", md_get_module_fullname(module));
+        assert_string_equal_bt("", module->prefix);
+        assert_string_equal_bt("", module->ns);
+        assert_string_equal_bt(md_submodule_B_sub2_filepath, module->filepath);
+        assert_true_bt(module->latest_revision);
         if (implemented.B) {
-            assert_true(module->implemented);
+            assert_true_bt(module->implemented);
         } else {
-            assert_false(module->implemented);
+            assert_false_bt(module->implemented);
         }
-        assert_false(module->has_data);
+        assert_false_bt(module->has_data);
         /* inst_ids */
         check_list_size(module->inst_ids, 0);
         /* op_data_subtrees */
         check_list_size(module->op_data_subtrees, 0);
         /* outside references */
-        assert_non_null(module->ly_data);
-        assert_non_null(module->ll_node);
+        assert_non_null_bt(module->ly_data);
+        assert_non_null_bt(module->ll_node);
         /* dependencies */
         check_list_size(module->deps, 0);
         check_list_size(module->inv_deps, 1);
         validate_dependency(module->inv_deps, "B", 1, md_test_dep(MD_DEP_INCLUDE, true));
     } else {
-        assert_int_equal(SR_ERR_NOT_FOUND, rc);
-        assert_null(module);
+        assert_int_equal_bt(SR_ERR_NOT_FOUND, rc);
+        assert_null_bt(module);
     }
 
     /* validate submodule Bs3 */
     rc = md_get_module_info(md_ctx, TEST_SUBMODULE_PREFIX "Bs3", NULL, &module);
     if (inserted.B) {
-        assert_int_equal(SR_ERR_OK, rc);
-        assert_non_null(module);
-        assert_string_equal(TEST_SUBMODULE_PREFIX "Bs3", module->name);
-        assert_string_equal("", module->revision_date);
-        assert_string_equal(TEST_SUBMODULE_PREFIX "Bs3", md_get_module_fullname(module));
-        assert_string_equal("", module->prefix);
-        assert_string_equal("", module->ns);
-        assert_string_equal(md_submodule_B_sub3_filepath, module->filepath);
-        assert_true(module->latest_revision);
+        assert_int_equal_bt(SR_ERR_OK, rc);
+        assert_non_null_bt(module);
+        assert_string_equal_bt(TEST_SUBMODULE_PREFIX "Bs3", module->name);
+        assert_string_equal_bt("", module->revision_date);
+        assert_string_equal_bt(TEST_SUBMODULE_PREFIX "Bs3", md_get_module_fullname(module));
+        assert_string_equal_bt("", module->prefix);
+        assert_string_equal_bt("", module->ns);
+        assert_string_equal_bt(md_submodule_B_sub3_filepath, module->filepath);
+        assert_true_bt(module->latest_revision);
         if (implemented.B) {
-            assert_true(module->implemented);
+            assert_true_bt(module->implemented);
         } else {
-            assert_false(module->implemented);
+            assert_false_bt(module->implemented);
         }
-        assert_false(module->has_data);
+        assert_false_bt(module->has_data);
         /* inst_ids */
         check_list_size(module->inst_ids, 0);
         /* op_data_subtrees */
         check_list_size(module->op_data_subtrees, 0);
         /* outside references */
-        assert_non_null(module->ly_data);
-        assert_non_null(module->ll_node);
+        assert_non_null_bt(module->ly_data);
+        assert_non_null_bt(module->ll_node);
         /* dependencies */
         check_list_size(module->deps, 0);
         check_list_size(module->inv_deps, 1);
         validate_dependency(module->inv_deps, "B", 1, md_test_dep(MD_DEP_INCLUDE, true));
     } else {
-        assert_int_equal(SR_ERR_NOT_FOUND, rc);
-        assert_null(module);
+        assert_int_equal_bt(SR_ERR_NOT_FOUND, rc);
+        assert_null_bt(module);
     }
 
     /* validate module C */
     rc = md_get_module_info(md_ctx, TEST_MODULE_PREFIX "C", NULL, &module);
     if (inserted.C) {
-        assert_int_equal(SR_ERR_OK, rc);
-        assert_non_null(module);
-        assert_string_equal(TEST_MODULE_PREFIX "C", module->name);
-        assert_string_equal("", module->revision_date);
-        assert_string_equal(TEST_MODULE_PREFIX "C", md_get_module_fullname(module));
-        assert_string_equal("C", module->prefix);
-        assert_string_equal("urn:ietf:params:xml:ns:yang:C", module->ns);
-        assert_string_equal(md_module_C_filepath, module->filepath);
+        assert_int_equal_bt(SR_ERR_OK, rc);
+        assert_non_null_bt(module);
+        assert_string_equal_bt(TEST_MODULE_PREFIX "C", module->name);
+        assert_string_equal_bt("", module->revision_date);
+        assert_string_equal_bt(TEST_MODULE_PREFIX "C", md_get_module_fullname(module));
+        assert_string_equal_bt("C", module->prefix);
+        assert_string_equal_bt("urn:ietf:params:xml:ns:yang:C", module->ns);
+        assert_string_equal_bt(md_module_C_filepath, module->filepath);
         assert_true(module->latest_revision);
         if (implemented.C) {
-            assert_true(module->implemented);
+            assert_true_bt(module->implemented);
         } else {
-            assert_false(module->implemented);
+            assert_false_bt(module->implemented);
         }
-        assert_true(module->has_data);
+        assert_true_bt(module->has_data);
         /* inst_ids */
         check_list_size(module->inst_ids, 2);
         validate_subtree_ref(md_ctx, module->inst_ids, "/" TEST_MODULE_PREFIX "C:inst-id1", "C");
@@ -1208,8 +1208,8 @@ validate_context(md_ctx_t *md_ctx)
         check_list_size(module->op_data_subtrees, 1);
         validate_subtree_ref(md_ctx, module->op_data_subtrees, "/" TEST_MODULE_PREFIX "C:partly-op-data/nested-op-data", "C");
         /* outside references */
-        assert_non_null(module->ly_data);
-        assert_non_null(module->ll_node);
+        assert_non_null_bt(module->ly_data);
+        assert_non_null_bt(module->ll_node);
         /* dependencies */
         validate_dependency(module->deps, "A", 2, md_test_dep(MD_DEP_IMPORT, true), md_test_dep(MD_DEP_DATA, true, 1, "C"));
         if (inserted.D_rev2) {
@@ -1238,39 +1238,39 @@ validate_context(md_ctx_t *md_ctx)
         validate_dependency(module->inv_deps, "E@2016-06-11", 2, md_test_dep(MD_DEP_IMPORT, true), md_test_dep(MD_DEP_DATA, true, 1, "E@2016-06-11"));
         validate_dependency(module->inv_deps, "E@2016-06-21", 2, md_test_dep(MD_DEP_IMPORT, true), md_test_dep(MD_DEP_DATA, true, 1, "E@2016-06-21"));
     } else {
-        assert_int_equal(SR_ERR_NOT_FOUND, rc);
-        assert_null(module);
+        assert_int_equal_bt(SR_ERR_NOT_FOUND, rc);
+        assert_null_bt(module);
     }
 
     /* validate module D-rev1 */
     rc = md_get_module_info(md_ctx, TEST_MODULE_PREFIX "D", "2016-06-10", &module);
     if (inserted.D_rev1) {
-        assert_int_equal(SR_ERR_OK, rc);
-        assert_non_null(module);
-        assert_string_equal(TEST_MODULE_PREFIX "D", module->name);
-        assert_string_equal("2016-06-10", module->revision_date);
-        assert_string_equal(TEST_MODULE_PREFIX "D@2016-06-10", md_get_module_fullname(module));
-        assert_string_equal("D", module->prefix);
-        assert_string_equal("urn:ietf:params:xml:ns:yang:D", module->ns);
-        assert_string_equal(md_module_D_rev1_filepath, module->filepath);
+        assert_int_equal_bt(SR_ERR_OK, rc);
+        assert_non_null_bt(module);
+        assert_string_equal_bt(TEST_MODULE_PREFIX "D", module->name);
+        assert_string_equal_bt("2016-06-10", module->revision_date);
+        assert_string_equal_bt(TEST_MODULE_PREFIX "D@2016-06-10", md_get_module_fullname(module));
+        assert_string_equal_bt("D", module->prefix);
+        assert_string_equal_bt("urn:ietf:params:xml:ns:yang:D", module->ns);
+        assert_string_equal_bt(md_module_D_rev1_filepath, module->filepath);
         if (inserted.D_rev2) {
-            assert_false(module->latest_revision);
+            assert_false_bt(module->latest_revision);
         } else {
-            assert_true(module->latest_revision);
+            assert_true_bt(module->latest_revision);
         }
         if (implemented.D_rev1) {
-            assert_true(module->implemented);
+            assert_true_bt(module->implemented);
         } else {
-            assert_false(module->implemented);
+            assert_false_bt(module->implemented);
         }
-        assert_true(module->has_data);
+        assert_true_bt(module->has_data);
         /* inst_ids */
         check_list_size(module->inst_ids, 0);
         /* op_data_subtrees */
         check_list_size(module->op_data_subtrees, 0);
         /* outside references */
-        assert_non_null(module->ly_data);
-        assert_non_null(module->ll_node);
+        assert_non_null_bt(module->ly_data);
+        assert_non_null_bt(module->ll_node);
         /* dependencies */
         validate_dependency(module->deps, "A", 2, md_test_dep(MD_DEP_IMPORT, true), md_test_dep(MD_DEP_DATA, false, 0));
         if (inserted.D_rev2) {
@@ -1299,35 +1299,35 @@ validate_context(md_ctx_t *md_ctx)
         validate_dependency(module->inv_deps, "E@2016-06-11", 1, md_test_dep(MD_DEP_IMPORT, true));
         validate_dependency(module->inv_deps, "E@2016-06-21", 0);
     } else {
-        assert_int_equal(SR_ERR_NOT_FOUND, rc);
-        assert_null(module);
+        assert_int_equal_bt(SR_ERR_NOT_FOUND, rc);
+        assert_null_bt(module);
     }
 
     /* validate module D-rev2 */
     rc = md_get_module_info(md_ctx, TEST_MODULE_PREFIX "D", "2016-06-20", &module);
     if (inserted.D_rev2) {
-        assert_int_equal(SR_ERR_OK, rc);
-        assert_non_null(module);
-        assert_string_equal(TEST_MODULE_PREFIX "D", module->name);
-        assert_string_equal("2016-06-20", module->revision_date);
-        assert_string_equal(TEST_MODULE_PREFIX "D@2016-06-20", md_get_module_fullname(module));
-        assert_string_equal("D", module->prefix);
-        assert_string_equal("urn:ietf:params:xml:ns:yang:D", module->ns);
-        assert_string_equal(md_module_D_rev2_filepath, module->filepath);
-        assert_true(module->latest_revision);
+        assert_int_equal_bt(SR_ERR_OK, rc);
+        assert_non_null_bt(module);
+        assert_string_equal_bt(TEST_MODULE_PREFIX "D", module->name);
+        assert_string_equal_bt("2016-06-20", module->revision_date);
+        assert_string_equal_bt(TEST_MODULE_PREFIX "D@2016-06-20", md_get_module_fullname(module));
+        assert_string_equal_bt("D", module->prefix);
+        assert_string_equal_bt("urn:ietf:params:xml:ns:yang:D", module->ns);
+        assert_string_equal_bt(md_module_D_rev2_filepath, module->filepath);
+        assert_true_bt(module->latest_revision);
         if (implemented.D_rev2) {
-            assert_true(module->implemented);
+            assert_true_bt(module->implemented);
         } else {
-            assert_false(module->implemented);
+            assert_false_bt(module->implemented);
         }
-        assert_true(module->has_data);
+        assert_true_bt(module->has_data);
         /* inst_ids */
         check_list_size(module->inst_ids, 0);
         /* op_data_subtrees */
         check_list_size(module->op_data_subtrees, 0);
         /* outside references */
-        assert_non_null(module->ly_data);
-        assert_non_null(module->ll_node);
+        assert_non_null_bt(module->ly_data);
+        assert_non_null_bt(module->ll_node);
         /* dependencies */
         validate_dependency(module->deps, "A", 2, md_test_dep(MD_DEP_IMPORT, true), md_test_dep(MD_DEP_DATA, false, 0));
         validate_dependency(module->deps, "B", 2, md_test_dep(MD_DEP_IMPORT, true), md_test_dep(MD_DEP_DATA, true, 1, "D@2016-06-20"));
@@ -1352,67 +1352,67 @@ validate_context(md_ctx_t *md_ctx)
         validate_dependency(module->inv_deps, "E@2016-06-11", 0);
         validate_dependency(module->inv_deps, "E@2016-06-21", 1, md_test_dep(MD_DEP_IMPORT, true));
     } else {
-        assert_int_equal(SR_ERR_NOT_FOUND, rc);
-        assert_null(module);
+        assert_int_equal_bt(SR_ERR_NOT_FOUND, rc);
+        assert_null_bt(module);
     }
 
     /* validate submodule Dcommon */
     rc = md_get_module_info(md_ctx, TEST_SUBMODULE_PREFIX "Dcommon", NULL, &module);
     if (inserted.D_rev1 || inserted.D_rev2) {
-        assert_int_equal(SR_ERR_OK, rc);
-        assert_non_null(module);
-        assert_string_equal(TEST_SUBMODULE_PREFIX "Dcommon", module->name);
-        assert_string_equal("2016-06-10", module->revision_date);
-        assert_string_equal(TEST_SUBMODULE_PREFIX "Dcommon@2016-06-10", md_get_module_fullname(module));
-        assert_string_equal("", module->prefix);
-        assert_string_equal("", module->ns);
-        assert_string_equal(md_submodule_D_common_filepath, module->filepath);
-        assert_true(module->latest_revision);
+        assert_int_equal_bt(SR_ERR_OK, rc);
+        assert_non_null_bt(module);
+        assert_string_equal_bt(TEST_SUBMODULE_PREFIX "Dcommon", module->name);
+        assert_string_equal_bt("2016-06-10", module->revision_date);
+        assert_string_equal_bt(TEST_SUBMODULE_PREFIX "Dcommon@2016-06-10", md_get_module_fullname(module));
+        assert_string_equal_bt("", module->prefix);
+        assert_string_equal_bt("", module->ns);
+        assert_string_equal_bt(md_submodule_D_common_filepath, module->filepath);
+        assert_true_bt(module->latest_revision);
         if (implemented.D_rev1 || implemented.D_rev2) {
-            assert_true(module->implemented);
+            assert_true_bt(module->implemented);
         } else {
-            assert_false(module->implemented);
+            assert_false_bt(module->implemented);
         }
-        assert_false(module->has_data);
+        assert_false_bt(module->has_data);
         /* inst_ids */
         check_list_size(module->inst_ids, 0);
         /* op_data_subtrees */
         check_list_size(module->op_data_subtrees, 0);
         /* outside references */
-        assert_non_null(module->ly_data);
-        assert_non_null(module->ll_node);
+        assert_non_null_bt(module->ly_data);
+        assert_non_null_bt(module->ll_node);
         /* dependencies */
         check_list_size(module->deps, 0);
         check_list_size(module->inv_deps, inserted.D_rev1 + inserted.D_rev2);
         validate_dependency(module->inv_deps, "D@2016-06-10", 1, md_test_dep(MD_DEP_INCLUDE, true));
         validate_dependency(module->inv_deps, "D@2016-06-20", 1, md_test_dep(MD_DEP_INCLUDE, true));
     } else {
-        assert_int_equal(SR_ERR_NOT_FOUND, rc);
-        assert_null(module);
+        assert_int_equal_bt(SR_ERR_NOT_FOUND, rc);
+        assert_null_bt(module);
     }
 
     /* validate module E-rev1 */
     rc = md_get_module_info(md_ctx, TEST_MODULE_PREFIX "E", "2016-06-11", &module);
     if (inserted.E_rev1) {
-        assert_int_equal(SR_ERR_OK, rc);
-        assert_non_null(module);
-        assert_string_equal(TEST_MODULE_PREFIX "E", module->name);
-        assert_string_equal("2016-06-11", module->revision_date);
-        assert_string_equal(TEST_MODULE_PREFIX "E@2016-06-11", md_get_module_fullname(module));
-        assert_string_equal("E", module->prefix);
-        assert_string_equal("urn:ietf:params:xml:ns:yang:E", module->ns);
-        assert_string_equal(md_module_E_rev1_filepath, module->filepath);
+        assert_int_equal_bt(SR_ERR_OK, rc);
+        assert_non_null_bt(module);
+        assert_string_equal_bt(TEST_MODULE_PREFIX "E", module->name);
+        assert_string_equal_bt("2016-06-11", module->revision_date);
+        assert_string_equal_bt(TEST_MODULE_PREFIX "E@2016-06-11", md_get_module_fullname(module));
+        assert_string_equal_bt("E", module->prefix);
+        assert_string_equal_bt("urn:ietf:params:xml:ns:yang:E", module->ns);
+        assert_string_equal_bt(md_module_E_rev1_filepath, module->filepath);
         if (inserted.E_rev2) {
-            assert_false(module->latest_revision);
+            assert_false_bt(module->latest_revision);
         } else {
-            assert_true(module->latest_revision);
+            assert_true_bt(module->latest_revision);
         }
         if (implemented.E_rev1) {
-            assert_true(module->implemented);
+            assert_true_bt(module->implemented);
         } else {
-            assert_false(module->implemented);
+            assert_false_bt(module->implemented);
         }
-        assert_true(module->has_data);
+        assert_true_bt(module->has_data);
         /* inst_ids */
         check_list_size(module->inst_ids, 1);
         validate_subtree_ref(md_ctx, module->inst_ids, "/" TEST_MODULE_PREFIX "E:inst-id-list/inst-id", "E@2016-06-11");
@@ -1423,8 +1423,8 @@ validate_context(md_ctx_t *md_ctx)
         validate_subtree_ref(md_ctx, module->op_data_subtrees,
                 "/" TEST_MODULE_PREFIX "E:partly-op-data/nested-op-data", "E@2016-06-11");
         /* outside references */
-        assert_non_null(module->ly_data);
-        assert_non_null(module->ll_node);
+        assert_non_null_bt(module->ly_data);
+        assert_non_null_bt(module->ll_node);
         /* dependencies */
         validate_dependency(module->deps, "A", 2, md_test_dep(MD_DEP_IMPORT, false), md_test_dep(MD_DEP_DATA, false, 0));
         if (inserted.D_rev2) {
@@ -1453,28 +1453,28 @@ validate_context(md_ctx_t *md_ctx)
         validate_dependency(module->inv_deps, "E@2016-06-11", 0);
         validate_dependency(module->inv_deps, "E@2016-06-21", 0);
     } else {
-        assert_int_equal(SR_ERR_NOT_FOUND, rc);
-        assert_null(module);
+        assert_int_equal_bt(SR_ERR_NOT_FOUND, rc);
+        assert_null_bt(module);
     }
 
     /* validate module E-rev2 */
     rc = md_get_module_info(md_ctx, TEST_MODULE_PREFIX "E", "2016-06-21", &module);
     if (inserted.E_rev2) {
-        assert_int_equal(SR_ERR_OK, rc);
-        assert_non_null(module);
-        assert_string_equal(TEST_MODULE_PREFIX "E", module->name);
-        assert_string_equal("2016-06-21", module->revision_date);
-        assert_string_equal(TEST_MODULE_PREFIX "E@2016-06-21", md_get_module_fullname(module));
-        assert_string_equal("E", module->prefix);
-        assert_string_equal("urn:ietf:params:xml:ns:yang:E", module->ns);
-        assert_string_equal(md_module_E_rev2_filepath, module->filepath);
-        assert_true(module->latest_revision);
+        assert_int_equal_bt(SR_ERR_OK, rc);
+        assert_non_null_bt(module);
+        assert_string_equal_bt(TEST_MODULE_PREFIX "E", module->name);
+        assert_string_equal_bt("2016-06-21", module->revision_date);
+        assert_string_equal_bt(TEST_MODULE_PREFIX "E@2016-06-21", md_get_module_fullname(module));
+        assert_string_equal_bt("E", module->prefix);
+        assert_string_equal_bt("urn:ietf:params:xml:ns:yang:E", module->ns);
+        assert_string_equal_bt(md_module_E_rev2_filepath, module->filepath);
+        assert_true_bt(module->latest_revision);
         if (implemented.E_rev2) {
-            assert_true(module->implemented);
+            assert_true_bt(module->implemented);
         } else {
-            assert_false(module->implemented);
+            assert_false_bt(module->implemented);
         }
-        assert_true(module->has_data);
+        assert_true_bt(module->has_data);
         /* inst_ids */
         check_list_size(module->inst_ids, 1);
         validate_subtree_ref(md_ctx, module->inst_ids, "/" TEST_MODULE_PREFIX "E:inst-id-list/inst-id", "E@2016-06-21");
@@ -1487,8 +1487,8 @@ validate_context(md_ctx_t *md_ctx)
         validate_subtree_ref(md_ctx, module->op_data_subtrees,
                 "/" TEST_MODULE_PREFIX "E:partly-op-data/nested-op-data/nested-leaf2", "E@2016-06-21");
         /* outside references */
-        assert_non_null(module->ly_data);
-        assert_non_null(module->ll_node);
+        assert_non_null_bt(module->ly_data);
+        assert_non_null_bt(module->ll_node);
         /* dependencies */
         validate_dependency(module->deps, "A", 2, md_test_dep(MD_DEP_IMPORT, false), md_test_dep(MD_DEP_DATA, false, 0));
         if (inserted.D_rev2) {
@@ -1517,8 +1517,8 @@ validate_context(md_ctx_t *md_ctx)
         validate_dependency(module->inv_deps, "E@2016-06-11", 0);
         validate_dependency(module->inv_deps, "E@2016-06-21", 0);
      } else {
-        assert_int_equal(SR_ERR_NOT_FOUND, rc);
-        assert_null(module);
+        assert_int_equal_bt(SR_ERR_NOT_FOUND, rc);
+        assert_null_bt(module);
     }
 }
 

--- a/tests/nacm_cl_test.c
+++ b/tests/nacm_cl_test.c
@@ -549,7 +549,7 @@ daemon_log_reader(void *arg)
         while (readline(daemon_stderr, &line, &len)) {
             msg = strdup(line);
             assert_non_null(msg);
-//            SR_LOG_DBG("Appending message: %s", msg);
+            SR_LOG_DBG("DAEMON: %s", msg);
             assert_int_equal(SR_ERR_OK, sr_list_add(log_history.logs, msg));
         }
         running = log_history.running;

--- a/tests/nacm_cl_test.c
+++ b/tests/nacm_cl_test.c
@@ -450,10 +450,7 @@ verify_cb_call_count(bool async_cb, int exp_count)
         }
     } while (async_cb && count < exp_count && attempt < MAX_ATTEMPTS);
 
-    if (exp_count != count) {
-        print_backtrace();
-    }
-    assert_int_equal(exp_count, count);
+    assert_int_equal_bt(exp_count, count);
 }
 
 static void
@@ -472,28 +469,28 @@ verify_nacm_stats()
 
     /* check the number of denied RPCs */
     rc = sr_get_item(nacm_stats.session, "/ietf-netconf-acm:nacm/denied-operations", &value);
-    assert_int_equal(SR_ERR_OK, rc);
-    assert_non_null(value);
-    assert_int_equal(SR_UINT32_T, value->type);
-    assert_int_equal(nacm_stats.denied_operations, value->data.uint32_val);
+    assert_int_equal_bt(SR_ERR_OK, rc);
+    assert_non_null_bt(value);
+    assert_int_equal_bt(SR_UINT32_T, value->type);
+    assert_int_equal_bt(nacm_stats.denied_operations, value->data.uint32_val);
     sr_free_val(value);
     value = NULL;
 
     /* check the number of denied Event notifications */
     rc = sr_get_item(nacm_stats.session, "/ietf-netconf-acm:nacm/denied-notifications", &value);
-    assert_int_equal(SR_ERR_OK, rc);
-    assert_non_null(value);
-    assert_int_equal(SR_UINT32_T, value->type);
-    assert_int_equal(nacm_stats.denied_notifications, value->data.uint32_val);
+    assert_int_equal_bt(SR_ERR_OK, rc);
+    assert_non_null_bt(value);
+    assert_int_equal_bt(SR_UINT32_T, value->type);
+    assert_int_equal_bt(nacm_stats.denied_notifications, value->data.uint32_val);
     sr_free_val(value);
     value = NULL;
 
     /* check the number of denied operations with write effect */
     rc = sr_get_item(nacm_stats.session, "/ietf-netconf-acm:nacm/denied-data-writes", &value);
-    assert_int_equal(SR_ERR_OK, rc);
-    assert_non_null(value);
-    assert_int_equal(SR_UINT32_T, value->type);
-    assert_int_equal(nacm_stats.denied_data_writes, value->data.uint32_val);
+    assert_int_equal_bt(SR_ERR_OK, rc);
+    assert_non_null_bt(value);
+    assert_int_equal_bt(SR_UINT32_T, value->type);
+    assert_int_equal_bt(nacm_stats.denied_data_writes, value->data.uint32_val);
     sr_free_val(value);
     value = NULL;
 
@@ -510,18 +507,18 @@ daemon_kill(bool last_attempt)
 
     /* read PID of the daemon from sysrepo PID file */
     pidfile = open(SR_DAEMON_PID_FILE, O_RDONLY);
-    assert_int_not_equal(-1, pidfile);
+    assert_int_not_equal_bt(-1, pidfile);
     if (readline(pidfile, &line, &len)) {
         pid = atoi(line);
     }
     free(line);
-    assert_int_equal(0, close(pidfile));
+    assert_int_equal_bt(0, close(pidfile));
 
     if (-1 != pid) {
         /* send SIGTERM/SIGKILL to the daemon process */
         SR_LOG_DBG("Sending %s signal to PID=%d.", (last_attempt ? "SIGKILL" : "SIGTERM"), pid);
         ret = kill(pid, last_attempt ? SIGKILL : SIGTERM);
-        assert_int_not_equal(-1, ret);
+        assert_int_not_equal_bt(-1, ret);
     }
 }
 #endif
@@ -542,15 +539,15 @@ daemon_log_reader(void *arg)
             wait_ms(DELAY_DURATION);
         }
     } while (!running);
-    assert_true(daemon_stderr >= 0);
+    assert_true_bt(daemon_stderr >= 0);
 
     while (running) {
         pthread_mutex_lock(&log_history.lock);
         while (readline(daemon_stderr, &line, &len)) {
             msg = strdup(line);
-            assert_non_null(msg);
+            assert_non_null_bt(msg);
             SR_LOG_DBG("DAEMON: %s", msg);
-            assert_int_equal(SR_ERR_OK, sr_list_add(log_history.logs, msg));
+            assert_int_equal_bt(SR_ERR_OK, sr_list_add(log_history.logs, msg));
         }
         running = log_history.running;
         pthread_mutex_unlock(&log_history.lock);
@@ -585,7 +582,7 @@ start_sysrepo_daemon(sr_conn_ctx_t **conn_p)
         rc = sr_connect("nacm_cl_test", SR_CONN_DAEMON_REQUIRED, &conn);
         sr_disconnect(conn);
         conn = NULL;
-        assert_true(SR_ERR_OK == rc || SR_ERR_DISCONNECT == rc);
+        assert_true_bt(SR_ERR_OK == rc || SR_ERR_DISCONNECT == rc);
 
         /* kill the daemon if it was running */
         if (SR_ERR_OK == rc) {
@@ -615,8 +612,9 @@ start_sysrepo_daemon(sr_conn_ctx_t **conn_p)
     /* start sysrepo in the daemon debug mode as a child process */
     pthread_create(&stderr_reader, NULL, daemon_log_reader, NULL);
     daemon_pid = sr_popen("../src/sysrepod -l4 -d", NULL, NULL, &daemon_stderr);
-    assert_int_not_equal(-1, daemon_pid);
-    assert_true(daemon_stderr >= 0);
+    SR_LOG_INF("Started Sysrepo daemon with PID=%d", daemon_pid);
+    assert_int_not_equal_bt(-1, daemon_pid);
+    assert_true_bt(daemon_stderr >= 0);
 
     /* start log reader */
     flags = fcntl(daemon_stderr, F_GETFL, 0);
@@ -629,13 +627,13 @@ start_sysrepo_daemon(sr_conn_ctx_t **conn_p)
     wait_ms(DAEMON_WAIT_DURATION);
 #endif
     rc = sr_connect("nacm_cl_test", SR_CONN_DAEMON_REQUIRED, &conn);
-    assert_int_equal(rc, SR_ERR_OK);
-    assert_non_null(conn_p);
+    assert_int_equal_bt(rc, SR_ERR_OK);
+    assert_non_null_bt(conn_p);
     *conn_p = conn;
 
     /* start a session that will be used to obtain the NACM statistics */
     rc = sr_session_start(conn, SR_DS_RUNNING, SR_SESS_ENABLE_NACM, &nacm_stats.session);
-    assert_int_equal(rc, SR_ERR_OK);
+    assert_int_equal_bt(rc, SR_ERR_OK);
 }
 
 static void
@@ -660,7 +658,7 @@ clear_log_history()
 static char *
 escape(const char *regex)
 {
-    assert_non_null(regex);
+    assert_non_null_bt((void *)regex);
     static char *special_chars = ".^$*+?()[{\\|^-]";
     char *escaped = NULL;
     size_t new_size = strlen(regex);
@@ -673,7 +671,7 @@ escape(const char *regex)
     }
 
     escaped = calloc(new_size+1, sizeof *escaped);
-    assert_non_null(escaped);
+    assert_non_null_bt(escaped);
 
     for (size_t i = 0; i < strlen(regex); ++i) {
         if (strchr(special_chars, regex[i])) {
@@ -706,7 +704,7 @@ verify_existence_of_log_msg(const char *msg_re, bool should_exist)
             char *message = (char *)log_history.logs->data[i];
             regex_t re;
             /* Compile regular expression */
-            assert_int_equal(0, regcomp(&re, msg_re, REG_NOSUB | REG_EXTENDED));
+            assert_int_equal_bt(0, regcomp(&re, msg_re, REG_NOSUB | REG_EXTENDED));
             if (0 == regexec(&re, message, 0, NULL, 0)) {
                 exists = true;
             }
@@ -728,10 +726,7 @@ verify_existence_of_log_msg(const char *msg_re, bool should_exist)
         }
     } while (should_exist && !exists && attempt < MAX_ATTEMPTS);
 
-    if (should_exist != exists) {
-        print_backtrace();
-    }
-    assert_true(should_exist == exists);
+    assert_true_bt(should_exist == exists);
 #endif
 }
 
@@ -1039,17 +1034,17 @@ static void
 start_user_sessions(sr_conn_ctx_t *conn, sr_session_ctx_t **handler_session, user_sessions_t *sessions)
 {
     int rc = SR_ERR_OK;
-    assert_non_null(conn);
+    assert_non_null_bt(conn);
     if (NULL != handler_session) {
         rc = sr_session_start(conn, SR_DS_STARTUP, SR_SESS_DEFAULT, handler_session);
-        assert_int_equal(rc, SR_ERR_OK);
+        assert_int_equal_bt(rc, SR_ERR_OK);
     }
     for (int i = 0; i < NUM_OF_USERS; ++i) {
         char *username = NULL;
-        assert_int_equal(SR_ERR_OK, sr_asprintf(&username, "sysrepo-user%d", i+1));
+        assert_int_equal_bt(SR_ERR_OK, sr_asprintf(&username, "sysrepo-user%d", i+1));
         rc = sr_session_start_user(conn, username, SR_DS_STARTUP,
                 i == NUM_OF_USERS-1 ? SR_SESS_DEFAULT : SR_SESS_ENABLE_NACM, (*sessions)+i);
-        assert_int_equal(rc, SR_ERR_OK);
+        assert_int_equal_bt(rc, SR_ERR_OK);
         free(username);
     }
 }
@@ -1062,24 +1057,24 @@ subscribe_dummy_rpc_callback(sr_session_ctx_t *handler_session, void *private_ct
     /* subscribe for RPCs with dummy callback */
     rc = sr_rpc_subscribe(handler_session, "/test-module:activate-software-image", dummy_rpc_cb, private_ctx,
             SR_SUBSCR_DEFAULT, subscription);
-    assert_int_equal(rc, SR_ERR_OK);
+    assert_int_equal_bt(rc, SR_ERR_OK);
     rc = sr_rpc_subscribe(handler_session, "/ietf-netconf:close-session", dummy_rpc_cb, private_ctx,
             SR_SUBSCR_CTX_REUSE, subscription);
-    assert_int_equal(rc, SR_ERR_OK);
+    assert_int_equal_bt(rc, SR_ERR_OK);
     rc = sr_rpc_subscribe(handler_session, "/ietf-netconf:kill-session", dummy_rpc_cb, private_ctx,
             SR_SUBSCR_CTX_REUSE, subscription);
-    assert_int_equal(rc, SR_ERR_OK);
+    assert_int_equal_bt(rc, SR_ERR_OK);
     rc = sr_rpc_subscribe(handler_session, "/turing-machine:initialize", dummy_rpc_cb, private_ctx,
             SR_SUBSCR_CTX_REUSE, subscription);
-    assert_int_equal(rc, SR_ERR_OK);
+    assert_int_equal_bt(rc, SR_ERR_OK);
 
     /* subscribe for Actions with dummy callback */
     rc = sr_action_subscribe(handler_session, "/test-module:kernel-modules/kernel-module/unload",
             dummy_rpc_cb, private_ctx, SR_SUBSCR_CTX_REUSE, subscription);
-    assert_int_equal(rc, SR_ERR_OK);
+    assert_int_equal_bt(rc, SR_ERR_OK);
     rc = sr_action_subscribe(handler_session, "/test-module:kernel-modules/kernel-module/load",
             dummy_rpc_cb, private_ctx, SR_SUBSCR_CTX_REUSE, subscription);
-    assert_int_equal(rc, SR_ERR_OK);
+    assert_int_equal_bt(rc, SR_ERR_OK);
 }
 
 static void
@@ -1098,22 +1093,22 @@ subscribe_dummy_event_notif_callback(sr_session_ctx_t *user_session, void *priva
     /* subscribe for Event notifications with dummy callback */
     rc = sr_event_notif_subscribe(user_session, "/test-module:link-discovered",
             dummy_event_notif_cb, private_ctx, SR_SUBSCR_DEFAULT, subscription);
-    assert_int_equal(rc, SR_ERR_OK);
+    assert_int_equal_bt(rc, SR_ERR_OK);
     rc = sr_event_notif_subscribe(user_session, "/test-module:link-removed",
             dummy_event_notif_cb, private_ctx, SR_SUBSCR_CTX_REUSE, subscription);
-    assert_int_equal(rc, SR_ERR_OK);
+    assert_int_equal_bt(rc, SR_ERR_OK);
     rc = sr_event_notif_subscribe(user_session, "/test-module:kernel-modules/kernel-module[name='netlink_diag.ko']/status-change",
             dummy_event_notif_cb, private_ctx, SR_SUBSCR_CTX_REUSE, subscription);
-    assert_int_equal(rc, SR_ERR_OK);
+    assert_int_equal_bt(rc, SR_ERR_OK);
     rc = sr_event_notif_subscribe(user_session, "/turing-machine:halted",
             dummy_event_notif_cb, private_ctx, SR_SUBSCR_CTX_REUSE, subscription);
-    assert_int_equal(rc, SR_ERR_OK);
+    assert_int_equal_bt(rc, SR_ERR_OK);
     rc = sr_event_notif_subscribe(user_session, "/ietf-netconf-notifications:netconf-capability-change",
             dummy_event_notif_cb, private_ctx, SR_SUBSCR_CTX_REUSE, subscription);
-    assert_int_equal(rc, SR_ERR_OK);
+    assert_int_equal_bt(rc, SR_ERR_OK);
     rc = sr_event_notif_subscribe(user_session, "/nc-notifications:replayComplete",
             dummy_event_notif_cb, private_ctx, SR_SUBSCR_CTX_REUSE, subscription);
-    assert_int_equal(rc, SR_ERR_OK);
+    assert_int_equal_bt(rc, SR_ERR_OK);
 
 }
 

--- a/tests/nacm_test.c
+++ b/tests/nacm_test.c
@@ -61,13 +61,13 @@ daemon_kill()
 
     /* read PID of the daemon from sysrepo PID file */
     pidfile = fopen(SR_DAEMON_PID_FILE, "r");
-    assert_non_null(pidfile);
+    assert_non_null_bt(pidfile);
     ret = fscanf(pidfile, "%d", &pid);
-    assert_int_equal(ret, 1);
+    assert_int_equal_bt(ret, 1);
 
     /* send SIGTERM to the daemon process */
     ret = kill(pid, SIGTERM);
-    assert_int_not_equal(ret, -1);
+    assert_int_not_equal_bt(ret, -1);
 }
 
 static void
@@ -75,20 +75,20 @@ verify_sr_btree_size(sr_btree_t* btree, size_t expected)
 {
     size_t i = 0;
 
-    assert_non_null(btree);
+    assert_non_null_bt(btree);
 
     while (sr_btree_get_at(btree, i)) {
         ++i;
     }
 
-    assert_int_equal(expected, i);
+    assert_int_equal_bt(expected, i);
 }
 
 static void
 verify_sr_list_size(sr_list_t *list, size_t expected)
 {
-    assert_non_null(list);
-    assert_int_equal(expected, list->count);
+    assert_non_null_bt(list);
+    assert_int_equal_bt(expected, list->count);
 }
 
 static void
@@ -96,7 +96,7 @@ verify_child_count(sr_node_t *parent, size_t expected)
 {
     sr_node_t *child = NULL;
     size_t child_cnt = 0;
-    assert_non_null(parent);
+    assert_non_null_bt(parent);
 
     child = parent->first_child;
     while (NULL != child) {
@@ -104,14 +104,14 @@ verify_child_count(sr_node_t *parent, size_t expected)
         child = child->next;
     }
 
-    assert_int_equal(expected, child_cnt);
+    assert_int_equal_bt(expected, child_cnt);
 }
 
 static sr_node_t *
 node_get_child(sr_node_t *parent, const char *child_name)
 {
     sr_node_t *child = NULL;
-    assert_non_null(parent);
+    assert_non_null_bt(parent);
 
     child = parent->first_child;
     while (NULL != child) {
@@ -132,7 +132,7 @@ verify_tree_size(sr_node_t *root, size_t expected)
     bool backtrack = false;
 
     if (NULL == root) {
-        assert_int_equal(0, expected);
+        assert_int_equal_bt(0, expected);
     }
 
     node = root;
@@ -152,28 +152,28 @@ verify_tree_size(sr_node_t *root, size_t expected)
                 backtrack = false;
             } else {
                 node = node->parent;
-                assert_non_null(node);
+                assert_non_null_bt(node);
             }
         }
     } while (node != root);
 
-    assert_int_equal(expected, node_cnt);
+    assert_int_equal_bt(expected, node_cnt);
 }
 
 void
 check_bit_value(sr_bitset_t *bitset, size_t pos, bool expected)
 {
-    assert_non_null(bitset);
+    assert_non_null_bt(bitset);
     bool value = false;
 
-    assert_int_equal(SR_ERR_OK, sr_bitset_get(bitset, pos, &value));
-    assert_true(expected == value);
+    assert_int_equal_bt(SR_ERR_OK, sr_bitset_get(bitset, pos, &value));
+    assert_true_bt(expected == value);
 }
 
 static void
 reset_get_items_ctx(rp_dt_get_items_ctx_t *get_items_ctx)
 {
-    assert_non_null(get_items_ctx);
+    assert_non_null_bt(get_items_ctx);
     get_items_ctx->offset = 0;
     ly_set_free(get_items_ctx->nodes);
     get_items_ctx->nodes = NULL;
@@ -191,7 +191,7 @@ nacm_tests_setup(void **state)
     /* connect to sysrepo, force daemon connection */
     rc = sr_connect("daemon_test", SR_CONN_DAEMON_REQUIRED, &conn);
     sr_disconnect(conn);
-    assert_true(SR_ERR_OK == rc || SR_ERR_DISCONNECT == rc);
+    assert_true_bt(SR_ERR_OK == rc || SR_ERR_DISCONNECT == rc);
 
     /* kill the daemon if it was running */
     if (SR_ERR_OK == rc) {
@@ -224,7 +224,7 @@ nacm_tests_teardown(void **state)
     /* restart the daemon if it was running before the test */
     if (daemon_run_before_test) {
         ret = system("../src/sysrepod -l 4");
-        assert_int_equal(0, ret);
+        assert_int_equal_bt(0, ret);
     }
 
     test_rp_ctx_cleanup(rp_ctx);
@@ -240,8 +240,8 @@ get_nacm_ctx()
 {
     nacm_ctx_t *nacm_ctx;
 
-    assert_non_null(rp_ctx);
-    assert_int_equal(SR_ERR_OK, dm_get_nacm_ctx(rp_ctx->dm_ctx, &nacm_ctx));
+    assert_non_null_bt(rp_ctx);
+    assert_int_equal_bt(SR_ERR_OK, dm_get_nacm_ctx(rp_ctx->dm_ctx, &nacm_ctx));
     return nacm_ctx;
 }
 
@@ -251,7 +251,7 @@ nacm_get_group(nacm_ctx_t *nacm_ctx, const char *name)
     nacm_group_t group_lookup = { (char *)name, 0 }, *group = NULL;
 
     group = sr_btree_search(nacm_ctx->groups, &group_lookup);
-    assert_non_null(group);
+    assert_non_null_bt(group);
 
     return group;
 }
@@ -262,7 +262,7 @@ nacm_get_user(nacm_ctx_t *nacm_ctx, const char *name)
     nacm_user_t user_lookup = { (char *)name, NULL }, *user = NULL;
 
     user = sr_btree_search(nacm_ctx->users, &user_lookup);
-    assert_non_null(user);
+    assert_non_null_bt(user);
 
     return user;
 }
@@ -270,20 +270,20 @@ nacm_get_user(nacm_ctx_t *nacm_ctx, const char *name)
 static nacm_rule_list_t *
 nacm_get_rule_list(nacm_ctx_t *nacm_ctx, size_t index)
 {
-    assert_non_null(nacm_ctx);
-    assert_non_null(nacm_ctx->rule_lists);
-    assert_true(index < nacm_ctx->rule_lists->count);
-    assert_non_null(nacm_ctx->rule_lists->data[index]);
+    assert_non_null_bt(nacm_ctx);
+    assert_non_null_bt(nacm_ctx->rule_lists);
+    assert_true_bt(index < nacm_ctx->rule_lists->count);
+    assert_non_null_bt(nacm_ctx->rule_lists->data[index]);
     return (nacm_rule_list_t *)nacm_ctx->rule_lists->data[index];
 }
 
 static nacm_rule_t *
 nacm_get_rule(nacm_rule_list_t *rule_list, size_t index)
 {
-    assert_non_null(rule_list);
-    assert_non_null(rule_list->rules);
-    assert_true(index < rule_list->rules->count);
-    assert_non_null(rule_list->rules->data[index]);
+    assert_non_null_bt(rule_list);
+    assert_non_null_bt(rule_list->rules);
+    assert_true_bt(index < rule_list->rules->count);
+    assert_non_null_bt(rule_list->rules->data[index]);
     return (nacm_rule_t *)rule_list->rules->data[index];
 }
 

--- a/tests/sysrepocfg_test.c
+++ b/tests/sysrepocfg_test.c
@@ -71,23 +71,23 @@ srcfg_test_cmp_data_file_content(const char *file_path, LYD_FORMAT file_format, 
     size_t count = 0, skip_differences = 0;
 
     fd = open(file_path, O_RDONLY);
-    assert_true(fd >= 0);
+    assert_true_bt(fd >= 0);
 
     file_data = lyd_parse_fd(srcfg_test_libyang_ctx, fd, file_format, LYD_OPT_TRUSTED | LYD_OPT_CONFIG);
     if (!file_data && LY_SUCCESS != ly_errno) {
         fprintf(stderr, "lyd_parse_fd error: %s (%s)", ly_errmsg(), ly_errpath());
     }
-    assert_true(file_data || LY_SUCCESS == ly_errno);
+    assert_true_bt(file_data || LY_SUCCESS == ly_errno);
     if (NULL != exp) {
         exp_data = lyd_parse_mem(srcfg_test_libyang_ctx, exp, exp_format, LYD_OPT_TRUSTED | LYD_OPT_CONFIG);
         if (!exp_data && LY_SUCCESS != ly_errno) {
             fprintf(stderr, "lyd_parse_mem error: %s (%s)", ly_errmsg(), ly_errpath());
         }
-        assert_true(exp_data || LY_SUCCESS == ly_errno);
+        assert_true_bt(exp_data || LY_SUCCESS == ly_errno);
     }
 
     diff = lyd_diff(file_data, exp_data, LYD_DIFFOPT_WITHDEFAULTS);
-    assert_non_null(diff);
+    assert_non_null_bt(diff);
 
     while (diff->type && LYD_DIFF_END != diff->type[count]) {
         if (NULL != diff->first[count] && LYS_ANYDATA == diff->first[count]->schema->nodetype) {
@@ -129,18 +129,18 @@ srcfg_test_cmp_data_files(const char *file1_path, LYD_FORMAT file1_format, const
     char *file2_content = NULL;
 
     fd = open(file2_path, O_RDONLY);
-    assert_true(fd >= 0);
+    assert_true_bt(fd >= 0);
 
-    assert_int_equal(0, fstat(fd, &file_info));
+    assert_int_equal_bt(0, fstat(fd, &file_info));
     if (0 < file_info.st_size) {
         file2_content = mmap(0, file_info.st_size, PROT_READ, MAP_SHARED, fd, 0);
-        assert_true(file2_content && MAP_FAILED != file2_content);
+        assert_true_bt(file2_content && MAP_FAILED != file2_content);
     }
 
     rc = srcfg_test_cmp_data_file_content(file1_path, file1_format, file2_content, file2_format);
 
     if (0 < file_info.st_size) {
-        assert_int_equal(0, munmap(file2_content, file_info.st_size));
+        assert_int_equal_bt(0, munmap(file2_content, file_info.st_size));
     }
     close(fd);
     return rc;
@@ -213,7 +213,7 @@ srcfg_test_set_startup_datastore(void **state)
 {
     createDataTreeIETFinterfacesModule();
     srcfg_test_datastore = strdup("startup");
-    assert_non_null(srcfg_test_datastore);
+    assert_non_null_bt(srcfg_test_datastore);
     return 0;
 }
 
@@ -222,7 +222,7 @@ srcfg_test_set_running_datastore(void **state)
 {
     createDataTreeIETFinterfacesModule();
     srcfg_test_datastore = strdup("running");
-    assert_non_null(srcfg_test_datastore);
+    assert_non_null_bt(srcfg_test_datastore);
     return 0;
 }
 

--- a/tests/trees_test.c
+++ b/tests/trees_test.c
@@ -38,12 +38,12 @@
 static sr_node_t *
 get_child_by_index(sr_node_t *parent, int index)
 {
-    assert_non_null(parent->first_child);
+    assert_non_null_bt(parent->first_child);
     sr_node_t *child = parent->first_child;
 
     while (index) {
         child = child->next;
-        assert_non_null(child);
+        assert_non_null_bt(child);
         --index;
     }
     return child;


### PR DESCRIPTION
This pull request includes:

- some more detailed logs
- use of asserts that print backtrace in unit test helpers
- yet another "watchdog", but this one on the process level that will kill the test (with core dump) if it doesn't finish inside the 6min time limit or cannot kill itself (actually, the thread-based watchdog could be reverted now).
- added uint64_t ID for requests -- identifying requests by pointer is not safe because our memory management re-uses memory a lot, thus a newly created request will very likely use the same memory region (i.e. the same ID) as a recently de-allocated request.
- temporarily, I have also added a script to be run only on Travis in the background, that prints backtrace of the currently running test at 60 seconds intervals. It will be there only until we catch the issue with frozen build again, to see if non-related processes are also affected and potentially get a backtrace of the critical point. For the time being it may occasionally clutter the build output (but not return value), so please ignore it.