### PR TITLE
BUGFIX memory leak

### DIFF
--- a/src/module_dependencies.c
+++ b/src/module_dependencies.c
@@ -2287,7 +2287,7 @@ cleanup:
     if (tmp_ly_ctx) {
         ly_ctx_destroy(tmp_ly_ctx, NULL);
     }
-    if (SR_ERR_OK != rc) {
+    if (SR_ERR_OK != rc || NULL == implicitly_inserted_p) {
         md_free_module_key_list(implicitly_inserted);
     }
     return rc;

--- a/src/module_dependencies.c
+++ b/src/module_dependencies.c
@@ -2696,10 +2696,8 @@ md_remove_module(md_ctx_t *md_ctx, const char *name, const char *revision, sr_li
 
     rc = md_remove_module_internal(md_ctx, name, revision, false, implicitly_removed);
 
-    if (SR_ERR_OK == rc) {
-        if (implicitly_removed_p) {
-            *implicitly_removed_p = implicitly_removed;
-        }
+    if (SR_ERR_OK == rc && implicitly_removed_p) {
+        *implicitly_removed_p = implicitly_removed;
     } else {
         md_free_module_key_list(implicitly_removed);
     }


### PR DESCRIPTION
Bugfix for a memory leak in sysrepoctl.

How to reproduce it:
1) run sysrepoctl install, for an example:
`valgrind sysrepoctl --install --yang=/opt/fork/sysrepo/tests/yang/ietf-interfaces\@2014-05-08.yang --owner=root:root --permissions=644`

Output
```
Installing a new module from file '/opt/fork/sysrepo/tests/yang/ietf-interfaces@2014-05-08.yang'...
Installing the YANG file to '/etc/sysrepo/yang/ietf-interfaces@2014-05-08.yang'...
Installing data files for module 'ietf-interfaces'...
Notifying sysrepo about the change...
Install operation completed successfully.
==1962== 
==1962== HEAP SUMMARY:
==1962==     in use at exit: 75 bytes in 3 blocks
==1962==   total heap usage: 13,588 allocs, 13,585 frees, 6,512,684 bytes allocated
==1962== 
==1962== LEAK SUMMARY:
==1962==    definitely lost: 24 bytes in 1 blocks
==1962==    indirectly lost: 0 bytes in 0 blocks
==1962==      possibly lost: 0 bytes in 0 blocks
==1962==    still reachable: 51 bytes in 2 blocks
==1962==         suppressed: 0 bytes in 0 blocks
==1962== Rerun with --leak-check=full to see details of leaked memory
==1962== 
==1962== For counts of detected and suppressed errors, rerun with: -v
==1962== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```

The problem occurs when the function `implicitly_inserted_p` is never used.