### PR TITLE
Insert mod fix

### DIFF
--- a/deploy/travis/install-libs.sh
+++ b/deploy/travis/install-libs.sh
@@ -21,7 +21,7 @@ if [ ! -d "$INSTALL_PREFIX_DIR/lib" ]; then
     git clone git://git.cryptomilk.org/projects/cmocka.git
     cd cmocka ; mkdir build; cd build
     cmake -DCMAKE_INSTALL_PREFIX=$INSTALL_PREFIX_DIR -DCMAKE_C_FLAGS="-DUNIT_TESTING_DEBUG" ..
-    make -j2 && make install
+    make -j2 > /dev/null && make install
     cd ../..
 
     # protobuf 
@@ -29,7 +29,7 @@ if [ ! -d "$INSTALL_PREFIX_DIR/lib" ]; then
     tar -xzf v3.2.0.tar.gz
     cd protobuf-3.2.0
     ./autogen.sh && ./configure --prefix=$INSTALL_PREFIX_DIR 
-    make -j2 && make install
+    make -j2 > /dev/null && make install
     cd ..
 
     # protobuf-c
@@ -37,7 +37,7 @@ if [ ! -d "$INSTALL_PREFIX_DIR/lib" ]; then
     tar -xzf v1.2.1.tar.gz
     cd protobuf-c-1.2.1
     ./autogen.sh && ./configure --prefix=$INSTALL_PREFIX_DIR
-    make -j2 && make install
+    make -j2 > /dev/null && make install
     cd ..
 
 else
@@ -54,6 +54,6 @@ else
 fi
 cd libyang ; mkdir build ; cd build
 cmake -DCMAKE_BUILD_TYPE=Debug -DENABLE_BUILD_TESTS=OFF ..
-make -j2 && sudo make install
+make -j2 > /dev/null && sudo make install
 cd ../..
 

--- a/src/executables/sysrepoctl.c
+++ b/src/executables/sysrepoctl.c
@@ -181,6 +181,7 @@ srctl_list_modules()
         for (size_t i = 0; i < schema_cnt; i++) {
             printf("%-30s| %-11s| ", schemas[i].module_name,
                     (NULL == schemas[i].revision.revision ? "" : schemas[i].revision.revision));
+
             /* print conformance */
             if (schemas[i].installed) {
                 printf("Installed   | ");
@@ -189,18 +190,30 @@ srctl_list_modules()
             } else {
                 printf("Imported    | ");
             }
+
             /* print owner */
-            srctl_print_module_owner(schemas[i].module_name, buff);
+            if (schemas[i].implemented) {
+                srctl_print_module_owner(schemas[i].module_name, buff);
+            } else {
+                buff[0] = '\0';
+            }
             printf("%-20s| ", buff);
+
             /* print permissions */
-            srctl_print_module_permissions(schemas[i].module_name, buff);
+            if (schemas[i].implemented) {
+                srctl_print_module_permissions(schemas[i].module_name, buff);
+            } else {
+                buff[0] = '\0';
+            }
             printf("%-12s| ", buff);
+
             /* print submodules */
             size_t printed = 0;
             for (size_t j = 0; j < schemas[i].submodule_count; j++) {
                 printed += printf(" %s", schemas[i].submodules[j].submodule_name);
             }
             for (size_t j = printed; j < 30; j++) printf(" ");
+
             /* print enabled features */
             printf("|");
             for (size_t j = 0; j < schemas[i].enabled_feature_cnt; j++) {

--- a/src/executables/sysrepoctl.c
+++ b/src/executables/sysrepoctl.c
@@ -848,7 +848,7 @@ srctl_data_install(const struct lys_module *module, const char *owner, const cha
     int ret = 0, rc = SR_ERR_OK;
 
     /* install data files only if module can contain any data */
-    if (sr_lys_module_has_data(module)) {
+    if (module->implemented && sr_lys_module_has_data(module)) {
         printf("Installing data files for module '%s'...\n", module->name);
         ret = srctl_data_files_apply(module->name, srctl_file_create, NULL, false);
         if (0 != ret) {

--- a/src/module_dependencies.c
+++ b/src/module_dependencies.c
@@ -2119,16 +2119,16 @@ implemented_dependencies:
         }
     }
 
-    /* inform caller about implicitly installed modules */
-    if (!module->submodule && !installed) {
-        rc = md_get_module_key(module, &module_key);
-        CHECK_RC_MSG_GOTO(rc, cleanup, "md_get_module_key failed");
-        rc = sr_list_add(implicitly_inserted, module_key);
-        CHECK_RC_MSG_GOTO(rc, cleanup, "sr_list_add failed");
-        module_key = NULL;
-    }
-
     if (!already_present) {
+        /* inform caller about implicitly inserted modules */
+        if (!module->submodule && !installed) {
+            rc = md_get_module_key(module, &module_key);
+            CHECK_RC_MSG_GOTO(rc, cleanup, "md_get_module_key failed");
+            rc = sr_list_add(implicitly_inserted, module_key);
+            CHECK_RC_MSG_GOTO(rc, cleanup, "sr_list_add failed");
+            module_key = NULL;
+        }
+
         /* insert the new module into the linked list */
         rc = sr_llist_add_new(md_ctx->modules, module);
         if (SR_ERR_OK != rc) {

--- a/src/module_dependencies.c
+++ b/src/module_dependencies.c
@@ -1717,11 +1717,9 @@ next_node:
  */
 static int
 md_insert_lys_module(md_ctx_t *md_ctx, const struct lys_module *module_schema, const char *revision, bool installed,
-                     bool implemented, md_module_t *belongsto, sr_list_t *implicitly_inserted, sr_list_t *being_parsed)
+                     md_module_t *belongsto, sr_list_t *implicitly_inserted, sr_list_t *being_parsed)
 {
     int rc = SR_ERR_INTERNAL;
-    struct ly_ctx *tmp_ly_ctx = NULL;
-    const struct lys_module *imp_module_schema = NULL;
     bool already_installed = false;
     md_module_t *module = NULL, *module2 = NULL, *main_module = NULL, *match_implemented, *match_latest_rev, *match_revision;
     sr_llist_node_t *module_ll_node = NULL;
@@ -1733,8 +1731,8 @@ md_insert_lys_module(md_ctx_t *md_ctx, const struct lys_module *module_schema, c
     md_module_key_t *module_key = NULL;
 
     CHECK_NULL_ARG3(md_ctx, module_schema, revision);
-    if (installed && !implemented) {
-        SR_LOG_ERR_MSG("Invalid arguments to install module.");
+    if (installed && !lys_main_module(module_schema)->implemented) {
+        SR_LOG_ERR("Invalid arguments to install module '%s'.", module_schema->name);
         rc = SR_ERR_INTERNAL;
         goto cleanup;
     }
@@ -1773,7 +1771,7 @@ md_insert_lys_module(md_ctx_t *md_ctx, const struct lys_module *module_schema, c
     module->filepath = strdup(module_schema->filepath);
     CHECK_NULL_NOMEM_GOTO(module->filepath, rc, cleanup);
     module->installed = installed;
-    module->implemented = implemented;
+    module->implemented = module->submodule ? belongsto->implemented : module_schema->implemented;
 
     /* Go through all the modules and collect information about existing modules */
     match_implemented = NULL;
@@ -1802,7 +1800,7 @@ md_insert_lys_module(md_ctx_t *md_ctx, const struct lys_module *module_schema, c
                 rc = SR_ERR_OK;
                 goto cleanup;
             }
-        } else if (implemented) {
+        } else if (module_schema->implemented) {
             SR_LOG_ERR("Module '%s' is already implemented in revision '%s'.", module->name, match_implemented->revision_date);
             rc = SR_ERR_DATA_EXISTS;
             goto cleanup;
@@ -1829,8 +1827,8 @@ md_insert_lys_module(md_ctx_t *md_ctx, const struct lys_module *module_schema, c
         }
 
         /* submodules need to always be processed again */
-        if ((implemented && !match_revision->implemented) || match_revision->submodule) {
-            if (implemented && !match_revision->implemented) {
+        if ((module_schema->implemented && !match_revision->implemented) || match_revision->submodule) {
+            if (module_schema->implemented && !match_revision->implemented) {
                 /* update implemented flag */
                 match_revision->implemented = true;
                 rc = md_lyd_new_path(md_ctx, MD_XPATH_IMPLEMENTED_FLAG, "true", match_revision, "set implemented flag",
@@ -1932,7 +1930,7 @@ dependencies:
             continue;
         }
         rc = md_insert_lys_module(md_ctx, (struct lys_module *)inc->submodule, md_get_inc_revision(inc), installed,
-                                  implemented, module->submodule ? belongsto : module, implicitly_inserted, being_parsed);
+                                  module->submodule ? belongsto : module, implicitly_inserted, being_parsed);
         if (SR_ERR_OK != rc) {
             goto cleanup;
         }
@@ -1951,30 +1949,12 @@ dependencies:
             /* skip libyang's internal modules */
             continue;
         }
-        /* Use a separate context in which the imported module will be implemented. */
-        tmp_ly_ctx = ly_ctx_new(md_ctx->schema_search_dir);
-        if (NULL == tmp_ly_ctx) {
-            rc = SR_ERR_INTERNAL;
-            SR_LOG_ERR("Unable to initialize libyang context: %s", ly_errmsg());
-            goto cleanup;
-        }
-        /* load module schema into the temporary context. */
-        imp_module_schema = lys_parse_path(tmp_ly_ctx, imp->module->filepath,
-                                           sr_str_ends_with(imp->module->filepath,
-                                                            SR_SCHEMA_YIN_FILE_EXT) ? LYS_IN_YIN : LYS_IN_YANG);
-        if (NULL == imp_module_schema) {
-            rc = SR_ERR_INTERNAL;
-            SR_LOG_ERR("Unable to parse '%s' schema file: %s", imp->module->filepath, ly_errmsg());
-            goto cleanup;
-        }
-        /* non-implemented dependency will have all dependencies only imported */
-        rc = md_insert_lys_module(md_ctx, imp_module_schema, md_get_module_revision(imp_module_schema), false,
-                                  implemented ? imp->module->implemented : false, NULL, implicitly_inserted, being_parsed);
+
+        rc = md_insert_lys_module(md_ctx, imp->module, md_get_module_revision(imp->module),
+                                  false, NULL, implicitly_inserted, being_parsed);
         if (SR_ERR_OK != rc) {
             goto cleanup;
         }
-        ly_ctx_destroy(tmp_ly_ctx, NULL);
-        tmp_ly_ctx = NULL;
     }
 
     /**
@@ -2034,18 +2014,58 @@ dependencies:
         }
     }
 
-    /* process dependencies introduced by identities */
-    for (uint32_t i = 0; i < module_schema->ident_size; ++i) {
-        ident = module_schema->ident + i;
-        for (uint8_t b = 0; b < ident->base_size; b++) {
-            if (ident->base && module_schema != lys_node_module((struct lys_node *)ident->base[b])) {
-                module_lkp.name = (char *)lys_node_module((struct lys_node *)ident->base[b])->name;
-                module_lkp.revision_date = (char *)md_get_module_revision(lys_node_module((struct lys_node *)ident->base[b]));
+    /* the following dependencies are introduced only by implemented modules */
+    if (module_schema->implemented) {
+
+        /* process dependencies introduced by identities */
+        for (uint32_t i = 0; i < module_schema->ident_size; ++i) {
+            ident = module_schema->ident + i;
+            for (uint8_t b = 0; b < ident->base_size; b++) {
+                if (ident->base && module_schema != lys_node_module((struct lys_node *)ident->base[b])) {
+                    module_lkp.name = (char *)lys_node_module((struct lys_node *)ident->base[b])->name;
+                    module_lkp.revision_date = (char *)md_get_module_revision(lys_node_module((struct lys_node *)ident->base[b]));
+                    module2 = (md_module_t *)sr_btree_search(md_ctx->modules_btree, &module_lkp);
+                    if (NULL == module2) {
+                        SR_LOG_ERR_MSG("Unable to resolve dependency induced by a derived identity.");
+                        rc = SR_ERR_INTERNAL;
+                        goto cleanup;
+                    }
+                    if (SR_ERR_OK != md_add_dependency(module2->deps, MD_DEP_EXTENSION, main_module, true, NULL) ||
+                        SR_ERR_OK != md_add_dependency(main_module->inv_deps, MD_DEP_EXTENSION, module2, true, NULL)) {
+                        SR_LOG_ERR_MSG("Failed to add an edge into the dependency graph.");
+                        rc = SR_ERR_INTERNAL;
+                        goto cleanup;
+                    }
+                    /* add entry also into data_tree */
+                    rc = md_lyd_new_path(md_ctx, MD_XPATH_MODULE_DEPENDENCY, NULL, main_module,
+                                        "add (extension) dependency into the data tree", NULL,
+                                        module2->name, module2->revision_date,
+                                        main_module->name, main_module->revision_date,
+                                        md_get_dep_type_to_str(MD_DEP_EXTENSION));
+                    if (SR_ERR_OK != rc) {
+                        goto cleanup;
+                    }
+                }
+            }
+        }
+
+        /* process dependencies introduced by augments */
+        for (uint32_t i = 0; i < module_schema->augment_size; ++i) {
+            augment = module_schema->augment + i;
+            if (module_schema != lys_node_module(augment->target)) {
+                module_lkp.name = (char *)lys_node_module(augment->target)->name;
+                module_lkp.revision_date = (char *)md_get_module_revision(lys_node_module(augment->target));
                 module2 = (md_module_t *)sr_btree_search(md_ctx->modules_btree, &module_lkp);
                 if (NULL == module2) {
-                    SR_LOG_ERR_MSG("Unable to resolve dependency induced by a derived identity.");
-                    rc = SR_ERR_INTERNAL;
-                    goto cleanup;
+                    if (module->submodule && NULL != belongsto &&
+                        0 == strcmp(belongsto->name, module_lkp.name) &&
+                        0 == strcmp(belongsto->revision_date, module_lkp.revision_date)) {
+                        continue;
+                    } else {
+                        SR_LOG_ERR_MSG("Unable to resolve dependency induced by an augment.");
+                        rc = SR_ERR_INTERNAL;
+                        goto cleanup;
+                    }
                 }
                 if (SR_ERR_OK != md_add_dependency(module2->deps, MD_DEP_EXTENSION, main_module, true, NULL) ||
                     SR_ERR_OK != md_add_dependency(main_module->inv_deps, MD_DEP_EXTENSION, module2, true, NULL)) {
@@ -2055,78 +2075,42 @@ dependencies:
                 }
                 /* add entry also into data_tree */
                 rc = md_lyd_new_path(md_ctx, MD_XPATH_MODULE_DEPENDENCY, NULL, main_module,
-                                     "add (extension) dependency into the data tree", NULL,
-                                     module2->name, module2->revision_date,
-                                     main_module->name, main_module->revision_date,
-                                     md_get_dep_type_to_str(MD_DEP_EXTENSION));
+                                    "add (extension) dependency into the data tree", NULL,
+                                    module2->name, module2->revision_date,
+                                    main_module->name, main_module->revision_date,
+                                    md_get_dep_type_to_str(MD_DEP_EXTENSION));
                 if (SR_ERR_OK != rc) {
                     goto cleanup;
                 }
             }
         }
-    }
 
-    /* process dependencies introduced by augments */
-    for (uint32_t i = 0; i < module_schema->augment_size; ++i) {
-        augment = module_schema->augment + i;
-        if (augment->target && module_schema != lys_node_module(augment->target)) {
-            module_lkp.name = (char *)lys_node_module(augment->target)->name;
-            module_lkp.revision_date = (char *)md_get_module_revision(lys_node_module(augment->target));
-            module2 = (md_module_t *)sr_btree_search(md_ctx->modules_btree, &module_lkp);
-            if (NULL == module2) {
-                if (module->submodule && NULL != belongsto &&
-                    0 == strcmp(belongsto->name, module_lkp.name) &&
-                    0 == strcmp(belongsto->revision_date, module_lkp.revision_date)) {
-                    continue;
-                } else {
-                    SR_LOG_ERR_MSG("Unable to resolve dependency induced by an augment.");
-                    rc = SR_ERR_INTERNAL;
-                    goto cleanup;
-                }
-            }
-            if (SR_ERR_OK != md_add_dependency(module2->deps, MD_DEP_EXTENSION, main_module, true, NULL) ||
-                SR_ERR_OK != md_add_dependency(main_module->inv_deps, MD_DEP_EXTENSION, module2, true, NULL)) {
-                SR_LOG_ERR_MSG("Failed to add an edge into the dependency graph.");
-                rc = SR_ERR_INTERNAL;
-                goto cleanup;
-            }
-            /* add entry also into data_tree */
-            rc = md_lyd_new_path(md_ctx, MD_XPATH_MODULE_DEPENDENCY, NULL, main_module,
-                                 "add (extension) dependency into the data tree", NULL,
-                                 module2->name, module2->revision_date,
-                                 main_module->name, main_module->revision_date,
-                                 md_get_dep_type_to_str(MD_DEP_EXTENSION));
+        /* collect instance identifiers and operational data subtrees */
+        if (!module->submodule) {
+            rc = md_traverse_schema_tree(md_ctx, module, module_schema->data, being_parsed);
             if (SR_ERR_OK != rc) {
                 goto cleanup;
             }
         }
-    }
-
-    /* collect instance identifiers and operational data subtrees */
-    if (!module->submodule) {
-        rc = md_traverse_schema_tree(md_ctx, module, module_schema->data, being_parsed);
-        if (SR_ERR_OK != rc) {
-            goto cleanup;
+        for (uint32_t i = 0; i < module_schema->augment_size; ++i) {
+            augment = module_schema->augment + i;
+            rc = md_traverse_schema_tree(md_ctx, main_module, (struct lys_node *)augment, being_parsed);
+            if (SR_ERR_OK != rc) {
+                goto cleanup;
+            }
         }
-    }
-    for (uint32_t i = 0; i < module_schema->augment_size; ++i) {
-        augment = module_schema->augment + i;
-        rc = md_traverse_schema_tree(md_ctx, main_module, (struct lys_node *)augment, being_parsed);
-        if (SR_ERR_OK != rc) {
-            goto cleanup;
-        }
-    }
 
-    /* process dependencies introduced by deviations */
-    for (uint32_t i = 0; i < module_schema->deviation_size; ++i) {
-        struct lys_deviate *deviate = module_schema->deviation[i].deviate;
-        if (NULL != deviate) {
-            for (size_t j = 0; j < deviate->must_size; ++j) {
-                /* orig_node will fail to be traversed further for relative paths, lets hope it will not come to that */
-                rc = md_collect_data_dependencies(md_ctx, deviate->must[j].expr, main_module, main_module,
-                                                  being_parsed, module_schema->deviation[i].orig_node, LYXP_MUST);
-                if (SR_ERR_OK != rc) {
-                    goto cleanup;
+        /* process dependencies introduced by deviations */
+        for (uint32_t i = 0; i < module_schema->deviation_size; ++i) {
+            struct lys_deviate *deviate = module_schema->deviation[i].deviate;
+            if (NULL != deviate) {
+                for (size_t j = 0; j < deviate->must_size; ++j) {
+                    /* orig_node will fail to be traversed further for relative paths, lets hope it will not come to that */
+                    rc = md_collect_data_dependencies(md_ctx, deviate->must[j].expr, main_module, main_module,
+                                                    being_parsed, module_schema->deviation[i].orig_node, LYXP_MUST);
+                    if (SR_ERR_OK != rc) {
+                        goto cleanup;
+                    }
                 }
             }
         }
@@ -2174,9 +2158,6 @@ cleanup:
     if (!already_installed && module) { /*< not inserted into the btree */
         md_free_module(module);
     }
-    if (tmp_ly_ctx) {
-        ly_ctx_destroy(tmp_ly_ctx, NULL);
-    }
     return rc;
 }
 
@@ -2212,7 +2193,7 @@ md_insert_module(md_ctx_t *md_ctx, const char *filepath, sr_list_t **implicitly_
     }
 
     /* insert module into the dependency graph */
-    rc = md_insert_lys_module(md_ctx, module_schema, md_get_module_revision(module_schema), true, true, NULL,
+    rc = md_insert_lys_module(md_ctx, module_schema, md_get_module_revision(module_schema), true, NULL,
                               implicitly_inserted, being_parsed);
     sr_list_cleanup(being_parsed);
     being_parsed = NULL;

--- a/tests/nacm_cl_test.c
+++ b/tests/nacm_cl_test.c
@@ -1063,12 +1063,6 @@ subscribe_dummy_rpc_callback(sr_session_ctx_t *handler_session, void *private_ct
     rc = sr_rpc_subscribe(handler_session, "/test-module:activate-software-image", dummy_rpc_cb, private_ctx,
             SR_SUBSCR_DEFAULT, subscription);
     assert_int_equal_bt(rc, SR_ERR_OK);
-    rc = sr_rpc_subscribe(handler_session, "/ietf-netconf:close-session", dummy_rpc_cb, private_ctx,
-            SR_SUBSCR_CTX_REUSE, subscription);
-    assert_int_equal_bt(rc, SR_ERR_OK);
-    rc = sr_rpc_subscribe(handler_session, "/ietf-netconf:kill-session", dummy_rpc_cb, private_ctx,
-            SR_SUBSCR_CTX_REUSE, subscription);
-    assert_int_equal_bt(rc, SR_ERR_OK);
     rc = sr_rpc_subscribe(handler_session, "/turing-machine:initialize", dummy_rpc_cb, private_ctx,
             SR_SUBSCR_CTX_REUSE, subscription);
     assert_int_equal_bt(rc, SR_ERR_OK);
@@ -1128,8 +1122,6 @@ nacm_cl_test_rpc_nacm_with_empty_nacm_cfg(void **state)
     bool permitted = true;
     sr_val_t *input = NULL;
     sr_node_t *input_tree = NULL;
-    const sr_error_info_t *error_info = NULL;
-    char *error_msg = NULL;
 
     if (!satisfied_requirements) {
         skip();
@@ -1154,46 +1146,6 @@ nacm_cl_test_rpc_nacm_with_empty_nacm_cfg(void **state)
     /*  -> sysrepo-user4 */
     RPC_PERMITED(3, RPC_XPATH, NULL, 0, 2);
     RPC_PERMITED_TREE(3, RPC_XPATH, NULL, 0, 2);
-
-    /* test NETCONF operation "close-session" */
-#undef RPC_XPATH
-#define RPC_XPATH "/ietf-netconf:close-session"
-    /*  -> sysrepo-user1 */
-    RPC_PERMITED(0, RPC_XPATH, NULL, 0, 0);
-    RPC_PERMITED_TREE(0, RPC_XPATH, NULL, 0, 0);
-    /*  -> sysrepo-user2 */
-    RPC_PERMITED(1, RPC_XPATH, NULL, 0, 0);
-    RPC_PERMITED_TREE(1, RPC_XPATH, NULL, 0, 0);
-    /*  -> sysrepo-user3 */
-    RPC_PERMITED(2, RPC_XPATH, NULL, 0, 0);
-    RPC_PERMITED_TREE(2, RPC_XPATH, NULL, 0, 0);
-    /*  -> sysrepo-user4 */
-    RPC_PERMITED(3, RPC_XPATH, NULL, 0, 0);
-    RPC_PERMITED_TREE(3, RPC_XPATH, NULL, 0, 0);
-
-    /* test NETCONF operation "kill-session" */
-#undef RPC_XPATH
-#define RPC_XPATH "/ietf-netconf:kill-session"
-    assert_int_equal(SR_ERR_OK, sr_new_val(RPC_XPATH "/session-id", &input));
-    input->type = SR_UINT32_T;
-    input->data.uint32_val = 12;
-    assert_int_equal(SR_ERR_OK, sr_new_tree("session-id", "ietf-netconf", &input_tree));
-    input_tree->type = SR_UINT32_T;
-    input_tree->data.uint32_val = 12;
-    /*  -> sysrepo-user1 */
-    RPC_DENIED(0, RPC_XPATH, input, 1, "", "");
-    RPC_DENIED_TREE(0, RPC_XPATH, input_tree, 1, "", "");
-    /*  -> sysrepo-user2 */
-    RPC_DENIED(1, RPC_XPATH, input, 1, "", "");
-    RPC_DENIED_TREE(1, RPC_XPATH, input_tree, 1, "", "");
-    /*  -> sysrepo-user3 */
-    RPC_DENIED(2, RPC_XPATH, input, 1, "", "");
-    RPC_DENIED_TREE(2, RPC_XPATH, input_tree, 1, "", "");
-    /*  -> sysrepo-user4 */
-    RPC_PERMITED(3, RPC_XPATH, input, 1, 0);
-    RPC_PERMITED_TREE(3, RPC_XPATH, input_tree, 1, 0);
-    sr_free_val(input);
-    sr_free_tree(input_tree);
 
     /* test RPC "initialize" from turing-machine */
 #undef RPC_XPATH
@@ -1305,46 +1257,6 @@ nacm_cl_test_rpc_nacm(void **state)
     RPC_PERMITED(3, RPC_XPATH, NULL, 0, 2);
     RPC_PERMITED_TREE(3, RPC_XPATH, NULL, 0, 2);
 
-    /* test NETCONF operation "close-session" */
-#undef RPC_XPATH
-#define RPC_XPATH "/ietf-netconf:close-session"
-    /*  -> sysrepo-user1 */
-    RPC_PERMITED(0, RPC_XPATH, NULL, 0, 0);
-    RPC_PERMITED_TREE(0, RPC_XPATH, NULL, 0, 0);
-    /*  -> sysrepo-user2 */
-    RPC_PERMITED(1, RPC_XPATH, NULL, 0, 0);
-    RPC_PERMITED_TREE(1, RPC_XPATH, NULL, 0, 0);
-    /*  -> sysrepo-user3 */
-    RPC_PERMITED(2, RPC_XPATH, NULL, 0, 0);
-    RPC_PERMITED_TREE(2, RPC_XPATH, NULL, 0, 0);
-    /*  -> sysrepo-user4 */
-    RPC_PERMITED(3, RPC_XPATH, NULL, 0, 0);
-    RPC_PERMITED_TREE(3, RPC_XPATH, NULL, 0, 0);
-
-    /* test NETCONF operation "kill-session" */
-#undef RPC_XPATH
-#define RPC_XPATH "/ietf-netconf:kill-session"
-    assert_int_equal(SR_ERR_OK, sr_new_val(RPC_XPATH "/session-id", &input));
-    input->type = SR_UINT32_T;
-    input->data.uint32_val = 12;
-    assert_int_equal(SR_ERR_OK, sr_new_tree("session-id", "ietf-netconf", &input_tree));
-    input_tree->type = SR_UINT32_T;
-    input_tree->data.uint32_val = 12;
-    /*  -> sysrepo-user1 */
-    RPC_DENIED(0, RPC_XPATH, input, 1, "", "");
-    RPC_DENIED_TREE(0, RPC_XPATH, input_tree, 1, "", "");
-    /*  -> sysrepo-user2 */
-    RPC_PERMITED(1, RPC_XPATH, input, 1, 0);
-    RPC_PERMITED_TREE(1, RPC_XPATH, input_tree, 1, 0);
-    /*  -> sysrepo-user3 */
-    RPC_PERMITED(2, RPC_XPATH, input, 1, 0);
-    RPC_PERMITED_TREE(2, RPC_XPATH, input_tree, 1, 0);
-    /*  -> sysrepo-user4 */
-    RPC_PERMITED(3, RPC_XPATH, input, 1, 0);
-    RPC_PERMITED_TREE(3, RPC_XPATH, input_tree, 1, 0);
-    sr_free_val(input);
-    sr_free_tree(input_tree);
-
     /* test RPC "initialize" from turing-machine */
 #undef RPC_XPATH
 #define RPC_XPATH "/turing-machine:initialize"
@@ -1455,46 +1367,6 @@ nacm_cl_test_rpc_nacm_with_denied_exec_by_dflt(void **state)
     RPC_PERMITED(3, RPC_XPATH, NULL, 0, 2);
     RPC_PERMITED_TREE(3, RPC_XPATH, NULL, 0, 2);
 
-    /* test NETCONF operation "close-session" */
-#undef RPC_XPATH
-#define RPC_XPATH "/ietf-netconf:close-session"
-    /*  -> sysrepo-user1 */
-    RPC_PERMITED(0, RPC_XPATH, NULL, 0, 0);
-    RPC_PERMITED_TREE(0, RPC_XPATH, NULL, 0, 0);
-    /*  -> sysrepo-user2 */
-    RPC_PERMITED(1, RPC_XPATH, NULL, 0, 0);
-    RPC_PERMITED_TREE(1, RPC_XPATH, NULL, 0, 0);
-    /*  -> sysrepo-user3 */
-    RPC_PERMITED(2, RPC_XPATH, NULL, 0, 0);
-    RPC_PERMITED_TREE(2, RPC_XPATH, NULL, 0, 0);
-    /*  -> sysrepo-user4 */
-    RPC_PERMITED(3, RPC_XPATH, NULL, 0, 0);
-    RPC_PERMITED_TREE(3, RPC_XPATH, NULL, 0, 0);
-
-    /* test NETCONF operation "kill-session" */
-#undef RPC_XPATH
-#define RPC_XPATH "/ietf-netconf:kill-session"
-    assert_int_equal(SR_ERR_OK, sr_new_val(RPC_XPATH "/session-id", &input));
-    input->type = SR_UINT32_T;
-    input->data.uint32_val = 12;
-    assert_int_equal(SR_ERR_OK, sr_new_tree("session-id", "ietf-netconf", &input_tree));
-    input_tree->type = SR_UINT32_T;
-    input_tree->data.uint32_val = 12;
-    /*  -> sysrepo-user1 */
-    RPC_DENIED(0, RPC_XPATH, input, 1, "", "");
-    RPC_DENIED_TREE(0, RPC_XPATH, input_tree, 1, "", "");
-    /*  -> sysrepo-user2 */
-    RPC_PERMITED(1, RPC_XPATH, input, 1, 0);
-    RPC_PERMITED_TREE(1, RPC_XPATH, input_tree, 1, 0);
-    /*  -> sysrepo-user3 */
-    RPC_PERMITED(2, RPC_XPATH, input, 1, 0);
-    RPC_PERMITED_TREE(2, RPC_XPATH, input_tree, 1, 0);
-    /*  -> sysrepo-user4 */
-    RPC_PERMITED(3, RPC_XPATH, input, 1, 0);
-    RPC_PERMITED_TREE(3, RPC_XPATH, input_tree, 1, 0);
-    sr_free_val(input);
-    sr_free_tree(input_tree);
-
     /* test RPC "initialize" from turing-machine */
 #undef RPC_XPATH
 #define RPC_XPATH "/turing-machine:initialize"
@@ -1604,46 +1476,6 @@ nacm_cl_test_rpc_nacm_with_ext_groups(void **state)
     /*  -> sysrepo-user4 */
     RPC_PERMITED(3, RPC_XPATH, NULL, 0, 2);
     RPC_PERMITED_TREE(3, RPC_XPATH, NULL, 0, 2);
-
-    /* test NETCONF operation "close-session" */
-#undef RPC_XPATH
-#define RPC_XPATH "/ietf-netconf:close-session"
-    /*  -> sysrepo-user1 */
-    RPC_PERMITED(0, RPC_XPATH, NULL, 0, 0);
-    RPC_PERMITED_TREE(0, RPC_XPATH, NULL, 0, 0);
-    /*  -> sysrepo-user2 */
-    RPC_PERMITED(1, RPC_XPATH, NULL, 0, 0);
-    RPC_PERMITED_TREE(1, RPC_XPATH, NULL, 0, 0);
-    /*  -> sysrepo-user3 */
-    RPC_PERMITED(2, RPC_XPATH, NULL, 0, 0);
-    RPC_PERMITED_TREE(2, RPC_XPATH, NULL, 0, 0);
-    /*  -> sysrepo-user4 */
-    RPC_PERMITED(3, RPC_XPATH, NULL, 0, 0);
-    RPC_PERMITED_TREE(3, RPC_XPATH, NULL, 0, 0);
-
-    /* test NETCONF operation "kill-session" */
-#undef RPC_XPATH
-#define RPC_XPATH "/ietf-netconf:kill-session"
-    assert_int_equal(SR_ERR_OK, sr_new_val(RPC_XPATH "/session-id", &input));
-    input->type = SR_UINT32_T;
-    input->data.uint32_val = 12;
-    assert_int_equal(SR_ERR_OK, sr_new_tree("session-id", "ietf-netconf", &input_tree));
-    input_tree->type = SR_UINT32_T;
-    input_tree->data.uint32_val = 12;
-    /*  -> sysrepo-user1 */
-    RPC_DENIED(0, RPC_XPATH, input, 1, "", "");
-    RPC_DENIED_TREE(0, RPC_XPATH, input_tree, 1, "", "");
-    /*  -> sysrepo-user2 */
-    RPC_PERMITED(1, RPC_XPATH, input, 1, 0);
-    RPC_PERMITED_TREE(1, RPC_XPATH, input_tree, 1, 0);
-    /*  -> sysrepo-user3 */
-    RPC_PERMITED(2, RPC_XPATH, input, 1, 0);
-    RPC_PERMITED_TREE(2, RPC_XPATH, input_tree, 1, 0);
-    /*  -> sysrepo-user4 */
-    RPC_PERMITED(3, RPC_XPATH, input, 1, 0);
-    RPC_PERMITED_TREE(3, RPC_XPATH, input_tree, 1, 0);
-    sr_free_val(input);
-    sr_free_tree(input_tree);
 
     /* test RPC "initialize" from turing-machine */
 #undef RPC_XPATH


### PR DESCRIPTION
### Description
When a module A is installed that imports and uses a grouping from B and in the grouping there is a leafref to module C (imported in B), A is implemented, B is imported, and C should also be implemented, but it was not (it was assumed that dependencies of imported modules will always be only imported).

Also, `sysrepoctl` installed and printed information about data files for only imported modules, which is wrong.

Replaces #872

### Closure
Refs #839 
