### PR TITLE
Honor the option CALL_TARGET_BINS_DIRECTLY

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -46,7 +46,11 @@ macro(INSTALL_EXAMPLE_YANG MODULE_NAME REVISION)
         # import data into module
         set(CMD "${CMD}\; ${CMAKE_BINARY_DIR}/src/sysrepocfg --import=${CMAKE_CURRENT_SOURCE_DIR}/yang/${MODULE_NAME}.data.xml --datastore=startup --format=xml --level=0 ${MODULE_NAME}")
     endif()
-    EXEC_AT_INSTALL_TIME(${CMD})
+    if(CALL_TARGET_BINS_DIRECTLY)
+        EXEC_AT_INSTALL_TIME(${CMD})
+    else()
+        set(SH_INSTALL_YANG_CMDS "${SH_INSTALL_YANG_CMDS}\\\${CMD}\n")
+    endif()
 endmacro(INSTALL_EXAMPLE_YANG)
 
 INSTALL_EXAMPLE_YANG("turing-machine" "")


### PR DESCRIPTION
In yocto we compile the project for a different architecture, as such executing any TARGET binary on the HOST is bad since it may not be CPU compatible. An option in the root CMakeList was created to call those binaries or not at install time based on the option value, but the examples/CMakeList.txt was not honoring it.