### PR TITLE
Fix coverity 'Uninitialized pointer field' error.

### DIFF
--- a/swig/cpp/src/Connection.cpp
+++ b/swig/cpp/src/Connection.cpp
@@ -35,6 +35,7 @@ Connection::Connection(const char *app_name, const sr_conn_options_t opts)
 {
     int ret;
     _opts = opts;
+    _conn = 0;
 
     /* connect to sysrepo */
     ret = sr_connect(app_name, _opts, &_conn);


### PR DESCRIPTION
### Description
Solve missing initialization coverity-scan error for c++ SWIG bindings.