### PR TITLE
C++: Add support for submitting notifications and some refactoring

### DIFF
--- a/swig/cpp/examples/cpp_rpc_example.cpp
+++ b/swig/cpp/examples/cpp_rpc_example.cpp
@@ -232,7 +232,7 @@ main(int argc, char **argv)
                            SR_STRING_T);
 
         cout << "\n ========== START RPC CALL ==========\n" << endl;
-        auto out_vals = subscribe->rpc_send("/test-module:activate-software-image", in_vals);
+        auto out_vals = sess->rpc_send("/test-module:activate-software-image", in_vals);
 
         cout << "\n ========== PRINT RETURN VALUE ==========\n" << endl;
         for(size_t n=0; n < out_vals->val_cnt(); ++n)
@@ -247,7 +247,7 @@ main(int argc, char **argv)
         in_trees->tree(0)->set("acmefw-2.3", SR_STRING_T);
 
         cout << "\n ========== START RPC TREE CALL ==========\n" << endl;
-        auto out_trees = subscribe->rpc_send_tree("/test-module:activate-software-image", in_trees);
+        auto out_trees = sess->rpc_send_tree("/test-module:activate-software-image", in_trees);
 
         cout << "\n ========== PRINT RETURN VALUE ==========\n" << endl;
         for(size_t n=0; n < out_trees->tree_cnt(); ++n)

--- a/swig/cpp/examples/cpp_rpc_example.cpp
+++ b/swig/cpp/examples/cpp_rpc_example.cpp
@@ -247,7 +247,7 @@ main(int argc, char **argv)
         in_trees->tree(0)->set("acmefw-2.3", SR_STRING_T);
 
         cout << "\n ========== START RPC TREE CALL ==========\n" << endl;
-        auto out_trees = sess->rpc_send_tree("/test-module:activate-software-image", in_trees);
+        auto out_trees = sess->rpc_send("/test-module:activate-software-image", in_trees);
 
         cout << "\n ========== PRINT RETURN VALUE ==========\n" << endl;
         for(size_t n=0; n < out_trees->tree_cnt(); ++n)

--- a/swig/cpp/src/Session.cpp
+++ b/swig/cpp/src/Session.cpp
@@ -658,11 +658,11 @@ void Subscribe::unsubscribe()
     _sub = NULL;
 }
 
-S_Vals Subscribe::rpc_send(const char *xpath, S_Vals input)
+S_Vals Session::rpc_send(const char *xpath, S_Vals input)
 {
     S_Vals output(new Vals());
 
-    int ret = sr_rpc_send(_sess->_sess, xpath, input->_vals, input->_cnt, &output->_vals, &output->_cnt);
+    int ret = sr_rpc_send(_sess, xpath, input->_vals, input->_cnt, &output->_vals, &output->_cnt);
     if (SR_ERR_OK != ret) {
         throw_exception(ret);
     }
@@ -676,11 +676,11 @@ S_Vals Subscribe::rpc_send(const char *xpath, S_Vals input)
     return output;
 }
 
-S_Vals Subscribe::action_send(const char *xpath, S_Vals input)
+S_Vals Session::action_send(const char *xpath, S_Vals input)
 {
     S_Vals output(new Vals());
 
-    int ret = sr_action_send(_sess->_sess, xpath, input->_vals, input->_cnt, &output->_vals, &output->_cnt);
+    int ret = sr_action_send(_sess, xpath, input->_vals, input->_cnt, &output->_vals, &output->_cnt);
     if (SR_ERR_OK != ret) {
         throw_exception(ret);
     }
@@ -694,11 +694,11 @@ S_Vals Subscribe::action_send(const char *xpath, S_Vals input)
     return output;
 }
 
-S_Trees Subscribe::rpc_send_tree(const char *xpath, S_Trees input)
+S_Trees Session::rpc_send_tree(const char *xpath, S_Trees input)
 {
     S_Trees output(new Trees());
 
-    int ret = sr_rpc_send_tree(_sess->_sess, xpath, input->_trees, input->_cnt, &output->_trees, &output->_cnt);
+    int ret = sr_rpc_send_tree(_sess, xpath, input->_trees, input->_cnt, &output->_trees, &output->_cnt);
     if (SR_ERR_OK != ret) {
         throw_exception(ret);
     }
@@ -712,11 +712,11 @@ S_Trees Subscribe::rpc_send_tree(const char *xpath, S_Trees input)
     return output;
 }
 
-S_Trees Subscribe::action_send_tree(const char *xpath, S_Trees input)
+S_Trees Session::action_send_tree(const char *xpath, S_Trees input)
 {
     S_Trees output(new Trees());
 
-    int ret = sr_action_send_tree(_sess->_sess, xpath, input->_trees, input->_cnt, &output->_trees, &output->_cnt);
+    int ret = sr_action_send_tree(_sess, xpath, input->_trees, input->_cnt, &output->_trees, &output->_cnt);
     if (SR_ERR_OK != ret) {
         throw_exception(ret);
     }

--- a/swig/cpp/src/Session.cpp
+++ b/swig/cpp/src/Session.cpp
@@ -676,6 +676,25 @@ S_Vals Session::rpc_send(const char *xpath, S_Vals input)
     return output;
 }
 
+S_Trees Session::rpc_send(const char *xpath, S_Trees input)
+{
+    S_Trees output(new Trees());
+
+    int ret = sr_rpc_send_tree(_sess, xpath, input->_trees, input->_cnt, &output->_trees, &output->_cnt);
+    if (SR_ERR_OK != ret) {
+        throw_exception(ret);
+    }
+
+    // ensure that the class is not freed before
+    if (input == NULL) {
+        throw_exception(SR_ERR_INTERNAL);
+    }
+
+    output->_deleter = std::make_shared<Deleter>(output->_trees, output->_cnt);
+    return output;
+}
+
+
 S_Vals Session::action_send(const char *xpath, S_Vals input)
 {
     S_Vals output(new Vals());
@@ -694,25 +713,7 @@ S_Vals Session::action_send(const char *xpath, S_Vals input)
     return output;
 }
 
-S_Trees Session::rpc_send_tree(const char *xpath, S_Trees input)
-{
-    S_Trees output(new Trees());
-
-    int ret = sr_rpc_send_tree(_sess, xpath, input->_trees, input->_cnt, &output->_trees, &output->_cnt);
-    if (SR_ERR_OK != ret) {
-        throw_exception(ret);
-    }
-
-    // ensure that the class is not freed before
-    if (input == NULL) {
-        throw_exception(SR_ERR_INTERNAL);
-    }
-
-    output->_deleter = std::make_shared<Deleter>(output->_trees, output->_cnt);
-    return output;
-}
-
-S_Trees Session::action_send_tree(const char *xpath, S_Trees input)
+S_Trees Session::action_send(const char *xpath, S_Trees input)
 {
     S_Trees output(new Trees());
 

--- a/swig/cpp/src/Session.cpp
+++ b/swig/cpp/src/Session.cpp
@@ -669,7 +669,7 @@ S_Vals Subscribe::rpc_send(const char *xpath, S_Vals input)
 
     // ensure that the class is not freed before
     if (input->_vals == NULL) {
-	throw_exception(SR_ERR_INTERNAL);
+        throw_exception(SR_ERR_INTERNAL);
     }
 
     output->_deleter = std::make_shared<Deleter>(output->_vals, output->_cnt);
@@ -687,7 +687,7 @@ S_Vals Subscribe::action_send(const char *xpath, S_Vals input)
 
     // ensure that the class is not freed before
     if (input->_vals == NULL) {
-	throw_exception(SR_ERR_INTERNAL);
+        throw_exception(SR_ERR_INTERNAL);
     }
 
     output->_deleter = std::make_shared<Deleter>(output->_vals, output->_cnt);
@@ -705,7 +705,7 @@ S_Trees Subscribe::rpc_send_tree(const char *xpath, S_Trees input)
 
     // ensure that the class is not freed before
     if (input == NULL) {
-	throw_exception(SR_ERR_INTERNAL);
+        throw_exception(SR_ERR_INTERNAL);
     }
 
     output->_deleter = std::make_shared<Deleter>(output->_trees, output->_cnt);
@@ -723,7 +723,7 @@ S_Trees Subscribe::action_send_tree(const char *xpath, S_Trees input)
 
     // ensure that the class is not freed before
     if (input == NULL) {
-	throw_exception(SR_ERR_INTERNAL);
+        throw_exception(SR_ERR_INTERNAL);
     }
 
     output->_deleter = std::make_shared<Deleter>(output->_trees, output->_cnt);

--- a/swig/cpp/src/Session.cpp
+++ b/swig/cpp/src/Session.cpp
@@ -730,3 +730,17 @@ S_Trees Session::action_send(const char *xpath, S_Trees input)
     output->_deleter = std::make_shared<Deleter>(output->_trees, output->_cnt);
     return output;
 }
+
+void Session::send_event(const char *xpath, S_Vals values, const sr_ev_notif_flag_t options)
+{
+    int ret = sr_event_notif_send(_sess, xpath, values->_vals, values->val_cnt(), options);
+    if (ret != SR_ERR_OK)
+        throw_exception(ret);
+}
+
+void Session::send_event(const char *xpath, S_Trees trees, const sr_ev_notif_flag_t options)
+{
+    int ret = sr_event_notif_send_tree(_sess, xpath, trees->_trees, trees->tree_cnt(), options);
+    if (ret != SR_ERR_OK)
+        throw_exception(ret);
+}

--- a/swig/cpp/src/Session.h
+++ b/swig/cpp/src/Session.h
@@ -84,9 +84,9 @@ public:
     ~Session();
 
     S_Vals rpc_send(const char *xpath, S_Vals input);
+    S_Trees rpc_send(const char *xpath, S_Trees input);
     S_Vals action_send(const char *xpath, S_Vals input);
-    S_Trees rpc_send_tree(const char *xpath, S_Trees input);
-    S_Trees action_send_tree(const char *xpath, S_Trees input);
+    S_Trees action_send(const char *xpath, S_Trees input);
 
     friend class Subscribe;
 

--- a/swig/cpp/src/Session.h
+++ b/swig/cpp/src/Session.h
@@ -83,6 +83,11 @@ public:
     S_Change get_change_next(S_Iter_Change iter);
     ~Session();
 
+    S_Vals rpc_send(const char *xpath, S_Vals input);
+    S_Vals action_send(const char *xpath, S_Vals input);
+    S_Trees rpc_send_tree(const char *xpath, S_Trees input);
+    S_Trees action_send_tree(const char *xpath, S_Trees input);
+
     friend class Subscribe;
 
 private:
@@ -135,10 +140,6 @@ public:
     std::vector<S_Callback > cb_list;
 
     void unsubscribe();
-    S_Vals rpc_send(const char *xpath, S_Vals input);
-    S_Vals action_send(const char *xpath, S_Vals input);
-    S_Trees rpc_send_tree(const char *xpath, S_Trees input);
-    S_Trees action_send_tree(const char *xpath, S_Trees input);
     ~Subscribe();
 
     // SWIG specific

--- a/swig/cpp/src/Session.h
+++ b/swig/cpp/src/Session.h
@@ -87,6 +87,8 @@ public:
     S_Trees rpc_send(const char *xpath, S_Trees input);
     S_Vals action_send(const char *xpath, S_Vals input);
     S_Trees action_send(const char *xpath, S_Trees input);
+    void send_event(const char * xpath, S_Vals values, const sr_ev_notif_flag_t options = SR_EV_NOTIF_DEFAULT);
+    void send_event(const char * xpath, S_Trees trees, const sr_ev_notif_flag_t options = SR_EV_NOTIF_DEFAULT);
 
     friend class Subscribe;
 

--- a/swig/python2/examples/rpc_example.py
+++ b/swig/python2/examples/rpc_example.py
@@ -140,7 +140,7 @@ try:
     in_trees.tree(0).set("acmefw-2.3", sr.SR_STRING_T);
 
     print "\n ========== START RPC TREE CALL ==========\n"
-    out_trees = sess.rpc_send_tree("/test-module:activate-software-image", in_trees)
+    out_trees = sess.rpc_send("/test-module:activate-software-image", in_trees)
 
     print "\n ========== PRINT RETURN VALUE ==========\n"
     for n in range (out_trees.tree_cnt()):

--- a/swig/python2/examples/rpc_example.py
+++ b/swig/python2/examples/rpc_example.py
@@ -125,7 +125,7 @@ try:
 
 
     print "\n ========== START RPC CALL =========="
-    out_vals = subscribe.rpc_send("/test-module:activate-software-image", in_vals)
+    out_vals = sess.rpc_send("/test-module:activate-software-image", in_vals)
 
     print "\n ========== PRINT RETURN VALUE =========="
     for n in range (out_vals.val_cnt()):
@@ -140,7 +140,7 @@ try:
     in_trees.tree(0).set("acmefw-2.3", sr.SR_STRING_T);
 
     print "\n ========== START RPC TREE CALL ==========\n"
-    out_trees = subscribe.rpc_send_tree("/test-module:activate-software-image", in_trees)
+    out_trees = sess.rpc_send_tree("/test-module:activate-software-image", in_trees)
 
     print "\n ========== PRINT RETURN VALUE ==========\n"
     for n in range (out_trees.tree_cnt()):

--- a/swig/swig_base/cpp_classes.i
+++ b/swig/swig_base/cpp_classes.i
@@ -56,6 +56,7 @@
 %newobject Session::get_change_next;
 %newobject Session::rpc_send;
 %newobject Session::action_send;
+%newobject Session::send_event;
 
 #ifndef SWIGLUA
 %shared_ptr(Callback);

--- a/swig/swig_base/cpp_classes.i
+++ b/swig/swig_base/cpp_classes.i
@@ -55,9 +55,7 @@
 %newobject Session::get_changes_iter;
 %newobject Session::get_change_next;
 %newobject Session::rpc_send;
-%newobject Session::rpc_send_tree;
 %newobject Session::action_send;
-%newobject Session::action_send_tree;
 
 #ifndef SWIGLUA
 %shared_ptr(Callback);

--- a/swig/swig_base/cpp_classes.i
+++ b/swig/swig_base/cpp_classes.i
@@ -54,6 +54,10 @@
 %newobject Session::get_subtrees;
 %newobject Session::get_changes_iter;
 %newobject Session::get_change_next;
+%newobject Session::rpc_send;
+%newobject Session::rpc_send_tree;
+%newobject Session::action_send;
+%newobject Session::action_send_tree;
 
 #ifndef SWIGLUA
 %shared_ptr(Callback);
@@ -67,8 +71,6 @@
 %ignore Subscribe::swig_sess;
 %ignore Subscribe::wrap_cb_l;
 %ignore Subscribe::additional_cleanup(void *);
-%newobject Subscribe::rpc_send;
-%newobject Subscribe::rpc_send_tree;
 
 #ifndef SWIGLUA
 %shared_ptr(Data);


### PR DESCRIPTION
Cc: @mislavn 

- move the RPC and Action invocation out of the ``Subscribe`` class to ``Session`` because it doesn't depend on some subscriptions
- make use of overloading based on arguments so that there's just one ``rpc_send`` in place of ``rpc_send`` and ``rpc_send_tree``
- add support for submitting events using these new conventions