### PR TITLE
BUGFIX sr_get_* support for full xpath

### DIFF
--- a/src/rp_dt_lookup.c
+++ b/src/rp_dt_lookup.c
@@ -42,7 +42,7 @@ rp_dt_find_nodes(const dm_ctx_t *dm_ctx, struct lyd_node *data_tree, const char 
     }
     struct ly_set *res = lyd_find_path(data_tree, xpath);
     if (NULL == res) {
-        SR_LOG_ERR_MSG("Lyd get node failed");
+        SR_LOG_ERR_MSG("Lyd find path failed");
         return LY_EINVAL == ly_errno || LY_EVALID == ly_errno ? SR_ERR_INVAL_ARG : SR_ERR_INTERNAL;
     }
 

--- a/tests/cl_test.c
+++ b/tests/cl_test.c
@@ -442,21 +442,16 @@ cl_get_item_test(void **state)
 
     /* bad element in existing module */
     rc = sr_get_item(session, "/example-module:unknown/next", &value);
-    assert_int_equal(SR_ERR_BAD_ELEMENT, rc);
+    assert_int_equal(SR_ERR_NOT_FOUND, rc);
     assert_null(value);
-
-    const sr_error_info_t *err = NULL;
-    sr_get_last_error(session, &err);
-    assert_non_null(err->xpath);
-    assert_string_equal("/example-module:unknown/next", err->xpath);
 
     /* unknown key node */
     rc = sr_get_item(session, "/example-module:container/list[key1='abc'][unknownKey='def']/leaf", &value);
-    assert_int_equal(SR_ERR_BAD_ELEMENT, rc);
+    assert_int_equal(SR_ERR_NOT_FOUND, rc);
 
     /* bad element in augment */
     rc = sr_get_item(session, "/ietf-interfaces:interfaces/interface[name='eth0']/ietf-ip:ipv4/unknown", &value);
-    assert_int_equal(SR_ERR_BAD_ELEMENT, rc);
+    assert_int_equal(SR_ERR_NOT_FOUND, rc);
 
     /* existing leaf */
     rc = sr_get_item(session, "/example-module:container/list[key1='key1'][key2='key2']/leaf", &value);
@@ -529,7 +524,7 @@ cl_get_subtree_test(void **state)
 
     /* bad element in existing module */
     rc = sr_get_subtree(session, "/example-module:unknown/next", 0, &tree);
-    assert_int_equal(SR_ERR_BAD_ELEMENT, rc);
+    assert_int_equal(SR_ERR_NOT_FOUND, rc);
     assert_null(tree);
 
     /* existing leaf */
@@ -682,7 +677,7 @@ cl_get_items_test(void **state)
 
     /* bad element in existing */
     rc = sr_get_items(session, "/example-module:unknown", &values, &values_cnt);
-    assert_int_equal(SR_ERR_BAD_ELEMENT, rc);
+    assert_int_equal(SR_ERR_NOT_FOUND, rc);
 
     /* container */
     rc = sr_get_items(session, "/ietf-interfaces:interfaces/*", &values, &values_cnt);
@@ -752,7 +747,7 @@ cl_get_subtrees_test(void **state)
 
     /* bad element in existing module produces */
     rc = sr_get_subtrees(session, "/example-module:unknown", 0, &trees, &tree_cnt);
-    assert_int_equal(SR_ERR_BAD_ELEMENT, rc);
+    assert_int_equal(SR_ERR_NOT_FOUND, rc);
 
     /* container */
     rc = sr_get_subtrees(session, "/ietf-interfaces:interfaces/*", 0, &trees, &tree_cnt);
@@ -1945,18 +1940,18 @@ cl_get_error_test(void **state)
 
     /* attempt to get item on bad element in existing module */
     rc = sr_get_item(session, "/example-module:container/unknown", &value);
-    assert_int_equal(SR_ERR_BAD_ELEMENT, rc);
+    assert_int_equal(SR_ERR_NOT_FOUND, rc);
     assert_null(value);
 
     /* retrieve last error information */
     rc = sr_get_last_error(session, &error_info);
-    assert_int_equal(SR_ERR_BAD_ELEMENT, rc);
+    assert_int_equal(SR_ERR_NOT_FOUND, rc);
     assert_non_null(error_info);
     assert_non_null(error_info->message);
 
     /* retrieve last error information */
     rc = sr_get_last_errors(session, &error_info, &error_cnt);
-    assert_int_equal(SR_ERR_BAD_ELEMENT, rc);
+    assert_int_equal(SR_ERR_NOT_FOUND, rc);
     assert_non_null(error_info);
     assert_int_equal(error_cnt, 1);
     assert_non_null(error_info[0].message);

--- a/tests/sysrepocfg_test.c
+++ b/tests/sysrepocfg_test.c
@@ -431,7 +431,7 @@ srcfg_test_xpath(void **state)
         printf("Error by sr_session_refresh %s\n", sr_strerror(rc));
     }
     rc = sr_get_item(srcfg_test_session, "/ietf-interfaces:interfaces/interface[name='eth0']/ietf-ip:ipv4/fakeleaf", &rvalue);
-    assert_int_equal(rc, SR_ERR_BAD_ELEMENT);
+    assert_int_equal(rc, SR_ERR_NOT_FOUND);
     sr_free_val(rvalue);
     rvalue = NULL;
 


### PR DESCRIPTION
### Description
Data were retrieved correctly, but in case
of an error, teh path was checked against schema
and more detailed error was generated. However,
libyang no longer supports such evaluations and
implementing it all (xpath on schema) in sysrepo
would be a duplication of previous libyang
that got removed. So, this schema check was removed.

Specifically, SR_ERR_BAD_ELEMENT is no longer returned
by these functions, no other visible change happened.

### Closure
Fixes #920
Fixes cesnet/netopeer2#172