### PR TITLE
Copy config NACM read checks

### DIFF
--- a/src/data_manager.c
+++ b/src/data_manager.c
@@ -55,31 +55,6 @@ typedef struct dm_tmp_ly_ctx_s {
 } dm_tmp_ly_ctx_t;
 
 /**
- * @brief Data manager context holding loaded schemas, data trees
- * and corresponding locks
- */
-typedef struct dm_ctx_s {
-    ac_ctx_t *ac_ctx;             /**< Access Control module context */
-    np_ctx_t *np_ctx;             /**< Notification Processor context */
-    pm_ctx_t *pm_ctx;             /**< Persistence Manager context */
-    md_ctx_t *md_ctx;             /**< Module Dependencies context */
-    nacm_ctx_t *nacm_ctx;         /**< NACM context */
-    cm_connection_mode_t conn_mode;  /**< Mode in which Connection Manager operates */
-    char *schema_search_dir;      /**< location where schema files are located */
-    char *data_search_dir;        /**< location where data files are located */
-    sr_locking_set_t *locking_ctx;/**< lock context for lock/unlock/commit operations */
-    bool *ds_lock;                /**< Flags if the ds lock is hold by a session*/
-    pthread_mutex_t ds_lock_mutex;/**< Data store lock mutex */
-    sr_btree_t *schema_info_tree; /**< Binary tree holding information about schemas */
-    pthread_rwlock_t schema_tree_lock;  /**< rwlock for access schema_info_tree */
-    dm_commit_ctxs_t commit_ctxs; /**< Structure holding commit contexts and corresponding lock */
-    struct timespec last_commit_time;  /**< Time of the last commit */
-    dm_tmp_ly_ctx_t *tmp_ly_ctx;  /**< Structure wrapping libyang context that is used to validate/print/parse date
-                                   * where the set of required yang module can vary */
-
-} dm_ctx_t;
-
-/**
  * @brief Structure that holds Data Manager's per-session context.
  */
 typedef struct dm_session_s {
@@ -4351,23 +4326,140 @@ dm_commit_nacm_subtree(dm_session_t *session, nacm_data_val_ctx_t *nacm_data_val
     return SR_ERR_OK;
 }
 
-int
-dm_commit_netconf_access_control(dm_ctx_t *dm_ctx, dm_session_t *session, dm_commit_context_t *c_ctx, bool copy_config,
-        sr_error_info_t **errors, size_t *err_cnt)
+static int
+dm_perform_netconf_access_control(nacm_ctx_t *nacm_ctx, dm_session_t *session, dm_data_info_t *prev_info,
+                                  dm_data_info_t *new_info, bool copy_config, sr_error_info_t **errors, size_t *err_cnt,
+                                  dm_commit_context_t *c_ctx)
 {
-    CHECK_NULL_ARG3(dm_ctx, session, c_ctx);
+    CHECK_NULL_ARG4(nacm_ctx, session, prev_info, new_info);
     int rc = SR_ERR_OK;
-    size_t i = 0, d_cnt = 0, d_idx = 0;
+    size_t d_cnt = 0, d_idx = 0;
     bool denied = false, saved_diff = false;
     int denied_cnt = 0;
     nacm_data_val_ctx_t *nacm_data_val_ctx = NULL;
     struct lyd_difflist *diff = NULL;
     dm_module_difflist_t *module_difflist = NULL;
-    dm_data_info_t *info = NULL, *commit_info = NULL, *prev_info = NULL, lookup_info = {0};
 
-    if (NULL == dm_ctx->nacm_ctx || !(c_ctx->init_session->options & SR_SESS_ENABLE_NACM)) {
+    /* get the set of changes */
+    saved_diff = false;
+    diff = lyd_diff(prev_info->node, new_info->node, LYD_DIFFOPT_WITHDEFAULTS);
+    if (NULL == diff) {
+        SR_LOG_ERR("Lyd diff failed for module %s", prev_info->schema->module->name);
+        rc = SR_ERR_INTERNAL;
         goto cleanup;
     }
+
+    if (NULL != c_ctx) {
+        /* save diff for VERIFY notifications (even if the set is empty) */
+        module_difflist = calloc(1, sizeof *module_difflist);
+        CHECK_NULL_NOMEM_GOTO(module_difflist, rc, cleanup);
+        module_difflist->schema_info = prev_info->schema;
+        module_difflist->difflist = diff;
+        saved_diff = true;
+        rc = sr_btree_insert(c_ctx->difflists, (void *)module_difflist);
+        CHECK_RC_LOG_GOTO(rc, cleanup, "Failed to insert diff-list for module %s into the binary tree",
+                    prev_info->schema->module->name);
+        module_difflist = NULL;
+    }
+
+    if (diff->type[0] == LYD_DIFF_END) {
+        SR_LOG_DBG("No changes in module %s", prev_info->schema->module->name);
+        return SR_ERR_OK;
+    }
+
+    /* start NACM data access validation for this module */
+    rc = nacm_data_validation_start(nacm_ctx, session->user_credentials, new_info->node->schema,
+            &nacm_data_val_ctx);
+    CHECK_RC_MSG_GOTO(rc, cleanup, "Failed to start NACM data validation.");
+
+    if (copy_config) {
+        /* count diff items */
+        for (d_cnt = 0; LYD_DIFF_END != diff->type[d_cnt]; ++d_cnt);
+        ++d_cnt;
+
+        /* for copy_config perform read access checks */
+        d_idx = d_cnt - 1;
+        do {
+            --d_idx;
+            switch (diff->type[d_idx]) {
+            case LYD_DIFF_CHANGED:
+            case LYD_DIFF_MOVEDAFTER1:
+            case LYD_DIFF_DELETED:
+                rc = dm_copy_config_read_nacm_single_node(session, nacm_data_val_ctx, diff->first[d_idx],
+                        diff, d_idx, &d_cnt, new_info->node, NULL);
+                break;
+            case LYD_DIFF_CREATED:
+                rc = dm_copy_config_read_nacm_subtree(session, nacm_data_val_ctx, diff->first[d_idx],
+                        diff, d_idx, &d_cnt);
+                break;
+            case LYD_DIFF_MOVEDAFTER2:
+                break;
+            default:
+                assert(0 && "not reachable");
+            }
+            if (SR_ERR_OK != rc) {
+                goto cleanup;
+            }
+        } while (d_idx > 0);
+
+        if (diff->type[0] == LYD_DIFF_END) {
+            SR_LOG_DBG("No changes in module %s", prev_info->schema->module->name);
+            rc = SR_ERR_OK;
+            goto cleanup;
+        }
+    }
+
+    /* Iterate over all changes. Some changes may include whole subtrees. */
+    for (d_idx = 0; LYD_DIFF_END != diff->type[d_idx]; d_idx++) {
+        /* get node, access_type */
+        switch (diff->type[d_idx]) {
+        case LYD_DIFF_CHANGED:
+        case LYD_DIFF_MOVEDAFTER1:
+            rc = dm_commit_nacm_single_node(session, nacm_data_val_ctx, diff->first[d_idx],
+                    NACM_ACCESS_UPDATE, &denied, errors, err_cnt);
+            denied_cnt += denied;
+            break;
+        case LYD_DIFF_DELETED:
+            rc = dm_commit_nacm_subtree(session, nacm_data_val_ctx, diff->first[d_idx],
+                    NACM_ACCESS_DELETE, &denied_cnt, errors, err_cnt);
+            break;
+        case LYD_DIFF_CREATED:
+            rc = dm_commit_nacm_subtree(session, nacm_data_val_ctx, diff->second[d_idx],
+                    NACM_ACCESS_CREATE, &denied_cnt, errors, err_cnt);
+            break;
+        case LYD_DIFF_MOVEDAFTER2:
+            continue; /* access control performed already for LYD_DIFF_CREATED of this node */
+            break;
+        default:
+            assert(0 && "not reachable");
+        }
+        if (SR_ERR_OK != rc) {
+            goto cleanup;
+        }
+    }
+
+cleanup:
+    if (SR_ERR_OK == rc && denied_cnt > 0) {
+        rc = SR_ERR_UNAUTHORIZED;
+        /* update NACM stats */
+        (void)nacm_stats_add_denied_data_write(nacm_ctx);
+    }
+    if (!saved_diff && NULL != diff) {
+        lyd_free_diff(diff);
+    }
+    dm_module_difflist_free(module_difflist);
+    nacm_data_validation_stop(nacm_data_val_ctx);
+    return rc;
+}
+
+int
+dm_commit_netconf_access_control(nacm_ctx_t *nacm_ctx, dm_session_t *session, dm_commit_context_t *c_ctx, bool copy_config,
+                                 sr_error_info_t **errors, size_t *err_cnt)
+{
+    CHECK_NULL_ARG3(nacm_ctx, session, c_ctx);
+    int rc = SR_ERR_OK;
+    size_t i = 0;
+    dm_data_info_t *info = NULL, *new_info = NULL, *prev_info = NULL, lookup_info = {0};
 
     while (NULL != (info = sr_btree_get_at(session->session_modules[session->datastore], i++))) {
         lookup_info.schema = info->schema;
@@ -4379,131 +4471,24 @@ dm_commit_netconf_access_control(dm_ctx_t *dm_ctx, dm_session_t *session, dm_com
         prev_info = sr_btree_search(c_ctx->prev_data_trees, &lookup_info);
         if (NULL == prev_info) {
             SR_LOG_ERR("Current data tree for module %s not found", info->schema->module->name);
-            rc = SR_ERR_INTERNAL;
-            goto cleanup;
+            return SR_ERR_INTERNAL;
         }
 
         /* configuration after commit */
-        commit_info = sr_btree_search(c_ctx->session->session_modules[c_ctx->session->datastore], &lookup_info);
-        if (NULL == commit_info) {
+        new_info = sr_btree_search(c_ctx->session->session_modules[c_ctx->session->datastore], &lookup_info);
+        if (NULL == new_info) {
             SR_LOG_ERR("Commit data tree for module %s not found", info->schema->module->name);
-            rc = SR_ERR_INTERNAL;
-            goto cleanup;
+            return SR_ERR_INTERNAL;
         }
 
-        /* get the set of changes */
-        saved_diff = false;
-        diff = lyd_diff(prev_info->node, commit_info->node, LYD_DIFFOPT_WITHDEFAULTS);
-        if (NULL == diff) {
-            SR_LOG_ERR("Lyd diff failed for module %s", info->schema->module->name);
-            rc = SR_ERR_INTERNAL;
-            goto cleanup;
+        rc = dm_perform_netconf_access_control(nacm_ctx, session, prev_info, new_info, copy_config, errors, err_cnt, c_ctx);
+        if (SR_ERR_OK != rc) {
+            SR_LOG_ERR_MSG("NACM access check failed");
+            return rc;
         }
-
-        /* save diff for VERIFY notifications (even if the set is empty) */
-        module_difflist = calloc(1, sizeof *module_difflist);
-        CHECK_NULL_NOMEM_GOTO(module_difflist, rc, cleanup);
-        module_difflist->schema_info = info->schema;
-        module_difflist->difflist = diff;
-        saved_diff = true;
-        rc = sr_btree_insert(c_ctx->difflists, (void *)module_difflist);
-        CHECK_RC_LOG_GOTO(rc, cleanup, "Failed to insert diff-list for module %s into the binary tree",
-                info->schema->module->name);
-        module_difflist = NULL;
-
-        if (diff->type[0] == LYD_DIFF_END) {
-            SR_LOG_DBG("No changes in module %s", info->schema->module->name);
-            continue;
-        }
-
-        /* start NACM data access validation for this module */
-        rc = nacm_data_validation_start(dm_ctx->nacm_ctx, session->user_credentials, commit_info->node->schema,
-                &nacm_data_val_ctx);
-        CHECK_RC_MSG_GOTO(rc, cleanup, "Failed to start NACM data validation.");
-
-        if (copy_config) {
-            /* count diff items */
-            for (d_cnt = 0; LYD_DIFF_END != diff->type[d_cnt]; ++d_cnt);
-            ++d_cnt;
-
-            /* for copy_config perform read access checks */
-            d_idx = d_cnt - 1;
-            do {
-                --d_idx;
-                switch (diff->type[d_idx]) {
-                    case LYD_DIFF_CHANGED:
-                    case LYD_DIFF_MOVEDAFTER1:
-                    case LYD_DIFF_DELETED:
-                        rc = dm_copy_config_read_nacm_single_node(session, nacm_data_val_ctx, diff->first[d_idx],
-                                diff, d_idx, &d_cnt, commit_info->node, NULL);
-                        break;
-                    case LYD_DIFF_CREATED:
-                        rc = dm_copy_config_read_nacm_subtree(session, nacm_data_val_ctx, diff->first[d_idx],
-                                diff, d_idx, &d_cnt);
-                        break;
-                    case LYD_DIFF_MOVEDAFTER2:
-                        break;
-                    default:
-                        assert(0 && "not reachable");
-                }
-                if (SR_ERR_OK != rc) {
-                    goto cleanup;
-                }
-            } while (d_idx > 0);
-
-            if (diff->type[0] == LYD_DIFF_END) {
-                SR_LOG_DBG("No changes in module %s", info->schema->module->name);
-                nacm_data_validation_stop(nacm_data_val_ctx);
-                nacm_data_val_ctx = NULL;
-                continue;
-            }
-        }
-
-        /* Iterate over all changes. Some changes may include whole subtrees. */
-        for (d_idx = 0; LYD_DIFF_END != diff->type[d_idx]; d_idx++) {
-            /* get node, access_type */
-            switch (diff->type[d_idx]) {
-                case LYD_DIFF_CHANGED:
-                case LYD_DIFF_MOVEDAFTER1:
-                    rc = dm_commit_nacm_single_node(session, nacm_data_val_ctx, diff->first[d_idx],
-                            NACM_ACCESS_UPDATE, &denied, errors, err_cnt);
-                    denied_cnt += denied;
-                    break;
-                case LYD_DIFF_DELETED:
-                    rc = dm_commit_nacm_subtree(session, nacm_data_val_ctx, diff->first[d_idx],
-                            NACM_ACCESS_DELETE, &denied_cnt, errors, err_cnt);
-                    break;
-                case LYD_DIFF_CREATED:
-                    rc = dm_commit_nacm_subtree(session, nacm_data_val_ctx, diff->second[d_idx],
-                            NACM_ACCESS_CREATE, &denied_cnt, errors, err_cnt);
-                    break;
-                case LYD_DIFF_MOVEDAFTER2:
-                    continue; /* access control performed already for LYD_DIFF_CREATED of this node */
-                    break;
-                default:
-                    assert(0 && "not reachable");
-            }
-            if (SR_ERR_OK != rc) {
-                goto cleanup;
-            }
-        }
-
-        nacm_data_validation_stop(nacm_data_val_ctx);
-        nacm_data_val_ctx = NULL;
     }
 
-cleanup:
-    if (SR_ERR_OK == rc && denied_cnt > 0) {
-        rc = SR_ERR_UNAUTHORIZED;
-        /* update NACM stats */
-        (void)nacm_stats_add_denied_data_write(dm_ctx->nacm_ctx);
-    }
-    if (!saved_diff && NULL != diff) {
-        lyd_free_diff(diff);
-    }
-    dm_module_difflist_free(module_difflist);
-    nacm_data_validation_stop(nacm_data_val_ctx);
-    return rc;
+    return SR_ERR_OK;
 }
 
 /**
@@ -5106,7 +5091,8 @@ dm_remove_non_matching_diff(dm_model_subscription_t *ms, const np_subscription_t
  */
 static int
 dm_create_difflist_for_enabled_notif(dm_ctx_t *dm_ctx, const ac_ucred_t *user_credentials, dm_session_t *src_session,
-        const char *module_name, const np_subscription_t *subscription, dm_commit_context_t *c_ctx) {
+        const char *module_name, const np_subscription_t *subscription, dm_commit_context_t *c_ctx)
+{
 
     CHECK_NULL_ARG5(dm_ctx, src_session, module_name, subscription, c_ctx);
 
@@ -5162,7 +5148,8 @@ cleanup:
  * @return Error code (SR_ERR_OK on success)
  */
 static int
-dm_send_enabled_notification(dm_ctx_t *dm_ctx, dm_commit_context_t *c_ctx, const np_subscription_t *subscription) {
+dm_send_enabled_notification(dm_ctx_t *dm_ctx, dm_commit_context_t *c_ctx, const np_subscription_t *subscription)
+{
     int rc = SR_ERR_OK;
     sr_list_t *notif_list = NULL;
 
@@ -5199,14 +5186,15 @@ cleanup:
 }
 
 static int
-dm_copy_config(dm_ctx_t *dm_ctx, dm_session_t *session, const sr_list_t *module_names, sr_datastore_t src, sr_datastore_t dst, const np_subscription_t *subscription)
+dm_copy_config(dm_ctx_t *dm_ctx, dm_session_t *session, const sr_list_t *module_names, sr_datastore_t src,
+               sr_datastore_t dst, const np_subscription_t *subscription, bool nacm_on, sr_error_info_t **errors, size_t *err_cnt)
 {
     CHECK_NULL_ARG2(dm_ctx, module_names);
     int rc = SR_ERR_OK;
     dm_session_t *src_session = NULL;
     dm_session_t *dst_session = NULL;
     char *module_name = NULL;
-    dm_data_info_t **src_infos = NULL;
+    dm_data_info_t **src_infos = NULL, *dst_info = NULL;
     size_t opened_files = 0;
     char *file_name = NULL;
     int *fds = NULL;
@@ -5279,9 +5267,18 @@ dm_copy_config(dm_ctx_t *dm_ctx, dm_session_t *session, const sr_list_t *module_
             CHECK_RC_LOG_GOTO(rc, cleanup, "Module %s can not be locked in destination datastore", module_name);
         }
 
-        /* load data tree to be copied*/
+        /* load data tree to be copied */
         rc = dm_get_data_info(dm_ctx, src_session, module_name, &(src_infos[i]));
         CHECK_RC_MSG_GOTO(rc, cleanup, "Get data info failed");
+
+        if (NULL != session && NULL != dm_ctx->nacm_ctx && nacm_on) {
+            /* load data tree to be replaced */
+            rc = dm_get_data_info(dm_ctx, session, module_name, &dst_info);
+            CHECK_RC_MSG_GOTO(rc, cleanup, "Get data info failed");
+
+            rc = dm_perform_netconf_access_control(dm_ctx->nacm_ctx, session, dst_info, src_infos[i], true, errors, err_cnt, NULL);
+            CHECK_RC_MSG_GOTO(rc, cleanup, "Checking NACM failed");
+        }
 
         if (NULL != subscription && 0 == i) {
             /* subscription is supposed to be used when only one module/subtree is copied */
@@ -5315,7 +5312,7 @@ dm_copy_config(dm_ctx_t *dm_ctx, dm_session_t *session, const sr_list_t *module_
     for (size_t i = 0; i < module_names->count; i++) {
         module_name = module_names->data[i];
         if (SR_DS_CANDIDATE != dst) {
-            /* write dest file, dst is either startup or running*/
+            /* write dest file, dst is either startup or running */
             if (0 != lyd_print_fd(fds[i], src_infos[i]->node, LYD_XML, LYP_WITHSIBLINGS | LYP_FORMAT)) {
                 SR_LOG_ERR("Copy of module %s failed", module_name);
                 rc = SR_ERR_INTERNAL;
@@ -5432,7 +5429,7 @@ dm_enable_module_running(dm_ctx_t *ctx, dm_session_t *session, const char *modul
     pthread_rwlock_unlock(&si->model_lock);
     CHECK_RC_LOG_RETURN(rc, "Enable module %s running failed", module_name);
 
-    rc = dm_copy_module(ctx, session, module_name, SR_DS_STARTUP, SR_DS_RUNNING, subscription);
+    rc = dm_copy_module(ctx, session, module_name, SR_DS_STARTUP, SR_DS_RUNNING, subscription, 0, NULL, NULL);
 
     return rc;
 }
@@ -5592,7 +5589,7 @@ dm_copy_subtree_startup_running(dm_ctx_t *ctx, dm_session_t *session, const char
     CHECK_RC_MSG_GOTO(rc, cleanup, "Failed to copy mandatory nodes for subtree");
 
     /* copy module candidate -> running */
-    rc = dm_copy_module(ctx, tmp_session, module_name, SR_DS_CANDIDATE, SR_DS_RUNNING, subscription);
+    rc = dm_copy_module(ctx, tmp_session, module_name, SR_DS_CANDIDATE, SR_DS_RUNNING, subscription, 0, NULL, NULL);
 
 cleanup:
     ly_set_free(nodes);
@@ -5683,7 +5680,7 @@ cleanup:
 
 int
 dm_copy_module(dm_ctx_t *dm_ctx, dm_session_t *session, const char *module_name, sr_datastore_t src, sr_datastore_t dst,
-        const np_subscription_t *subscription)
+        const np_subscription_t *subscription, bool nacm_on, sr_error_info_t **errors, size_t *err_cnt)
 {
     CHECK_NULL_ARG2(dm_ctx, module_name);
     sr_list_t *module_list = NULL;
@@ -5699,7 +5696,7 @@ dm_copy_module(dm_ctx_t *dm_ctx, dm_session_t *session, const char *module_name,
     rc = sr_list_add(module_list, (void *) module_name);
     CHECK_RC_MSG_GOTO(rc, cleanup, "Adding to sr_list failed");
 
-    rc = dm_copy_config(dm_ctx, session, module_list, src, dst, subscription);
+    rc = dm_copy_config(dm_ctx, session, module_list, src, dst, subscription, nacm_on, errors, err_cnt);
     CHECK_RC_MSG_GOTO(rc, cleanup, "Dm copy config failed");
 
 cleanup:
@@ -5708,7 +5705,8 @@ cleanup:
 }
 
 int
-dm_copy_all_models(dm_ctx_t *dm_ctx, dm_session_t *session, sr_datastore_t src, sr_datastore_t dst)
+dm_copy_all_models(dm_ctx_t *dm_ctx, dm_session_t *session, sr_datastore_t src, sr_datastore_t dst, bool nacm_on,
+                   sr_error_info_t **errors, size_t *err_cnt)
 {
     CHECK_NULL_ARG2(dm_ctx, session);
     sr_list_t *enabled_modules = NULL;
@@ -5717,7 +5715,7 @@ dm_copy_all_models(dm_ctx_t *dm_ctx, dm_session_t *session, sr_datastore_t src, 
     rc = dm_get_all_modules(dm_ctx, session, (SR_DS_RUNNING == src || SR_DS_RUNNING == dst), &enabled_modules);
     CHECK_RC_MSG_GOTO(rc, cleanup, "Get all modules failed");
 
-    rc = dm_copy_config(dm_ctx, session, enabled_modules, src, dst, NULL);
+    rc = dm_copy_config(dm_ctx, session, enabled_modules, src, dst, NULL, nacm_on, errors, err_cnt);
     CHECK_RC_MSG_GOTO(rc, cleanup, "Dm copy config failed");
 
 cleanup:

--- a/src/data_manager.c
+++ b/src/data_manager.c
@@ -4389,7 +4389,7 @@ dm_perform_netconf_access_control(nacm_ctx_t *nacm_ctx, dm_session_t *session, d
                         diff, d_idx, &d_cnt, new_info->node, NULL);
                 break;
             case LYD_DIFF_CREATED:
-                rc = dm_copy_config_read_nacm_subtree(session, nacm_data_val_ctx, diff->first[d_idx],
+                rc = dm_copy_config_read_nacm_subtree(session, nacm_data_val_ctx, diff->second[d_idx],
                         diff, d_idx, &d_cnt);
                 break;
             case LYD_DIFF_MOVEDAFTER2:

--- a/src/data_manager.c
+++ b/src/data_manager.c
@@ -770,30 +770,6 @@ dm_enable_module_running_internal(dm_ctx_t *ctx, dm_session_t *session, dm_schem
     return rc;
 }
 
-/**
- *
- * @note Function expects that a schema info is locked for writing.
- *
- * @param [in] ctx
- * @param [in] session
- * @param [in] module_name
- * @param [in] xpath
- * @param [in] schema_info
- * @return Error code (SR_ERR_OK on success)
- */
-static int
-dm_enable_module_subtree_running_internal(dm_ctx_t *ctx, dm_session_t *session, dm_schema_info_t *schema_info, const char *module_name, const char *xpath)
-{
-    CHECK_NULL_ARG3(ctx, module_name, xpath); /* session can be NULL */
-    int rc = SR_ERR_OK;
-
-    /* enable the subtree specified by xpath */
-    rc = rp_dt_enable_xpath(ctx, session, schema_info, xpath);
-    CHECK_RC_LOG_RETURN(rc, "Enabling of xpath %s failed", xpath);
-
-    return rc;
-}
-
 static int
 dm_apply_persist_data_for_model(dm_ctx_t *dm_ctx, dm_session_t *session, const char *module_name, dm_schema_info_t *si,
                                 bool features_only)
@@ -829,7 +805,7 @@ dm_apply_persist_data_for_model(dm_ctx_t *dm_ctx, dm_session_t *session, const c
             } else {
                 /* enable running datastore for specified subtrees */
                 for (size_t i = 0; i < enabled_subtrees_cnt; i++) {
-                    rc = dm_enable_module_subtree_running_internal(dm_ctx, NULL, si, module_name, enabled_subtrees[i]);
+                    rc = rp_dt_enable_xpath(dm_ctx, NULL, si, enabled_subtrees[i]);
                     if (SR_ERR_OK != rc) {
                         SR_LOG_WRN("Unable to enable subtree '%s' in module '%s' in running ds.", enabled_subtrees[i], module_name);
                     }
@@ -5609,7 +5585,7 @@ dm_enable_module_subtree_running(dm_ctx_t *ctx, dm_session_t *session, const cha
     rc = dm_get_module_and_lockw(ctx, module_name, &si);
     CHECK_RC_LOG_RETURN(rc, "Lock schema %s for write failed", module_name);
 
-    rc = dm_enable_module_subtree_running_internal(ctx, session, si, module_name, xpath);
+    rc = rp_dt_enable_xpath(ctx, session, si, xpath);
     pthread_rwlock_unlock(&si->model_lock);
     CHECK_RC_LOG_RETURN(rc, "Enabling of xpath %s failed", xpath);
 

--- a/tests/cl_test.c
+++ b/tests/cl_test.c
@@ -3689,18 +3689,6 @@ candidate_ds_test(void **state)
 
     rc = sr_commit(session_candidate);
     assert_int_equal(SR_ERR_OK, rc);
-    rc = sr_copy_config(session_candidate, "example-module", SR_DS_CANDIDATE, SR_DS_STARTUP);
-    assert_int_equal(rc, SR_ERR_OK);
-
-    /* get-config from startup, candidate should be copied to the startup */
-    rc = sr_get_item(session_startup, "/example-module:container/list[key1='key1'][key2='key2']/leaf", &val);
-    assert_int_equal(rc, SR_ERR_OK);
-    assert_int_equal(value.type, val->type);
-    assert_string_equal(value.data.string_val, val->data.string_val);
-    sr_free_val(val);
-
-    rc = sr_commit(session_candidate);
-    assert_int_equal(SR_ERR_OK, rc);
 
     /* copy-config should fail because non enabled nodes are modified */
     rc = sr_copy_config(session_candidate, "example-module", SR_DS_CANDIDATE, SR_DS_RUNNING);

--- a/tests/dm_test.c
+++ b/tests/dm_test.c
@@ -433,7 +433,7 @@ dm_copy_module_test(void **state)
    rc = dm_session_start(ctx, NULL, SR_DS_STARTUP, &sessionA);
    assert_int_equal(SR_ERR_OK, rc);
 
-   rc = dm_copy_module(ctx, sessionA, "example-module", SR_DS_STARTUP, SR_DS_RUNNING, NULL);
+   rc = dm_copy_module(ctx, sessionA, "example-module", SR_DS_STARTUP, SR_DS_RUNNING, NULL, 0, NULL, NULL);
    assert_int_equal(SR_ERR_OK, rc);
 
    rc = dm_get_module_and_lockw(ctx, "test-module", &si);
@@ -444,7 +444,7 @@ dm_copy_module_test(void **state)
 
    pthread_rwlock_unlock(&si->model_lock);
 
-   rc = dm_copy_all_models(ctx, sessionA, SR_DS_STARTUP, SR_DS_RUNNING);
+   rc = dm_copy_all_models(ctx, sessionA, SR_DS_STARTUP, SR_DS_RUNNING, 0, NULL, NULL);
    assert_int_equal(SR_ERR_OK, rc);
 
    dm_session_stop(ctx, sessionA);

--- a/tests/dm_test.c
+++ b/tests/dm_test.c
@@ -433,16 +433,19 @@ dm_copy_module_test(void **state)
    rc = dm_session_start(ctx, NULL, SR_DS_STARTUP, &sessionA);
    assert_int_equal(SR_ERR_OK, rc);
 
-   rc = dm_copy_module(ctx, sessionA, "example-module", SR_DS_STARTUP, SR_DS_RUNNING, NULL, 0, NULL, NULL);
-   assert_int_equal(SR_ERR_OK, rc);
+   /* not enabled */
+   rc = dm_copy_module(ctx, sessionA, "test-module", SR_DS_STARTUP, SR_DS_RUNNING, NULL, 0, NULL, NULL);
+   assert_int_equal(SR_ERR_OPERATION_FAILED, rc);
 
-   rc = dm_get_module_and_lockw(ctx, "test-module", &si);
+   rc = dm_get_module_without_lock(ctx, "test-module", &si);
    assert_int_equal(SR_ERR_OK, rc);
 
    rc = rp_dt_enable_xpath(ctx, sessionA, si, "/test-module:main");
    assert_int_equal(SR_ERR_OK, rc);
 
-   pthread_rwlock_unlock(&si->model_lock);
+   /* now enabled */
+   rc = dm_copy_module(ctx, sessionA, "test-module", SR_DS_STARTUP, SR_DS_RUNNING, NULL, 0, NULL, NULL);
+   assert_int_equal(SR_ERR_OK, rc);
 
    rc = dm_copy_all_models(ctx, sessionA, SR_DS_STARTUP, SR_DS_RUNNING, 0, NULL, NULL);
    assert_int_equal(SR_ERR_OK, rc);

--- a/tests/rp_dt_edit_test.c
+++ b/tests/rp_dt_edit_test.c
@@ -31,6 +31,7 @@
 #include "sr_common.h"
 #include "rp_dt_get.h"
 #include "rp_dt_edit.h"
+#include "rp_dt_xpath.h"
 #include "test_module_helper.h"
 #include "rp_dt_context_helper.h"
 #include "rp_internal.h"
@@ -2293,6 +2294,8 @@ candidate_edit_test(void **state)
     rp_ctx_t *ctx = *state;
     rp_session_t *sessionA = NULL;
     sr_val_t *value = NULL;
+    sr_error_info_t *errors = NULL;
+    size_t e_cnt = 0;
 
     test_rp_session_create(ctx, SR_DS_CANDIDATE, &sessionA);
 
@@ -2307,13 +2310,15 @@ candidate_edit_test(void **state)
     sr_free_val_content(&iftype);
 
     /* modified module in cadidate is validated before copy */
-    rc = dm_copy_module(ctx->dm_ctx, sessionA->dm_session, "test-module", SR_DS_CANDIDATE, SR_DS_STARTUP, NULL, 0, NULL, NULL);
+    rc = dm_validate_session_data_trees(ctx->dm_ctx, sessionA->dm_session, &errors, &e_cnt);
     assert_int_equal(SR_ERR_VALIDATION_FAILED, rc);
+    sr_free_errors(errors, e_cnt);
+    errors = NULL;
+    e_cnt = 0;
 
     rc = dm_discard_changes(ctx->dm_ctx, sessionA->dm_session);
     assert_int_equal(SR_ERR_OK, rc);
 
-    /* refresh candidate session */
     sr_val_t *v = NULL;
     v = calloc(1, sizeof(*v));
     assert_non_null(v);
@@ -2328,9 +2333,7 @@ candidate_edit_test(void **state)
     rc = rp_dt_set_item_wrapper(ctx, sessionA, v->xpath, v, NULL, SR_EDIT_DEFAULT);
     assert_int_equal(SR_ERR_OK, rc);
 
-    sr_error_info_t *errors = NULL;
-    size_t e_cnt = 0;
-
+    /* refresh candidate session */
     rc = rp_dt_refresh_session(ctx, sessionA, &errors, &e_cnt);
     assert_int_equal(SR_ERR_OK, rc);
 
@@ -2356,7 +2359,7 @@ copy_to_running_test(void **state)
     test_rp_session_create(ctx, SR_DS_CANDIDATE, &sessionA);
     test_rp_session_create(ctx, SR_DS_STARTUP, &sessionB);
 
-    /* only enabled modules are copied, no module is enabled => no operation*/
+    /* only enabled modules are copied, no module is enabled => no operation */
     rc = rp_dt_copy_config(ctx, sessionB, NULL, SR_DS_STARTUP, SR_DS_RUNNING, &errors, &e_cnt);
     assert_int_equal(SR_ERR_OK, rc);
 
@@ -2367,16 +2370,8 @@ copy_to_running_test(void **state)
     errors = NULL;
     e_cnt = 0;
 
-    /* only enabled modules are copied, no module is enabled => no operation*/
+    /* only enabled modules are copied, no module is enabled => no operation */
     rc = rp_dt_copy_config(ctx, sessionA, NULL, SR_DS_CANDIDATE, SR_DS_RUNNING, &errors, &e_cnt);
-    assert_int_equal(SR_ERR_OK, rc);
-
-    /* empty data tree loaded from running (source of candidate) can be copied to running */
-    rc = rp_dt_copy_config(ctx, sessionA, "test-module", SR_DS_CANDIDATE, SR_DS_RUNNING, &errors, &e_cnt);
-    assert_int_equal(SR_ERR_OK, rc);
-
-    /* copy startup to candidate */
-    rc = rp_dt_copy_config(ctx, sessionA, "test-module", SR_DS_STARTUP, SR_DS_CANDIDATE, &errors, &e_cnt);
     assert_int_equal(SR_ERR_OK, rc);
 
     /* copy of not enabled module to running should fail */

--- a/tests/rp_dt_edit_test.c
+++ b/tests/rp_dt_edit_test.c
@@ -2307,7 +2307,7 @@ candidate_edit_test(void **state)
     sr_free_val_content(&iftype);
 
     /* modified module in cadidate is validated before copy */
-    rc = dm_copy_module(ctx->dm_ctx, sessionA->dm_session, "test-module", SR_DS_CANDIDATE, SR_DS_STARTUP, NULL);
+    rc = dm_copy_module(ctx->dm_ctx, sessionA->dm_session, "test-module", SR_DS_CANDIDATE, SR_DS_STARTUP, NULL, 0, NULL, NULL);
     assert_int_equal(SR_ERR_VALIDATION_FAILED, rc);
 
     rc = dm_discard_changes(ctx->dm_ctx, sessionA->dm_session);


### PR DESCRIPTION
### Description
The second part of copy-config NACM read check commits which add these checks also for copy-config to candidate and startup.

### Test case
Added 2 new tests to `nacm_cl_test`.