### PR TITLE
sysrepocfg not-strict flag

### DIFF
--- a/src/data_manager.c
+++ b/src/data_manager.c
@@ -6463,7 +6463,7 @@ dm_get_all_modules(dm_ctx_t *dm_ctx, dm_session_t *session, bool enabled_only, s
             /* skip submodules */
             continue;
         }
-        if (!module->latest_revision) {
+        if (!module->implemented || !module->has_data) {
             continue;
         }
 


### PR DESCRIPTION
### Description
In sysrepocfg import operation the user in majority of the cases will use a file with only the data they want to import - silently skipping unknown elements can hide a problem. In case it is intentional, it can be specified by a flag.