### PR TITLE
Fix verifying version on sysrepo socket connections

### DIFF
--- a/src/clientlib/cl_subscription_manager.c
+++ b/src/clientlib/cl_subscription_manager.c
@@ -469,8 +469,9 @@ cl_sm_get_data_session(cl_sm_ctx_t *sm_ctx, cl_sm_subscription_ctx_t *subscripti
         if (SR_ERR_OK == rc) {
             rc = cl_socket_connect(connection, connection->dst_address);
         }
-        /* version is not expected to be verified since we are just re-creating
-         * previously seen connection and the other side is still holding the connection */
+        if (SR_ERR_OK == rc) {
+            rc = cl_version_verify(connection);
+        }
         if (SR_ERR_OK == rc) {
             rc = sr_btree_insert(sm_ctx->data_connection_btree, connection);
         }

--- a/src/clientlib/client_library.c
+++ b/src/clientlib/client_library.c
@@ -447,14 +447,10 @@ sr_connect(const char *app_name, const sr_conn_options_t opts, sr_conn_ctx_t **c
 
     /*
      * version verification
-     * - not performed in case of local mode when only intra-process communication is allowed
-     * and client library versions mismatch is not possible
      */
-    if (!connection->library_mode) {
-        rc = cl_version_verify(connection);
-        if (SR_ERR_OK != rc) {
-            goto cleanup;
-        }
+    rc = cl_version_verify(connection);
+    if (SR_ERR_OK != rc) {
+        goto cleanup;
     }
 
     if (NULL != cm_ctx) {


### PR DESCRIPTION
Remove optimization of not sending version-verify request on local
(intra-process) communication. It is not able to get this information
surely on both the communication sides so the version-verify request
is now sent/expected whenever a new connection is created.

Fixes sysrepo/sysrepo#836