### PR TITLE
BUGFIX use correct revision when searching for module info

### DIFF
--- a/src/module_dependencies.c
+++ b/src/module_dependencies.c
@@ -1360,7 +1360,8 @@ md_collect_data_dependencies(md_ctx_t *md_ctx, const char *ref, md_module_t *mod
         }
         /* then try the whole md context */
         if (!module2) {
-            rc = md_get_module_info(md_ctx, lys_node_module(parent)->name, "", &module2);
+            rc = md_get_module_info(md_ctx, lys_node_module(parent)->name,
+                    (lys_node_module(parent)->rev_size ? lys_node_module(parent)->rev[0].date : NULL), &module2);
             if (SR_ERR_OK != rc) {
                 SR_LOG_WRN_MSG("Failed to get the module schema based on the prefix");
                 continue;


### PR DESCRIPTION
### Description
When searching for modules, empty string ("") is always an incorrect value, either specific revision or NULL must be used instead.

### Closure
Fixes #830
Fixes cesnet/libyang#321