### PR TITLE
Commit change

### DIFF
--- a/doc/datastores.dox
+++ b/doc/datastores.dox
@@ -9,7 +9,8 @@ the session is operating can be changed during the lifetime of the session using
 
 The changes made within a session are not applied into the datastore
 until ::sr_commit is requested. While not committed, changes are visible only
-within the same configuration session. This applies for all three datastores.
+within the same configuration session. This applies for all three datastores,
+but \b candidate has some differences, which are mentioned in its section.
 
 
 @section sds Startup Datastore
@@ -40,8 +41,10 @@ after restarts (see ::sr_copy_config).
 
 @section cds Candidate Datastore
 The candidate configuration is a full configuration data set that serves as a work
-place for creating and manipulating configuration data. ::sr_commit operation sets
-running configuration to the value of the candidate content (overwrites the running
-datastore content with the content of candidate datastore).
+place for creating and manipulating configuration data. Every session always has
+a separate candidate datastore with changes never being visible in other sessions.
+::sr_commit operation only validates the changes and optionally performs a NACM check,
+if NACM is enabled. To apply these changes to a datastore visible for all the sessions
+and applications, use copy-config (see ::sr_copy_config).
 
 */

--- a/src/clientlib/client_library.c
+++ b/src/clientlib/client_library.c
@@ -2156,6 +2156,7 @@ sr_copy_config(sr_session_ctx_t *session, const char *module_name,
 {
     Sr__Msg *msg_req = NULL, *msg_resp = NULL;
     sr_mem_ctx_t *sr_mem = NULL;
+    Sr__CopyConfigResp *copy_config_resp = NULL;
     int rc = SR_ERR_OK;
 
     CHECK_NULL_ARG2(session, session->conn_ctx);
@@ -2178,12 +2179,26 @@ sr_copy_config(sr_session_ctx_t *session, const char *module_name,
 
     /* send the request and receive the response */
     rc = cl_request_process(session, msg_req, &msg_resp, NULL, SR__OPERATION__COPY_CONFIG);
-    CHECK_RC_MSG_GOTO(rc, cleanup, "Error by processing of the request.");
+    if ((SR_ERR_OK != rc) && (SR_ERR_OPERATION_FAILED != rc) && (SR_ERR_VALIDATION_FAILED != rc) &&
+        (SR_ERR_UNAUTHORIZED != rc)) {
+        SR_LOG_ERR_MSG("Error by processing of copy_config request.");
+        goto cleanup;
+    }
+
+    copy_config_resp = msg_resp->response->copy_config_resp;
+    if ((SR_ERR_OPERATION_FAILED == rc) || (SR_ERR_VALIDATION_FAILED == rc) || (SR_ERR_UNAUTHORIZED == rc)) {
+        SR_LOG_ERR("Copy_config operation failed with %zu error(s).", copy_config_resp->n_errors);
+
+        /* store commit errors within the session */
+        if (copy_config_resp->n_errors > 0) {
+            cl_session_set_errors(session, copy_config_resp->errors, copy_config_resp->n_errors);
+        }
+    }
 
     sr_msg_free(msg_req);
     sr_msg_free(msg_resp);
 
-    return cl_session_return(session, SR_ERR_OK);
+    return cl_session_return(session, rc);
 
 cleanup:
     if (NULL != msg_req) {

--- a/src/cm_session_manager.c
+++ b/src/cm_session_manager.c
@@ -486,9 +486,13 @@ sm_session_drop(const sm_ctx_t *sm_ctx, sm_session_t *session)
 
     SR_LOG_INF("Dropping session id=%"PRIu32".", session->id);
 
-    rc = sm_connection_remove_session(sm_ctx, session->connection, session);
-    if (SR_ERR_OK != rc) {
-        SR_LOG_WRN("Cannot remove the session from connection (id=%"PRIu32").", session->id);
+    /* connection can be NULL if this is a leftover session on an already-closed connection (it had some
+     * pending messages) */
+    if (session->connection) {
+        rc = sm_connection_remove_session(sm_ctx, session->connection, session);
+        if (SR_ERR_OK != rc) {
+            SR_LOG_WRN("Cannot remove the session from connection (id=%"PRIu32").", session->id);
+        }
     }
 
     sr_btree_delete(sm_ctx->session_id_btree, session); /* sm_session_cleanup auto-invoked */

--- a/src/connection_manager.c
+++ b/src/connection_manager.c
@@ -435,7 +435,8 @@ cm_conn_close(cm_ctx_t *cm_ctx, sm_connection_t *conn)
                 /* drop the session in Session Manager */
                 sm_session_drop(cm_ctx->sm_ctx, sess->session);
             } else {
-                /* just remove the session from the connection's session list */
+                /* just remove the session from the connection's session list and vice versa */
+                sess->session->connection = NULL;
                 conn->session_list = conn->session_list->next;
                 free(sess);
             }

--- a/src/connection_manager.c
+++ b/src/connection_manager.c
@@ -1172,7 +1172,7 @@ cm_conn_read_cb(struct ev_loop *loop, ev_io *w, int revents)
     cm_ctx = conn->cm_data->cm_ctx;
     buff = &conn->cm_data->in_buff;
 
-    SR_LOG_DBG("fd %d readable", conn->fd);
+    SR_LOG_DBG("fd %d readable (revents %d)", conn->fd, revents);
 
     do {
         /* expand input buffer if needed */
@@ -1239,7 +1239,7 @@ cm_conn_write_cb(struct ev_loop *loop, ev_io *w, int revents)
     CHECK_NULL_ARG_VOID3(conn, conn->cm_data, conn->cm_data->cm_ctx);
     cm_ctx = conn->cm_data->cm_ctx;
 
-    SR_LOG_DBG("fd %d writeable", conn->fd);
+    SR_LOG_DBG("fd %d writeable (revents %d)", conn->fd, revents);
 
     ev_io_stop(cm_ctx->event_loop, &conn->cm_data->write_watcher);
 

--- a/src/data_manager.c
+++ b/src/data_manager.c
@@ -3657,7 +3657,7 @@ dm_release_resources_commit_context(dm_ctx_t *dm_ctx, dm_commit_context_t *c_ctx
     return SR_ERR_OK;
 }
 
-int
+static int
 dm_save_commit_context(dm_ctx_t *dm_ctx, dm_commit_context_t *c_ctx)
 {
     CHECK_NULL_ARG(c_ctx);

--- a/src/data_manager.c
+++ b/src/data_manager.c
@@ -1458,6 +1458,11 @@ dm_lock_datastore(dm_ctx_t *dm_ctx, dm_session_t *session)
     session->holds_ds_lock[session->datastore] = true;
 
     for (size_t i = 0; i < schema_count; i++) {
+        if (!schemas[i].implemented) {
+            /* nothing to lock */
+            continue;
+        }
+
         rc = dm_lock_module(dm_ctx, session, (char *) schemas[i].module_name);
         if (SR_ERR_OK != rc) {
             if (SR_ERR_UNAUTHORIZED == rc) {

--- a/src/data_manager.c
+++ b/src/data_manager.c
@@ -3937,8 +3937,8 @@ dm_commit_load_modified_models(dm_ctx_t *dm_ctx, const dm_session_t *session, dm
         rc = dm_is_info_copy_uptodate(dm_ctx, file_name, info, &copy_uptodate);
         CHECK_RC_MSG_GOTO(rc, cleanup, "File up to date check failed");
 
-        /* ops are skipped also when candidate is committed to the running */
-        if (copy_uptodate || SR_DS_CANDIDATE == session->datastore) {
+        /* ops are skipped also when running is committed */
+        if (copy_uptodate || SR_DS_RUNNING == session->datastore) {
             SR_LOG_DBG("Timestamp for the model %s matches, ops will be skipped", info->schema->module->name);
             rc = sr_list_add(c_ctx->up_to_date_models, (void *) info->schema->module->name);
             CHECK_RC_MSG_GOTO(rc, cleanup, "Adding to sr_list failed");
@@ -3986,7 +3986,7 @@ dm_commit_load_modified_models(dm_ctx_t *dm_ctx, const dm_session_t *session, dm
              * If config change notifications are generated we have to save prev state for startup as well.
              * if NACM is enabled, we need to get the previous state in any case.
              */
-            if (SR_DS_CANDIDATE == session->datastore || copy_uptodate) {
+            if (SR_DS_RUNNING == session->datastore || copy_uptodate) {
                 /* load data tree from file system */
                 rc = dm_load_data_tree_file(dm_ctx, c_ctx->existed[count] ? c_ctx->fds[count] : -1, file_name, info->schema, &di);
                 CHECK_RC_MSG_GOTO(rc, cleanup, "Loading data file failed");

--- a/src/data_manager.c
+++ b/src/data_manager.c
@@ -998,7 +998,7 @@ dm_load_module(dm_ctx_t *dm_ctx, const char *module_name, const char *revision, 
 
     /* compute xpath hashes for all schema nodes (referenced from data tree) */
     rc = dm_init_missing_node_priv_data(si);
-    CHECK_RC_LOG_GOTO(rc, unlock, "Failed to initialize private data for module %s", module->name);
+    CHECK_RC_LOG_GOTO(rc, cleanup, "Failed to initialize private data for module %s", module->name);
 
     /* apply persist data enable features, running datastore */
     if (module->has_persist) {

--- a/src/data_manager.c
+++ b/src/data_manager.c
@@ -3739,7 +3739,7 @@ dm_commit_prepare_context(dm_ctx_t *dm_ctx, dm_session_t *session, dm_commit_con
 
     SR_LOG_DBG("Commit: In the session there are %zu / %zu modified models", c_ctx->modif_count, i);
 
-    if (0 == session->oper_count[session->datastore] && 0 != c_ctx->modif_count && SR_DS_CANDIDATE != session->datastore) {
+    if (0 == session->oper_count[session->datastore] && 0 != c_ctx->modif_count && SR_DS_RUNNING != session->datastore) {
         SR_LOG_WRN_MSG("No operation logged, however data tree marked as modified");
         c_ctx->modif_count = 0;
         *commit_ctx = c_ctx;
@@ -3756,7 +3756,7 @@ dm_commit_prepare_context(dm_ctx_t *dm_ctx, dm_session_t *session, dm_commit_con
     CHECK_NULL_NOMEM_GOTO(c_ctx->existed, rc, cleanup);
 
     /* create commit session */
-    rc = dm_session_start(dm_ctx, session->user_credentials, SR_DS_CANDIDATE == session->datastore ? SR_DS_RUNNING : session->datastore, &c_ctx->session);
+    rc = dm_session_start(dm_ctx, session->user_credentials, session->datastore, &c_ctx->session);
     CHECK_RC_MSG_GOTO(rc, cleanup, "Commit session initialization failed");
 
     rc = sr_list_init(&c_ctx->up_to_date_models);
@@ -3868,7 +3868,7 @@ dm_commit_load_modified_models(dm_ctx_t *dm_ctx, const dm_session_t *session, dm
         }
         rc = dm_commit_lock_model(dm_ctx, (dm_session_t *) session, c_ctx, info->schema->module->name);
         CHECK_RC_LOG_RETURN(rc, "Module %s can not be locked", info->schema->module->name);
-        if (SR_DS_CANDIDATE == session->datastore) {
+        if (SR_DS_RUNNING == session->datastore) {
             /* check if all subtrees are enabled */
             bool has_not_enabled = true;
             rc = dm_has_not_enabled_nodes(info, &has_not_enabled);

--- a/src/data_manager.c
+++ b/src/data_manager.c
@@ -3797,16 +3797,17 @@ dm_commit_lock_model(dm_ctx_t *dm_ctx, dm_session_t *session, dm_commit_context_
             /* check if the lock is hold by session that issued commit */
             rc = dm_lock_module(dm_ctx, session, module_name);
         }
-        dm_session_switch_ds(c_ctx->session, SR_DS_RUNNING);
         CHECK_RC_LOG_RETURN(rc, "Failed to lock %s in candidate ds", module_name);
+
         /* acquire running lock*/
+        dm_session_switch_ds(c_ctx->session, SR_DS_RUNNING);
         rc = dm_lock_module(dm_ctx, c_ctx->session, module_name);
         if (SR_ERR_LOCKED == rc) {
             /* check if the lock is hold by session that issued commit */
-            dm_session_switch_ds(session, SR_DS_RUNNING);
             rc = dm_lock_module(dm_ctx, session, module_name);
-            dm_session_switch_ds(session, SR_DS_CANDIDATE);
         }
+        /* switch DS back */
+        dm_session_switch_ds(c_ctx->session, SR_DS_CANDIDATE);
         CHECK_RC_LOG_RETURN(rc, "Failed to lock %s in running ds", module_name);
     } else {
         /* in case of startup/running ds acquire only startup/running */

--- a/src/data_manager.c
+++ b/src/data_manager.c
@@ -3725,7 +3725,7 @@ dm_commit_prepare_context(dm_ctx_t *dm_ctx, dm_session_t *session, dm_commit_con
         if (info->modified) {
             c_ctx->modif_count++;
 
-            if (SR_DS_STARTUP != session->datastore) {
+            if (SR_DS_RUNNING == session->datastore) {
                 rc = dm_prepare_module_subscriptions(dm_ctx, session, info->schema, &ms);
                 CHECK_RC_LOG_GOTO(rc, cleanup, "Prepare module subscription failed %s", info->schema->module->name);
 

--- a/src/data_manager.h
+++ b/src/data_manager.h
@@ -498,14 +498,6 @@ int dm_commit_notify(dm_ctx_t *dm_ctx, dm_session_t *session, sr_notif_event_t e
 void dm_free_commit_context(void *commit_ctx);
 
 /**
- * @brief Saves commit context to be used for notifications. Releases acquired locks
- * and closes opened files.
- * @param [in] dm_ctx
- * @param [in] c_ctx
- */
-int dm_save_commit_context(dm_ctx_t *dm_ctx, dm_commit_context_t *c_ctx);
-
-/**
  * @brief Logs operation into session operation list. The operation list is used
  * during the commit. Passed allocated arguments are freed in case of error also.
  * @param [in] session

--- a/src/data_manager.h
+++ b/src/data_manager.h
@@ -442,12 +442,15 @@ int dm_commit_prepare_context(dm_ctx_t *dm_ctx, dm_session_t *session, dm_commit
  * @param [in] dm_ctx
  * @param [in] session
  * @param [in] c_ctx - commit context
+ * @param [in] force_copy_uptodate True if timestamp check of session info datatree and datastore file should be
+ * skipped and session info datatree should be always used (otherwise if the timestamp of session datatrees is older
+ * than of datastore file, the datatrees are overwritten with data loaded from the datastore file)
  * @param [out] errors
  * @param [out] err_cnt
  * @return Error code (SR_ERR_OK on success)
  */
 int dm_commit_load_modified_models(dm_ctx_t *dm_ctx, const dm_session_t *session, dm_commit_context_t *c_ctx,
-        sr_error_info_t **errors, size_t *err_cnt);
+        bool force_copy_uptodate, sr_error_info_t **errors, size_t *err_cnt);
 
 /**
  * @brief Tries to acquire write locks on opened fds

--- a/src/executables/sysrepoctl.c
+++ b/src/executables/sysrepoctl.c
@@ -56,8 +56,7 @@ const char * const data_files_ext[] = { SR_STARTUP_FILE_EXT,
                                         SR_RUNNING_FILE_EXT,
                                         SR_STARTUP_FILE_EXT SR_LOCK_FILE_EXT,
                                         SR_RUNNING_FILE_EXT SR_LOCK_FILE_EXT,
-                                        SR_PERSIST_FILE_EXT,
-                                        SR_CANDIDATE_FILE_EXT SR_LOCK_FILE_EXT};
+                                        SR_PERSIST_FILE_EXT};
 
 
 

--- a/src/notification_processor.c
+++ b/src/notification_processor.c
@@ -1680,7 +1680,7 @@ np_store_event_notification(np_ctx_t *np_ctx, const ac_ucred_t *user_cred, const
     /* make sure there will be no invalid quotes */
     if (strchr(xpath, '\'')) {
         tmp_xpath = strdup(xpath);
-        for (ptr = strchr(xpath, '\''); ptr; ptr = strchr(ptr, '\'')) {
+        for (ptr = strchr(tmp_xpath, '\''); ptr; ptr = strchr(ptr + 1, '\'')) {
             *ptr = '"';
         }
     }

--- a/src/notification_processor.c
+++ b/src/notification_processor.c
@@ -1683,7 +1683,7 @@ np_store_event_notification(np_ctx_t *np_ctx, const ac_ucred_t *user_cred, const
             (uint32_t) (((logged_time_spec.tv_sec * 100) + (uint32_t)(logged_time_spec.tv_nsec / 1.0e7)) % UINT32_MAX));
     new_node = lyd_new_path(data_tree, np_ctx->ly_ctx, data_xpath, NULL, 0, 0);
     if (NULL == new_node) {
-        SR_LOG_WRN("Error by adding new notification entry: %s.", ly_errmsg());
+        SR_LOG_WRN("Error by adding new notification entry %s: %s.", data_xpath, ly_errmsg());
         goto cleanup; /* do not set error code - it may be just too much notifications within the same hundred of second */
     }
     if (NULL == data_tree) {

--- a/src/persistence_manager.c
+++ b/src/persistence_manager.c
@@ -1185,7 +1185,7 @@ pm_add_subscription(pm_ctx_t *pm_ctx, const ac_ucred_t *user_cred, const char *m
     rc = pm_save_data_tree(data_tree, fd);
 
     if (SR_ERR_OK == rc) {
-        SR_LOG_DBG("Subscription entry successfully added into '%s' persist data tree.", module_name);
+        SR_LOG_DBG("Subscription entry '%s' successfully added into '%s' persist data tree.", subscription->xpath, module_name);
     }
 
 cleanup:

--- a/src/persistence_manager.c
+++ b/src/persistence_manager.c
@@ -1088,7 +1088,7 @@ int
 pm_add_subscription(pm_ctx_t *pm_ctx, const ac_ucred_t *user_cred, const char *module_name,
         const np_subscription_t *subscription, const bool exclusive)
 {
-    char xpath[PATH_MAX] = { 0, }, buff[15] = { 0, };
+    char xpath[PATH_MAX] = { 0, }, buff[15] = { 0, }, *tmp_xpath = NULL, *ptr;
     const char *value = NULL;
     struct lyd_node *data_tree = NULL;
     int fd = -1;
@@ -1102,8 +1102,18 @@ pm_add_subscription(pm_ctx_t *pm_ctx, const ac_ucred_t *user_cred, const char *m
         SR_LOG_DBG("Removing all existing %s subscriptions from '%s' persist data tree.",
                 sr_subscription_type_gpb_to_str(subscription->type), module_name);
 
+        /* make sure there will be no illegal quotes */
+        if (strchr(subscription->xpath, '\'')) {
+            tmp_xpath = strdup(subscription->xpath);
+            for (ptr = strchr(tmp_xpath, '\''); ptr; ptr = strchr(ptr + 1, '\'')) {
+                *ptr = '"';
+            }
+        }
+
         snprintf(xpath, PATH_MAX, PM_XPATH_SUBSCRIPTIONS_BY_TYPE_XPATH, module_name,
-                sr_subscription_type_gpb_to_str(subscription->type), subscription->xpath);
+                sr_subscription_type_gpb_to_str(subscription->type), tmp_xpath ? tmp_xpath : subscription->xpath);
+        free(tmp_xpath);
+
         rc = pm_modify_persist_data_tree(pm_ctx, &data_tree, xpath, NULL, false, true, NULL);
         if (SR_ERR_OK != rc) {
             SR_LOG_WRN("Unable to delete existing %s subscriptions.", sr_subscription_type_gpb_to_str(subscription->type));

--- a/src/request_processor.c
+++ b/src/request_processor.c
@@ -1456,7 +1456,7 @@ rp_commit_req_process(rp_ctx_t *rp_ctx, rp_session_t *session, Sr__Msg *msg, boo
 
     if (SR_ERR_OK == rc ) {
         session->req = msg;
-        rc = rp_dt_commit(rp_ctx, session, c_ctx, &errors, &err_cnt);
+        rc = rp_dt_commit(rp_ctx, session, c_ctx, false, &errors, &err_cnt);
     }
     if (SR_ERR_OK == rc && RP_REQ_WAITING_FOR_VERIFIERS == session->state) {
         SR_LOG_DBG_MSG("Commit request paused, waiting for verifiers");

--- a/src/request_processor.c
+++ b/src/request_processor.c
@@ -1531,11 +1531,14 @@ rp_discard_changes_req_process(const rp_ctx_t *rp_ctx, const rp_session_t *sessi
  * @brief Processes a copy-config request.
  */
 static int
-rp_copy_config_req_process(rp_ctx_t *rp_ctx, rp_session_t *session, Sr__Msg *msg)
+rp_copy_config_req_process(rp_ctx_t *rp_ctx, rp_session_t *session, Sr__Msg *msg, bool *skip_msg_cleanup)
 {
     Sr__Msg *resp = NULL;
     sr_mem_ctx_t *sr_mem = NULL;
     int rc = SR_ERR_OK;
+    sr_error_info_t *errors = NULL;
+    size_t err_cnt = 0;
+    bool locked = false;
 
     CHECK_NULL_ARG5(rp_ctx, session, msg, msg->request, msg->request->copy_config_req);
 
@@ -1559,23 +1562,41 @@ rp_copy_config_req_process(rp_ctx_t *rp_ctx, rp_session_t *session, Sr__Msg *msg
     pthread_mutex_unlock(&rp_ctx->commit_block_mutex);
     CHECK_RC_MSG_GOTO(rc, cleanup, "Stop requested, commits are blocked.");
 
+    MUTEX_LOCK_TIMED_CHECK_GOTO(&session->cur_req_mutex, rc, cleanup);
+    locked = true;
+
     session->req = msg;
     rc = rp_dt_copy_config(rp_ctx, session, msg->request->copy_config_req->module_name,
                 sr_datastore_gpb_to_sr(msg->request->copy_config_req->src_datastore),
-                sr_datastore_gpb_to_sr(msg->request->copy_config_req->dst_datastore));
+                sr_datastore_gpb_to_sr(msg->request->copy_config_req->dst_datastore), &errors, &err_cnt);
 
+    if (SR_ERR_OK == rc && RP_REQ_WAITING_FOR_VERIFIERS == session->state) {
+        SR_LOG_DBG_MSG("Copy_config request paused, waiting for verifiers");
+        /* we are waiting for verifiers data do not free the request */
+        *skip_msg_cleanup = true;
+        sr_msg_free(resp);
+        pthread_mutex_unlock(&session->cur_req_mutex);
+        return SR_ERR_OK;
+    }
+
+cleanup:
+    session->state = RP_REQ_FINISHED;
+    session->req = NULL;
+    if (locked) {
+        pthread_mutex_unlock(&session->cur_req_mutex);
+    }
     /* set response code */
     resp->response->result = rc;
 
-    rc = rp_resp_fill_errors(resp, session->dm_session);
-    if (SR_ERR_OK != rc) {
-        SR_LOG_ERR_MSG("Copying errors to gpb failed");
+    /* copy error information to GPB  (if any) */
+    if (err_cnt > 0) {
+        sr_gpb_fill_errors(errors, err_cnt, sr_mem, &resp->response->copy_config_resp->errors,
+                &resp->response->copy_config_resp->n_errors);
+        sr_free_errors(errors, err_cnt);
     }
 
     /* send the response */
     rc = cm_msg_send(rp_ctx->cm_ctx, resp);
-
-cleanup:
     return rc;
 }
 
@@ -3376,7 +3397,7 @@ rp_req_dispatch(rp_ctx_t *rp_ctx, rp_session_t *session, Sr__Msg *msg, bool *ski
             rc = rp_discard_changes_req_process(rp_ctx, session, msg);
             break;
         case SR__OPERATION__COPY_CONFIG:
-            rc = rp_copy_config_req_process(rp_ctx, session, msg);
+            rc = rp_copy_config_req_process(rp_ctx, session, msg, skip_msg_cleanup);
             break;
         case SR__OPERATION__SESSION_REFRESH:
             rc = rp_session_refresh_req_process(rp_ctx, session, msg);

--- a/src/rp_dt_edit.c
+++ b/src/rp_dt_edit.c
@@ -789,7 +789,8 @@ rp_dt_reload_nacm(rp_ctx_t *rp_ctx)
 }
 
 int
-rp_dt_commit(rp_ctx_t *rp_ctx, rp_session_t *session, dm_commit_context_t *c_ctx, sr_error_info_t **errors, size_t *err_cnt)
+rp_dt_commit(rp_ctx_t *rp_ctx, rp_session_t *session, dm_commit_context_t *c_ctx, bool force_copy_uptodate,
+        sr_error_info_t **errors, size_t *err_cnt)
 {
     int rc = SR_ERR_OK;
     CHECK_NULL_ARG_NORET4(rc, rp_ctx, session, errors, err_cnt);
@@ -834,7 +835,7 @@ rp_dt_commit(rp_ctx_t *rp_ctx, rp_session_t *session, dm_commit_context_t *c_ctx
             pthread_mutex_lock(&commit_ctx->mutex);
             commit_ctx->disabled_config_change = rp_ctx->do_not_generate_config_change;
             /* open all files */
-            rc = dm_commit_load_modified_models(rp_ctx->dm_ctx, session->dm_session, commit_ctx,
+            rc = dm_commit_load_modified_models(rp_ctx->dm_ctx, session->dm_session, commit_ctx, force_copy_uptodate,
                     errors, err_cnt);
             CHECK_RC_MSG_GOTO(rc, cleanup, "Loading of modified models failed");
             SR_LOG_DBG_MSG("Commit (3/10): all modified models loaded successfully");
@@ -1115,7 +1116,7 @@ rp_dt_copy_config_to_running(rp_ctx_t* rp_ctx, rp_session_t* session, const char
     }
 
     /* commit */
-    rc = rp_dt_commit(rp_ctx, session, c_ctx, errors, err_cnt);
+    rc = rp_dt_commit(rp_ctx, session, c_ctx, true, errors, err_cnt);
 
 cleanup:
     first_err = rc;

--- a/src/rp_dt_edit.c
+++ b/src/rp_dt_edit.c
@@ -1053,7 +1053,7 @@ cleanup:
  * @return Error code (SR_ERR_OK on success)
  */
 static int
-rp_dt_copy_config_to_running(rp_ctx_t* rp_ctx, rp_session_t* session, const char* module_name, sr_datastore_t src)
+rp_dt_copy_config_to_running(rp_ctx_t* rp_ctx, rp_session_t* session, const char* module_name, sr_datastore_t src, sr_error_info_t **errors, size_t *err_cnt)
 {
     CHECK_NULL_ARG2(rp_ctx, session);
     int rc = SR_ERR_OK;
@@ -1063,8 +1063,6 @@ rp_dt_copy_config_to_running(rp_ctx_t* rp_ctx, rp_session_t* session, const char
     dm_commit_context_t *c_ctx = NULL;
     dm_data_info_t *info = NULL;
     int first_err = SR_ERR_OK;
-    sr_error_info_t *errors = NULL;
-    size_t e_cnt = 0;
 
     /* are we resuming a copy_config commit? */
     if (RP_REQ_RESUMED == session->state) {
@@ -1117,8 +1115,7 @@ rp_dt_copy_config_to_running(rp_ctx_t* rp_ctx, rp_session_t* session, const char
     }
 
     /* commit */
-    rc = rp_dt_commit(rp_ctx, session, c_ctx, &errors, &e_cnt);
-    sr_free_errors(errors, e_cnt);
+    rc = rp_dt_commit(rp_ctx, session, c_ctx, errors, err_cnt);
 
 cleanup:
     first_err = rc;
@@ -1139,7 +1136,7 @@ cleanup_sess_stop:
 }
 
 int
-rp_dt_copy_config(rp_ctx_t *rp_ctx, rp_session_t *session, const char *module_name, sr_datastore_t src, sr_datastore_t dst)
+rp_dt_copy_config(rp_ctx_t *rp_ctx, rp_session_t *session, const char *module_name, sr_datastore_t src, sr_datastore_t dst, sr_error_info_t **errors, size_t *err_cnt)
 {
     CHECK_NULL_ARG2(rp_ctx, session);
     SR_LOG_INF("Copy config: %s -> %s, model: %s", sr_ds_to_str(src), sr_ds_to_str(dst), module_name);
@@ -1165,7 +1162,7 @@ rp_dt_copy_config(rp_ctx_t *rp_ctx, rp_session_t *session, const char *module_na
         }
 
     } else {
-        rc = rp_dt_copy_config_to_running(rp_ctx, session, module_name, src);
+        rc = rp_dt_copy_config_to_running(rp_ctx, session, module_name, src, errors, err_cnt);
     }
 
     rp_dt_switch_datastore(rp_ctx, session, prev_ds);

--- a/src/rp_dt_edit.c
+++ b/src/rp_dt_edit.c
@@ -959,6 +959,8 @@ cleanup:
             rc = dm_discard_changes(rp_ctx->dm_ctx, session->dm_session);
         }
         SR_LOG_DBG_MSG("Commit (10/10): finished successfully");
+    } else {
+        SR_LOG_DBG_MSG("Commit (10/10): finished with an error");
     }
     return rc;
 }

--- a/src/rp_dt_edit.h
+++ b/src/rp_dt_edit.h
@@ -143,9 +143,11 @@ int rp_dt_refresh_session(rp_ctx_t *rp_ctx, rp_session_t *session, sr_error_info
  * @param [in] module_name
  * @param [in] src
  * @param [in] dst
+ * @param [out] errors
+ * @param [out] err_cnt
  * @return Error code (SR_ERR_OK on success)
  */
-int rp_dt_copy_config(rp_ctx_t *rp_ctx, rp_session_t *session, const char *module_name, sr_datastore_t src, sr_datastore_t dst);
+int rp_dt_copy_config(rp_ctx_t *rp_ctx, rp_session_t *session, const char *module_name, sr_datastore_t src, sr_datastore_t dst, sr_error_info_t **errors, size_t *err_cnt);
 
 /**
  * @brief Changes the datastore of the session. Subsequent call will operate on the

--- a/src/rp_dt_edit.h
+++ b/src/rp_dt_edit.h
@@ -117,11 +117,15 @@ int rp_dt_delete_item_wrapper(rp_ctx_t *rp_ctx, rp_session_t *session, const cha
  * @param [in] rp_ctx
  * @param [in] session
  * @param [in] c_ctx - if argument is not NULL it is used as context to continue commit process
+ * @param [in] force_copy_uptodate True if timestamp check of session info datatree and datastore file should be
+ * skipped and session info datatree should be always used (otherwise if the timestamp of session datatrees is older
+ * than of datastore file, the datatrees are overwritten with data loaded from the datastore file)
  * @param [out] errors
  * @param [out] err_cnt
  * @return Error code (SR_ERR_OK on success), SR_ERR_COMMIT_FAILED, SR_ERR_VALIDATION_FAILED, SR_ERR_IO
  */
-int rp_dt_commit(rp_ctx_t *rp_ctx, rp_session_t *session, dm_commit_context_t *c_ctx, sr_error_info_t **errors, size_t *err_cnt);
+int rp_dt_commit(rp_ctx_t *rp_ctx, rp_session_t *session, dm_commit_context_t *c_ctx, bool force_copy_uptodate,
+        sr_error_info_t **errors, size_t *err_cnt);
 
 /**
  * @brief Tries to merge the current state of session with the file system change.

--- a/src/sysrepo.proto
+++ b/src/sysrepo.proto
@@ -537,6 +537,7 @@ message CopyConfigReq {
  * @brief Response to sr_copy_config request.
  */
 message CopyConfigResp {
+  repeated Error errors = 1;
 }
 
 

--- a/tests/cl_fd_watcher_test.c
+++ b/tests/cl_fd_watcher_test.c
@@ -172,6 +172,8 @@ cl_fd_poll_test(void **state)
     /* commit changes */
     rc = sr_commit(session);
     assert_int_equal(rc, SR_ERR_OK);
+    rc = sr_copy_config(session, "example-module", SR_DS_CANDIDATE, SR_DS_RUNNING);
+    assert_int_equal(rc, SR_ERR_OK);
 
     do {
         ret = poll(poll_fd_set, poll_fd_cnt, -1);

--- a/tests/cl_notifications_test.c
+++ b/tests/cl_notifications_test.c
@@ -201,6 +201,8 @@ cl_get_changes_create_test(void **state)
     pthread_mutex_lock(&changes.mutex);
     rc = sr_commit(session);
     assert_int_equal(rc, SR_ERR_OK);
+    rc = sr_copy_config(session, "example-module", SR_DS_CANDIDATE, SR_DS_RUNNING);
+    assert_int_equal(rc, SR_ERR_OK);
 
     sr_clock_get_time(CLOCK_REALTIME, &ts);
     ts.tv_sec += COND_WAIT_SEC;
@@ -282,6 +284,8 @@ cl_get_changes_modified_test(void **state)
     pthread_mutex_lock(&changes.mutex);
     rc = sr_commit(session);
     assert_int_equal(rc, SR_ERR_OK);
+    rc = sr_copy_config(session, "example-module", SR_DS_CANDIDATE, SR_DS_RUNNING);
+    assert_int_equal(rc, SR_ERR_OK);
 
     sr_clock_get_time(CLOCK_REALTIME, &ts);
     ts.tv_sec += COND_WAIT_SEC;
@@ -349,6 +353,8 @@ cl_get_changes_deleted_test(void **state)
     /* save changes to running */
     pthread_mutex_lock(&changes.mutex);
     rc = sr_commit(session);
+    assert_int_equal(rc, SR_ERR_OK);
+    rc = sr_copy_config(session, "example-module", SR_DS_CANDIDATE, SR_DS_RUNNING);
     assert_int_equal(rc, SR_ERR_OK);
 
     sr_clock_get_time(CLOCK_REALTIME, &ts);
@@ -558,6 +564,8 @@ cl_get_changes_deleted_default_test(void **state)
     pthread_mutex_lock(&changes.mutex);
     rc = sr_commit(session);
     assert_int_equal(rc, SR_ERR_OK);
+    rc = sr_copy_config(session, "test-module", SR_DS_CANDIDATE, SR_DS_RUNNING);
+    assert_int_equal(rc, SR_ERR_OK);
 
     sr_clock_get_time(CLOCK_REALTIME, &ts);
     ts.tv_sec += COND_WAIT_SEC;
@@ -639,6 +647,8 @@ cl_get_changes_create_default_test(void **state)
     /* save changes to running */
     pthread_mutex_lock(&changes.mutex);
     rc = sr_commit(session);
+    assert_int_equal(rc, SR_ERR_OK);
+    rc = sr_copy_config(session, "test-module", SR_DS_CANDIDATE, SR_DS_RUNNING);
     assert_int_equal(rc, SR_ERR_OK);
 
     sr_clock_get_time(CLOCK_REALTIME, &ts);
@@ -723,6 +733,8 @@ cl_get_changes_parents_test(void **state)
     pthread_mutex_lock(&changes.mutex);
     rc = sr_commit(session);
     assert_int_equal(rc, SR_ERR_OK);
+    rc = sr_copy_config(session, "test-module", SR_DS_CANDIDATE, SR_DS_RUNNING);
+    assert_int_equal(rc, SR_ERR_OK);
 
     sr_clock_get_time(CLOCK_REALTIME, &ts);
     ts.tv_sec += COND_WAIT_SEC;
@@ -790,6 +802,8 @@ cl_get_changes_parents_test(void **state)
     pthread_mutex_lock(&changes.mutex);
     rc = sr_commit(session);
     assert_int_equal(rc, SR_ERR_OK);
+    rc = sr_copy_config(session, "test-module", SR_DS_CANDIDATE, SR_DS_RUNNING);
+    assert_int_equal(rc, SR_ERR_OK);
 
     sr_clock_get_time(CLOCK_REALTIME, &ts);
     ts.tv_sec += COND_WAIT_SEC;
@@ -853,6 +867,8 @@ cl_get_changes_parents_test(void **state)
     pthread_mutex_lock(&changes.mutex);
     rc = sr_commit(session);
     assert_int_equal(rc, SR_ERR_OK);
+    rc = sr_copy_config(session, "test-module", SR_DS_CANDIDATE, SR_DS_RUNNING);
+    assert_int_equal(rc, SR_ERR_OK);
 
     sr_clock_get_time(CLOCK_REALTIME, &ts);
     ts.tv_sec += COND_WAIT_SEC;
@@ -911,6 +927,8 @@ cl_get_changes_parents_test(void **state)
     /* save changes to running */
     pthread_mutex_lock(&changes.mutex);
     rc = sr_commit(session);
+    assert_int_equal(rc, SR_ERR_OK);
+    rc = sr_copy_config(session, "test-module", SR_DS_CANDIDATE, SR_DS_RUNNING);
     assert_int_equal(rc, SR_ERR_OK);
 
     sr_clock_get_time(CLOCK_REALTIME, &ts);
@@ -1431,6 +1449,8 @@ cl_basic_verifier(void **state)
     pthread_mutex_lock(&changes.mutex);
     rc = sr_commit(session);
     assert_int_equal(rc, SR_ERR_OK);
+    rc = sr_copy_config(session, "example-module", SR_DS_CANDIDATE, SR_DS_RUNNING);
+    assert_int_equal(rc, SR_ERR_OK);
 
     sr_clock_get_time(CLOCK_REALTIME, &ts);
     ts.tv_sec += COND_WAIT_SEC;
@@ -1519,6 +1539,8 @@ cl_combined_subscribers(void **state)
     /* save changes to running */
     pthread_mutex_lock(&changesV.mutex);
     rc = sr_commit(session);
+    assert_int_equal(rc, SR_ERR_OK);
+    rc = sr_copy_config(session, NULL, SR_DS_CANDIDATE, SR_DS_RUNNING);
     assert_int_equal(rc, SR_ERR_OK);
 
     sr_clock_get_time(CLOCK_REALTIME, &ts);
@@ -1637,6 +1659,8 @@ cl_successful_verifiers(void **state)
     /* save changes to running */
     pthread_mutex_lock(&changesA.mutex);
     rc = sr_commit(session);
+    assert_int_equal(rc, SR_ERR_OK);
+    rc = sr_copy_config(session, NULL, SR_DS_CANDIDATE, SR_DS_RUNNING);
     assert_int_equal(rc, SR_ERR_OK);
 
     sr_clock_get_time(CLOCK_REALTIME, &ts);
@@ -1757,6 +1781,8 @@ cl_refused_by_verifier(void **state)
     /* save changes to running */
     pthread_mutex_lock(&changesA.mutex);
     rc = sr_commit(session);
+    assert_int_equal(rc, SR_ERR_OK);
+    rc = sr_copy_config(session, NULL, SR_DS_CANDIDATE, SR_DS_RUNNING);
     assert_int_equal(rc, SR_ERR_OPERATION_FAILED);
 
     sr_clock_get_time(CLOCK_REALTIME, &ts);
@@ -1863,6 +1889,8 @@ cl_no_abort_notifications(void **state)
 
     /* save changes to running */
     rc = sr_commit(session);
+    assert_int_equal(rc, SR_ERR_OK);
+    rc = sr_copy_config(session, "example-module", SR_DS_CANDIDATE, SR_DS_RUNNING);
     assert_int_equal(rc, SR_ERR_OPERATION_FAILED);
 
     assert_int_equal(changes.cnt, 0);
@@ -1935,6 +1963,8 @@ cl_one_abort_notification(void **state)
     /* save changes to running */
     pthread_mutex_lock(&changes.mutex);
     rc = sr_commit(session);
+    assert_int_equal(rc, SR_ERR_OK);
+    rc = sr_copy_config(session, "example-module", SR_DS_CANDIDATE, SR_DS_RUNNING);
     assert_int_equal(rc, SR_ERR_OPERATION_FAILED);
 
     sr_clock_get_time(CLOCK_REALTIME, &ts);
@@ -2006,6 +2036,8 @@ cl_subtree_verifier(void **state)
     /* save changes to running */
     pthread_mutex_lock(&changes.mutex);
     rc = sr_commit(session);
+    assert_int_equal(rc, SR_ERR_OK);
+    rc = sr_copy_config(session, "example-module", SR_DS_CANDIDATE, SR_DS_RUNNING);
     assert_int_equal(rc, SR_ERR_OK);
 
     sr_clock_get_time(CLOCK_REALTIME, &ts);
@@ -2682,6 +2714,8 @@ cl_read_old_config_in_verify_test(void **state)
     pthread_mutex_lock(&old_cfg.mutex);
     rc = sr_commit(session);
     assert_int_equal(rc, SR_ERR_OK);
+    rc = sr_copy_config(session, "example-module", SR_DS_CANDIDATE, SR_DS_RUNNING);
+    assert_int_equal(rc, SR_ERR_OK);
 
     sr_clock_get_time(CLOCK_REALTIME, &ts);
     ts.tv_sec += COND_WAIT_SEC;
@@ -2782,6 +2816,8 @@ cl_config_change_replay_test(void **state)
     /* save changes to running */
     pthread_mutex_lock(&changes.mutex);
     rc = sr_commit(session);
+    assert_int_equal(rc, SR_ERR_OK);
+    rc = sr_copy_config(session, "example-module", SR_DS_CANDIDATE, SR_DS_RUNNING);
     assert_int_equal(rc, SR_ERR_OK);
 
     sr_clock_get_time(CLOCK_REALTIME, &ts);

--- a/tests/cl_notifications_test.c
+++ b/tests/cl_notifications_test.c
@@ -456,6 +456,8 @@ cl_get_changes_moved_test(void **state)
     pthread_mutex_lock(&changes.mutex);
     rc = sr_commit(session);
     assert_int_equal(rc, SR_ERR_OK);
+    rc = sr_copy_config(session, "test-module", SR_DS_CANDIDATE, SR_DS_RUNNING);
+    assert_int_equal(rc, SR_ERR_OK);
 
     sr_clock_get_time(CLOCK_REALTIME, &ts);
     ts.tv_sec += COND_WAIT_SEC;

--- a/tests/cl_test.c
+++ b/tests/cl_test.c
@@ -4716,6 +4716,7 @@ cl_event_notif_tree_test(void **state)
     cl_test_en_cb_status_t cb_status;
     sr_node_t *trees = NULL;
     sr_node_t *tree = NULL;
+    sr_subscription_ctx_t *subscr = NULL;
     size_t tree_cnt = 0;
     size_t i;
     int rc = SR_ERR_OK;
@@ -4734,6 +4735,11 @@ cl_event_notif_tree_test(void **state)
         rc = sr_session_start(conn, SR_DS_RUNNING, SR_SESS_DEFAULT, &sub_session[i].session);
         assert_int_equal(rc, SR_ERR_OK);
     }
+
+    /* enable module */
+    rc = sr_module_change_subscribe(notif_session, "test-module", empty_module_change_cb, NULL,
+            0, SR_SUBSCR_DEFAULT | SR_SUBSCR_APPLY_ONLY, &subscr);
+    assert_int_equal(rc, SR_ERR_OK);
 
     /* subscribe for link discovery in every session */
     for (i = 0; i < CL_TEST_EN_NUM_SESSIONS; ++i) {
@@ -4893,6 +4899,8 @@ cl_event_notif_tree_test(void **state)
         rc = sr_unsubscribe(NULL, sub_session[i].subscription_st);
         assert_int_equal(rc, SR_ERR_OK);
     }
+    rc = sr_unsubscribe(NULL, subscr);
+    assert_int_equal(rc, SR_ERR_OK);
 
     /* stop sessions */
     rc = sr_session_stop(notif_session);
@@ -4919,6 +4927,7 @@ cl_event_notif_combo_test(void **state)
     cl_test_en_cb_status_t cb_status;
     sr_node_t *trees = NULL;
     sr_node_t *tree = NULL;
+    sr_subscription_ctx_t *subscr = NULL;
     sr_val_t values[4];
     size_t tree_cnt = 0;
     size_t i;
@@ -4939,6 +4948,11 @@ cl_event_notif_combo_test(void **state)
         rc = sr_session_start(conn, SR_DS_RUNNING, SR_SESS_DEFAULT, &sub_session[i].session);
         assert_int_equal(rc, SR_ERR_OK);
     }
+
+    /* enable module */
+    rc = sr_module_change_subscribe(notif_session, "test-module", empty_module_change_cb, NULL,
+            0, SR_SUBSCR_DEFAULT | SR_SUBSCR_APPLY_ONLY, &subscr);
+    assert_int_equal(rc, SR_ERR_OK);
 
     /* subscribe for link discovery in every session (mix of values and nodes) */
     for (i = 0; i < CL_TEST_EN_NUM_SESSIONS; ++i) {
@@ -5125,6 +5139,8 @@ cl_event_notif_combo_test(void **state)
         rc = sr_unsubscribe(NULL, sub_session[i].subscription_st);
         assert_int_equal(rc, SR_ERR_OK);
     }
+    rc = sr_unsubscribe(NULL, subscr);
+    assert_int_equal(rc, SR_ERR_OK);
 
     /* stop sessions */
     rc = sr_session_stop(notif_session);

--- a/tests/cl_test.c
+++ b/tests/cl_test.c
@@ -1685,6 +1685,19 @@ cl_locking_test(void **state)
     assert_string_equal("test-module", error->xpath);
     assert_string_equal("Module has been modified, it can not be locked. Discard or commit changes", error->message);
 
+    /* try locking one candidate module from 2 sessions */
+    rc = sr_session_switch_ds(sessionA, SR_DS_CANDIDATE);
+    assert_int_equal(rc, SR_ERR_OK);
+
+    rc = sr_session_switch_ds(sessionB, SR_DS_CANDIDATE);
+    assert_int_equal(rc, SR_ERR_OK);
+
+    rc = sr_lock_module(sessionA, "example-module");
+    assert_int_equal(rc, SR_ERR_OK);
+
+    rc = sr_lock_module(sessionB, "example-module");
+    assert_int_equal(rc, SR_ERR_OK);
+
     /* stop the sessions */
     rc = sr_session_stop(sessionA);
     assert_int_equal(rc, SR_ERR_OK);
@@ -1715,7 +1728,7 @@ cl_ds_locking_test(void **state)
     rc = sr_lock_datastore(sessionB);
     assert_int_equal(rc, SR_ERR_OK);
 
-    /* switch and lock candidate*/
+    /* switch and lock candidate */
     rc = sr_unlock_datastore(sessionA);
     assert_int_equal(rc, SR_ERR_OK);
 
@@ -1725,12 +1738,12 @@ cl_ds_locking_test(void **state)
     rc = sr_lock_datastore(sessionA);
     assert_int_equal(rc, SR_ERR_OK);
 
-    /* try to lock candidate from different session*/
+    /* try to lock candidate from different session, should succeed */
     rc = sr_session_switch_ds(sessionB, SR_DS_CANDIDATE);
     assert_int_equal(SR_ERR_OK, rc);
 
     rc = sr_lock_datastore(sessionB);
-    assert_int_equal(rc, SR_ERR_LOCKED);
+    assert_int_equal(rc, SR_ERR_OK);
 
     /* stop the sessions */
     rc = sr_session_stop(sessionA);
@@ -3674,6 +3687,8 @@ candidate_ds_test(void **state)
     assert_string_equal(value.data.string_val, val->data.string_val);
     sr_free_val(val);
 
+    rc = sr_commit(session_candidate);
+    assert_int_equal(SR_ERR_OK, rc);
     rc = sr_copy_config(session_candidate, "example-module", SR_DS_CANDIDATE, SR_DS_STARTUP);
     assert_int_equal(rc, SR_ERR_OK);
 

--- a/tests/cl_test.c
+++ b/tests/cl_test.c
@@ -3684,10 +3684,10 @@ candidate_ds_test(void **state)
     assert_string_equal(value.data.string_val, val->data.string_val);
     sr_free_val(val);
 
-    /* commit should fail because non enabled nodes are modified */
     rc = sr_commit(session_candidate);
-    assert_int_equal(SR_ERR_OPERATION_FAILED, rc);
+    assert_int_equal(SR_ERR_OK, rc);
 
+    /* copy-config should fail because non enabled nodes are modified */
     rc = sr_copy_config(session_candidate, "example-module", SR_DS_CANDIDATE, SR_DS_RUNNING);
     assert_int_equal(SR_ERR_OPERATION_FAILED, rc);
 
@@ -3696,8 +3696,11 @@ candidate_ds_test(void **state)
             &callback_called, 0, SR_SUBSCR_DEFAULT | SR_SUBSCR_APPLY_ONLY, &subscription);
     assert_int_equal(rc, SR_ERR_OK);
 
-    /* commit should pass */
-    rc = sr_commit(session_candidate);
+    /* copy-config should pass */
+    rc = sr_copy_config(session_candidate, "example-module", SR_DS_CANDIDATE, SR_DS_RUNNING);
+    assert_int_equal(SR_ERR_OK, rc);
+
+    rc = sr_session_refresh(session_running);
     assert_int_equal(SR_ERR_OK, rc);
 
     rc = sr_get_item(session_running, "/example-module:container/list[key1='key1'][key2='key2']/leaf", &val);
@@ -3706,7 +3709,7 @@ candidate_ds_test(void **state)
     assert_string_equal(value.data.string_val, val->data.string_val);
     sr_free_val(val);
 
-    /* copy config should work as well*/
+    /* another copy-config should work as well*/
     value.data.string_val = "xyz";
     rc = sr_set_item(session_candidate, value.xpath, &value, SR_EDIT_DEFAULT);
     assert_int_equal(rc, SR_ERR_OK);
@@ -3945,6 +3948,8 @@ cl_get_changes_iter_test(void **state)
     /* save changes to running */
     rc = sr_commit(session);
     assert_int_equal(rc, SR_ERR_OK);
+    rc = sr_copy_config(session, "example-module", SR_DS_CANDIDATE, SR_DS_RUNNING);
+    assert_int_equal(rc, SR_ERR_OK);
 
     sr_clock_get_time(CLOCK_REALTIME, &ts);
     ts.tv_sec += COND_WAIT_SEC;
@@ -4004,6 +4009,8 @@ cl_get_changes_iter_multi_test(void **state)
     /* save changes to running */
     rc = sr_commit(session);
     assert_int_equal(rc, SR_ERR_OK);
+    rc = sr_copy_config(session, "example-module", SR_DS_CANDIDATE, SR_DS_RUNNING);
+    assert_int_equal(rc, SR_ERR_OK);
 
     sr_clock_get_time(CLOCK_REALTIME, &ts);
     ts.tv_sec += COND_WAIT_SEC;
@@ -4030,6 +4037,8 @@ cl_get_changes_iter_multi_test(void **state)
     /* save changes to running */
     rc = sr_commit(session);
     assert_int_equal(rc, SR_ERR_OK);
+    rc = sr_copy_config(session, "example-module", SR_DS_CANDIDATE, SR_DS_RUNNING);
+    assert_int_equal(rc, SR_ERR_OK);
 
     sr_clock_get_time(CLOCK_REALTIME, &ts);
     ts.tv_sec += COND_WAIT_SEC;
@@ -4051,6 +4060,8 @@ cl_get_changes_iter_multi_test(void **state)
 
     /* save changes to running */
     rc = sr_commit(session);
+    assert_int_equal(rc, SR_ERR_OK);
+    rc = sr_copy_config(session, "example-module", SR_DS_CANDIDATE, SR_DS_RUNNING);
     assert_int_equal(rc, SR_ERR_OK);
 
     sr_clock_get_time(CLOCK_REALTIME, &ts);

--- a/tests/rp_datatree_test.c
+++ b/tests/rp_datatree_test.c
@@ -1515,7 +1515,7 @@ default_nodes_test(void **state)
     /* cleanup - remove all list instances */
     rc = rp_dt_delete_item_wrapper(ctx, ses_ctx, "/test-module:with_def", SR_EDIT_DEFAULT);
     assert_int_equal(SR_ERR_OK, rc);
-    rc = rp_dt_commit(ctx, ses_ctx, NULL, &errors, &e_cnt);
+    rc = rp_dt_commit(ctx, ses_ctx, NULL, false, &errors, &e_cnt);
     assert_int_equal(SR_ERR_OK, rc);
 
 
@@ -1690,7 +1690,7 @@ default_nodes_test(void **state)
     assert_false(tree->dflt);
     sr_free_tree(tree);
 
-    rc = rp_dt_commit(ctx, ses_ctx, NULL, &errors, &e_cnt);
+    rc = rp_dt_commit(ctx, ses_ctx, NULL, false, &errors, &e_cnt);
     assert_int_equal(SR_ERR_OK, rc);
 
     /* check after commit */
@@ -1781,7 +1781,7 @@ default_nodes_test(void **state)
     /* clean up*/
     rc = rp_dt_delete_item_wrapper(ctx, ses_ctx, "/test-module:with_def", SR_EDIT_DEFAULT);
     assert_int_equal(SR_ERR_OK, rc);
-    rc = rp_dt_commit(ctx, ses_ctx, NULL, &errors, &e_cnt);
+    rc = rp_dt_commit(ctx, ses_ctx, NULL, false, &errors, &e_cnt);
     assert_int_equal(SR_ERR_OK, rc);
 
     test_rp_session_cleanup(ctx, ses_ctx);
@@ -1829,7 +1829,7 @@ default_nodes_toplevel_test(void **state)
     assert_int_equal(SR_ERR_OK, rc);
     rc = rp_dt_delete_item_wrapper(ctx, ses_ctx, "/referenced-data:*", SR_EDIT_DEFAULT);
     assert_int_equal(SR_ERR_OK, rc);
-    rc = rp_dt_commit(ctx, ses_ctx, NULL, &errors, &e_cnt);
+    rc = rp_dt_commit(ctx, ses_ctx, NULL, false, &errors, &e_cnt);
     assert_int_equal(SR_ERR_OK, rc);
 
     ses_ctx->state = RP_REQ_NEW;

--- a/tests/rp_dt_edit_test.c
+++ b/tests/rp_dt_edit_test.c
@@ -1152,7 +1152,7 @@ void edit_instance_id_test(void **state) {
     rc = rp_dt_set_item_wrapper(ctx, session, "/test-module:main/instance_id", value, NULL, SR_EDIT_DEFAULT);
     assert_int_equal(SR_ERR_OK, rc);
 
-    rc = rp_dt_commit(ctx, session, NULL, &errors, &e_cnt);
+    rc = rp_dt_commit(ctx, session, NULL, false, &errors, &e_cnt);
     assert_int_equal(SR_ERR_OK, rc);
 
     rc = rp_dt_refresh_session(ctx, session, &errors, &e_cnt);
@@ -1175,7 +1175,7 @@ void edit_instance_id_test(void **state) {
     rc = rp_dt_set_item_wrapper(ctx, session, "/test-module:main/instance_id", value, NULL, SR_EDIT_DEFAULT);
     assert_int_equal(SR_ERR_OK, rc);
 
-    rc = rp_dt_commit(ctx, session, NULL, &errors, &e_cnt);
+    rc = rp_dt_commit(ctx, session, NULL, false, &errors, &e_cnt);
     assert_int_equal(SR_ERR_OK, rc);
 
     rc = rp_dt_refresh_session(ctx, session, &errors, &e_cnt);
@@ -1198,7 +1198,7 @@ void edit_instance_id_test(void **state) {
     rc = rp_dt_set_item_wrapper(ctx, session, "/test-module:main/instance_id", value, NULL, SR_EDIT_DEFAULT);
     assert_int_equal(SR_ERR_OK, rc);
 
-    rc = rp_dt_commit(ctx, session, NULL, &errors, &e_cnt);
+    rc = rp_dt_commit(ctx, session, NULL, false, &errors, &e_cnt);
     assert_int_equal(SR_ERR_OK, rc);
 
     rc = rp_dt_refresh_session(ctx, session, &errors, &e_cnt);
@@ -1221,7 +1221,7 @@ void edit_instance_id_test(void **state) {
     rc = rp_dt_set_item_wrapper(ctx, session, "/test-module:main/instance_id", value, NULL, SR_EDIT_DEFAULT);
     assert_int_equal(SR_ERR_OK, rc);
 
-    rc = rp_dt_commit(ctx, session, NULL, &errors, &e_cnt);
+    rc = rp_dt_commit(ctx, session, NULL, false, &errors, &e_cnt);
     assert_int_equal(SR_ERR_OK, rc);
 
     rc = rp_dt_refresh_session(ctx, session, &errors, &e_cnt);
@@ -1647,7 +1647,7 @@ empty_commit_test(void **state)
     /* no session copy made*/
     sr_error_info_t *errors = NULL;
     size_t err_cnt = 0;
-    rc = rp_dt_commit(ctx, session, NULL, &errors, &err_cnt);
+    rc = rp_dt_commit(ctx, session, NULL, false, &errors, &err_cnt);
     assert_int_equal(SR_ERR_OK, rc);
     sr_free_errors(errors, err_cnt);
 
@@ -1655,7 +1655,7 @@ empty_commit_test(void **state)
     rc = dm_get_data_info(ctx->dm_ctx, session->dm_session, "test-module", &info);
     assert_int_equal(SR_ERR_OK, rc);
 
-    rc = rp_dt_commit(ctx, session, NULL, &errors, &err_cnt);
+    rc = rp_dt_commit(ctx, session, NULL, false, &errors, &err_cnt);
     assert_int_equal(SR_ERR_OK, rc);
     sr_free_errors(errors, err_cnt);
 
@@ -1663,7 +1663,7 @@ empty_commit_test(void **state)
     assert_int_equal(SR_ERR_OK, rc);
     info->modified = true;
 
-    rc = rp_dt_commit(ctx, session, NULL, &errors, &err_cnt);
+    rc = rp_dt_commit(ctx, session, NULL, false, &errors, &err_cnt);
     assert_int_equal(SR_ERR_OK, rc);
     sr_free_errors(errors, err_cnt);
 
@@ -1720,7 +1720,7 @@ edit_commit_test(void **state)
     sr_error_info_t *errors = NULL;
     size_t e_cnt = 0;
 
-    rc = rp_dt_commit(ctx, sessionA, NULL, &errors, &e_cnt);
+    rc = rp_dt_commit(ctx, sessionA, NULL, false, &errors, &e_cnt);
     assert_int_equal(SR_ERR_OK, rc);
     sr_free_errors(errors, e_cnt);
 
@@ -1757,7 +1757,7 @@ edit_commit_test(void **state)
     rc = rp_dt_set_item_wrapper(ctx, sessionA, XP_TEST_MODULE_INT64, valueA, NULL, SR_EDIT_DEFAULT);
     assert_int_equal(SR_ERR_OK, rc);
 
-    rc = rp_dt_commit(ctx, sessionA, NULL, &errors, &e_cnt);
+    rc = rp_dt_commit(ctx, sessionA, NULL, false, &errors, &e_cnt);
     assert_int_equal(SR_ERR_OK, rc);
     sr_free_errors(errors, e_cnt);
 
@@ -1783,11 +1783,11 @@ edit_commit2_test(void **state)
 
     sr_error_info_t *errors = NULL;
     size_t e_cnt = 0;
-    rc = rp_dt_commit(ctx, session, NULL, &errors, &e_cnt);
+    rc = rp_dt_commit(ctx, session, NULL, false, &errors, &e_cnt);
     assert_int_equal(SR_ERR_OK, rc);
 
     /*this commit should failed because main container is already deleted */
-    rc = rp_dt_commit(ctx, sessionB, NULL, &errors, &e_cnt);
+    rc = rp_dt_commit(ctx, sessionB, NULL, false, &errors, &e_cnt);
     assert_int_equal(SR_ERR_DATA_MISSING, rc);
     sr_free_errors(errors, e_cnt);
 
@@ -1828,11 +1828,11 @@ edit_commit3_test(void **state)
     sr_error_info_t *errors = NULL;
     size_t e_cnt = 0;
 
-    rc = rp_dt_commit(ctx, session, NULL, &errors, &e_cnt);
+    rc = rp_dt_commit(ctx, session, NULL, false, &errors, &e_cnt);
     assert_int_equal(SR_ERR_OK, rc);
 
     /* the leaf-list value was committed during the first commit */
-    rc = rp_dt_commit(ctx, sessionB, NULL, &errors, &e_cnt);
+    rc = rp_dt_commit(ctx, sessionB, NULL, false, &errors, &e_cnt);
     assert_int_equal(SR_ERR_DATA_EXISTS, rc);
     sr_free_errors(errors, e_cnt);
 
@@ -1864,7 +1864,7 @@ edit_commit4_test(void **state)
 
     sr_error_info_t *errors = NULL;
     size_t e_cnt = 0;
-    rc = rp_dt_commit(ctx, session, NULL, &errors, &e_cnt);
+    rc = rp_dt_commit(ctx, session, NULL, false, &errors, &e_cnt);
     assert_int_equal(SR_ERR_OK, rc);
 
     test_rp_session_cleanup(ctx, session);
@@ -2233,7 +2233,7 @@ lock_commit_test(void **state)
    /* commit A should fail */
    size_t e_cnt = 0;
    sr_error_info_t *errors = NULL;
-   rc = rp_dt_commit(ctx, sessionA, NULL, &errors, &e_cnt);
+   rc = rp_dt_commit(ctx, sessionA, NULL, false, &errors, &e_cnt);
    assert_int_equal(SR_ERR_LOCKED, rc);
 
    /* unlock B */
@@ -2241,7 +2241,7 @@ lock_commit_test(void **state)
    assert_int_equal(SR_ERR_OK, rc);
 
    /* commit A should succeed */
-   rc = rp_dt_commit(ctx, sessionA, NULL, &errors, &e_cnt);
+   rc = rp_dt_commit(ctx, sessionA, NULL, false, &errors, &e_cnt);
    assert_int_equal(SR_ERR_OK, rc);
 
    /* should be still locked even after commit */
@@ -2273,7 +2273,7 @@ empty_string_leaf_test(void **state)
 
    size_t e_cnt = 0;
    sr_error_info_t *errors = NULL;
-   rc = rp_dt_commit(ctx, sessionA, NULL, &errors, &e_cnt);
+   rc = rp_dt_commit(ctx, sessionA, NULL, false, &errors, &e_cnt);
    assert_int_equal(SR_ERR_OK, rc);
 
    sr_val_t *retrieved = NULL;
@@ -2430,7 +2430,7 @@ candidate_commit_lock_test(void **state)
     assert_int_equal(SR_ERR_OK, rc);
 
     /* commit failed running locked */
-    rc = rp_dt_commit(ctx, sessionA, NULL, &errors, &e_cnt);
+    rc = rp_dt_commit(ctx, sessionA, NULL, false, &errors, &e_cnt);
     assert_int_equal(SR_ERR_LOCKED, rc);
     sr_free_errors(errors, e_cnt);
 
@@ -2438,7 +2438,7 @@ candidate_commit_lock_test(void **state)
     assert_int_equal(SR_ERR_OK, rc);
 
     /* commit failed running & candidate locked */
-    rc = rp_dt_commit(ctx, sessionA, NULL, &errors, &e_cnt);
+    rc = rp_dt_commit(ctx, sessionA, NULL, false, &errors, &e_cnt);
     assert_int_equal(SR_ERR_LOCKED, rc);
     sr_free_errors(errors, e_cnt);
 
@@ -2446,14 +2446,14 @@ candidate_commit_lock_test(void **state)
     assert_int_equal(SR_ERR_OK, rc);
 
     /* commit failed candidate locked */
-    rc = rp_dt_commit(ctx, sessionA, NULL, &errors, &e_cnt);
+    rc = rp_dt_commit(ctx, sessionA, NULL, false, &errors, &e_cnt);
     assert_int_equal(SR_ERR_LOCKED, rc);
     sr_free_errors(errors, e_cnt);
 
     rc = dm_unlock_module(ctx->dm_ctx, sessionC->dm_session, "test-module");
     assert_int_equal(SR_ERR_OK, rc);
 
-    rc = rp_dt_commit(ctx, sessionA, NULL, &errors, &e_cnt);
+    rc = rp_dt_commit(ctx, sessionA, NULL, false, &errors, &e_cnt);
     assert_int_equal(SR_ERR_OK, rc);
 
     rc = rp_dt_get_value_wrapper(ctx, sessionA, NULL, "/test-module:main/i8", &value);

--- a/tests/rp_dt_edit_test.c
+++ b/tests/rp_dt_edit_test.c
@@ -2359,32 +2359,34 @@ copy_to_running_test(void **state)
     int rc = 0;
     rp_ctx_t *ctx = *state;
     rp_session_t *sessionA = NULL, *sessionB = NULL;
+    sr_error_info_t *errors = NULL;
+    size_t e_cnt = 0;
 
     test_rp_session_create(ctx, SR_DS_CANDIDATE, &sessionA);
     test_rp_session_create(ctx, SR_DS_STARTUP, &sessionB);
 
     /* only enabled modules are copied, no module is enabled => no operation*/
-    rc = rp_dt_copy_config(ctx, sessionB, NULL, SR_DS_STARTUP, SR_DS_RUNNING);
+    rc = rp_dt_copy_config(ctx, sessionB, NULL, SR_DS_STARTUP, SR_DS_RUNNING, &errors, &e_cnt);
     assert_int_equal(SR_ERR_OK, rc);
 
     /* explictly select a module which is not enabled copy fails*/
-    rc = rp_dt_copy_config(ctx, sessionB, "test-module", SR_DS_STARTUP, SR_DS_RUNNING);
+    rc = rp_dt_copy_config(ctx, sessionB, "test-module", SR_DS_STARTUP, SR_DS_RUNNING, &errors, &e_cnt);
     assert_int_equal(SR_ERR_OPERATION_FAILED, rc);
 
     /* only enabled modules are copied, no module is enabled => no operation*/
-    rc = rp_dt_copy_config(ctx, sessionA, NULL, SR_DS_CANDIDATE, SR_DS_RUNNING);
+    rc = rp_dt_copy_config(ctx, sessionA, NULL, SR_DS_CANDIDATE, SR_DS_RUNNING, &errors, &e_cnt);
     assert_int_equal(SR_ERR_OK, rc);
 
     /* empty data tree loaded from running (source of candidate) can be copied to running */
-    rc = rp_dt_copy_config(ctx, sessionA, "test-module", SR_DS_CANDIDATE, SR_DS_RUNNING);
+    rc = rp_dt_copy_config(ctx, sessionA, "test-module", SR_DS_CANDIDATE, SR_DS_RUNNING, &errors, &e_cnt);
     assert_int_equal(SR_ERR_OK, rc);
 
     /* copy startup to candidate */
-    rc = rp_dt_copy_config(ctx, sessionA, "test-module", SR_DS_STARTUP, SR_DS_CANDIDATE);
+    rc = rp_dt_copy_config(ctx, sessionA, "test-module", SR_DS_STARTUP, SR_DS_CANDIDATE, &errors, &e_cnt);
     assert_int_equal(SR_ERR_OK, rc);
 
     /* copy of not enabled module to running should fail */
-    rc = rp_dt_copy_config(ctx, sessionA, "test-module", SR_DS_CANDIDATE, SR_DS_RUNNING);
+    rc = rp_dt_copy_config(ctx, sessionA, "test-module", SR_DS_CANDIDATE, SR_DS_RUNNING, &errors, &e_cnt);
     assert_int_equal(SR_ERR_OPERATION_FAILED, rc);
 
     test_rp_session_cleanup(ctx, sessionA);

--- a/tests/rp_dt_edit_test.c
+++ b/tests/rp_dt_edit_test.c
@@ -2372,6 +2372,9 @@ copy_to_running_test(void **state)
     /* explictly select a module which is not enabled copy fails*/
     rc = rp_dt_copy_config(ctx, sessionB, "test-module", SR_DS_STARTUP, SR_DS_RUNNING, &errors, &e_cnt);
     assert_int_equal(SR_ERR_OPERATION_FAILED, rc);
+    sr_free_errors(errors, e_cnt);
+    errors = NULL;
+    e_cnt = 0;
 
     /* only enabled modules are copied, no module is enabled => no operation*/
     rc = rp_dt_copy_config(ctx, sessionA, NULL, SR_DS_CANDIDATE, SR_DS_RUNNING, &errors, &e_cnt);
@@ -2388,6 +2391,7 @@ copy_to_running_test(void **state)
     /* copy of not enabled module to running should fail */
     rc = rp_dt_copy_config(ctx, sessionA, "test-module", SR_DS_CANDIDATE, SR_DS_RUNNING, &errors, &e_cnt);
     assert_int_equal(SR_ERR_OPERATION_FAILED, rc);
+    sr_free_errors(errors, e_cnt);
 
     test_rp_session_cleanup(ctx, sessionA);
     test_rp_session_cleanup(ctx, sessionB);

--- a/tests/sysrepocfg_test.c
+++ b/tests/sysrepocfg_test.c
@@ -1224,7 +1224,7 @@ main() {
             cmocka_unit_test_setup_teardown(srcfg_test_editing, srcfg_test_set_startup_datastore, srcfg_test_teardown),
             cmocka_unit_test_setup_teardown(srcfg_test_editing, srcfg_test_set_running_datastore, srcfg_test_teardown),
             cmocka_unit_test_setup_teardown(srcfg_test_import, srcfg_test_init_datastore_content, NULL),
-            cmocka_unit_test_setup_teardown(srcfg_test_xpath, srcfg_test_set_running_datastore, NULL),
+            cmocka_unit_test_setup_teardown(srcfg_test_xpath, srcfg_test_set_running_datastore, srcfg_test_teardown),
             cmocka_unit_test_setup_teardown(srcfg_test_merge, srcfg_test_set_running_datastore_merge, NULL)
     };
 

--- a/tests/sysrepoctl_test.c
+++ b/tests/sysrepoctl_test.c
@@ -89,7 +89,6 @@ sysrepoctl_test_uninstall(void **state)
     test_file_exists(TEST_DATA_SEARCH_DIR "ietf-interfaces.startup.lock", true);
     test_file_exists(TEST_DATA_SEARCH_DIR "ietf-interfaces.running", true);
     test_file_exists(TEST_DATA_SEARCH_DIR "ietf-interfaces.running.lock", true);
-    test_file_exists(TEST_DATA_SEARCH_DIR "ietf-interfaces.candidate.lock", true);
     test_file_exists(TEST_DATA_SEARCH_DIR "ietf-interfaces.persist", true);
     exec_shell_command("../src/sysrepoctl -l", "ietf-interfaces", true, 0);
 
@@ -108,7 +107,6 @@ sysrepoctl_test_uninstall(void **state)
     test_file_exists(TEST_DATA_SEARCH_DIR "ietf-interfaces.startup.lock", true);
     test_file_exists(TEST_DATA_SEARCH_DIR "ietf-interfaces.running", true);
     test_file_exists(TEST_DATA_SEARCH_DIR "ietf-interfaces.running.lock", true);
-    test_file_exists(TEST_DATA_SEARCH_DIR "ietf-interfaces.candidate.lock", true);
     test_file_exists(TEST_DATA_SEARCH_DIR "ietf-interfaces.persist", true);
     exec_shell_command("../src/sysrepoctl -l", "ietf-interfaces", true, 0);
 
@@ -124,7 +122,6 @@ sysrepoctl_test_uninstall(void **state)
     test_file_exists(TEST_DATA_SEARCH_DIR "ietf-interfaces.startup.lock", false);
     test_file_exists(TEST_DATA_SEARCH_DIR "ietf-interfaces.running", false);
     test_file_exists(TEST_DATA_SEARCH_DIR "ietf-interfaces.running.lock", false);
-    test_file_exists(TEST_DATA_SEARCH_DIR "ietf-interfaces.candidate.lock", false);
     test_file_exists(TEST_DATA_SEARCH_DIR "ietf-interfaces.persist", false);
     exec_shell_command("../src/sysrepoctl -l", "!ietf-interfaces", true, 0);
 
@@ -169,7 +166,6 @@ sysrepoctl_test_install(void **state)
     test_file_exists(TEST_DATA_SEARCH_DIR "ietf-ip.startup.lock", false);
     test_file_exists(TEST_DATA_SEARCH_DIR "ietf-ip.running", false);
     test_file_exists(TEST_DATA_SEARCH_DIR "ietf-ip.running.lock", false);
-    test_file_exists(TEST_DATA_SEARCH_DIR "ietf-ip.candidate.lock", false);
     /* since file contains feature definition persist file is created */
     test_file_exists(TEST_DATA_SEARCH_DIR "ietf-ip.persist", true);
 
@@ -179,7 +175,6 @@ sysrepoctl_test_install(void **state)
     test_file_exists(TEST_DATA_SEARCH_DIR "ietf-interfaces.startup.lock", true);
     test_file_exists(TEST_DATA_SEARCH_DIR "ietf-interfaces.running", true);
     test_file_exists(TEST_DATA_SEARCH_DIR "ietf-interfaces.running.lock", true);
-    test_file_exists(TEST_DATA_SEARCH_DIR "ietf-interfaces.candidate.lock", true);
     test_file_exists(TEST_DATA_SEARCH_DIR "ietf-interfaces.persist", true);
     snprintf(buff, PATH_MAX, "ietf-interfaces[[:space:]]*\\| 2014-05-08 \\| Implemented[[:space:]]*\\| %s:[[:alnum:]]*[[:space:]]*\\| 644[[:space:]]*\\|", user);
     exec_shell_command("../src/sysrepoctl -l", buff, true, 0);
@@ -190,7 +185,6 @@ sysrepoctl_test_install(void **state)
     test_file_exists(TEST_DATA_SEARCH_DIR "test-dep-installed.startup.lock", true);
     test_file_exists(TEST_DATA_SEARCH_DIR "test-dep-installed.running", true);
     test_file_exists(TEST_DATA_SEARCH_DIR "test-dep-installed.running.lock", true);
-    test_file_exists(TEST_DATA_SEARCH_DIR "test-dep-installed.candidate.lock", true);
     test_file_exists(TEST_DATA_SEARCH_DIR "test-dep-installed.persist", true);
     snprintf(buff, PATH_MAX, "test-dep-installed[[:space:]]*\\|[[:space:]]*\\| Installed[[:space:]]*\\| %s:[[:alnum:]]*[[:space:]]*\\| 644[[:space:]]*\\|", user);
     exec_shell_command("../src/sysrepoctl -l", buff, true, 0);
@@ -247,7 +241,6 @@ sysrepoctl_test_change(void **state)
     test_file_owner(TEST_DATA_SEARCH_DIR "ietf-interfaces.startup.lock", user);
     test_file_owner(TEST_DATA_SEARCH_DIR "ietf-interfaces.running", user);
     test_file_owner(TEST_DATA_SEARCH_DIR "ietf-interfaces.running.lock", user);
-    test_file_owner(TEST_DATA_SEARCH_DIR "ietf-interfaces.candidate.lock", user);
     test_file_owner(TEST_DATA_SEARCH_DIR "ietf-interfaces.persist", user);
 
     mode_t mode = S_IRUSR | S_IWUSR | S_IRGRP | S_IWGRP | S_IROTH;
@@ -255,7 +248,6 @@ sysrepoctl_test_change(void **state)
     test_file_permissions(TEST_DATA_SEARCH_DIR "ietf-interfaces.startup.lock", mode);
     test_file_permissions(TEST_DATA_SEARCH_DIR "ietf-interfaces.running", mode);
     test_file_permissions(TEST_DATA_SEARCH_DIR "ietf-interfaces.running.lock", mode);
-    test_file_permissions(TEST_DATA_SEARCH_DIR "ietf-interfaces.candidate.lock", mode);
     test_file_permissions(TEST_DATA_SEARCH_DIR "ietf-interfaces.persist", mode);
 }
 


### PR DESCRIPTION
### Description
Bulky pull request, whose main feature is changing commit functionality and candidate datastore behavior. Commit is now unified for all datastores and always applies performed changes and checks NACM. For candidate datastore there is nowhere to apply the changes since they always are session-exclusive, so only NACM is checked. Also, candidate lock is now session-exclusive as it should have been. To perform NETCONF commit, copy_config can be used.

Another major change includes finishing copy_config (candidate -> running was significantly broken and unfinished). Also, non-deterministic cl_test failures should be fixed now. Lastly, some minor bugfixes, improvements, and optimizations are included.

### Test case
New features briefly tested in cl_test, cl_notifications_test and rp_dt_edit_test.
