### PR TITLE
Github templates for issues and pull requests.

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,39 @@
+### Things you may try first 
+(put "x" in "[]" if you already tried those. If you haven't - we will)
+* [] Did you check if this is a duplicate issue?
+* [] Did you test it on the latest sysrepo devel branch?
+
+### Description
+[Description of the bug or feature]
+
+### Steps to Reproduce
+1. [First Step]
+2. [Second Step]
+3. [and so on...]
+
+**Expected behavior:**
+ [What you expected to happen]
+
+**Actual behavior:**
+ [What actually happened]
+
+### Versions
+Please provide versions for software needed to reproduce the bug:
+Sysrepo version: `sysrepod -v`.
+libyang version: `yanglint -v`
+netopeer2-server: `netopeer2-server -V` (optional)
+
+### Attachments
+Please run sysrepo daemon in debug mode and write the logs to a file. For example:
+`sysrepod -d -l 4 &> sysrepod.log`.
+
+Similarly, if Netopeer2 server is used, also provide us with its log:
+`netopeer2-server -d -v3 &> netopeer2-server.log` (optional)
+
+You're also welcomed to provide us with any other data you think may be useful.
+For example:
+Installed modules: `sysrepoctl -l`
+Content of datastore used: check files in  Sysrepo data directory (default `/etc/sysrepo/data`).
+
+Provide us with those attachments and keep your fingers crossed. 
+Thanks!

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,5 +1,12 @@
-### Things you may try first 
-(put "x" in "[]" if you already tried those. If you haven't - we will)
+### How to submit issue
+Please use this text as a template and replace text in the sections or remove
+the entire section if that does not apply to your issue. For example in case of
+question or feature request, just description with some example is probably
+fine. Also remember to use github's markup form properly, especially in case of
+output or code listing.
+
+### Things you may try first
+(put "x" in "[]" if you already tried following)
 * [] Did you check if this is a duplicate issue?
 * [] Did you test it on the latest sysrepo devel branch?
 
@@ -35,5 +42,4 @@ For example:
 Installed modules: `sysrepoctl -l`
 Content of datastore used: check files in  Sysrepo data directory (default `/etc/sysrepo/data`).
 
-Provide us with those attachments and keep your fingers crossed. 
 Thanks!

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,16 @@
+Pull requests are mostly made to solve problems, add features and make other necessary adjustments.
+Every pull request should be preceded by an issue which it is supposed to solve. 
+Issue is needed before pull request so community could discuss what actually should be done about it. 
+Developers have to know if applying the request would make (breaking) changes to API/ABI (versioning purposes), what kind of test it needs (QA), etc.
+On making pull request, delete this paragraph (after reading it) and fill in following.
+
+### Description 
+In short, why is this pull request created. What it solves and how.
+
+### Test case
+Give us reason why you think it is correct solution.
+For new code, make test which tests the addition.
+For modifications, reference existing test.
+
+### Closure
+Put closes #XXXX in your comment to auto-close the issue that pull request fixes.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,10 +1,11 @@
 Pull requests are mostly made to solve problems, add features and make other necessary adjustments.
-Every pull request should be preceded by an issue which it is supposed to solve. 
-Issue is needed before pull request so community could discuss what actually should be done about it. 
+Every pull request should be preceded by an issue which it is supposed to solve.
+Issue is needed before pull request so community could discuss what actually should be done about it.
 Developers have to know if applying the request would make (breaking) changes to API/ABI (versioning purposes), what kind of test it needs (QA), etc.
 On making pull request, delete this paragraph (after reading it) and fill in following.
+Use default coding style defined at CODINGSTYLE.md
 
-### Description 
+### Description
 In short, why is this pull request created. What it solves and how.
 
 ### Test case


### PR DESCRIPTION
This is a suggestion for github templates and issues.

To better use of developers time, a filter is needed for repetative and/or basic issues.
It's no fun telling users same thing over and over (like attach log, steps to reproduce, did you check devel, etc.).

We're thinking that this current version has too much text, but it also seems necessary.
And it could still grow. Some kind of readme file would be better place for much of it. Headers would be left for issuel to fill out.

Signed-off-by: Antonio Paunovic <antonio.paunovic@sartura.hr>