### PR TITLE
BUGFIX separate node test from predicate first

### DIFF
--- a/src/common/sr_utils.c
+++ b/src/common/sr_utils.c
@@ -2476,6 +2476,10 @@ sr_find_schema_node(const struct lys_module *module, const struct lys_node *star
 
     /* main loop */
     while (1) {
+        if ((predicate = strchr(name, '['))) {
+            predicate[0] = '\0';
+            ++predicate;
+        }
         mod_name = strchr(name, ':');
         if (mod_name) {
             mod_name[0] = '\0';
@@ -2489,10 +2493,6 @@ sr_find_schema_node(const struct lys_module *module, const struct lys_node *star
         } else if (name[0] == '/') {
             all_desc = 1;
             ++name;
-        }
-        if ((predicate = strchr(name, '['))) {
-            predicate[0] = '\0';
-            ++predicate;
         }
         if (all_desc && (0 != strcmp(name, ".")) && (0 != strcmp(name, "*"))) {
             /* we do not support "node//node" */


### PR DESCRIPTION
### Description
Otherwise some characters could be found in the predicate and thought to be in the node test such as colon for a prefix in the predicate.

### Closure
Fixes #926