### PR TITLE
Fixed incorrect array index inside (cl_)fd_start_watching() functions

### DIFF
--- a/examples/application_fd_watcher_example.c
+++ b/examples/application_fd_watcher_example.c
@@ -94,7 +94,7 @@ fd_start_watching(int fd, int events)
     for (size_t j = 0; j < poll_fd_cnt; j++) {
         if (fd == poll_fd_set[j].fd) {
             /* fond existing entry */
-            poll_fd_set[poll_fd_cnt].events |= (SR_FD_INPUT_READY == events) ? POLLIN : POLLOUT;
+            poll_fd_set[j].events |= (SR_FD_INPUT_READY == events) ? POLLIN : POLLOUT;
             matched = true;
         }
     }

--- a/tests/cl_fd_watcher_test.c
+++ b/tests/cl_fd_watcher_test.c
@@ -87,7 +87,7 @@ cl_fd_start_watching(int fd, int events)
     for (size_t j = 0; j < poll_fd_cnt; j++) {
         if (fd == poll_fd_set[j].fd) {
             /* fond existing entry */
-            poll_fd_set[poll_fd_cnt].events |= (SR_FD_INPUT_READY == events) ? POLLIN : POLLOUT;
+            poll_fd_set[j].events |= (SR_FD_INPUT_READY == events) ? POLLIN : POLLOUT;
             matched = true;
         }
     }


### PR DESCRIPTION
### What does this patch do?
Fixed incorrect array index used inside the fd_start_watching() function in _examples/application_fd_watcher_example.c_ source file, and in a very similar function
called cl_fd_start_watching() in _tests/cl_fd_watcher_test.c_.

### Detailed description
I think that the index should be "j" instead of "poll_fd_cnt", because the purpose of the for cycle is to traverse the array of pollfd structs and find one which has some specific file descriptor number. If we find such pollfd struct, we append appropriate flag to it's "events" member.

Before this patch, the for cycle would find out if some specific descriptor is watched and if so, it changes "events" member of the first struct which is actually NOT watched (with index "poll_fd_cnt"), rendering the whole for cycle meaningless.