### PR TITLE
libyang instance-identifier format changed

### DIFF
--- a/tests/cl_test.c
+++ b/tests/cl_test.c
@@ -5618,7 +5618,7 @@ cl_inst_id_to_known_deps_test (void **state)
     rc = sr_set_item_str(session, "/test-module:list[key='abc']/instance_id", "/referenced-data:magic_number", SR_EDIT_DEFAULT);
     assert_int_equal(SR_ERR_OK, rc);
 
-    rc = sr_set_item_str(session, "/test-module:main/instance_id", "/test-module:main/test-module:i8", SR_EDIT_DEFAULT);
+    rc = sr_set_item_str(session, "/test-module:main/instance_id", "/test-module:main/i8", SR_EDIT_DEFAULT);
     assert_int_equal(SR_ERR_OK, rc);
 
     rc = sr_set_item_str(session, "/referenced-data:magic_number", "42", SR_EDIT_DEFAULT);
@@ -5644,7 +5644,7 @@ cl_inst_id_to_one_module_test (void **state)
     rc = sr_set_item_str(session, "/test-module:list[key='abc']/instance_id", "/referenced-data:magic_number", SR_EDIT_DEFAULT);
     assert_int_equal(SR_ERR_OK, rc);
 
-    rc = sr_set_item_str(session, "/test-module:main/instance_id", "/example-module:container/example-module:list[example-module:key1='key1'][example-module:key2='key2']", SR_EDIT_DEFAULT);
+    rc = sr_set_item_str(session, "/test-module:main/instance_id", "/example-module:container/list[key1='key1'][key2='key2']", SR_EDIT_DEFAULT);
     assert_int_equal(SR_ERR_OK, rc);
 
     rc = sr_set_item_str(session, "/referenced-data:magic_number", "42", SR_EDIT_DEFAULT);
@@ -5660,7 +5660,7 @@ cl_inst_id_to_one_module_test (void **state)
 
     assert_non_null(val);
     assert_int_equal(SR_INSTANCEID_T, val->type);
-    assert_string_equal("/example-module:container/example-module:list[example-module:key1='key1'][example-module:key2='key2']", val->data.instanceid_val);
+    assert_string_equal("/example-module:container/list[key1='key1'][key2='key2']", val->data.instanceid_val);
 
     sr_free_val(val);
 
@@ -5669,7 +5669,7 @@ cl_inst_id_to_one_module_test (void **state)
     rc = sr_set_item_str(session, "/ietf-interfaces:interfaces/interface[name='ifA']/type", "iana-if-type:ethernetCsmacd", SR_EDIT_DEFAULT);
     assert_int_equal(SR_ERR_OK, rc);
 
-    rc = sr_set_item_str(session, "/test-module:main/instance_id", "/ietf-interfaces:interfaces/ietf-interfaces:interface[ietf-interfaces:name='ifA']", SR_EDIT_DEFAULT);
+    rc = sr_set_item_str(session, "/test-module:main/instance_id", "/ietf-interfaces:interfaces/interface[name='ifA']", SR_EDIT_DEFAULT);
     assert_int_equal(SR_ERR_OK, rc);
 
     rc = sr_commit(session);
@@ -5682,7 +5682,7 @@ cl_inst_id_to_one_module_test (void **state)
 
     assert_non_null(val);
     assert_int_equal(SR_INSTANCEID_T, val->type);
-    assert_string_equal("/ietf-interfaces:interfaces/ietf-interfaces:interface[ietf-interfaces:name='ifA']", val->data.instanceid_val);
+    assert_string_equal("/ietf-interfaces:interfaces/interface[name='ifA']", val->data.instanceid_val);
 
     sr_free_val(val);
 
@@ -5715,7 +5715,7 @@ cl_inst_id_to_more_modules_test (void **state)
     rc = sr_set_item_str(session, "/test-module:list[key='abc']/instance_id", "/referenced-data:magic_number", SR_EDIT_DEFAULT);
     assert_int_equal(SR_ERR_OK, rc);
 
-    rc = sr_set_item_str(session, "/test-module:main/instance_id", "/example-module:container/example-module:list[example-module:key1='key1'][example-module:key2='key2']", SR_EDIT_DEFAULT);
+    rc = sr_set_item_str(session, "/test-module:main/instance_id", "/example-module:container/list[key1='key1'][key2='key2']", SR_EDIT_DEFAULT);
     assert_int_equal(SR_ERR_OK, rc);
 
     rc = sr_set_item_str(session, "/referenced-data:magic_number", "1", SR_EDIT_DEFAULT);
@@ -5724,7 +5724,7 @@ cl_inst_id_to_more_modules_test (void **state)
     rc = sr_set_item_str(session, "/ietf-interfaces:interfaces/interface[name='ifA']/type", "iana-if-type:ethernetCsmacd", SR_EDIT_DEFAULT);
     assert_int_equal(SR_ERR_OK, rc);
 
-    rc = sr_set_item_str(session, "/test-module:list[key='def']/instance_id", "/ietf-interfaces:interfaces/ietf-interfaces:interface[ietf-interfaces:name='ifA']", SR_EDIT_DEFAULT);
+    rc = sr_set_item_str(session, "/test-module:list[key='def']/instance_id", "/ietf-interfaces:interfaces/interface[name='ifA']", SR_EDIT_DEFAULT);
     assert_int_equal(SR_ERR_OK, rc);
 
     rc = sr_commit(session);
@@ -5737,7 +5737,7 @@ cl_inst_id_to_more_modules_test (void **state)
 
     assert_non_null(val);
     assert_int_equal(SR_INSTANCEID_T, val->type);
-    assert_string_equal("/example-module:container/example-module:list[example-module:key1='key1'][example-module:key2='key2']", val->data.instanceid_val);
+    assert_string_equal("/example-module:container/list[key1='key1'][key2='key2']", val->data.instanceid_val);
     sr_free_val(val);
 
 
@@ -5752,7 +5752,7 @@ cl_inst_id_to_more_modules_test (void **state)
     assert_int_equal(SR_ERR_OK, rc);
     assert_non_null(val);
     assert_int_equal(SR_INSTANCEID_T, val->type);
-    assert_string_equal("/ietf-interfaces:interfaces/ietf-interfaces:interface[ietf-interfaces:name='ifA']", val->data.instanceid_val);
+    assert_string_equal("/ietf-interfaces:interfaces/interface[name='ifA']", val->data.instanceid_val);
     sr_free_val(val);
 
     sr_unsubscribe(session, subs);

--- a/tests/helpers/test_module_helper.h
+++ b/tests/helpers/test_module_helper.h
@@ -142,7 +142,7 @@ void skip_if_daemon_running();
 #define XP_TEST_MODULE_ANYDATA_VALUE "<container><leaf1>value1</leaf1><leaf2>value2</leaf2></container>"
 
 #define XP_TEST_MODULE_INSTANCE_ID "/test-module:main/instance_id"
-#define XP_TEST_MODULE_INSTANCE_ID_VALUE "/test-module:main/test-module:i64"
+#define XP_TEST_MODULE_INSTANCE_ID_VALUE "/test-module:main/i64"
 
 #define XP_TEST_MODULE_DEC64_IN_UNION "/test-module:dec64-in-union"
 #define XP_TEST_MODULE_DEC64_IN_UNION_VALUE "-11.17"

--- a/tests/rp_dt_edit_test.c
+++ b/tests/rp_dt_edit_test.c
@@ -1163,7 +1163,7 @@ void edit_instance_id_test(void **state) {
     rc = rp_dt_get_value_wrapper(ctx, session, NULL, "/test-module:main/instance_id", &new_val);
     assert_int_equal(SR_ERR_OK, rc);
 
-    assert_string_equal("/test-module:main/test-module:string", new_val->data.instanceid_val);
+    assert_string_equal("/test-module:main/string", new_val->data.instanceid_val);
     sr_free_val(new_val);
 
     /* container */
@@ -1209,14 +1209,14 @@ void edit_instance_id_test(void **state) {
     rc = rp_dt_get_value_wrapper(ctx, session, NULL, "/test-module:main/instance_id", &new_val);
     assert_int_equal(SR_ERR_OK, rc);
 
-    assert_string_equal("/test-module:list[test-module:key='k1']", new_val->data.instanceid_val);
+    assert_string_equal("/test-module:list[key='k1']", new_val->data.instanceid_val);
     sr_free_val(new_val);
 
     /* leaf-list */
     value = calloc(1, sizeof(*value));
     assert_non_null(value);
     value->type = SR_INSTANCEID_T;
-    value->data.instanceid_val = strdup("/test-module:main/test-module:numbers[.='42']");
+    value->data.instanceid_val = strdup("/test-module:main/numbers[.='42']");
     assert_non_null(value->data.instanceid_val);
 
     rc = rp_dt_set_item_wrapper(ctx, session, "/test-module:main/instance_id", value, NULL, SR_EDIT_DEFAULT);
@@ -1232,7 +1232,7 @@ void edit_instance_id_test(void **state) {
     rc = rp_dt_get_value_wrapper(ctx, session, NULL, "/test-module:main/instance_id", &new_val);
     assert_int_equal(SR_ERR_OK, rc);
 
-    assert_string_equal("/test-module:main/test-module:numbers[.='42']", new_val->data.instanceid_val);
+    assert_string_equal("/test-module:main/numbers[.='42']", new_val->data.instanceid_val);
     sr_free_val(new_val);
 
     //TODO: node outside of the module


### PR DESCRIPTION
### Description
libyang was internally using XML instance-identifier format (all nodes qualified), but now it uses standard JSON because it actually was an oversight.

### Test case
Affected tests updated.
