### PR TITLE
sysrepocfg: fixed memleaks and minor performance optimization

### DIFF
--- a/src/executables/sysrepocfg.c
+++ b/src/executables/sysrepocfg.c
@@ -998,81 +998,22 @@ sr_type_t srcfg_convert_format(struct lys_node_leaf* leaf)
 static int
 srcfg_write_xpath_value(sr_type_t srtype, const char *xpath, const char *xpathvalue)
 {
-    int rc = SR_ERR_INTERNAL;
-    sr_val_t value = { 0 };
-
-    if (srtype != SR_LIST_T) {
-        value.type = srtype;
-        rc = sr_val_set_xpath(&value, xpath);
-        if (SR_ERR_OK != rc) {
-            printf("Error by sr_val_set_xpath: %s for %s\n", strerror(rc), xpath);
-            goto cleanup;
-        }
-
-        switch (srtype) {
-            case SR_BINARY_T:
-            case SR_BITS_T:
-            case SR_ENUM_T:
-            case SR_IDENTITYREF_T:
-            case SR_INSTANCEID_T:
-            case SR_STRING_T:
-                rc = sr_val_set_str_data(&value, srtype, xpathvalue);
-                if (SR_ERR_OK != rc) {
-                    printf("Error by sr_val_set_str_data: %s for %s\n", strerror(rc), xpath);
-                    goto cleanup;
-                }
-                break;
-            case SR_BOOL_T:
-                value.data.bool_val = atoi(xpathvalue);
-                break;
-            case SR_UINT8_T:
-                value.data.uint8_val = atoi(xpathvalue);
-                break;
-            case SR_UINT16_T:
-                value.data.uint16_val = atoi(xpathvalue);
-                break;
-            case SR_UINT32_T:
-                value.data.uint32_val = atoi(xpathvalue);
-                break;
-            case SR_UINT64_T:
-                value.data.uint64_val = atoll(xpathvalue);
-                break;
-            case SR_INT8_T:
-                value.data.int8_val = atoi(xpathvalue);
-                break;
-            case SR_INT16_T:
-                value.data.int16_val = atoi(xpathvalue);
-                break;
-            case SR_INT32_T:
-                value.data.int32_val = atoi(xpathvalue);
-                break;
-            case SR_INT64_T:
-                value.data.int64_val = atoll(xpathvalue);
-                break;
-            case SR_DECIMAL64_T:
-                value.data.decimal64_val = atof(xpathvalue);
-                break;
-            default:
-                printf("%s type %d not supported\n", __FUNCTION__, srtype);
-                goto cleanup;
-                break;
-        }
-        if (xpathvalue) {
-            rc = sr_set_item(srcfg_session, xpath, &value, SR_EDIT_DEFAULT);
-            if (SR_ERR_OK != rc) {
-                printf("Error by sr_set_item: %s for %s\n", strerror(rc), xpath);
-                goto cleanup;
-            }
-        }
-    } else {
-        rc = sr_set_item(srcfg_session, xpath, NULL, SR_EDIT_DEFAULT);
+    if (srtype == SR_LIST_T) {
+        int rc = sr_set_item(srcfg_session, xpath, NULL, SR_EDIT_DEFAULT);
         if (SR_ERR_OK != rc) {
             printf("Error by sr_set_item: %s for %s\n", strerror(rc), xpath);
-            goto cleanup;
+            return rc;
+        }
+    } else if (!xpathvalue) {
+        return SR_ERR_INTERNAL;
+    } else {
+        int rc = sr_set_item_str(srcfg_session, xpath, xpathvalue, SR_EDIT_DEFAULT);
+        if (SR_ERR_OK != rc) {
+            printf("Error by sr_set_item_str: %s for %s\n", strerror(rc), xpath);
+            return rc;
         }
     }
-cleanup:
-    return rc;
+    return 0;
 }
 
 /**

--- a/src/executables/sysrepocfg.c
+++ b/src/executables/sysrepocfg.c
@@ -1026,7 +1026,7 @@ srcfg_import_xpath(struct ly_ctx *ly_ctx, const char *xpath, const char *xpathva
     //struct lyd_node *new_dt = NULL;
     struct lyd_node *current_dt = NULL;
     struct lyd_node *deps_dt = NULL;
-    int ret = 0, j = 0;
+    int j = 0;
     struct ly_set *lyset;
 
     CHECK_NULL_ARG2(ly_ctx, module);
@@ -1048,11 +1048,7 @@ srcfg_import_xpath(struct ly_ctx *ly_ctx, const char *xpath, const char *xpathva
     if (SR_ERR_OK == rc) {
         rc = srcfg_merge_data_trees(&current_dt, deps_dt);
     }
-    if (SR_ERR_OK == rc) {
-        ret = lyd_validate(&current_dt, LYD_OPT_STRICT | LYD_OPT_CONFIG, ly_ctx);
-        CHECK_ZERO_LOG_GOTO(ret, rc, SR_ERR_INTERNAL, cleanup, "Data returned by sysrepo are not valid: %s (%s)",
-                            ly_errmsg(), ly_errpath());
-    } else {
+    if (SR_ERR_OK != rc) {
         goto cleanup;
     }
 

--- a/src/executables/sysrepocfg.c
+++ b/src/executables/sysrepocfg.c
@@ -1026,7 +1026,6 @@ srcfg_import_xpath(struct ly_ctx *ly_ctx, const char *xpath, const char *xpathva
     //struct lyd_node *new_dt = NULL;
     struct lyd_node *current_dt = NULL;
     struct lyd_node *deps_dt = NULL;
-    int j = 0;
     struct ly_set *lyset;
 
     CHECK_NULL_ARG2(ly_ctx, module);
@@ -1054,7 +1053,7 @@ srcfg_import_xpath(struct ly_ctx *ly_ctx, const char *xpath, const char *xpathva
 
     lyset = lys_find_xpath(current_dt->schema, xpath, 0);
     if (lyset && lyset->number) {
-        for (j=0; j < lyset->number; j++) {
+        for (int j=0; j < lyset->number; j++) {
             //printf("node name %s,%s,%d nodetype %d\n", lyset->set.s[j]->name, lys_path(lyset->set.s[j]), lyset->number, lyset->set.s[j]->nodetype);
             if (lyset->set.s[j]) {
                 sr_type_t srtype = SR_UNKNOWN_T;

--- a/src/executables/sysrepocfg.c
+++ b/src/executables/sysrepocfg.c
@@ -1049,6 +1049,9 @@ srcfg_write_xpath_value(sr_type_t srtype, const char *xpath, const char *xpathva
             case SR_INT64_T:
                 value.data.int64_val = atoll(xpathvalue);
                 break;
+            case SR_DECIMAL64_T:
+                value.data.decimal64_val = atof(xpathvalue);
+                break;
             default:
                 printf("%s type %d not supported\n", __FUNCTION__, srtype);
                 goto cleanup;


### PR DESCRIPTION
- simplify the `sysrepocfg --set ... --set-val ...`
- remove duplicate validation in `sysrepocfg`

cc: #892 , but it doesn't really fix the underlying problem