### PR TITLE
State data prefixes and latest-revision flag fixes

### DIFF
--- a/src/data_manager.c
+++ b/src/data_manager.c
@@ -1929,7 +1929,7 @@ dm_load_dependant_data(dm_ctx_t *dm_ctx, dm_session_t *session, dm_data_info_t *
         ll_node = module->deps->first;
         while (ll_node) {
             dep = (md_dep_t *)ll_node->data;
-            if (MD_DEP_DATA == dep->type && dep->dest->latest_revision && dep->dest->has_data) {
+            if (MD_DEP_DATA == dep->type && dep->dest->implemented && dep->dest->has_data) {
                 const char *dependant_module = dep->dest->name;
                 rc = dm_append_data_tree(session->dm_ctx, session, info, dependant_module);
                 CHECK_RC_LOG_GOTO(rc, unlock, "Failed to append data tree %s", dependant_module);
@@ -4570,7 +4570,7 @@ dm_feature_enable(dm_ctx_t *dm_ctx, const char *module_name, const char *feature
     ll_node = module->inv_deps->first;
     while (ll_node) {
         dep = (md_dep_t *) ll_node->data;
-        if (dep->type == MD_DEP_EXTENSION && true == dep->dest->latest_revision) {
+        if (dep->type == MD_DEP_EXTENSION && dep->dest->implemented) {
             lookup.module_name = (char *) dep->dest->name;
             si = sr_btree_search(dm_ctx->schema_info_tree, &lookup);
             if (NULL != si && NULL != si->ly_ctx) {
@@ -4683,7 +4683,7 @@ dm_install_module(dm_ctx_t *dm_ctx, dm_session_t *session, const char *module_na
         ll_node = module->inv_deps->first;
         while (ll_node) {
             dep = (md_dep_t *)ll_node->data;
-            if (dep->type == MD_DEP_EXTENSION && true == dep->dest->latest_revision) {
+            if (dep->type == MD_DEP_EXTENSION && dep->dest->implemented) {
                 lookup.module_name = (char *)dep->dest->name;
                 si_ext = sr_btree_search(dm_ctx->schema_info_tree, &lookup);
                 if (NULL != si_ext && NULL != si_ext->ly_ctx) {

--- a/src/request_processor.c
+++ b/src/request_processor.c
@@ -2438,10 +2438,19 @@ rp_data_provide_request_nested(rp_ctx_t *rp_ctx, rp_session_t *session, const ch
         if (subs_index < session->state_data_ctx.subscription_nodes->count) {
             for (size_t i = 0; i < xp_count; i++) {
                 size_t len = strlen(xpaths[i]) + strlen(iter->name) + 2 /* slash + zero byte */;
+
+                if (lys_node_module(sch_node) != lys_node_module(iter)) {
+                    len += strlen(lys_node_module(iter)->name) + 1;
+                }
+
                 request_xp = calloc(len, sizeof(*request_xp));
                 CHECK_NULL_NOMEM_GOTO(request_xp, rc, cleanup);
 
-                snprintf(request_xp, len, "%s/%s", xpaths[i], iter->name);
+                if (lys_node_module(sch_node) == lys_node_module(iter)) {
+                    snprintf(request_xp, len, "%s/%s", xpaths[i], iter->name);
+                } else {
+                    snprintf(request_xp, len, "%s/%s:%s", xpaths[i], lys_node_module(iter)->name, iter->name);
+                }
 
                 rc = np_data_provider_request(rp_ctx->np_ctx, session->state_data_ctx.subscriptions->data[subs_index],
                         session, request_xp);


### PR DESCRIPTION
### Description
When creating XPath identifying state data nodes, it was not checked whether children of subscription nodes are from a different module and should therefore have an explicit prefix. Also, hopefully last instances of obsolete `latest_revision` flag use.

### Closure
Fixes #860 