### PR TITLE
BUGFIX do not rtn err for empty data when get nodes by schema

### DIFF
--- a/src/data_manager.c
+++ b/src/data_manager.c
@@ -6571,10 +6571,14 @@ dm_get_nodes_by_schema(dm_session_t *session, const char *module_name, const str
     rc = dm_get_data_info(session->dm_ctx, session, module_name, &di);
     CHECK_RC_MSG_RETURN(rc, "Get data info failed");
 
-    *res = lyd_find_instance(di->node, node);
-    if (NULL == *res) {
-        SR_LOG_ERR("Failed to find nodes %s in module %s", node->name, module_name);
-        rc = SR_ERR_INTERNAL;
+    if (di->node == NULL) {
+        *res = ly_set_new();
+    } else {
+        *res = lyd_find_instance(di->node, node);
+        if (NULL == *res) {
+            SR_LOG_ERR("Failed to find nodes %s in module %s", node->name, module_name);
+            rc = SR_ERR_INTERNAL;
+        }
     }
 
     return rc;


### PR DESCRIPTION
Hi,
The `get` operation will return an internal error when data is empty and schema has state node, such as follow module:
```
module test{
	namespace "urn:it:params:xml:ns:yang:test";
	prefix "test";
    	
	container C1{
	    presence "enable C1";
		list L1{
			key "name";
			leaf name{
				type string;
			}
			leaf value{
				type string;
				config false;
			}
		}
	}
}
```
if you do not configure any data and execute `get --filter-xpath=/test:C1` in netopeer, you will get an error like this:
```
> get --filter-xpath=/test:C1
ERROR
        type:     application
        tag:      operation-failed
        severity: error
        message:  Getting items (/test:C1//.) from sysrepo failed (Sysrepo-internal error).

> 
```
