### PR TITLE
BUGFIX repeated typedef removed

### DIFF
--- a/inc/sysrepo.h
+++ b/inc/sysrepo.h
@@ -1182,12 +1182,6 @@ typedef enum sr_subscr_flag_e {
 } sr_subscr_flag_t;
 
 /**
- * @brief Options overriding default behavior of subscriptions,
- * it is supposed to be a bitwise OR-ed value of any ::sr_subscr_flag_t flags.
- */
-typedef uint32_t sr_subscr_options_t;
-
-/**
  * @brief Type of the notification event that has occurred (passed to notification callbacks).
  *
  * @note Each change is normally notified twice: first as ::SR_EV_VERIFY event and then as ::SR_EV_APPLY or ::SR_EV_ABORT
@@ -1240,6 +1234,12 @@ typedef struct sr_subscription_ctx_s sr_subscription_ctx_t;
  * @brief Iterator used for retrieval of a changeset using ::sr_get_changes_iter call.
  */
 typedef struct sr_change_iter_s sr_change_iter_t;
+
+/**
+ * @brief Options overriding default behavior of subscriptions,
+ * it is supposed to be a bitwise OR-ed value of any ::sr_subscr_flag_t flags.
+ */
+typedef uint32_t sr_subscr_options_t;
 
 /**
  * @brief Callback to be called by the event of changing any running datastore
@@ -1684,12 +1684,6 @@ typedef enum sr_ev_notif_flag_e {
     SR_EV_NOTIF_EPHEMERAL = 1,    /**< Notification will not be stored in the notification store
                                        (and therefore will be also delivered faster). */
 } sr_ev_notif_flag_t;
-
-/**
- * @brief Options overriding default behavior of subscriptions,
- * it is supposed to be a bitwise OR-ed value of any ::sr_subscr_flag_t flags.
- */
-typedef uint32_t sr_subscr_options_t;
 
 /**
  * @brief Callback to be called by the delivery of event notification specified by xpath.


### PR DESCRIPTION
### Description
There was a type defined twice in the main public include header.

### Closure
Fixes #866