### PR TITLE
Bugfixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -304,6 +304,7 @@ endif()
 
 INSTALL_YANG("ietf-netconf-notifications" "" "666")
 INSTALL_YANG("nc-notifications" "" "666")
+INSTALL_YANG("notifications" "" "666")
 
 if(GEN_LANGUAGE_BINDINGS)
     add_subdirectory(swig)

--- a/src/common/sr_utils.h
+++ b/src/common/sr_utils.h
@@ -209,7 +209,16 @@ int sr_copy_first_ns(const char *xpath, char **namespace);
  * @param [out] namespaces
  * @param [out] namespace_cnt
  */
-int sr_copy_first_ns_from_expr(const char *expr, char*** namespaces, size_t *namespace_cnt);
+int sr_copy_first_ns_from_expr(const char *expr, char ***namespaces, size_t *namespace_cnt);
+
+/**
+ * @brief Returns an allocated C-array of all namespaces found in the given expression.
+ *
+ * @param [in] expr
+ * @param [out] namespaces
+ * @param [out] ns_count
+ */
+int sr_copy_all_ns(const char *xpath, char ***namespaces, size_t *ns_count);
 
 /**
  * @brief Compares the first namespace of the xpath. If an argument is NULL


### PR DESCRIPTION
Schema notifications must be installed and implemented, instance-identifiers must be traversed wholly when looking for required schemas as their first namespace is not enough.

Refs cesnet/netopeer2#120