### PR TITLE
Merge master into devel

### DIFF
--- a/deploy/travis/install-libs.sh
+++ b/deploy/travis/install-libs.sh
@@ -24,11 +24,11 @@ if [ ! -d "$INSTALL_PREFIX_DIR/lib" ]; then
     make -j2 > /dev/null && make install
     cd ../..
 
-    # protobuf 
+    # protobuf
     wget https://github.com/google/protobuf/archive/v3.2.0.tar.gz
     tar -xzf v3.2.0.tar.gz
     cd protobuf-3.2.0
-    ./autogen.sh && ./configure --prefix=$INSTALL_PREFIX_DIR 
+    ./autogen.sh && ./configure --prefix=$INSTALL_PREFIX_DIR
     make -j2 > /dev/null && make install
     cd ..
 

--- a/inc/sysrepo.h
+++ b/inc/sysrepo.h
@@ -54,6 +54,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <time.h>
 #ifdef __APPLE__
     #include <sys/types.h>
 #endif


### PR DESCRIPTION
Without this merge, git says that this branch is not an ancestor of either the 0.6 or 0.7 tags, and therefore `git describe --tags` only refers to v0.5. That was misleading.

There were also two minor changes which were not part of `devel` by accident.