### PR TITLE
Skip initial commit validation

### DIFF
--- a/src/data_manager.c
+++ b/src/data_manager.c
@@ -416,7 +416,7 @@ cleanup:
  * @brief The function is called to load the requested module into the context.
  */
 const struct lys_module *
-dm_module_clb (struct ly_ctx *ctx, const char *name, const char *ns, int options, void *user_data)
+dm_module_clb(struct ly_ctx *ctx, const char *name, const char *ns, int options, void *user_data)
 {
     SR_LOG_DBG("CALLBACK FOR MODULE %s %s", name, ns);
     dm_ctx_t *dm_ctx = (dm_ctx_t *) user_data;
@@ -2282,7 +2282,7 @@ dm_string_cmp(void *a, void *b)
 static int
 dm_requires_tmp_context(dm_ctx_t *dm_ctx, dm_session_t *session, dm_data_info_t *di, sr_list_t **required_data, sr_list_t **required_modules)
 {
-    CHECK_NULL_ARG5(dm_ctx, session, di, required_data, required_modules);
+    CHECK_NULL_ARG4(dm_ctx, session, di, required_modules);
 
     int rc = SR_ERR_OK;
     md_module_t *module = NULL;
@@ -2295,7 +2295,7 @@ dm_requires_tmp_context(dm_ctx_t *dm_ctx, dm_session_t *session, dm_data_info_t 
     md_dep_t *dep = NULL;
     char *namespace = NULL;
     char *inserted_namespace = NULL;
-    bool inserted = false;
+    bool inserted = false, must_be_freed = false;
     char *module_name = NULL;
     dm_data_info_t *recursive_info = NULL;
 
@@ -2312,26 +2312,29 @@ dm_requires_tmp_context(dm_ctx_t *dm_ctx, dm_session_t *session, dm_data_info_t 
             /* installation time dependencies */
             ll_dep = module->deps->first;
             while (ll_dep) {
-               dep = (md_dep_t *) ll_dep->data;
-               ll_dep = ll_dep->next;
+                dep = (md_dep_t *) ll_dep->data;
+                ll_dep = ll_dep->next;
 
-               module_name = strdup(dep->dest->name);
-               CHECK_NULL_NOMEM_GOTO(module_name, rc, cleanup);
+                module_name = strdup(dep->dest->name);
+                CHECK_NULL_NOMEM_GOTO(module_name, rc, cleanup);
 
-               rc = sr_list_insert_unique_ord(*required_modules, module_name, dm_string_cmp, &inserted);
-               CHECK_RC_MSG_GOTO(rc, cleanup, "Failed to insert item into the list");
+                rc = sr_list_insert_unique_ord(*required_modules, module_name, dm_string_cmp, &inserted);
+                CHECK_RC_MSG_GOTO(rc, cleanup, "Failed to insert item into the list");
 
-               /* if dep has instanced id and it was inserted call recursively */
-               if (inserted && NULL != dep->dest->inst_ids->first) {
-                   rc = dm_get_data_info(dm_ctx, session, dep->dest->name, &recursive_info);
-                   CHECK_RC_LOG_GOTO(rc, cleanup, "Get data info failed for %s", dep->dest->name);
+                /* if dep has instanced id and it was inserted call recursively */
+                if (inserted && NULL != dep->dest->inst_ids->first) {
+                    rc = dm_get_data_info_internal(dm_ctx, session, dep->dest->name, true, &must_be_freed, &recursive_info);
+                    CHECK_RC_LOG_GOTO(rc, cleanup, "Get data info failed for %s", dep->dest->name);
 
-                   rc = dm_requires_tmp_context(dm_ctx, session, recursive_info, required_data, required_modules);
-                   CHECK_RC_LOG_GOTO(rc, cleanup, "Failed to resolve recusrive deps in %s", recursive_info->schema->module_name);
+                    rc = dm_requires_tmp_context(dm_ctx, session, recursive_info, required_data, required_modules);
+                    CHECK_RC_LOG_GOTO(rc, cleanup, "Failed to resolve recusrive deps in %s", recursive_info->schema->module_name);
 
-               } else if (!inserted){
-                   free(module_name);
-               }
+                    if (must_be_freed) {
+                        dm_data_info_free(recursive_info);
+                    }
+                } else if (!inserted){
+                    free(module_name);
+                }
             }
 
         }
@@ -2399,8 +2402,10 @@ dm_requires_tmp_context(dm_ctx_t *dm_ctx, dm_session_t *session, dm_data_info_t 
                     rc = sr_list_init(required_modules);
                     CHECK_RC_MSG_GOTO(rc, cleanup, "List initialization failed");
 
-                    rc = sr_list_init(required_data);
-                    CHECK_RC_MSG_GOTO(rc, cleanup, "List initialization failed");
+                    if (required_data) {
+                        rc = sr_list_init(required_data);
+                        CHECK_RC_MSG_GOTO(rc, cleanup, "List initialization failed");
+                    }
 
                     /* insert module itself */
                     module_name = strdup(di->schema->module_name);
@@ -2409,37 +2414,42 @@ dm_requires_tmp_context(dm_ctx_t *dm_ctx, dm_session_t *session, dm_data_info_t 
                     rc = sr_list_insert_unique_ord(*required_modules, module_name, dm_string_cmp, &inserted);
                     CHECK_RC_MSG_GOTO(rc, cleanup, "Failed to insert item into the list");
 
-                    rc = sr_list_add(*required_data, module_name);
-                    CHECK_RC_MSG_GOTO(rc, cleanup, "Failed to insert item into the list");
+                    if (required_data) {
+                        rc = sr_list_add(*required_data, module_name);
+                        CHECK_RC_MSG_GOTO(rc, cleanup, "Failed to insert item into the list");
+                    }
 
                     /* add installation time dependencies */
                     ll_dep = module->deps->first;
                     while (ll_dep) {
-                       dep = (md_dep_t *) ll_dep->data;
-                       ll_dep = ll_dep->next;
+                        dep = (md_dep_t *) ll_dep->data;
+                        ll_dep = ll_dep->next;
 
-                       module_name = strdup(dep->dest->name);
-                       CHECK_NULL_NOMEM_GOTO(module_name, rc, cleanup);
+                        module_name = strdup(dep->dest->name);
+                        CHECK_NULL_NOMEM_GOTO(module_name, rc, cleanup);
 
-                       rc = sr_list_insert_unique_ord(*required_modules, module_name, dm_string_cmp, &inserted);
-                       CHECK_RC_MSG_GOTO(rc, cleanup, "Failed to insert item into the list");
+                        rc = sr_list_insert_unique_ord(*required_modules, module_name, dm_string_cmp, &inserted);
+                        CHECK_RC_MSG_GOTO(rc, cleanup, "Failed to insert item into the list");
 
-                       if (inserted && dep->dest->has_data) {
-                           rc = sr_list_add(*required_data, module_name);
-                           CHECK_RC_MSG_GOTO(rc, cleanup, "Failed to add item into the list");
-                       }
+                        if (inserted && dep->dest->has_data && required_data) {
+                            rc = sr_list_add(*required_data, module_name);
+                            CHECK_RC_MSG_GOTO(rc, cleanup, "Failed to add item into the list");
+                        }
 
-                       /* if dep has instanced id and it was inserted call recursively */
-                       if (inserted && NULL != dep->dest->inst_ids->first) {
-                           rc = dm_get_data_info(dm_ctx, session, dep->dest->name, &recursive_info);
-                           CHECK_RC_LOG_GOTO(rc, cleanup, "Get data info failed for %s", dep->dest->name);
+                        /* if dep has instanced id and it was inserted call recursively */
+                        if (inserted && NULL != dep->dest->inst_ids->first) {
+                            rc = dm_get_data_info_internal(dm_ctx, session, dep->dest->name, true, &must_be_freed, &recursive_info);
+                            CHECK_RC_LOG_GOTO(rc, cleanup, "Get data info failed for %s", dep->dest->name);
 
-                           rc = dm_requires_tmp_context(dm_ctx, session, recursive_info, required_data, required_modules);
-                           CHECK_RC_LOG_GOTO(rc, cleanup, "Failed to resolve recusrive deps in %s", recursive_info->schema->module_name);
+                            rc = dm_requires_tmp_context(dm_ctx, session, recursive_info, required_data, required_modules);
+                            CHECK_RC_LOG_GOTO(rc, cleanup, "Failed to resolve recusrive deps in %s", recursive_info->schema->module_name);
 
-                       } else if (!inserted){
-                           free(module_name);
-                       }
+                            if (must_be_freed) {
+                                dm_data_info_free(recursive_info);
+                            }
+                        } else if (!inserted){
+                            free(module_name);
+                        }
                     }
                 }
                 inserted = false;
@@ -2449,15 +2459,21 @@ dm_requires_tmp_context(dm_ctx_t *dm_ctx, dm_session_t *session, dm_data_info_t 
                 namespace = NULL; /* do not free namespace in this function case of cleanup */
 
                 if (inserted) {
-                    rc = sr_list_add(*required_data, inserted_namespace);
-                    CHECK_RC_MSG_GOTO(rc, cleanup, "Failed to insert an item into the list");
+                    if (required_data) {
+                        rc = sr_list_add(*required_data, inserted_namespace);
+                        CHECK_RC_MSG_GOTO(rc, cleanup, "Failed to insert an item into the list");
+                    }
 
                     /* call recursively */
-                    rc = dm_get_data_info(dm_ctx, session, inserted_namespace, &recursive_info);
+                    rc = dm_get_data_info_internal(dm_ctx, session, inserted_namespace, true, &must_be_freed, &recursive_info);
                     CHECK_RC_LOG_GOTO(rc, cleanup, "Get data info failed for %s", inserted_namespace);
 
                     rc = dm_requires_tmp_context(dm_ctx, session, recursive_info, required_data, required_modules);
                     CHECK_RC_LOG_GOTO(rc, cleanup, "Failed to resolve recusrive deps in %s", recursive_info->schema->module_name);
+
+                    if (must_be_freed) {
+                        dm_data_info_free(recursive_info);
+                    }
                 }
             }
         }

--- a/src/data_manager.h
+++ b/src/data_manager.h
@@ -149,7 +149,7 @@ typedef enum dm_operation_e {
  */
 typedef enum dm_commit_state_e {
     DM_COMMIT_STARTED,
-    DM_COMMIT_VALIDATION,
+    DM_COMMIT_LOAD_MODEL_DEPS,
     DM_COMMIT_LOAD_MODIFIED_MODELS,
     DM_COMMIT_REPLAY_OPS,
     DM_COMMIT_VALIDATE_MERGED,
@@ -456,6 +456,15 @@ int dm_update_session_data_trees(dm_ctx_t *dm_ctx, dm_session_t *session, sr_lis
  * @return Error code (SR_ERR_OK on success)
  */
 int dm_commit_prepare_context(dm_ctx_t *dm_ctx, dm_session_t *session, dm_commit_context_t **c_ctx);
+
+/**
+ * @brief Fill required modules for all modules loaded in the session for the current session datastore.
+ *
+ * @param [in] dm_ctx
+ * @param [in] session
+ * @return Error code (SR_ERR_OK on success)
+ */
+int dm_commit_load_session_module_deps(dm_ctx_t *dm_ctx, dm_session_t *session);
 
 /**
  * @brief Loads the data tree which has been modified in the session to the commit context. If the session copy has

--- a/src/rp_dt_edit.c
+++ b/src/rp_dt_edit.c
@@ -813,15 +813,15 @@ rp_dt_commit(rp_ctx_t *rp_ctx, rp_session_t *session, dm_commit_context_t *c_ctx
         switch (state) {
         case DM_COMMIT_STARTED:
             SR_LOG_DBG_MSG("Commit (1/10): process started");
-            state = DM_COMMIT_VALIDATION;
+            state = DM_COMMIT_LOAD_MODEL_DEPS;
             break;
-        case DM_COMMIT_VALIDATION:
-            rc = dm_validate_session_data_trees(rp_ctx->dm_ctx, session->dm_session, errors, err_cnt);
+        case DM_COMMIT_LOAD_MODEL_DEPS:
+            rc = dm_commit_load_session_module_deps(rp_ctx->dm_ctx, session->dm_session);
             if (SR_ERR_OK != rc) {
-                SR_LOG_ERR("Data validation failed: %s", *err_cnt > 0 ? errors[0]->message : "(no error)");
-                return SR_ERR_VALIDATION_FAILED;
+                SR_LOG_ERR_MSG("Loading module dependencies failed.");
+                return SR_ERR_INTERNAL;
             }
-            SR_LOG_DBG_MSG("Commit (2/10): validation succeeded");
+            SR_LOG_DBG_MSG("Commit (2/10): loading module dependencies succeeded");
             state = DM_COMMIT_LOAD_MODIFIED_MODELS;
             break;
         case DM_COMMIT_LOAD_MODIFIED_MODELS:

--- a/tests/cl_notifications_test.c
+++ b/tests/cl_notifications_test.c
@@ -878,21 +878,21 @@ cl_get_changes_parents_test(void **state)
 
     assert_int_equal(changes.cnt, 4);
 
-    /* /test-module:presence-container/child2/grandchild2/grandchild2-leaf1 */
+    /* /test-module:presence-container/child2/child2-leaf */
     assert_int_equal(changes.oper[0], SR_OP_DELETED);
     assert_non_null(changes.old_values[0]);
-    assert_string_equal(GRANDCHILD2_LEAF1, changes.old_values[0]->xpath);
+    assert_string_equal(CHILD2_LEAF, changes.old_values[0]->xpath);
     assert_int_equal(SR_INT8_T, changes.old_values[0]->type);
-    assert_int_equal(13, changes.old_values[0]->data.int8_val);
+    assert_int_equal(12, changes.old_values[0]->data.int8_val);
     assert_false(changes.old_values[0]->dflt);
     assert_null(changes.new_values[0]);
 
-    /* /test-module:presence-container/child2/child2-leaf */
+    /* /test-module:presence-container/child2/grandchild2/grandchild2-leaf1 */
     assert_int_equal(changes.oper[1], SR_OP_DELETED);
     assert_non_null(changes.old_values[1]);
-    assert_string_equal(CHILD2_LEAF, changes.old_values[1]->xpath);
+    assert_string_equal(GRANDCHILD2_LEAF1, changes.old_values[1]->xpath);
     assert_int_equal(SR_INT8_T, changes.old_values[1]->type);
-    assert_int_equal(12, changes.old_values[1]->data.int8_val);
+    assert_int_equal(13, changes.old_values[1]->data.int8_val);
     assert_false(changes.old_values[1]->dflt);
     assert_null(changes.new_values[1]);
 


### PR DESCRIPTION
### Description
Initial datastore validation before every commit is redundant and hence was removed.

### Closure
Fixes #892
