### PR TITLE
BUGFIX incorrect array indexes fixed

### DIFF
--- a/examples/application_fd_watcher_example.c
+++ b/examples/application_fd_watcher_example.c
@@ -94,7 +94,7 @@ fd_start_watching(int fd, int events)
     for (size_t j = 0; j < poll_fd_cnt; j++) {
         if (fd == poll_fd_set[j].fd) {
             /* fond existing entry */
-            poll_fd_set[poll_fd_cnt].events |= (SR_FD_INPUT_READY == events) ? POLLIN : POLLOUT;
+            poll_fd_set[j].events |= (SR_FD_INPUT_READY == events) ? POLLIN : POLLOUT;
             matched = true;
         }
     }
@@ -260,4 +260,3 @@ cleanup:
 
     return rc;
 }
-

--- a/tests/cl_fd_watcher_test.c
+++ b/tests/cl_fd_watcher_test.c
@@ -87,7 +87,7 @@ cl_fd_start_watching(int fd, int events)
     for (size_t j = 0; j < poll_fd_cnt; j++) {
         if (fd == poll_fd_set[j].fd) {
             /* fond existing entry */
-            poll_fd_set[poll_fd_cnt].events |= (SR_FD_INPUT_READY == events) ? POLLIN : POLLOUT;
+            poll_fd_set[j].events |= (SR_FD_INPUT_READY == events) ? POLLIN : POLLOUT;
             matched = true;
         }
     }


### PR DESCRIPTION
**Short description:**

I believe I have found two places with incorrect index variables and this pull request fixes them.

**Detailed description:**

There are two practically indentical functions:

_fd_start_watching()_ in _examples/application_fd_watcher_example.c_ source file,
_cl_fd_start_watching()_ in _tests/cl_fd_watcher_test.c_ source file

Both contain a for cycle that goes through an array of pollfd structs and looks for an element which has member variable "fd" equal to some number "fd" passed as argument to the function. I believe that we search for such element in order to add a flag to it's "events" member variable.

However, currently we change "events" member variable of "poll_fd_cnt"-nth array member, which is the first pollfd struct that is actually **NOT** watched, and therefore it's "events" member variable is useless and changing it means nothing. I believe, that we should access the "j"-nth member, because that's the pollfd with the file descriptor number we were originally looking for.