### PR TITLE
UPDATE update dockerfiles

### DIFF
--- a/deploy/docker/sysrepo-netopeer2/platforms/Dockerfile.arch
+++ b/deploy/docker/sysrepo-netopeer2/platforms/Dockerfile.arch
@@ -16,6 +16,7 @@ RUN \
       vim \
       supervisor \
       # libyang
+      pkg-config \
       # sysrepo
       libev \
       protobuf-c \
@@ -37,11 +38,16 @@ RUN \
 RUN mkdir /opt/dev
 WORKDIR /opt/dev
 
+# generate default ssh key
+RUN \
+      pacman -S --noconfirm openssh && \
+      ssh-keygen -t rsa -N "" -f /etc/ssh/ssh_host_rsa_key
+
 # libredblack
 RUN \
       git clone https://github.com/sysrepo/libredblack.git && \
       cd libredblack && \
-      ./configure && \
+      ./configure --prefix=/usr && \
       make && \
       make install && \
       ldconfig
@@ -50,8 +56,7 @@ RUN \
 RUN \
       git clone https://github.com/CESNET/libyang.git && \
       cd libyang && mkdir build && cd build && \
-      git checkout master-sysrepo && \
-      cmake -DCMAKE_BUILD_TYPE:String="Release" -DENABLE_BUILD_TESTS=OFF .. && \
+      cmake -DCMAKE_INSTALL_PREFIX=/usr -DCMAKE_BUILD_TYPE:String="Release" .. && \
       make -j2 && \
       make install && \
       ldconfig
@@ -60,16 +65,7 @@ RUN \
 RUN \
       git clone https://github.com/sysrepo/sysrepo.git && \
       cd sysrepo && mkdir build && cd build && \
-      cmake -DCMAKE_BUILD_TYPE:String="Release" -DENABLE_TESTS=OFF -DREPOSITORY_LOC:PATH=/etc/sysrepo .. && \
-      make -j2 && \
-      make install && \
-      ldconfig
-
-# libssh
-RUN \
-      git clone http://git.libssh.org/projects/libssh.git && \
-      cd libssh && mkdir build && cd build && \
-      cmake .. && \
+      cmake -DCMAKE_INSTALL_PREFIX=/usr -DCMAKE_BUILD_TYPE:String="Release" -DREPOSITORY_LOC:PATH=/etc/sysrepo .. && \
       make -j2 && \
       make install && \
       ldconfig
@@ -78,20 +74,31 @@ RUN \
 RUN \
       git clone https://github.com/CESNET/libnetconf2.git && \
       cd libnetconf2 && mkdir build && cd build && \
-      cmake -DCMAKE_BUILD_TYPE:String="Release" -DENABLE_BUILD_TESTS=OFF .. && \
+      cmake -DCMAKE_INSTALL_PREFIX=/usr -DCMAKE_BUILD_TYPE:String="Release" .. && \
+      make -j2 && \
+      make install && \
+      ldconfig
+
+# keystore
+RUN \
+      cd /opt/dev && \
+      git clone https://github.com/CESNET/Netopeer2.git && \
+      cd Netopeer2 && \
+      cd keystored && mkdir build && cd build && \
+      cmake -DCMAKE_INSTALL_PREFIX=/usr -DCMAKE_BUILD_TYPE:String="Release" .. && \
       make -j2 && \
       make install && \
       ldconfig
 
 # netopeer2
 RUN \
-      git clone https://github.com/CESNET/Netopeer2.git && \
+      cd /opt/dev && \
       cd Netopeer2/server && mkdir build && cd build && \
-      cmake -DCMAKE_BUILD_TYPE:String="Release" .. && \
+      cmake -DCMAKE_INSTALL_PREFIX=/usr -DCMAKE_BUILD_TYPE:String="Release" .. && \
       make -j2 && \
       make install && \
       cd ../../cli && mkdir build && cd build && \
-      cmake -DCMAKE_BUILD_TYPE:String="Release" .. && \
+      cmake -DCMAKE_INSTALL_PREFIX=/usr -DCMAKE_BUILD_TYPE:String="Release" .. && \
       make -j2 && \
       make install
 
@@ -134,7 +141,7 @@ RUN \
       make install
 
 ENV EDITOR vim
-EXPOSE 6001
+EXPOSE 830
 
 COPY supervisord.conf /etc/supervisord.conf
 CMD ["/usr/bin/supervisord", "-c", "/etc/supervisord.conf"]

--- a/deploy/docker/sysrepo-netopeer2/platforms/Dockerfile.arch.devel
+++ b/deploy/docker/sysrepo-netopeer2/platforms/Dockerfile.arch.devel
@@ -16,6 +16,7 @@ RUN \
       vim \
       supervisor \
       # libyang
+      pkg-config \
       # sysrepo
       libev \
       protobuf-c \
@@ -46,7 +47,7 @@ RUN \
 RUN \
       git clone https://github.com/sysrepo/libredblack.git && \
       cd libredblack && \
-      sed -i '1s/^/#!\/usr\/bin\/env python2\n/' rbgen.in && \
+      sed -i '1s/^/#!\/usr\/bin\/env\n/' rbgen.in && \
       ./configure --prefix=/usr && \
       make && \
       make install && \
@@ -57,7 +58,7 @@ RUN \
       git clone https://github.com/CESNET/libyang.git && \
       cd libyang && mkdir build && cd build && \
       git checkout devel && \
-      cmake -DCMAKE_INSTALL_PREFIX=/usr -DCMAKE_BUILD_TYPE:String="Release" -DENABLE_BUILD_TESTS=OFF .. && \
+      cmake -DCMAKE_INSTALL_PREFIX=/usr .. && \
       make -j2 && \
       make install && \
       ldconfig
@@ -67,7 +68,7 @@ RUN \
       git clone https://github.com/sysrepo/sysrepo.git && \
       cd sysrepo && mkdir build && cd build && \
       git checkout devel && \
-      cmake -DCMAKE_INSTALL_PREFIX=/usr -DCMAKE_BUILD_TYPE:String="Release" -DENABLE_TESTS=OFF -DREPOSITORY_LOC:PATH=/etc/sysrepo .. && \
+      cmake -DCMAKE_INSTALL_PREFIX=/usr .. && \
       make -j2 && \
       make install && \
       ldconfig
@@ -77,7 +78,7 @@ RUN \
       git clone https://github.com/CESNET/libnetconf2.git && \
       cd libnetconf2 && mkdir build && cd build && \
       git checkout devel && \
-      cmake -DCMAKE_INSTALL_PREFIX=/usr -DCMAKE_BUILD_TYPE:String="Release" -DENABLE_BUILD_TESTS=OFF .. && \
+      cmake -DCMAKE_INSTALL_PREFIX=/usr .. && \
       make -j2 && \
       make install && \
       ldconfig
@@ -88,7 +89,7 @@ RUN \
       git clone https://github.com/CESNET/Netopeer2.git && \
       cd Netopeer2 && git checkout devel-server && \
       cd keystored && mkdir build && cd build && \
-      cmake -DCMAKE_INSTALL_PREFIX=/usr -DCMAKE_BUILD_TYPE:String="Release" .. && \
+      cmake -DCMAKE_INSTALL_PREFIX=/usr .. && \
       make -j2 && \
       make install && \
       ldconfig
@@ -98,12 +99,12 @@ RUN \
       cd /opt/dev && \
       cd Netopeer2/server && mkdir build && cd build && \
       git checkout devel-server && \
-      cmake -DCMAKE_INSTALL_PREFIX=/usr -DCMAKE_BUILD_TYPE:String="Release" .. && \
+      cmake -DCMAKE_INSTALL_PREFIX=/usr .. && \
       make -j2 && \
       make install && \
       cd ../../cli && mkdir build && cd build && \
       git checkout devel-cli && \
-      cmake -DCMAKE_INSTALL_PREFIX=/usr -DCMAKE_BUILD_TYPE:String="Release" .. && \
+      cmake -DCMAKE_INSTALL_PREFIX=/usr .. && \
       make -j2 && \
       make install
 

--- a/deploy/docker/sysrepo-netopeer2/platforms/Dockerfile.debian
+++ b/deploy/docker/sysrepo-netopeer2/platforms/Dockerfile.debian
@@ -17,6 +17,7 @@ RUN \
       supervisor \
       # libyang
       libpcre3-dev \
+      pkg-config \
       # sysrepo
       libavl-dev \
       libev-dev \
@@ -41,11 +42,15 @@ RUN \
 RUN mkdir /opt/dev
 WORKDIR /opt/dev
 
+# generate default ssh key
+RUN \
+      ssh-keygen -t rsa -N "" -f /etc/ssh/ssh_host_rsa_key
+
 # libredblack
 RUN \
       git clone https://github.com/sysrepo/libredblack.git && \
       cd libredblack && \
-      ./configure && \
+      ./configure --prefix=/usr && \
       make && \
       make install && \
       ldconfig
@@ -54,8 +59,7 @@ RUN \
 RUN \
       git clone https://github.com/CESNET/libyang.git && \
       cd libyang && mkdir build && cd build && \
-      git checkout master-sysrepo && \
-      cmake -DCMAKE_BUILD_TYPE:String="Release" -DENABLE_BUILD_TESTS=OFF .. && \
+      cmake -DCMAKE_INSTALL_PREFIX=/usr -DCMAKE_BUILD_TYPE:String="Release" .. && \
       make -j2 && \
       make install && \
       ldconfig
@@ -64,16 +68,7 @@ RUN \
 RUN \
       git clone https://github.com/sysrepo/sysrepo.git && \
       cd sysrepo && mkdir build && cd build && \
-      cmake -DCMAKE_BUILD_TYPE:String="Release" -DENABLE_TESTS=OFF -DREPOSITORY_LOC:PATH=/etc/sysrepo .. && \
-      make -j2 && \
-      make install && \
-      ldconfig
-
-# libssh
-RUN \
-      git clone http://git.libssh.org/projects/libssh.git && \
-      cd libssh && mkdir build && cd build && \
-      cmake .. && \
+      cmake -DCMAKE_INSTALL_PREFIX=/usr -DCMAKE_BUILD_TYPE:String="Release" -DREPOSITORY_LOC:PATH=/etc/sysrepo .. && \
       make -j2 && \
       make install && \
       ldconfig
@@ -82,20 +77,31 @@ RUN \
 RUN \
       git clone https://github.com/CESNET/libnetconf2.git && \
       cd libnetconf2 && mkdir build && cd build && \
-      cmake -DCMAKE_BUILD_TYPE:String="Release" -DENABLE_BUILD_TESTS=OFF .. && \
+      cmake -DCMAKE_INSTALL_PREFIX=/usr -DCMAKE_BUILD_TYPE:String="Release" .. && \
+      make -j2 && \
+      make install && \
+      ldconfig
+
+# keystore
+RUN \
+      cd /opt/dev && \
+      git clone https://github.com/CESNET/Netopeer2.git && \
+      cd Netopeer2 && \
+      cd keystored && mkdir build && cd build && \
+      cmake -DCMAKE_INSTALL_PREFIX=/usr -DCMAKE_BUILD_TYPE:String="Release" .. && \
       make -j2 && \
       make install && \
       ldconfig
 
 # netopeer2
 RUN \
-      git clone https://github.com/CESNET/Netopeer2.git && \
+      cd /opt/dev && \
       cd Netopeer2/server && mkdir build && cd build && \
-      cmake -DCMAKE_BUILD_TYPE:String="Release" .. && \
+      cmake -DCMAKE_INSTALL_PREFIX=/usr -DCMAKE_BUILD_TYPE:String="Release" .. && \
       make -j2 && \
       make install && \
       cd ../../cli && mkdir build && cd build && \
-      cmake -DCMAKE_BUILD_TYPE:String="Release" .. && \
+      cmake -DCMAKE_INSTALL_PREFIX=/usr -DCMAKE_BUILD_TYPE:String="Release" .. && \
       make -j2 && \
       make install
 
@@ -104,7 +110,7 @@ RUN apt-get install -y python-dev
 RUN \
       cd /opt/dev/sysrepo/build && \
       make clean && \
-      cmake -DGEN_PYTHON_VERSION=2 .. && \
+      cmake -DCMAKE_INSTALL_PREFIX=/usr -DGEN_PYTHON_VERSION=2 .. && \
       make -j2 && \
       make install
 
@@ -113,7 +119,7 @@ RUN apt-get install -y lua5.1-dev
 RUN \
       cd /opt/dev/sysrepo/build && \
       make clean && \
-      cmake -DGEN_LUA_VERSION=5.1 .. && \
+      cmake -DCMAKE_INSTALL_PREFIX=/usr -DGEN_LUA_VERSION=5.1 .. && \
       make -j2 && \
       make install
 
@@ -123,7 +129,7 @@ RUN \
       cd /opt/dev/sysrepo && \
       # cmake requires new directory for switching python version \
       mkdir build_python3 && cd build_python3 && \
-      cmake -DGEN_PYTHON_VERSION=3 .. && \
+      cmake -DCMAKE_INSTALL_PREFIX=/usr -DGEN_PYTHON_VERSION=3 .. && \
       make -j2 && \
       make install
 
@@ -133,12 +139,12 @@ RUN \
       cd /opt/dev/sysrepo && \
       # cmake requires new directory for switching lua version \
       mkdir build_lua52 && cd build_lua52 && \
-      cmake -DGEN_LUA_VERSION=5.2 .. && \
+      cmake -DCMAKE_INSTALL_PREFIX=/usr -DGEN_LUA_VERSION=5.2 .. && \
       make -j2 && \
       make install
 
 ENV EDITOR vim
-EXPOSE 6001
+EXPOSE 830
 
 COPY supervisord.conf /etc/supervisord.conf
 CMD ["/usr/bin/supervisord", "-c", "/etc/supervisord.conf"]

--- a/deploy/docker/sysrepo-netopeer2/platforms/Dockerfile.debian.devel
+++ b/deploy/docker/sysrepo-netopeer2/platforms/Dockerfile.debian.devel
@@ -17,6 +17,7 @@ RUN \
       supervisor \
       # libyang
       libpcre3-dev \
+      pkg-config \
       # sysrepo
       libavl-dev \
       libev-dev \
@@ -59,7 +60,7 @@ RUN \
       git clone https://github.com/CESNET/libyang.git && \
       cd libyang && mkdir build && cd build && \
       git checkout devel && \
-      cmake -DCMAKE_BUILD_TYPE:String="Release" -DENABLE_BUILD_TESTS=OFF .. && \
+      cmake .. && \
       make -j2 && \
       make install && \
       ldconfig
@@ -69,15 +70,6 @@ RUN \
       git clone https://github.com/sysrepo/sysrepo.git && \
       cd sysrepo && mkdir build && cd build && \
       git checkout devel && \
-      cmake -DCMAKE_BUILD_TYPE:String="Release" -DENABLE_TESTS=OFF -DREPOSITORY_LOC:PATH=/etc/sysrepo .. && \
-      make -j2 && \
-      make install && \
-      ldconfig
-
-# libssh
-RUN \
-      git clone http://git.libssh.org/projects/libssh.git && \
-      cd libssh && mkdir build && cd build && \
       cmake .. && \
       make -j2 && \
       make install && \
@@ -88,7 +80,18 @@ RUN \
       git clone https://github.com/CESNET/libnetconf2.git && \
       cd libnetconf2 && mkdir build && cd build && \
       git checkout devel && \
-      cmake -DCMAKE_BUILD_TYPE:String="Release" -DENABLE_BUILD_TESTS=OFF .. && \
+      cmake .. && \
+      make -j2 && \
+      make install && \
+      ldconfig
+
+# keystore
+RUN \
+      cd /opt/dev && \
+      git clone https://github.com/CESNET/Netopeer2.git && \
+      cd Netopeer2 && git checkout devel-server && \
+      cd keystored && mkdir build && cd build && \
+      cmake .. && \
       make -j2 && \
       make install && \
       ldconfig
@@ -98,12 +101,12 @@ RUN \
       git clone https://github.com/CESNET/Netopeer2.git && \
       cd Netopeer2/server && mkdir build && cd build && \
       git checkout devel-server && \
-      cmake -DCMAKE_BUILD_TYPE:String="Release" .. && \
+      cmake .. && \
       make -j2 && \
       make install && \
       cd ../../cli && mkdir build && cd build && \
       git checkout devel-cli && \
-      cmake -DCMAKE_BUILD_TYPE:String="Release" .. && \
+      cmake .. && \
       make -j2 && \
       make install
 

--- a/deploy/docker/sysrepo-netopeer2/platforms/Dockerfile.fedora
+++ b/deploy/docker/sysrepo-netopeer2/platforms/Dockerfile.fedora
@@ -22,6 +22,7 @@ RUN \
       flex \
       # libyang
       pcre-devel \
+      pkgconfig \
       # sysrepo
       protobuf-c-devel \
       libev-devel \
@@ -46,11 +47,15 @@ RUN \
 RUN mkdir /opt/dev
 WORKDIR /opt/dev
 
+# generate default ssh key
+RUN \
+      ssh-keygen -t rsa -N "" -f /etc/ssh/ssh_host_rsa_key
+
 # libredblack
 RUN \
       git clone https://github.com/sysrepo/libredblack.git && \
       cd libredblack && \
-      ./configure && \
+      ./configure --prefix=/usr && \
       make && \
       make install && \
       ldconfig
@@ -59,8 +64,7 @@ RUN \
 RUN \
       git clone https://github.com/CESNET/libyang.git && \
       cd libyang && mkdir build && cd build && \
-      git checkout master-sysrepo && \
-      cmake -DCMAKE_BUILD_TYPE:String="Release" -DENABLE_BUILD_TESTS=OFF .. && \
+      cmake -DCMAKE_INSTALL_PREFIX=/usr -DCMAKE_BUILD_TYPE:String="Release" .. && \
       make -j2 && \
       make install && \
       ldconfig
@@ -69,7 +73,7 @@ RUN \
 RUN \
       git clone https://github.com/sysrepo/sysrepo.git && \
       cd sysrepo && mkdir build && cd build && \
-      cmake -DCMAKE_BUILD_TYPE:String="Release" -DENABLE_TESTS=OFF -DREPOSITORY_LOC:PATH=/etc/sysrepo .. && \
+      cmake -DCMAKE_INSTALL_PREFIX=/usr -DCMAKE_BUILD_TYPE:String="Release" -DREPOSITORY_LOC:PATH=/etc/sysrepo .. && \
       make -j2 && \
       make install && \
       ldconfig
@@ -87,20 +91,32 @@ RUN \
 RUN \
       git clone https://github.com/CESNET/libnetconf2.git && \
       cd libnetconf2 && mkdir build && cd build && \
-      cmake -DCMAKE_BUILD_TYPE:String="Release" -DENABLE_BUILD_TESTS=OFF .. && \
+      cmake -DCMAKE_INSTALL_PREFIX=/usr -DCMAKE_BUILD_TYPE:String="Release" .. && \
+      make -j2 && \
+      make install && \
+      ldconfig
+
+# keystore
+RUN \
+      cd /opt/dev && \
+      git clone https://github.com/CESNET/Netopeer2.git && \
+      cd Netopeer2 && \
+      cd keystored && mkdir build && cd build && \
+      cmake -DCMAKE_INSTALL_PREFIX=/usr -DCMAKE_BUILD_TYPE:String="Release" .. && \
       make -j2 && \
       make install && \
       ldconfig
 
 # netopeer2
 RUN \
-      git clone https://github.com/CESNET/Netopeer2.git && \
-      cd Netopeer2/server && mkdir build && cd build && \
-      cmake -DCMAKE_BUILD_TYPE:String="Release" .. && \
+      cd /opt/dev && \
+      cd Netopeer2/server && \
+      mkdir build && cd build && \
+      cmake -DCMAKE_INSTALL_PREFIX=/usr -DCMAKE_BUILD_TYPE:String="Release" .. && \
       make -j2 && \
       make install && \
       cd ../../cli && mkdir build && cd build && \
-      cmake -DCMAKE_BUILD_TYPE:String="Release" .. && \
+      cmake -DCMAKE_INSTALL_PREFIX=/usr -DCMAKE_BUILD_TYPE:String="Release" .. && \
       make -j2 && \
       make install
 
@@ -109,7 +125,7 @@ RUN dnf -y install python-devel
 RUN \
       cd /opt/dev/sysrepo/build && \
       make clean && \
-      cmake -DGEN_PYTHON_VERSION=2 .. && \
+      cmake -DCMAKE_INSTALL_PREFIX=/usr -DGEN_PYTHON_VERSION=2 .. && \
       make -j2 && \
       make install
 
@@ -118,7 +134,7 @@ RUN dnf -y install lua-devel
 RUN \
       cd /opt/dev/sysrepo/build && \
       make clean && \
-      cmake -DGEN_LUA_VERSION=5.1 .. && \
+      cmake -DCMAKE_INSTALL_PREFIX=/usr -DGEN_LUA_VERSION=5.1 .. && \
       make -j2 && \
       make install
 
@@ -128,7 +144,7 @@ RUN \
       cd /opt/dev/sysrepo && \
       # cmake requires new directory for switching python version \
       mkdir build_python3 && cd build_python3 && \
-      cmake -DGEN_PYTHON_VERSION=3 .. && \
+      cmake -DCMAKE_INSTALL_PREFIX=/usr -DGEN_PYTHON_VERSION=3 .. && \
       make -j2 && \
       make install
 
@@ -137,12 +153,12 @@ RUN \
       cd /opt/dev/sysrepo && \
       # cmake requires new directory for switching lua version \
       mkdir build_lua52 && cd build_lua52 && \
-      cmake -DGEN_LUA_VERSION=5.2 .. && \
+      cmake -DCMAKE_INSTALL_PREFIX=/usr -DGEN_LUA_VERSION=5.2 .. && \
       make -j2 && \
       make install
 
 ENV EDITOR vim
-EXPOSE 6001
+EXPOSE 830
 
 COPY supervisord.conf /etc/supervisord.conf
 CMD ["/usr/bin/supervisord", "-c", "/etc/supervisord.conf"]

--- a/deploy/docker/sysrepo-netopeer2/platforms/Dockerfile.fedora.devel
+++ b/deploy/docker/sysrepo-netopeer2/platforms/Dockerfile.fedora.devel
@@ -22,6 +22,7 @@ RUN \
       flex \
       # libyang
       pcre-devel \
+      pkgconfig \
       # sysrepo
       protobuf-c-devel \
       libev-devel \
@@ -54,7 +55,7 @@ RUN \
 RUN \
       git clone https://github.com/sysrepo/libredblack.git && \
       cd libredblack && \
-      ./configure && \
+      ./configure --prefix=/usr && \
       make && \
       make install && \
       ldconfig
@@ -63,8 +64,8 @@ RUN \
 RUN \
       git clone https://github.com/CESNET/libyang.git && \
       cd libyang && mkdir build && cd build && \
-        git checkout devel && \
-      cmake -DCMAKE_BUILD_TYPE:String="Release" -DENABLE_BUILD_TESTS=OFF .. && \
+      git checkout devel && \
+      cmake -DCMAKE_INSTALL_PREFIX=/usr .. && \
       make -j2 && \
       make install && \
       ldconfig
@@ -74,7 +75,7 @@ RUN \
       git clone https://github.com/sysrepo/sysrepo.git && \
       cd sysrepo && mkdir build && cd build && \
       git checkout devel && \
-      cmake -DCMAKE_BUILD_TYPE:String="Release" -DENABLE_TESTS=OFF -DREPOSITORY_LOC:PATH=/etc/sysrepo .. && \
+      cmake -DCMAKE_INSTALL_PREFIX=/usr .. && \
       make -j2 && \
       make install && \
       ldconfig
@@ -93,7 +94,7 @@ RUN \
       git clone https://github.com/CESNET/libnetconf2.git && \
       cd libnetconf2 && mkdir build && cd build && \
       git checkout devel && \
-      cmake -DCMAKE_BUILD_TYPE:String="Release" -DENABLE_BUILD_TESTS=OFF .. && \
+      cmake -DCMAKE_INSTALL_PREFIX=/usr .. && \
       make -j2 && \
       make install && \
       ldconfig
@@ -104,7 +105,7 @@ RUN \
       git clone https://github.com/CESNET/Netopeer2.git && \
       cd Netopeer2 && git checkout devel-server && \
       cd keystored && mkdir build && cd build && \
-      cmake -DCMAKE_BUILD_TYPE:String="Release" .. && \
+      cmake -DCMAKE_INSTALL_PREFIX=/usr .. && \
       make -j2 && \
       make install && \
       ldconfig
@@ -114,12 +115,13 @@ RUN \
       cd /opt/dev && \
       cd Netopeer2/server && \
       git checkout devel-server && \
-      cmake -DCMAKE_BUILD_TYPE:String="Release" .. && \
+      mkdir build && cd build && \
+      cmake -DCMAKE_INSTALL_PREFIX=/usr .. && \
       make -j2 && \
       make install && \
       cd ../../cli && mkdir build && cd build && \
       git checkout devel-cli && \
-      cmake -DCMAKE_BUILD_TYPE:String="Release" .. && \
+      cmake -DCMAKE_INSTALL_PREFIX=/usr .. && \
       make -j2 && \
       make install
 
@@ -128,7 +130,7 @@ RUN dnf -y install python-devel
 RUN \
       cd /opt/dev/sysrepo/build && \
       make clean && \
-      cmake -DGEN_PYTHON_VERSION=2 .. && \
+      cmake -DCMAKE_INSTALL_PREFIX=/usr -DGEN_PYTHON_VERSION=2 .. && \
       make -j2 && \
       make install
 
@@ -137,7 +139,7 @@ RUN dnf -y install lua-devel
 RUN \
       cd /opt/dev/sysrepo/build && \
       make clean && \
-      cmake -DGEN_LUA_VERSION=5.1 .. && \
+      cmake -DCMAKE_INSTALL_PREFIX=/usr -DGEN_LUA_VERSION=5.1 .. && \
       make -j2 && \
       make install
 
@@ -147,7 +149,7 @@ RUN \
       cd /opt/dev/sysrepo && \
       # cmake requires new directory for switching python version \
       mkdir build_python3 && cd build_python3 && \
-      cmake -DGEN_PYTHON_VERSION=3 .. && \
+      cmake -DCMAKE_INSTALL_PREFIX=/usr -DGEN_PYTHON_VERSION=3 .. && \
       make -j2 && \
       make install
 
@@ -156,7 +158,7 @@ RUN \
       cd /opt/dev/sysrepo && \
       # cmake requires new directory for switching lua version \
       mkdir build_lua52 && cd build_lua52 && \
-      cmake -DGEN_LUA_VERSION=5.2 .. && \
+      cmake -DCMAKE_INSTALL_PREFIX=/usr -DGEN_LUA_VERSION=5.2 .. && \
       make -j2 && \
       make install
 
@@ -164,4 +166,4 @@ ENV EDITOR vim
 EXPOSE 830
 
 COPY supervisord.conf /etc/supervisord.conf
-MD ["/usr/bin/supervisord", "-c", "/etc/supervisord.conf"]
+CMD ["/usr/bin/supervisord", "-c", "/etc/supervisord.conf"]

--- a/deploy/docker/sysrepo-netopeer2/platforms/Dockerfile.gentoo
+++ b/deploy/docker/sysrepo-netopeer2/platforms/Dockerfile.gentoo
@@ -17,6 +17,7 @@ RUN \
       vim \
       supervisor \
       # libyang
+      pkg-config \
       # sysrepo
       libev \
       protobuf-c \
@@ -41,12 +42,16 @@ RUN \
 RUN mkdir /opt/dev
 WORKDIR /opt/dev
 
+# generate default ssh key
+RUN \
+      ssh-keygen -t rsa -N "" -f /etc/ssh/ssh_host_rsa_key
+
 # libredblack
 RUN \
       git clone https://github.com/sysrepo/libredblack.git && \
       cd libredblack && \
       sed -i '1s/^/#!\/usr\/bin\/env python2\n/' rbgen.in && \
-      ./configure && \
+      ./configure --prefix=/usr && \
       make && \
       make install && \
       ldconfig
@@ -55,8 +60,7 @@ RUN \
 RUN \
       git clone https://github.com/CESNET/libyang.git && \
       cd libyang && mkdir build && cd build && \
-      git checkout master-sysrepo && \
-      cmake -DCMAKE_BUILD_TYPE:String="Release" -DENABLE_BUILD_TESTS=OFF .. && \
+      cmake -DCMAKE_BUILD_TYPE:String="Release" .. && \
       make -j2 && \
       make install && \
       ldconfig
@@ -65,7 +69,7 @@ RUN \
 RUN \
       git clone https://github.com/sysrepo/sysrepo.git && \
       cd sysrepo && mkdir build && cd build && \
-      cmake -DCMAKE_BUILD_TYPE:String="Release" -DENABLE_TESTS=OFF -DREPOSITORY_LOC:PATH=/etc/sysrepo .. && \
+      cmake -DCMAKE_BUILD_TYPE:String="Release" -DREPOSITORY_LOC:PATH=/etc/sysrepo .. && \
       make -j2 && \
       make install && \
       ldconfig
@@ -74,20 +78,32 @@ RUN \
 RUN \
       git clone https://github.com/CESNET/libnetconf2.git && \
       cd libnetconf2 && mkdir build && cd build && \
-      cmake -DCMAKE_BUILD_TYPE:String="Release" -DENABLE_BUILD_TESTS=OFF .. && \
+      cmake -DCMAKE_BUILD_TYPE:String="Release" .. && \
+      make -j2 && \
+      make install && \
+      ldconfig
+
+# keystore
+RUN \
+      cd /opt/dev && \
+      git clone https://github.com/CESNET/Netopeer2.git && \
+      cd Netopeer2 && \
+      cd keystored && mkdir build && cd build && \
+      cmake -DCMAKE_INSTALL_PREFIX=/usr -DCMAKE_BUILD_TYPE:String="Release" .. && \
       make -j2 && \
       make install && \
       ldconfig
 
 # netopeer2
 RUN \
-      git clone https://github.com/CESNET/Netopeer2.git && \
-      cd Netopeer2/server && mkdir build && cd build && \
-      cmake -DCMAKE_BUILD_TYPE:String="Release" .. && \
+      cd /opt/dev && \
+      cd Netopeer2/server && \
+      mkdir build && cd build && \
+      cmake -DCMAKE_INSTALL_PREFIX=/usr -DCMAKE_BUILD_TYPE:String="Release" .. && \
       make -j2 && \
       make install && \
       cd ../../cli && mkdir build && cd build && \
-      cmake -DCMAKE_BUILD_TYPE:String="Release" .. && \
+      cmake -DCMAKE_INSTALL_PREFIX=/usr -DCMAKE_BUILD_TYPE:String="Release" .. && \
       make -j2 && \
       make install
 
@@ -133,7 +149,7 @@ RUN \
       make install
 
 ENV EDITOR vim
-EXPOSE 6001
+EXPOSE 830
 
 COPY supervisord.conf /etc/supervisord.conf
 CMD ["/usr/bin/supervisord", "-c", "/etc/supervisord.conf"]

--- a/deploy/docker/sysrepo-netopeer2/platforms/Dockerfile.gentoo.devel
+++ b/deploy/docker/sysrepo-netopeer2/platforms/Dockerfile.gentoo.devel
@@ -6,9 +6,13 @@ MAINTAINER mislav.novakovic@sartura.hr
 RUN \
       emerge --sync
 
+# read all news in case they are IMPORTANT
+RUN \
+      eselect news read --quiet all
+
 # install basic dependencies
 RUN \
-      emerge -q \
+      emerge -q --backtrack=300 \
       automake \
        bison \
        flex \
@@ -17,6 +21,7 @@ RUN \
       vim \
       supervisor \
       # libyang
+      pkg-config \
       # sysrepo
       libev \
       protobuf-c \
@@ -60,7 +65,7 @@ RUN \
       git clone https://github.com/CESNET/libyang.git && \
       cd libyang && mkdir build && cd build && \
       git checkout devel && \
-      cmake -DCMAKE_INSTALL_PREFIX=/usr -DCMAKE_BUILD_TYPE:String="Release" -DENABLE_BUILD_TESTS=OFF .. && \
+      cmake -DCMAKE_INSTALL_PREFIX=/usr .. && \
       make -j2 && \
       make install && \
       ldconfig
@@ -70,7 +75,7 @@ RUN \
       git clone https://github.com/sysrepo/sysrepo.git && \
       cd sysrepo && mkdir build && cd build && \
       git checkout devel && \
-      cmake -DCMAKE_INSTALL_PREFIX=/usr -DCMAKE_BUILD_TYPE:String="Release" -DENABLE_TESTS=OFF -DREPOSITORY_LOC:PATH=/etc/sysrepo .. && \
+      cmake -DCMAKE_INSTALL_PREFIX=/usr .. && \
       make -j2 && \
       make install && \
       ldconfig
@@ -80,7 +85,7 @@ RUN \
       git clone https://github.com/CESNET/libnetconf2.git && \
       cd libnetconf2 && mkdir build && cd build && \
       git checkout devel && \
-      cmake -DCMAKE_INSTALL_PREFIX=/usr -DCMAKE_BUILD_TYPE:String="Release" -DENABLE_BUILD_TESTS=OFF .. && \
+      cmake -DCMAKE_INSTALL_PREFIX=/usr .. && \
       make -j2 && \
       make install && \
       ldconfig
@@ -91,7 +96,7 @@ RUN \
       git clone https://github.com/CESNET/Netopeer2.git && \
       cd Netopeer2 && git checkout devel-server && \
       cd keystored && mkdir build && cd build && \
-      cmake -DCMAKE_INSTALL_PREFIX=/usr -DCMAKE_BUILD_TYPE:String="Release" .. && \
+      cmake -DCMAKE_INSTALL_PREFIX=/usr .. && \
       make -j2 && \
       make install && \
       ldconfig
@@ -99,14 +104,15 @@ RUN \
 # netopeer2
 RUN \
       cd /opt/dev && \
-      cd Netopeer2/server && mkdir build && cd build && \
+      cd Netopeer2/server && \
       git checkout devel-server && \
-      cmake -DCMAKE_INSTALL_PREFIX=/usr -DCMAKE_BUILD_TYPE:String="Release" .. && \
+      mkdir build && cd build && \
+      cmake -DCMAKE_INSTALL_PREFIX=/usr .. && \
       make -j2 && \
       make install && \
       cd ../../cli && mkdir build && cd build && \
       git checkout devel-cli && \
-      cmake -DCMAKE_INSTALL_PREFIX=/usr -DCMAKE_BUILD_TYPE:String="Release" .. && \
+      cmake -DCMAKE_INSTALL_PREFIX=/usr .. && \
       make -j2 && \
       make install
 
@@ -115,7 +121,7 @@ RUN emerge -q python:2.7
 RUN \
       cd /opt/dev/sysrepo/build && \
       make clean && \
-      cmake -DGEN_PYTHON_VERSION=2 .. && \
+      cmake -DCMAKE_INSTALL_PREFIX=/usr -DGEN_PYTHON_VERSION=2 .. && \
       make -j2 && \
       make install
 
@@ -129,7 +135,7 @@ RUN \
 RUN \
       cd /opt/dev/sysrepo/build && \
       make clean && \
-      cmake -DGEN_LUA_VERSION=5.1 .. && \
+      cmake -DCMAKE_INSTALL_PREFIX=/usr -DGEN_LUA_VERSION=5.1 .. && \
       make -j2 && \
       make install
 
@@ -138,7 +144,7 @@ RUN emerge -q python:3.4
 RUN \
       cd /opt/dev/sysrepo && \
       mkdir build_python3 && cd build_python3 && \
-      cmake -DGEN_PYTHON_VERSION=3 .. && \
+      cmake -DCMAKE_INSTALL_PREFIX=/usr -DGEN_PYTHON_VERSION=3 .. && \
       make -j2 && \
       make install
 
@@ -146,7 +152,7 @@ RUN \
       cd /opt/dev/sysrepo && \
       # cmake requires new directory for switching lua version \
       mkdir build_lua52 && cd build_lua52 && \
-      cmake -DGEN_LUA_VERSION=5.2 .. && \
+      cmake -DCMAKE_INSTALL_PREFIX=/usr -DGEN_LUA_VERSION=5.2 .. && \
       make -j2 && \
       make install
 

--- a/deploy/docker/sysrepo-netopeer2/platforms/Dockerfile.ubuntu
+++ b/deploy/docker/sysrepo-netopeer2/platforms/Dockerfile.ubuntu
@@ -17,13 +17,13 @@ RUN \
       supervisor \
       # libyang
       libpcre3-dev \
+      pkg-config \
       # sysrepo
       libavl-dev \
       libev-dev \
       libprotobuf-c-dev \
       protobuf-c-compiler \
       # netopeer2 \
-      libssh-dev \
       libssl-dev \
       # bindings
       swig \
@@ -42,11 +42,15 @@ RUN \
 RUN mkdir /opt/dev
 WORKDIR /opt/dev
 
+# generate default ssh key
+RUN \
+      ssh-keygen -t rsa -N "" -f /etc/ssh/ssh_host_rsa_key
+
 # libredblack
 RUN \
       git clone https://github.com/sysrepo/libredblack.git && \
       cd libredblack && \
-      ./configure && \
+      ./configure --prefix=/usr && \
       make && \
       make install && \
       ldconfig
@@ -55,8 +59,7 @@ RUN \
 RUN \
       git clone https://github.com/CESNET/libyang.git && \
       cd libyang && mkdir build && cd build && \
-      git checkout master-sysrepo && \
-      cmake -DCMAKE_BUILD_TYPE:String="Release" -DENABLE_BUILD_TESTS=OFF .. && \
+      cmake -DCMAKE_INSTALL_PREFIX=/usr -DCMAKE_BUILD_TYPE:String="Release" .. && \
       make -j2 && \
       make install && \
       ldconfig
@@ -65,7 +68,7 @@ RUN \
 RUN \
       git clone https://github.com/sysrepo/sysrepo.git && \
       cd sysrepo && mkdir build && cd build && \
-      cmake -DCMAKE_BUILD_TYPE:String="Release" -DENABLE_TESTS=OFF -DREPOSITORY_LOC:PATH=/etc/sysrepo .. && \
+      cmake -DCMAKE_INSTALL_PREFIX=/usr -DCMAKE_BUILD_TYPE:String="Release" -DREPOSITORY_LOC:PATH=/etc/sysrepo .. && \
       make -j2 && \
       make install && \
       ldconfig
@@ -83,20 +86,32 @@ RUN \
 RUN \
       git clone https://github.com/CESNET/libnetconf2.git && \
       cd libnetconf2 && mkdir build && cd build && \
-      cmake -DCMAKE_BUILD_TYPE:String="Release" -DENABLE_BUILD_TESTS=OFF .. && \
+      cmake -DCMAKE_INSTALL_PREFIX=/usr -DCMAKE_BUILD_TYPE:String="Release" .. && \
+      make -j2 && \
+      make install && \
+      ldconfig
+
+# keystore
+RUN \
+      cd /opt/dev && \
+      git clone https://github.com/CESNET/Netopeer2.git && \
+      cd Netopeer2 && \
+      cd keystored && mkdir build && cd build && \
+      cmake -DCMAKE_INSTALL_PREFIX=/usr -DCMAKE_BUILD_TYPE:String="Release" .. && \
       make -j2 && \
       make install && \
       ldconfig
 
 # netopeer2
 RUN \
-      git clone https://github.com/CESNET/Netopeer2.git && \
-      cd Netopeer2/server && mkdir build && cd build && \
-      cmake -DCMAKE_BUILD_TYPE:String="Release" .. && \
+      cd /opt/dev && \
+      cd Netopeer2/server && \
+      mkdir build && cd build && \
+      cmake -DCMAKE_INSTALL_PREFIX=/usr -DCMAKE_BUILD_TYPE:String="Release" .. && \
       make -j2 && \
       make install && \
       cd ../../cli && mkdir build && cd build && \
-      cmake -DCMAKE_BUILD_TYPE:String="Release" .. && \
+      cmake -DCMAKE_INSTALL_PREFIX=/usr -DCMAKE_BUILD_TYPE:String="Release" .. && \
       make -j2 && \
       make install
 
@@ -139,7 +154,7 @@ RUN \
       make install
 
 ENV EDITOR vim
-EXPOSE 6001
+EXPOSE 830
 
 COPY supervisord.conf /etc/supervisord.conf
 CMD ["/usr/bin/supervisord", "-c", "/etc/supervisord.conf"]

--- a/deploy/docker/sysrepo-netopeer2/platforms/Dockerfile.ubuntu.devel
+++ b/deploy/docker/sysrepo-netopeer2/platforms/Dockerfile.ubuntu.devel
@@ -17,13 +17,13 @@ RUN \
       supervisor \
       # libyang
       libpcre3-dev \
+      pkg-config \
       # sysrepo
       libavl-dev \
       libev-dev \
       libprotobuf-c-dev \
       protobuf-c-compiler \
       # netopeer2 \
-      libssh-dev \
       libssl-dev \
       # bindings
       swig \
@@ -60,7 +60,7 @@ RUN \
       git clone https://github.com/CESNET/libyang.git && \
       cd libyang && mkdir build && cd build && \
       git checkout devel && \
-      cmake -DCMAKE_BUILD_TYPE:String="Release" -DENABLE_BUILD_TESTS=OFF .. && \
+      cmake .. && \
       make -j2 && \
       make install && \
       ldconfig
@@ -70,7 +70,7 @@ RUN \
       git clone https://github.com/sysrepo/sysrepo.git && \
       cd sysrepo && mkdir build && cd build && \
       git checkout devel && \
-      cmake -DCMAKE_BUILD_TYPE:String="Release" -DENABLE_TESTS=OFF -DREPOSITORY_LOC:PATH=/etc/sysrepo .. && \
+      cmake .. && \
       make -j2 && \
       make install && \
       ldconfig
@@ -89,22 +89,35 @@ RUN \
       git clone https://github.com/CESNET/libnetconf2.git && \
       cd libnetconf2 && mkdir build && cd build && \
       git checkout devel && \
-      cmake -DCMAKE_BUILD_TYPE:String="Release" -DENABLE_BUILD_TESTS=OFF .. && \
+      cmake .. && \
+      make -j2 && \
+      make install && \
+      ldconfig
+
+# keystore
+RUN \
+      cd /opt/dev && \
+      git clone https://github.com/CESNET/Netopeer2.git && \
+      cd Netopeer2 && \
+      git checkout devel-server && \
+      cd keystored && mkdir build && cd build && \
+      cmake .. && \
       make -j2 && \
       make install && \
       ldconfig
 
 # netopeer2
 RUN \
-      git clone https://github.com/CESNET/Netopeer2.git && \
-      cd Netopeer2/server && mkdir build && cd build && \
+      cd /opt/dev && \
+      cd Netopeer2/server && \
       git checkout devel-server && \
-      cmake -DCMAKE_BUILD_TYPE:String="Release" .. && \
+      mkdir build && cd build && \
+      cmake .. && \
       make -j2 && \
       make install && \
       cd ../../cli && mkdir build && cd build && \
       git checkout devel-cli && \
-      cmake -DCMAKE_BUILD_TYPE:String="Release" .. && \
+      cmake .. && \
       make -j2 && \
       make install
 

--- a/deploy/docker/sysrepo-netopeer2/platforms/README.md
+++ b/deploy/docker/sysrepo-netopeer2/platforms/README.md
@@ -2,7 +2,7 @@
 
 Run `sysrepod` and `netopeer2-server` in the container:
 ```
-docker run -it --name sysrepo -p 830:6001 --rm sysrepo/sysrepo-netopeer2:latest
+docker run -it --name sysrepo -p 830:830 --rm sysrepo/sysrepo-netopeer2:latest
 ```
 
 On the devel branch the default port is 830.


### PR DESCRIPTION
Update the dockerfiles in preparation for the sysrepo release. The dockerfiles are used only for examples on how to build Sysrepo/Netopeer2 on various Linux platforms.