### PR TITLE
libyang api changes and xpath fixes

### DIFF
--- a/src/common/sr_utils.c
+++ b/src/common/sr_utils.c
@@ -1443,7 +1443,7 @@ sr_api_variant_from_str(const char *api_variant_str)
 /**
  * @brief Copy and convert content of a libyang node and its descendands into a sysrepo tree.
  *
- * @param [in] parent Parent node.
+ * @param [in] top_parent Top-level parent node.
  * @param [in] node libyang node.
  * @param [in] depth Depth of the node relative to the root node.
  * @param [in] slice_offset Number of child nodes of the chunk root to skip.
@@ -1453,7 +1453,7 @@ sr_api_variant_from_str(const char *api_variant_str)
  * @param [out] sr_tree Returned sysrepo tree.
  */
 static int
-sr_copy_node_to_tree_internal(const struct lyd_node *parent, const struct lyd_node *node, size_t depth,
+sr_copy_node_to_tree_internal(const struct lyd_node *top_parent, const struct lyd_node *node, size_t depth,
          size_t slice_offset, size_t slice_width, size_t child_limit, size_t depth_limit,
          sr_tree_pruning_cb pruning_cb, void *pruning_ctx, sr_node_t *sr_tree)
 {
@@ -1505,7 +1505,7 @@ sr_copy_node_to_tree_internal(const struct lyd_node *parent, const struct lyd_no
     sr_tree->dflt = node->dflt;
 
     /* set module_name */
-    if (NULL == parent || lyd_node_module(parent) != lyd_node_module(node)) {
+    if (NULL == top_parent || lyd_node_module(top_parent) != lyd_node_module(node)) {
         rc = sr_node_set_module(sr_tree, lyd_node_module(node)->name);
         CHECK_RC_MSG_GOTO(rc, cleanup, "Failed to set module of a sysrepo node.");
     }
@@ -1532,7 +1532,7 @@ sr_copy_node_to_tree_internal(const struct lyd_node *parent, const struct lyd_no
                 if (SR_ERR_OK != rc) {
                     goto cleanup;
                 }
-                rc = sr_copy_node_to_tree_internal(node, child, depth + 1, slice_offset, slice_width,
+                rc = sr_copy_node_to_tree_internal(top_parent ? top_parent : node, child, depth + 1, slice_offset, slice_width,
                         child_limit, depth_limit, pruning_cb, pruning_ctx, sr_subtree);
                 if (SR_ERR_OK != rc) {
                     goto cleanup;
@@ -2324,7 +2324,7 @@ struct lys_node *
 sr_find_schema_node(const struct lys_node *node, const char *expr, int options)
 {
     struct lys_node *result = NULL;
-    struct ly_set *set = lys_find_xpath(NULL, node, expr, options);
+    struct ly_set *set = lys_find_xpath(node, expr, options);
     if (NULL != set && 1 == set->number) {
         result = set->set.s[0];
     }

--- a/src/executables/sysrepocfg.c
+++ b/src/executables/sysrepocfg.c
@@ -1112,7 +1112,7 @@ srcfg_import_xpath(struct ly_ctx *ly_ctx, const char *xpath, const char *xpathva
         goto cleanup;
     }
 
-    lyset = lys_find_xpath(ly_ctx, current_dt->schema, xpath, 0);
+    lyset = lys_find_xpath(current_dt->schema, xpath, 0);
     if (lyset && lyset->number) {
         for (j=0; j < lyset->number; j++) {
             //printf("node name %s,%s,%d nodetype %d\n", lyset->set.s[j]->name, lys_path(lyset->set.s[j]), lyset->number, lyset->set.s[j]->nodetype);

--- a/src/notification_processor.c
+++ b/src/notification_processor.c
@@ -867,7 +867,7 @@ np_validate_subscription_xpath(np_ctx_t *np_ctx, Sr__SubscriptionType type, cons
         CHECK_RC_LOG_GOTO(rc, cleanup, "Failed to find module %s", module_name);
 
         if (SR__SUBSCRIPTION_TYPE__EVENT_NOTIF_SUBS == type) {
-            set = lys_find_xpath(NULL, si->module->data, xpath, 0);
+            set = lys_find_xpath(si->module->data, xpath, 0);
             if (NULL == set || 0 == set->number) {
                 SR_LOG_ERR("Node identified by xpath %s was not found", xpath);
                 rc = SR_ERR_BAD_ELEMENT;

--- a/src/rp_dt_get.c
+++ b/src/rp_dt_get.c
@@ -588,7 +588,7 @@ rp_dt_get_tree_roots(dm_schema_info_t *schema_info, const char *xpath, struct ly
     rc = rp_dt_get_start_node(schema_info, xpath, &start_node);
     CHECK_RC_LOG_RETURN(rc, "Failed to get the start node for xpath %s", xpath);
 
-    *roots = lys_find_xpath(NULL, start_node, xpath, 0);
+    *roots = lys_find_xpath(start_node, xpath, 0);
     if (NULL == *roots) {
         SR_LOG_ERR("Failed to get the set of tree roots for xpath %s", xpath);
         rc = SR_ERR_INVAL_ARG;

--- a/tests/cl_notifications_test.c
+++ b/tests/cl_notifications_test.c
@@ -2428,7 +2428,7 @@ cl_auto_enable_manadatory_nodes(void **state)
     rc = sr_session_start(conn, SR_DS_STARTUP, SR_SESS_DEFAULT, &session);
     assert_int_equal(rc, SR_ERR_OK);
 
-    rc = sr_subtree_change_subscribe(session, "/ietf-interfaces:interfaces/interface/ietf-ip:ipv4/address", cl_empty_module_cb, NULL,
+    rc = sr_subtree_change_subscribe(session, "/ietf-interfaces:interfaces/interface/ietf-ip:ipv4/ietf-ip:address", cl_empty_module_cb, NULL,
             0, SR_SUBSCR_DEFAULT, &subscription);
     assert_int_equal(rc, SR_ERR_OK);
 

--- a/tests/dm_test.c
+++ b/tests/dm_test.c
@@ -1055,13 +1055,13 @@ dm_schema_node_xpath_hash(void **state)
     verify_xpath_hash(node, hash);
     verify_data_depth(node, 2);
 
-    node = get_single_node(data_tree, "/ietf-interfaces:interfaces/interface[name='eth0']/ietf-ip:ipv4/enabled");
+    node = get_single_node(data_tree, "/ietf-interfaces:interfaces/interface[name='eth0']/ietf-ip:ipv4/ietf-ip:enabled");
     hash = sr_str_hash("ietf-interfaces:interfaces") + sr_str_hash("ietf-interfaces:interface")
            + sr_str_hash("ietf-ip:ipv4") + sr_str_hash("ietf-ip:enabled");
     verify_xpath_hash(node, hash);
     verify_data_depth(node, 3);
 
-    node = get_single_node(data_tree, "/ietf-interfaces:interfaces/interface[name='eth0']/ietf-ip:ipv4/address[ip='192.168.2.100']/ip");
+    node = get_single_node(data_tree, "/ietf-interfaces:interfaces/interface[name='eth0']/ietf-ip:ipv4/ietf-ip:address[ietf-ip:ip='192.168.2.100']/ietf-ip:ip");
     hash = sr_str_hash("ietf-interfaces:interfaces") + sr_str_hash("ietf-interfaces:interface")
            + sr_str_hash("ietf-ip:ipv4") + sr_str_hash("ietf-ip:address") + sr_str_hash("ietf-ip:ip");
     verify_xpath_hash(node, hash);

--- a/tests/helpers/test_module_helper.c
+++ b/tests/helpers/test_module_helper.c
@@ -351,12 +351,12 @@ createDataTreeLargeIETFinterfacesModule(size_t if_count)
     struct lyd_node *root = NULL;
 
     #define MAX_IF_LEN 150
-    const char *template_prefix_len = "/ietf-interfaces:interfaces/interface[name='eth%d']/ietf-ip:ipv4/address[ip='192.168.%d.%d']/prefix-length";
+    const char *template_prefix_len = "/ietf-interfaces:interfaces/interface[name='eth%d']/ietf-ip:ipv4/ietf-ip:address[ietf-ip:ip='192.168.%d.%d']/ietf-ip:prefix-length";
     const char *template_type = "/ietf-interfaces:interfaces/interface[name='eth%d']/type";
     const char *template_desc = "/ietf-interfaces:interfaces/interface[name='eth%d']/description";
     const char *template_enabled = "/ietf-interfaces:interfaces/interface[name='eth%d']/enabled";
-    const char *template_ipv4_enabled = "/ietf-interfaces:interfaces/interface[name='eth%d']/ietf-ip:ipv4/enabled";
-    const char *template_ipv4_mtu = "/ietf-interfaces:interfaces/interface[name='eth%d']/ietf-ip:ipv4/mtu";
+    const char *template_ipv4_enabled = "/ietf-interfaces:interfaces/interface[name='eth%d']/ietf-ip:ipv4/ietf-ip:enabled";
+    const char *template_ipv4_mtu = "/ietf-interfaces:interfaces/interface[name='eth%d']/ietf-ip:ipv4/ietf-ip:mtu";
     char xpath[MAX_IF_LEN] = {0,};
 
     const struct lys_module *module_interfaces = ly_ctx_load_module(ctx, "ietf-interfaces", NULL);

--- a/tests/md_test.c
+++ b/tests/md_test.c
@@ -79,7 +79,7 @@ static const char * const md_submodule_B_sub1_body =
 "  }\n"
 "\n"
 "  leaf tax-enabled {\n"
-"    when \"/A:base-container/name = 'tax authority'\";\n"
+"    when \"/A:base-container/A:name = 'tax authority'\";\n"
 "    type boolean;\n"
 "  }";
 
@@ -172,7 +172,7 @@ static const char * const md_module_C_body =
 "      type int16;\n"
 "    }\n"
 "    leaf tax {\n"
-"      when \"/A:base-container/num > ../limit\";\n"
+"      when \"/A:base-container/A:num > ../limit\";\n"
 "      type int16;\n"
 "    }\n"
 "  }";
@@ -192,7 +192,7 @@ static const char * const md_module_D_rev1_body =
 "  }\n"
 "\n"
 "  leaf vat {\n"
-"    must \". <= /C:conditional-data/tax\";\n"
+"    must \". <= /C:conditional-data/C:tax\";\n"
 "    type uint16;\n"
 "  }";
 
@@ -227,7 +227,7 @@ static const char * const md_module_D_rev2_body =
 "  }\n"
 "\n"
 "  leaf vat {\n"
-"    must \". <= /C:conditional-data/tax\";\n"
+"    must \". <= /C:conditional-data/C:tax\";\n"
 "    must \"/B:tax-enabled = 'true'\";\n"
 "    type uint16;\n"
 "  }";

--- a/tests/nacm_test.c
+++ b/tests/nacm_test.c
@@ -886,7 +886,7 @@ nacm_test_rules(void **state)
     add_nacm_rule(nacm_config, "admin-acl", "rule5", "example-module", NACM_RULE_DATA,
             "/example-module:container", "read", "permit", "This is rule5.");
     add_nacm_rule(nacm_config, "admin-acl", "rule6", "fake-module", NACM_RULE_DATA,
-            "/module1:container/module2:list[key='key-value']/container/module3:leaf", "read", "permit",
+            "/module1:container/module2:list[module2:key='key-value']/module2:container/module3:leaf", "read", "permit",
             "This is rule6.");
     save_nacm_config(nacm_config);
 
@@ -995,7 +995,7 @@ nacm_test_rules(void **state)
     assert_string_equal("rule6", rule->name);
     assert_string_equal("fake-module", rule->module);
     assert_int_equal(NACM_RULE_DATA, rule->type);
-    assert_string_equal("/module1:container/module2:list[key='key-value']/container/module3:leaf", rule->data.path);
+    assert_string_equal("/module1:container/module2:list[module2:key='key-value']/module2:container/module3:leaf", rule->data.path);
     hash = sr_str_hash("module1:container") + sr_str_hash("module2:list") + sr_str_hash("module2:container")
            + sr_str_hash("module3:leaf");
     assert_int_equal(hash, rule->data_hash);
@@ -1049,7 +1049,7 @@ nacm_config_for_basic_read_access_tests(bool disable_nacm, const char *read_dflt
     add_nacm_rule(nacm_config, "acl2", "deny-low-numbers", "test-module", NACM_RULE_DATA,
             "/test-module:main/numbers[.<10]", "*", "deny", NULL);
     add_nacm_rule(nacm_config, "acl2", "deny-interface-mtu", "ietf-ip", NACM_RULE_DATA,
-            "/ietf-interfaces:interfaces/interface/ietf-ip:ipv4/mtu", "*", "deny", NULL);
+            "/ietf-interfaces:interfaces/ietf-interfaces:interface/ietf-ip:ipv4/ietf-ip:mtu", "*", "deny", NULL);
     add_nacm_rule(nacm_config, "acl2", "deny-change-interface-status", "ietf-interfaces", NACM_RULE_DATA,
             "/ietf-interfaces:interfaces/interface/enabled", "update delete create", "deny", NULL);
     /*  -> acl3 */
@@ -1211,8 +1211,8 @@ nacm_test_read_access_single_value(void **state)
     rc = rp_dt_get_value(dm_ctx, rp_session[4], data_tree[4], NULL, IETF_INTERFACES, false, &value);
     assert_int_equal(SR_ERR_OK, rc);        /* access allowed */
     sr_free_val(value);
-    /* -> /ietf-interfaces:interfaces/interface[name='eth0']/ietf-ip:ipv4/address/ip */
-#define ETH0_IP_ADDRESS "/ietf-interfaces:interfaces/interface[name='eth0']/ietf-ip:ipv4/address/ip"
+    /* -> /ietf-interfaces:interfaces/interface[name='eth0']/ietf-ip:ipv4/ietf-ip:address/ietf-ip:ip */
+#define ETH0_IP_ADDRESS "/ietf-interfaces:interfaces/interface[name='eth0']/ietf-ip:ipv4/ietf-ip:address/ietf-ip:ip"
     rc = rp_dt_get_value(dm_ctx, rp_session[0], data_tree[0], NULL, ETH0_IP_ADDRESS, false, &value);
     assert_int_equal(SR_ERR_OK, rc);        /* access allowed */
     sr_free_val(value);
@@ -1275,8 +1275,8 @@ nacm_test_read_access_single_value(void **state)
     rc = rp_dt_get_value(dm_ctx, rp_session[4], data_tree[4], NULL, GIGAETH0_ENABLED, false, &value);
     assert_int_equal(SR_ERR_OK, rc);        /* access allowed */
     sr_free_val(value);
-    /* -> /ietf-interfaces:interfaces/interface[name='eth0']/ietf-ip:ipv4/mtu */
-#define ETH0_MTU    "/ietf-interfaces:interfaces/interface[name='eth0']/ietf-ip:ipv4/mtu"
+    /* -> /ietf-interfaces:interfaces/interface[name='eth0']/ietf-ip:ipv4/ietf-ip:mtu */
+#define ETH0_MTU    "/ietf-interfaces:interfaces/interface[name='eth0']/ietf-ip:ipv4/ietf-ip:mtu"
     rc = rp_dt_get_value(dm_ctx, rp_session[0], data_tree[0], NULL, ETH0_MTU, false, &value);
     assert_int_equal(SR_ERR_OK, rc);        /* access allowed */
     sr_free_val(value);

--- a/tests/rp_dt_running_test.c
+++ b/tests/rp_dt_running_test.c
@@ -104,12 +104,12 @@ enable_subtree_test(void **state)
    rc = dm_get_module_and_lockw(ctx->dm_ctx, "ietf-interfaces", &si);
    assert_int_equal(SR_ERR_OK, rc);
 
-   rc = rp_dt_enable_xpath(ctx->dm_ctx, session->dm_session, si, "/ietf-interfaces:interfaces/interface/ietf-ip:ipv4/address");
+   rc = rp_dt_enable_xpath(ctx->dm_ctx, session->dm_session, si, "/ietf-interfaces:interfaces/interface/ietf-ip:ipv4/ietf-ip:address");
    assert_int_equal(SR_ERR_OK, rc);
 
    pthread_rwlock_unlock(&si->model_lock);
 
-   rc = rp_dt_validate_node_xpath(ctx->dm_ctx, session->dm_session, "/ietf-interfaces:interfaces/interface/ietf-ip:ipv4/address", &si, &match);
+   rc = rp_dt_validate_node_xpath(ctx->dm_ctx, session->dm_session, "/ietf-interfaces:interfaces/interface/ietf-ip:ipv4/ietf-ip:address", &si, &match);
    assert_int_equal(SR_ERR_OK, rc);
 
    /* check address node */
@@ -130,7 +130,7 @@ enable_subtree_test(void **state)
    rc = dm_get_module_and_lockw(ctx->dm_ctx, "ietf-interfaces", &si);
    assert_int_equal(SR_ERR_OK, rc);
 
-   rc = rp_dt_enable_xpath(ctx->dm_ctx, session->dm_session, si, "/ietf-interfaces:interfaces/interface/ietf-ip:ipv4/address");
+   rc = rp_dt_enable_xpath(ctx->dm_ctx, session->dm_session, si, "/ietf-interfaces:interfaces/interface/ietf-ip:ipv4/ietf-ip:address");
    assert_int_equal(SR_ERR_OK, rc);
 
    pthread_rwlock_unlock(&si->model_lock);
@@ -237,7 +237,7 @@ enable_running_for_submodule(void **state)
    val.data.string_val = strdup("abc");
    rc = rp_dt_set_item(ctx->dm_ctx, session->dm_session, "/module-a:cont_a/something/a-string", SR_EDIT_DEFAULT, &val, NULL);
    assert_int_equal(SR_ERR_OK, rc);
-   
+
    /* enable a moudle has grouping/uses, per rfc6020 7.12.1 */
    rc = dm_enable_module_running(ctx->dm_ctx, session->dm_session, "servers", NULL);
    assert_int_equal(SR_ERR_OK, rc);

--- a/tests/sysrepocfg_test.c
+++ b/tests/sysrepocfg_test.c
@@ -411,62 +411,62 @@ srcfg_test_xpath(void **state)
     rvalue = NULL;
 
     /* set a leaf value */
-    exec_shell_command("../src/sysrepocfg -d running -s \"/ietf-interfaces:interfaces/interface[name='eth0']/ietf-ip:ipv4/mtu\" -w 1600", ".*", true, 0);
+    exec_shell_command("../src/sysrepocfg -d running -s \"/ietf-interfaces:interfaces/interface[name='eth0']/ietf-ip:ipv4/ietf-ip:mtu\" -w 1600", ".*", true, 0);
     rc = sr_session_refresh(srcfg_test_session);
     if (rc != SR_ERR_OK) {
         printf("Error by sr_session_refresh %s\n", sr_strerror(rc));
     }
-    rc = sr_get_item(srcfg_test_session, "/ietf-interfaces:interfaces/interface[name='eth0']/ietf-ip:ipv4/mtu", &rvalue);
+    rc = sr_get_item(srcfg_test_session, "/ietf-interfaces:interfaces/interface[name='eth0']/ietf-ip:ipv4/ietf-ip:mtu", &rvalue);
     assert_int_equal(rc, SR_ERR_OK);
     assert_int_equal(SR_UINT16_T, rvalue->type);
-    assert_string_equal("/ietf-interfaces:interfaces/interface[name='eth0']/ietf-ip:ipv4/mtu", rvalue->xpath);
+    assert_string_equal("/ietf-interfaces:interfaces/interface[name='eth0']/ietf-ip:ipv4/ietf-ip:mtu", rvalue->xpath);
     assert_int_equal(1600, rvalue->data.uint16_val);
     sr_free_val(rvalue);
     rvalue = NULL;
 
     /* set a not existing leaf */
-    exec_shell_command("../src/sysrepocfg -d running -s \"/ietf-interfaces:interfaces/interface[name='eth0']/ietf-ip:ipv4/fakeleaf\" -w 'not existing leaf'", ".*", true, 1);
+    exec_shell_command("../src/sysrepocfg -d running -s \"/ietf-interfaces:interfaces/interface[name='eth0']/ietf-ip:ipv4/ietf-ip:fakeleaf\" -w 'not existing leaf'", ".*", true, 1);
     rc = sr_session_refresh(srcfg_test_session);
     if (rc != SR_ERR_OK) {
         printf("Error by sr_session_refresh %s\n", sr_strerror(rc));
     }
-    rc = sr_get_item(srcfg_test_session, "/ietf-interfaces:interfaces/interface[name='eth0']/ietf-ip:ipv4/fakeleaf", &rvalue);
+    rc = sr_get_item(srcfg_test_session, "/ietf-interfaces:interfaces/interface[name='eth0']/ietf-ip:ipv4/ietf-ip:fakeleaf", &rvalue);
     assert_int_equal(rc, SR_ERR_BAD_ELEMENT);
     sr_free_val(rvalue);
     rvalue = NULL;
 
     /* set a leaf without a value */
-    exec_shell_command("../src/sysrepocfg -d running -s \"/ietf-interfaces:interfaces/interface[name='eth0']/ietf-ip:ipv4/mtu\"", ".*", true, 1);
+    exec_shell_command("../src/sysrepocfg -d running -s \"/ietf-interfaces:interfaces/interface[name='eth0']/ietf-ip:ipv4/ietf-ip:mtu\"", ".*", true, 1);
     rc = sr_session_refresh(srcfg_test_session);
     if (rc != SR_ERR_OK) {
         printf("Error by sr_session_refresh %s\n", sr_strerror(rc));
     }
-    rc = sr_get_item(srcfg_test_session, "/ietf-interfaces:interfaces/interface[name='eth0']/ietf-ip:ipv4/mtu", &rvalue);
+    rc = sr_get_item(srcfg_test_session, "/ietf-interfaces:interfaces/interface[name='eth0']/ietf-ip:ipv4/ietf-ip:mtu", &rvalue);
     assert_int_equal(rc, SR_ERR_OK);
     assert_int_equal(SR_UINT16_T, rvalue->type);
-    assert_string_equal("/ietf-interfaces:interfaces/interface[name='eth0']/ietf-ip:ipv4/mtu", rvalue->xpath);
+    assert_string_equal("/ietf-interfaces:interfaces/interface[name='eth0']/ietf-ip:ipv4/ietf-ip:mtu", rvalue->xpath);
     assert_int_equal(1600, rvalue->data.uint16_val);
     sr_free_val(rvalue);
     rvalue = NULL;
 
     /* remove a leaf */
-    exec_shell_command("../src/sysrepocfg -d running -r \"/ietf-interfaces:interfaces/interface[name='eth0']/ietf-ip:ipv4/mtu\" ietf-interfaces", ".*", true, 0);
+    exec_shell_command("../src/sysrepocfg -d running -r \"/ietf-interfaces:interfaces/interface[name='eth0']/ietf-ip:ipv4/ietf-ip:mtu\" ietf-interfaces", ".*", true, 0);
     rc = sr_session_refresh(srcfg_test_session);
     if (rc != SR_ERR_OK) {
         printf("Error by sr_session_refresh %s\n", sr_strerror(rc));
     }
-    rc = sr_get_item(srcfg_test_session, "/ietf-interfaces:interfaces/interface[name='eth0']/ietf-ip:ipv4/mtu", &rvalue);
+    rc = sr_get_item(srcfg_test_session, "/ietf-interfaces:interfaces/interface[name='eth0']/ietf-ip:ipv4/ietf-ip:mtu", &rvalue);
     assert_int_equal(rc, SR_ERR_NOT_FOUND);
     sr_free_val(rvalue);
     rvalue = NULL;
 
     /* remove multiple leaves in one shot */
-    exec_shell_command("../src/sysrepocfg -d running -r \"/ietf-interfaces:interfaces/interface[name='eth1']/ietf-ip:ipv4/mtu\" -r \"/ietf-interfaces:interfaces/interface[name='eth1']/description\" ietf-interfaces", ".*", true, 0);
+    exec_shell_command("../src/sysrepocfg -d running -r \"/ietf-interfaces:interfaces/interface[name='eth1']/ietf-ip:ipv4/ietf-ip:mtu\" -r \"/ietf-interfaces:interfaces/interface[name='eth1']/description\" ietf-interfaces", ".*", true, 0);
     rc = sr_session_refresh(srcfg_test_session);
     if (rc != SR_ERR_OK) {
         printf("Error by sr_session_refresh %s\n", sr_strerror(rc));
     }
-    rc = sr_get_item(srcfg_test_session, "/ietf-interfaces:interfaces/interface[name='eth1']/ietf-ip:ipv4/mtu", &rvalue);
+    rc = sr_get_item(srcfg_test_session, "/ietf-interfaces:interfaces/interface[name='eth1']/ietf-ip:ipv4/ietf-ip:mtu", &rvalue);
     assert_int_equal(rc, SR_ERR_NOT_FOUND);
     sr_free_val(rvalue);
     rvalue = NULL;
@@ -526,10 +526,10 @@ srcfg_test_merge(void **state)
     sr_free_val(rvalue);
     rvalue = NULL;
 
-    rc = sr_get_item(srcfg_test_session, "/ietf-interfaces:interfaces/interface[name='eth0']/ietf-ip:ipv4/mtu", &rvalue);
+    rc = sr_get_item(srcfg_test_session, "/ietf-interfaces:interfaces/interface[name='eth0']/ietf-ip:ipv4/ietf-ip:mtu", &rvalue);
     assert_int_equal(rc, SR_ERR_OK);
     assert_int_equal(SR_UINT16_T, rvalue->type);
-    assert_string_equal("/ietf-interfaces:interfaces/interface[name='eth0']/ietf-ip:ipv4/mtu", rvalue->xpath);
+    assert_string_equal("/ietf-interfaces:interfaces/interface[name='eth0']/ietf-ip:ipv4/ietf-ip:mtu", rvalue->xpath);
     assert_int_equal(1600, rvalue->data.uint16_val);
     sr_free_val(rvalue);
     rvalue = NULL;


### PR DESCRIPTION
### Description
Recent libyang fixes corrected some logical errors in XPath paths and addressing, which were also present both indirectly and directly in sysrepo. It was incorrectly implemented and understood, nodes in XPath do not inherit the local module from their parent, but always consider the "context" module to be local. For data, context module is the module of the context node (more about various context nodes in RFC 7950) and for schema, context module is the module where the path is defined.

Also, one libyang function API changed.

### Test case
Affected tests modified and fixed.

### Closure
Fixes #888