### PR TITLE
tests: Fix initialization of "local sysrepo directory"

### DIFF
--- a/src/executables/sysrepoctl.c
+++ b/src/executables/sysrepoctl.c
@@ -1283,7 +1283,7 @@ main(int argc, char* argv[])
     char *yang = NULL, *yin = NULL, *module = NULL, *revision = NULL;
     char *owner = NULL, *permissions = NULL;
     char *search_dir = NULL;
-    char local_schema_search_dir[PATH_MAX] = { 0, }, local_data_search_dir[PATH_MAX] = { 0, };
+    char local_schema_search_dir[PATH_MAX] = { 0, }, local_schema_search_submod_dir[PATH_MAX] = { 0, }, local_data_search_dir[PATH_MAX] = { 0, };
     char local_internal_schema_search_dir[PATH_MAX] = { 0, }, local_internal_data_search_dir[PATH_MAX] = { 0, };
     int rc = SR_ERR_OK;
     int search_installed = 0;
@@ -1368,10 +1368,13 @@ main(int argc, char* argv[])
                 strncpy(local_internal_schema_search_dir, optarg, PATH_MAX - 15);
                 strncpy(local_internal_data_search_dir, optarg, PATH_MAX - 15);
                 strcat(local_schema_search_dir, "/yang/");
+                strcat(local_schema_search_submod_dir, local_schema_search_dir);
+                strcat(local_schema_search_submod_dir, "/submodules/");
                 strcat(local_data_search_dir, "/data/");
                 strcat(local_internal_schema_search_dir, "/yang/internal");
                 strcat(local_internal_data_search_dir, "/data/internal");
                 srctl_schema_search_dir = local_schema_search_dir;
+                srctl_schema_search_submod_dir = local_schema_search_submod_dir;
                 srctl_data_search_dir = local_data_search_dir;
                 srctl_internal_schema_search_dir = local_internal_schema_search_dir;
                 srctl_internal_data_search_dir = local_internal_data_search_dir;


### PR DESCRIPTION
There's an undocumented option for `sysrepoctl` which enables overrides
for various repository locations. However, the submodule schema
directory was not being overridden.

When tests are enabled, `sysrepoctl` is invoked via CMake's POST_BUILD
option right after the `common_test` has been built. Because this is
running at the time of the *build*, i.e., prior to installation time,
the target directories have not yet been created. This leads to the
following failure:

```
  2017-04-20 06:51:52,422 [output] [114/140] Linking C executable tests/common_test
  2017-04-20 06:51:52,422 [output] FAILED: tests/common_test
  2017-04-20 06:51:52,423 [output] : && /opt/rh/devtoolset-6/root/usr/bin/cc  -Wall -Wpedantic -std=gnu11 -Wno-strict-aliasing -g -O0   tests/CMakeFiles/HELPERS.dir/helpers/rp_dt_context_helper.c.o tests/CMakeFiles/HELPERS.dir/helpers/test_module_helper.c.o tests/CMakeFiles/HELPERS.dir/helpers/system_helper.c.o tests/CMakeFiles/HELPERS.dir/helpers/nacm_module_helper.c.o tests/CMakeFiles/common_test.dir/common_test.c.o  -o tests/common_test  -rdynamic -lcmocka src/libsysrepo.a -lrt -lpthread /home/turbo-hipster/target/lib/libredblack.so -lev -lprotobuf-c /home/turbo-hipster/target/lib64/libyang.so -Wl,-rpath,/home/turbo-hipster/target/lib:/home/turbo-hipster/target/lib64 && cd /home/turbo-hipster/jobs/7ddabccd6e29/97/197/2/check/check-czechlight-devtoolset6-el7/637913a/sysrepo/sysrepo/build/tests && /home/turbo-hipster/jobs/7ddabccd6e29/97/197/2/check/check-czechlight-devtoolset6-el7/637913a/sysrepo/sysrepo/build/src/sysrepoctl --install --yang=/home/turbo-hipster/jobs/7ddabccd6e29/97/197/2/check/check-czechlight-devtoolset6-el7/637913a/sysrepo/sysrepo/tests/yang/ietf-netconf-acm@2012-02-22.yang -0 /home/turbo-hipster/jobs/7ddabccd6e29/97/197/2/check/check-czechlight-devtoolset6-el7/637913a/sysrepo/sysrepo/build/repository > /dev/null && cd /home/turbo-hipster/jobs/7ddabccd6e29/97/197/2/check/check-czechlight-devtoolset6-el7/637913a/sysrepo/sysrepo/build/tests && /home/turbo-hipster/jobs/7ddabccd6e29/97/197/2/check/check-czechlight-devtoolset6-el7/637913a/sysrepo/sysrepo/build/src/sysrepoctl --install --yang=/home/turbo-hipster/jobs/7ddabccd6e29/97/197/2/check/check-czechlight-devtoolset6-el7/637913a/sysrepo/sysrepo/tests/yang/example-module.yang -0 /home/turbo-hipster/jobs/7ddabccd6e29/97/197/2/check/check-czechlight-devtoolset6-el7/637913a/sysrepo/sysrepo/build/repository > /dev/null && cd /home/turbo-hipster/jobs/7ddabccd6e29/97/197/2/check/check-czechlight-devtoolset6-el7/637913a/sysrepo/sysrepo/build/tests && /home/turbo-hipster/jobs/7ddabccd6e29/97/197/2/check/check-czechlight-devtoolset6-el7/637913a/sysrepo/sysrepo/build/src/sysrepoctl --install --yang=/home/turbo-hipster/jobs/7ddabccd6e29/97/197/2/check/check-czechlight-devtoolset6-el7/637913a/sysrepo/sysrepo/tests/yang/test-module.yang -0 /home/turbo-hipster/jobs/7ddabccd6e29/97/197/2/check/check-czechlight-devtoolset6-el7/637913a/sysrepo/sysrepo/build/repository > /dev/null && cd /home/turbo-hipster/jobs/7ddabccd6e29/97/197/2/check/check-czechlight-devtoolset6-el7/637913a/sysrepo/sysrepo/build/tests && /home/turbo-hipster/jobs/7ddabccd6e29/97/197/2/check/check-czechlight-devtoolset6-el7/637913a/sysrepo/sysrepo/build/src/sysrepoctl --install --yang=/home/turbo-hipster/jobs/7ddabccd6e29/97/197/2/check/check-czechlight-devtoolset6-el7/637913a/sysrepo/sysrepo/tests/yang/small-module.yang -0 /home/turbo-hipster/jobs/7ddabccd6e29/97/197/2/check/check-czechlight-devtoolset6-el7/637913a/sysrepo/sysrepo/build/repository > /dev/null && cd /home/turbo-hipster/jobs/7ddabccd6e29/97/197/2/check/check-czechlight-devtoolset6-el7/637913a/sysrepo/sysrepo/build/tests && /home/turbo-hipster/jobs/7ddabccd6e29/97/197/2/check/check-czechlight-devtoolset6-el7/637913a/sysrepo/sysrepo/build/src/sysrepoctl --install --yang=/home/turbo-hipster/jobs/7ddabccd6e29/97/197/2/check/check-czechlight-devtoolset6-el7/637913a/sysrepo/sysrepo/tests/yang/info-module.yang -0 /home/turbo-hipster/jobs/7ddabccd6e29/97/197/2/check/check-czechlight-devtoolset6-el7/637913a/sysrepo/sysrepo/build/repository > /dev/null && cd /home/turbo-hipster/jobs/7ddabccd6e29/97/197/2/check/check-czechlight-devtoolset6-el7/637913a/sysrepo/sysrepo/build/tests && /home/turbo-hipster/jobs/7ddabccd6e29/97/197/2/check/check-czechlight-devtoolset6-el7/637913a/sysrepo/sysrepo/build/src/sysrepoctl --install --yang=/home/turbo-hipster/jobs/7ddabccd6e29/97/197/2/check/check-czechlight-devtoolset6-el7/637913a/sysrepo/sysrepo/tests/yang/module-a@2016-02-10.yang -0 /home/turbo-hipster/jobs/7ddabccd6e29/97/197/2/check/check-czechlight-devtoolset6-el7/637913a/sysrepo/sysrepo/build/repository > /dev/null && cd /home/turbo-hipster/jobs/7ddabccd6e29/97/197/2/check/check-czechlight-devtoolset6-el7/637913a/sysrepo/sysrepo/build/tests && /home/turbo-hipster/jobs/7ddabccd6e29/97/197/2/check/check-czechlight-devtoolset6-el7/637913a/sysrepo/sysrepo/build/src/sysrepoctl --install --yang=/home/turbo-hipster/jobs/7ddabccd6e29/97/197/2/check/check-czechlight-devtoolset6-el7/637913a/sysrepo/sysrepo/tests/yang/module-b@2016-02-05.yang -0 /home/turbo-hipster/jobs/7ddabccd6e29/97/197/2/check/check-czechlight-devtoolset6-el7/637913a/sysrepo/sysrepo/build/repository > /dev/null && cd /home/turbo-hipster/jobs/7ddabccd6e29/97/197/2/check/check-czechlight-devtoolset6-el7/637913a/sysrepo/sysrepo/build/tests && /home/turbo-hipster/jobs/7ddabccd6e29/97/197/2/check/check-czechlight-devtoolset6-el7/637913a/sysrepo/sysrepo/build/src/sysrepoctl --install --yang=/home/turbo-hipster/jobs/7ddabccd6e29/97/197/2/check/check-czechlight-devtoolset6-el7/637913a/sysrepo/sysrepo/tests/yang/ietf-interfaces@2014-05-08.yang -0 /home/turbo-hipster/jobs/7ddabccd6e29/97/197/2/check/check-czechlight-devtoolset6-el7/637913a/sysrepo/sysrepo/build/repository > /dev/null && cd /home/turbo-hipster/jobs/7ddabccd6e29/97/197/2/check/check-czechlight-devtoolset6-el7/637913a/sysrepo/sysrepo/build/tests && /home/turbo-hipster/jobs/7ddabccd6e29/97/197/2/check/check-czechlight-devtoolset6-el7/637913a/sysrepo/sysrepo/build/src/sysrepoctl --install --yang=/home/turbo-hipster/jobs/7ddabccd6e29/97/197/2/check/check-czechlight-devtoolset6-el7/637913a/sysrepo/sysrepo/tests/yang/iana-if-type.yang -0 /home/turbo-hipster/jobs/7ddabccd6e29/97/197/2/check/check-czechlight-devtoolset6-el7/637913a/sysrepo/sysrepo/build/repository > /dev/null && cd /home/turbo-hipster/jobs/7ddabccd6e29/97/197/2/check/check-czechlight-devtoolset6-el7/637913a/sysrepo/sysrepo/build/tests && /home/turbo-hipster/jobs/7ddabccd6e29/97/197/2/check/check-czechlight-devtoolset6-el7/637913a/sysrepo/sysrepo/build/src/sysrepoctl --install --yang=/home/turbo-hipster/jobs/7ddabccd6e29/97/197/2/check/check-czechlight-devtoolset6-el7/637913a/sysrepo/sysrepo/tests/yang/ietf-ip@2014-06-16.yang -0 /home/turbo-hipster/jobs/7ddabccd6e29/97/197/2/check/check-czechlight-devtoolset6-el7/637913a/sysrepo/sysrepo/build/repository > /dev/null && cd /home/turbo-hipster/jobs/7ddabccd6e29/97/197/2/check/check-czechlight-devtoolset6-el7/637913a/sysrepo/sysrepo/build/tests && /home/turbo-hipster/jobs/7ddabccd6e29/97/197/2/check/check-czechlight-devtoolset6-el7/637913a/sysrepo/sysrepo/build/src/sysrepoctl --install --yang=/home/turbo-hipster/jobs/7ddabccd6e29/97/197/2/check/check-czechlight-devtoolset6-el7/637913a/sysrepo/sysrepo/tests/yang/state-module@2016-07-01.yang -0 /home/turbo-hipster/jobs/7ddabccd6e29/97/197/2/check/check-czechlight-devtoolset6-el7/637913a/sysrepo/sysrepo/build/repository > /dev/null && cd /home/turbo-hipster/jobs/7ddabccd6e29/97/197/2/check/check-czechlight-devtoolset6-el7/637913a/sysrepo/sysrepo/build/tests && /home/turbo-hipster/jobs/7ddabccd6e29/97/197/2/check/check-czechlight-devtoolset6-el7/637913a/sysrepo/sysrepo/build/src/sysrepoctl --install --yang=/home/turbo-hipster/jobs/7ddabccd6e29/97/197/2/check/check-czechlight-devtoolset6-el7/637913a/sysrepo/sysrepo/tests/yang/top-level-mandatory.yang -0 /home/turbo-hipster/jobs/7ddabccd6e29/97/197/2/check/check-czechlight-devtoolset6-el7/637913a/sysrepo/sysrepo/build/repository > /dev/null && cd /home/turbo-hipster/jobs/7ddabccd6e29/97/197/2/check/check-czechlight-devtoolset6-el7/637913a/sysrepo/sysrepo/build/tests && /home/turbo-hipster/jobs/7ddabccd6e29/97/197/2/check/check-czechlight-devtoolset6-el7/637913a/sysrepo/sysrepo/build/src/sysrepoctl --install --yang=/home/turbo-hipster/jobs/7ddabccd6e29/97/197/2/check/check-czechlight-devtoolset6-el7/637913a/sysrepo/sysrepo/tests/yang/referenced-data.yang -0 /home/turbo-hipster/jobs/7ddabccd6e29/97/197/2/check/check-czechlight-devtoolset6-el7/637913a/sysrepo/sysrepo/build/repository > /dev/null && cd /home/turbo-hipster/jobs/7ddabccd6e29/97/197/2/check/check-czechlight-devtoolset6-el7/637913a/sysrepo/sysrepo/build/tests && /home/turbo-hipster/jobs/7ddabccd6e29/97/197/2/check/check-czechlight-devtoolset6-el7/637913a/sysrepo/sysrepo/build/src/sysrepoctl --install --yang=/home/turbo-hipster/jobs/7ddabccd6e29/97/197/2/check/check-czechlight-devtoolset6-el7/637913a/sysrepo/sysrepo/tests/yang/cross-module.yang -0 /home/turbo-hipster/jobs/7ddabccd6e29/97/197/2/check/check-czechlight-devtoolset6-el7/637913a/sysrepo/sysrepo/build/repository > /dev/null && cd /home/turbo-hipster/jobs/7ddabccd6e29/97/197/2/check/check-czechlight-devtoolset6-el7/637913a/sysrepo/sysrepo/build/tests && /home/turbo-hipster/jobs/7ddabccd6e29/97/197/2/check/check-czechlight-devtoolset6-el7/637913a/sysrepo/sysrepo/build/src/sysrepoctl --install --yang=/home/turbo-hipster/jobs/7ddabccd6e29/97/197/2/check/check-czechlight-devtoolset6-el7/637913a/sysrepo/sysrepo/tests/yang/turing-machine.yang -0 /home/turbo-hipster/jobs/7ddabccd6e29/97/197/2/check/check-czechlight-devtoolset6-el7/637913a/sysrepo/sysrepo/build/repository > /dev/null && cd /home/turbo-hipster/jobs/7ddabccd6e29/97/197/2/check/check-czechlight-devtoolset6-el7/637913a/sysrepo/sysrepo/build/tests && /home/turbo-hipster/jobs/7ddabccd6e29/97/197/2/check/check-czechlight-devtoolset6-el7/637913a/sysrepo/sysrepo/build/src/sysrepoctl --install --yang=/home/turbo-hipster/jobs/7ddabccd6e29/97/197/2/check/check-czechlight-devtoolset6-el7/637913a/sysrepo/sysrepo/tests/yang/ietf-netconf-notifications.yang -0 /home/turbo-hipster/jobs/7ddabccd6e29/97/197/2/check/check-czechlight-devtoolset6-el7/637913a/sysrepo/sysrepo/build/repository > /dev/null && cd /home/turbo-hipster/jobs/7ddabccd6e29/97/197/2/check/check-czechlight-devtoolset6-el7/637913a/sysrepo/sysrepo/build/tests && /home/turbo-hipster/jobs/7ddabccd6e29/97/197/2/check/check-czechlight-devtoolset6-el7/637913a/sysrepo/sysrepo/build/src/sysrepoctl --install --yang=/home/turbo-hipster/jobs/7ddabccd6e29/97/197/2/check/check-czechlight-devtoolset6-el7/637913a/sysrepo/sysrepo/tests/yang/nc-notifications.yang -0 /home/turbo-hipster/jobs/7ddabccd6e29/97/197/2/check/check-czechlight-devtoolset6-el7/637913a/sysrepo/sysrepo/build/repository > /dev/null && cd /home/turbo-hipster/jobs/7ddabccd6e29/97/197/2/check/check-czechlight-devtoolset6-el7/637913a/sysrepo/sysrepo/build/tests && /home/turbo-hipster/jobs/7ddabccd6e29/97/197/2/check/check-czechlight-devtoolset6-el7/637913a/sysrepo/sysrepo/build/src/sysrepoctl --install --yang=/home/turbo-hipster/jobs/7ddabccd6e29/97/197/2/check/check-czechlight-devtoolset6-el7/637913a/sysrepo/sysrepo/tests/yang/servers.yang -0 /home/turbo-hipster/jobs/7ddabccd6e29/97/197/2/check/check-czechlight-devtoolset6-el7/637913a/sysrepo/sysrepo/build/repository > /dev/null
  2017-04-20 06:51:52,423 [output] Error: Unable to create schema repository '/home/turbo-hipster/target/etc-sysrepo/yang//submodules/': No such file or directory.
```

This appears to happen only when configuring with ``-DREPOSITORY_LOC`` pointing
outside of the build directory.