### PR TITLE
Support handling of pending events with a custom event loop

### DIFF
--- a/examples/application_fd_watcher_example.c
+++ b/examples/application_fd_watcher_example.c
@@ -188,6 +188,12 @@ event_loop()
     } while ((SR_ERR_OK == rc) && !exit_application);
 }
 
+void
+flush_all_events()
+{
+    printf("We are single-threaded, no reason to wait for all pending events to be processed\n");
+}
+
 int
 main(int argc, char **argv)
 {
@@ -202,7 +208,7 @@ main(int argc, char **argv)
     }
 
     /* init app-local fd watcher */
-    rc = sr_fd_watcher_init(&poll_fd_set[0].fd);
+    rc = sr_fd_watcher_init(&poll_fd_set[0].fd, &flush_all_events);
     poll_fd_set[0].events = POLLIN;
     poll_fd_cnt = 1;
 

--- a/inc/sysrepo.h
+++ b/inc/sysrepo.h
@@ -1888,6 +1888,11 @@ typedef struct sr_fd_change_s {
 } sr_fd_change_t;
 
 /**
+ * @brief Callback when the subscription manager is terminated
+ */
+typedef void (*sr_fd_sm_terminated_cb)();
+
+/**
  * @brief Initializes application-local file descriptor watcher.
  *
  * This can be used in those applications that subscribe for changes or providing data in sysrepo, which have their
@@ -1902,9 +1907,14 @@ typedef struct sr_fd_change_s {
  * @param[out] fd Initial file descriptor that is supposed to be monitored for readable events by the application.
  * Once there is an event detected on this file descriptor, the application is supposed to call ::sr_fd_event_process.
  *
+ * @param[in] sm_terminate_cb Function to be called when the subscription manager is terminated. If this callback is provided,
+ * it shall block until all pending events on any file descriptor associated with sysrepo have been handled. I.e., ensure that
+ * the event loop has called sr_fd_event_process() for all pending events before returning from this callback. If this callback
+ * doesn't block, errors will be shown in the log.
+ *
  * @return Error code (SR_ERR_OK on success).
  */
-int sr_fd_watcher_init(int *fd);
+int sr_fd_watcher_init(int *fd, sr_fd_sm_terminated_cb sm_terminate_cb);
 
 /**
  * @brief Cleans-up the application-local file descriptor watcher previously initiated by ::sr_fd_watcher_init.

--- a/src/clientlib/cl_subscription_manager.c
+++ b/src/clientlib/cl_subscription_manager.c
@@ -290,7 +290,11 @@ cl_sm_connection_cleanup(void *connection_p)
 
         /* stop monitoring client file descriptor */
         if (conn->sm_ctx->local_fd_watcher) {
-            cl_sm_fd_changeset_add(conn->sm_ctx, conn->fd, (SR_FD_INPUT_READY | SR_FD_OUTPUT_READY), SR_FD_STOP_WATCHING);
+            if (conn->sm_ctx->local_watcher_terminate_cb) {
+                /* do nothing, we have already asked for the event loop to be stopped */
+            } else {
+                cl_sm_fd_changeset_add(conn->sm_ctx, conn->fd, (SR_FD_INPUT_READY | SR_FD_OUTPUT_READY), SR_FD_STOP_WATCHING);
+            }
         } else {
             if (NULL != conn->read_watcher.data) {
                 ev_io_stop(conn->sm_ctx->event_loop, &conn->read_watcher);
@@ -1365,8 +1369,12 @@ cl_sm_server_cleanup(cl_sm_ctx_t *sm_ctx, cl_sm_server_ctx_t *server_ctx)
     if (NULL != server_ctx) {
         /* stop monitoring the server socket */
         if (sm_ctx->local_fd_watcher) {
-            cl_sm_fd_changeset_add(sm_ctx, server_ctx->listen_socket_fd, (SR_FD_INPUT_READY | SR_FD_OUTPUT_READY),
-                    SR_FD_STOP_WATCHING);
+            if (sm_ctx->local_watcher_terminate_cb) {
+                /* do nothing, we have already asked for the event loop to be stopped */
+            } else {
+                cl_sm_fd_changeset_add(sm_ctx, server_ctx->listen_socket_fd, (SR_FD_INPUT_READY | SR_FD_OUTPUT_READY),
+                        SR_FD_STOP_WATCHING);
+            }
         } else {
             if (NULL != server_ctx->server_watcher.data) {
                 ev_io_stop(sm_ctx->event_loop, &server_ctx->server_watcher);

--- a/src/clientlib/cl_subscription_manager.h
+++ b/src/clientlib/cl_subscription_manager.h
@@ -85,13 +85,14 @@ typedef struct cl_sm_subscription_ctx_s {
  *
  * @param[in] local_fd_watcher TRUE in case that the application wants to use an application-local file descriptor
  * watcher instead of auto-created thread and event loop.
+ * @param[in] local_sm_terminate_cb Callback for synchronous flushing of event queue if using an application-local FD
  * @param[in] notify_pipe Pipe used for notifications about fd set changes towards application-local
  * file descriptor watcher.
  * @param[out] sm_ctx Subscription Manager context that can be used in subsequent SM API calls.
  *
  * @return Error code (SR_ERR_OK on success).
  */
-int cl_sm_init(bool local_fd_watcher, int notify_pipe[2], cl_sm_ctx_t **sm_ctx);
+int cl_sm_init(bool local_fd_watcher, sr_fd_sm_terminated_cb local_sm_terminate_cb, int notify_pipe[2], cl_sm_ctx_t **sm_ctx);
 
 /**
  * @brief Cleans up the Subscription Manager.

--- a/src/clientlib/client_library.c
+++ b/src/clientlib/client_library.c
@@ -100,6 +100,8 @@ static int subscriptions_cnt = 0;             /**< Number of active subscription
 static cm_ctx_t *local_cm_ctx = NULL;         /**< Local Connection Manager context in case of library mode. */
 static cl_sm_ctx_t *cl_sm_ctx = NULL;         /**< Subscription Manager context. */
 static int local_watcher_fd[2] = { -1, -1 };  /**< File descriptor pair of an application-local file descriptor watcher. */
+static sr_fd_sm_terminated_cb local_watcher_terminate_cb = NULL;
+                                              /**< Callback for blocking upon an exit of the last subscription manager */
 static pthread_mutex_t global_lock = PTHREAD_MUTEX_INITIALIZER;  /**< Mutex for locking shared global variables. */
 
 /**
@@ -292,7 +294,7 @@ cl_subscription_init(sr_session_ctx_t *session, Sr__SubscriptionType type, const
     pthread_mutex_lock(&global_lock);
     if (0 == subscriptions_cnt) {
         /* this is the first subscription - initialize subscription manager */
-        rc = cl_sm_init((-1 != local_watcher_fd[0]), local_watcher_fd, &cl_sm_ctx);
+        rc = cl_sm_init((-1 != local_watcher_fd[0]), local_watcher_terminate_cb, local_watcher_fd, &cl_sm_ctx);
     }
     subscriptions_cnt++;
     if (SR_ERR_OK == rc) {
@@ -3782,7 +3784,7 @@ cleanup:
 }
 
 int
-sr_fd_watcher_init(int *fd_p)
+sr_fd_watcher_init(int *fd_p, sr_fd_sm_terminated_cb sm_terminate_cb)
 {
     int pipefd[2] = { 0, };
     int ret = 0, rc = SR_ERR_OK;
@@ -3801,6 +3803,7 @@ sr_fd_watcher_init(int *fd_p)
     pthread_mutex_lock(&global_lock);
     local_watcher_fd[0] = pipefd[0];
     local_watcher_fd[1] = pipefd[1];
+    local_watcher_terminate_cb = sm_terminate_cb;
     pthread_mutex_unlock(&global_lock);
 
     *fd_p = pipefd[0]; /* return read end of the pipe */


### PR DESCRIPTION
When sysrepo is running with its own event loop, it ensures that all pending events have been processed when the subscription manager gets destroyed. This patch adds an equivalent functionality for scenarios where the application provides its own event loop.

This functionality requires a real blocking call, so it is not enough to reuse the existing event handling that is based on asynchronous writes to a notification pipe. A new callback function was needed.

I had to add both a new global static to `client_library.c` and an extra member to the `cl_sm_ctx_t` because `sr_fd_watcher_init` and `cl_sm_cleanup` are defined in separate translation units.

Technically speaking, it's still possible to call `sr_fd_watcher_init` with a NULL synchronizing callback. However, doing so results in some events not being handled if, e.g., the event loop runs in a different thread and the subscription manager gets destroyed "too soon", prior to the event loop having handled "everything".

Cc: @TrinityCoder