### PR TITLE
TEST sysrepoctl_test modified get user

### DIFF
--- a/tests/sysrepoctl_test.c
+++ b/tests/sysrepoctl_test.c
@@ -30,6 +30,7 @@
 #include <time.h>
 #include <sys/types.h>
 #include <sys/stat.h>
+#include <pwd.h>
 
 #include "sysrepo.h"
 #include "sr_common.h"
@@ -143,7 +144,13 @@ sysrepoctl_test_install(void **state)
     md_ctx_t *md_ctx = NULL;
     md_module_t *module = NULL;
     char buff[PATH_MAX] = { 0, };
-    char *user = getenv("USER");
+    char *user = NULL;
+    register struct passwd *pw = NULL;
+    register uid_t uid = geteuid();
+
+    pw = getpwuid(uid);
+    assert_non_null(pw);
+    user = pw->pw_name;
 
     skip_if_daemon_running(); /* module uninstall & install requires restart of the Sysrepo Engine */
 
@@ -210,7 +217,13 @@ static void
 sysrepoctl_test_change(void **state)
 {
     char buff[PATH_MAX] = { 0, };
-    char *user = getenv("USER");
+    char *user = NULL;
+    register struct passwd *pw = NULL;
+    register uid_t uid = geteuid();
+
+    pw = getpwuid(uid);
+    assert_non_null(pw);
+    user = pw->pw_name;
 
     /* invalid arguments */
     snprintf(buff, PATH_MAX, "../src/sysrepoctl --change --owner=%s --permissions=664", user);
@@ -244,7 +257,13 @@ static void
 sysrepoctl_test_feature(void **state)
 {
     char buff[PATH_MAX] = { 0, };
-    char *user = getenv("USER");
+    char *user = NULL;
+    register struct passwd *pw = NULL;
+    register uid_t uid = geteuid();
+
+    pw = getpwuid(uid);
+    assert_non_null(pw);
+    user = pw->pw_name;
 
     /* invalid arguments */
     exec_shell_command("../src/sysrepoctl --feature-enable=if-mib", ".*", true, 1);
@@ -292,7 +311,13 @@ sysrepoctl_test_init(void **state)
     md_ctx_t *md_ctx = NULL;
     md_module_t *module = NULL;
     char buff[PATH_MAX] = { 0, };
-    char *user = getenv("USER");
+    char *user = NULL;
+    register struct passwd *pw = NULL;
+    register uid_t uid = geteuid();
+
+    pw = getpwuid(uid);
+    assert_non_null(pw);
+    user = pw->pw_name;
 
     skip_if_daemon_running(); /* module uninstall & install requires restart of the Sysrepo Engine */
 


### PR DESCRIPTION
Replaced getenv with function calls for getting the current user. This
fixes a problem when the USER environment variable is empty.

This problem manifested it self in Docker.