### PR TITLE
BUGFIX for mutex handling

### DIFF
--- a/src/access_control.c
+++ b/src/access_control.c
@@ -493,7 +493,7 @@ ac_set_user_identity(ac_ctx_t *ac_ctx, const ac_ucred_t *user_credentials)
 }
 
 int
-ac_unset_user_identity(ac_ctx_t *ac_ctx)
+ac_unset_user_identity(ac_ctx_t *ac_ctx, const ac_ucred_t *user_credentials)
 {
     int rc = SR_ERR_OK;
 
@@ -507,7 +507,9 @@ ac_unset_user_identity(ac_ctx_t *ac_ctx)
     /* set the identity back to process original */
     rc = ac_set_identity(ac_ctx->proc_euid, ac_ctx->proc_egid);
 
-    pthread_mutex_unlock(&ac_ctx->lock);
+    if (NULL != user_credentials) {
+        pthread_mutex_unlock(&ac_ctx->lock);
+    }
 
     return rc;
 }

--- a/src/access_control.h
+++ b/src/access_control.h
@@ -169,10 +169,11 @@ int ac_set_user_identity(ac_ctx_t *ac_ctx, const ac_ucred_t *user_credentials);
  * to the process identity saved at the time of ::ac_init.
  *
  * @param[in] ac_ctx Access Control module context acquired by ::ac_init call.
+ * @param[in] user_credentials Credentials of a sysrepo user.
  *
  * @return Error code (SR_ERR_OK on success).
  */
-int ac_unset_user_identity(ac_ctx_t *ac_ctx);
+int ac_unset_user_identity(ac_ctx_t *ac_ctx, const ac_ucred_t *user_credentials);
 
 /**@} ac */
 

--- a/src/data_manager.c
+++ b/src/data_manager.c
@@ -1235,7 +1235,7 @@ dm_load_data_tree(dm_ctx_t *dm_ctx, dm_session_t *dm_session_ctx, dm_schema_info
 
     int fd = open(data_filename, O_RDONLY);
 
-    ac_unset_user_identity(dm_ctx->ac_ctx);
+    ac_unset_user_identity(dm_ctx->ac_ctx, dm_session_ctx->user_credentials);
 
     if (-1 != fd) {
         /* lock, read-only, blocking */
@@ -1362,7 +1362,7 @@ dm_lock_module(dm_ctx_t *dm_ctx, dm_session_t *session, const char *modul_name)
     rc = dm_lock_file(dm_ctx->locking_ctx, lock_file);
 
     /* switch identity back */
-    ac_unset_user_identity(dm_ctx->ac_ctx);
+    ac_unset_user_identity(dm_ctx->ac_ctx, session->user_credentials);
 
     /* log information about locked model */
     if (SR_ERR_OK != rc) {
@@ -3250,7 +3250,7 @@ dm_update_session_data_trees(dm_ctx_t *dm_ctx, dm_session_t *session, sr_list_t 
         CHECK_RC_MSG_GOTO(rc, cleanup, "Get data file name failed");
         ac_set_user_identity(dm_ctx->ac_ctx, session->user_credentials);
         fd = open(file_name, O_RDONLY);
-        ac_unset_user_identity(dm_ctx->ac_ctx);
+        ac_unset_user_identity(dm_ctx->ac_ctx, session->user_credentials);
 
         if (-1 == fd) {
             SR_LOG_DBG("File %s can not be opened for read write", file_name);
@@ -4012,12 +4012,12 @@ dm_commit_load_modified_models(dm_ctx_t *dm_ctx, const dm_session_t *session, dm
         count++;
     }
 
-    ac_unset_user_identity(dm_ctx->ac_ctx);
+    ac_unset_user_identity(dm_ctx->ac_ctx, session->user_credentials);
 
     return rc;
 
 cleanup:
-    ac_unset_user_identity(dm_ctx->ac_ctx);
+    ac_unset_user_identity(dm_ctx->ac_ctx, session->user_credentials);
     free(file_name);
     return rc;
 }
@@ -5103,7 +5103,7 @@ dm_copy_config(dm_ctx_t *dm_ctx, dm_session_t *session, const sr_list_t *module_
             }
             fds[opened_files] = open(file_name, O_RDWR | O_TRUNC);
             if (NULL != session) {
-                ac_unset_user_identity(dm_ctx->ac_ctx);
+                ac_unset_user_identity(dm_ctx->ac_ctx, session->user_credentials);
             }
             if (-1 == fds[opened_files]) {
                 SR_LOG_ERR("File %s can not be opened", file_name);

--- a/src/notification_processor.c
+++ b/src/notification_processor.c
@@ -366,7 +366,7 @@ np_load_data_tree(np_ctx_t *np_ctx, const ac_ucred_t *user_cred, const char *dat
     fd = open(data_filename, (read_only ? O_RDONLY : O_RDWR));
 
     if (NULL != user_cred) {
-        ac_unset_user_identity(np_ctx->rp_ctx->ac_ctx);
+        ac_unset_user_identity(np_ctx->rp_ctx->ac_ctx, user_cred);
     }
 
     if (-1 == fd) {
@@ -380,7 +380,7 @@ np_load_data_tree(np_ctx_t *np_ctx, const ac_ucred_t *user_cred, const char *dat
                 /* create new persist file */
                 ac_set_user_identity(np_ctx->rp_ctx->ac_ctx, user_cred);
                 fd = open(data_filename, O_RDWR | O_CREAT, S_IRUSR | S_IWUSR | S_IRGRP | S_IWGRP | S_IROTH | S_IWOTH);
-                ac_unset_user_identity(np_ctx->rp_ctx->ac_ctx);
+                ac_unset_user_identity(np_ctx->rp_ctx->ac_ctx, user_cred);
                 if (-1 == fd) {
                     SR_LOG_ERR("Unable to create a new data file '%s': %s", data_filename, sr_strerror_safe(errno));
                     rc = SR_ERR_INTERNAL;

--- a/src/persistence_manager.c
+++ b/src/persistence_manager.c
@@ -219,7 +219,7 @@ pm_load_data_tree(pm_ctx_t *pm_ctx, const ac_ucred_t *user_cred, const char *mod
     error = errno;
 
     if (NULL != user_cred) {
-        ac_unset_user_identity(pm_ctx->rp_ctx->ac_ctx);
+        ac_unset_user_identity(pm_ctx->rp_ctx->ac_ctx, user_cred);
     }
 
     if (-1 == fd) {
@@ -233,7 +233,7 @@ pm_load_data_tree(pm_ctx_t *pm_ctx, const ac_ucred_t *user_cred, const char *mod
                 /* create new persist file */
                 ac_set_user_identity(pm_ctx->rp_ctx->ac_ctx, user_cred);
                 fd = open(data_filename, O_RDWR | O_CREAT, S_IRUSR | S_IWUSR | S_IRGRP | S_IWGRP | S_IROTH | S_IWOTH);
-                ac_unset_user_identity(pm_ctx->rp_ctx->ac_ctx);
+                ac_unset_user_identity(pm_ctx->rp_ctx->ac_ctx, user_cred);
                 if (-1 == fd) {
                     SR_LOG_ERR("Unable to create new persist data file '%s': %s", data_filename, sr_strerror_safe(error));
                     rc = SR_ERR_INTERNAL;

--- a/tests/ac_test.c
+++ b/tests/ac_test.c
@@ -270,7 +270,7 @@ ac_test_identity_switch(void **state)
     }
 
     /* switch identity back */
-    rc = ac_unset_user_identity(ctx);
+    rc = ac_unset_user_identity(ctx, &credentials1);
     assert_int_equal(rc, SR_ERR_OK);
 
     /* make sure we can access passwd as before switching */
@@ -300,7 +300,7 @@ ac_test_identity_switch(void **state)
         assert_int_equal(fd, -1);
 
         /* switch identity back */
-        rc = ac_unset_user_identity(ctx);
+        rc = ac_unset_user_identity(ctx, &credentials2);
         assert_int_equal(rc, SR_ERR_OK);
     }
 


### PR DESCRIPTION
This patch fixes the case where ac_set_user_identity would not lock the
mutex and in ac_unset_user_identity it would get anyway unlocked which
resulted in a warning by sanitizer:

WARNING: ThreadSanitizer: unlock of an unlocked mutex (or by a wrong thread)

This is bug fix for the github issue https://github.com/sysrepo/sysrepo/issues/800.