### PR TITLE
Copy-config running backup restore removed

### DIFF
--- a/inc/sysrepo.h
+++ b/inc/sysrepo.h
@@ -1041,6 +1041,8 @@ int sr_discard_changes(sr_session_ctx_t *session);
  * @note Operation may fail, if it tries to copy a not enabled configuration to the
  * running datastore.
  *
+ * @note \p session \p dst_datastore uncommitted changes will get discarded.
+ *
  * @param[in] session Session context acquired with ::sr_session_start call.
  * @param[in] module_name If specified, only limits the copy operation only to
  * one specified module.

--- a/src/data_manager.c
+++ b/src/data_manager.c
@@ -6704,16 +6704,15 @@ dm_move_session_trees_in_session(dm_ctx_t *dm_ctx, dm_session_t *session, sr_dat
     rc = dm_discard_changes(dm_ctx, session, NULL);
     CHECK_RC_MSG_RETURN(rc, "Discard changes failed");
 
-    rc = dm_session_switch_ds(session, prev_ds);
+    dm_session_switch_ds(session, prev_ds);
     return rc;
 }
 
-int
+void
 dm_session_switch_ds(dm_session_t *session, sr_datastore_t ds)
 {
-    CHECK_NULL_ARG(session);
+    CHECK_NULL_ARG_VOID(session);
     session->datastore = ds;
-    return SR_ERR_OK;
 }
 
 int

--- a/src/data_manager.h
+++ b/src/data_manager.h
@@ -1039,9 +1039,8 @@ int dm_copy_if_not_loaded(dm_ctx_t *dm_ctx, dm_session_t *from_session, dm_sessi
  * will work on the selected datastore.
  * @param [in] session
  * @param [in] ds
- * @return Error code (SR_ERR_OK on success)
  */
-int dm_session_switch_ds(dm_session_t *session, sr_datastore_t ds);
+void dm_session_switch_ds(dm_session_t *session, sr_datastore_t ds);
 
 /**
  * @brief Moves session data trees and operations (for all datastores) from one session to another.

--- a/src/data_manager.h
+++ b/src/data_manager.h
@@ -1047,9 +1047,10 @@ void dm_session_switch_ds(dm_session_t *session, sr_datastore_t ds);
  * @param [in] dm_ctx
  * @param [in] from
  * @param [in] to
+ * @param [in] ds
  * @return Error code (SR_ERR_OK on success)
  */
-int dm_move_session_tree_and_ops_all_ds(dm_ctx_t *dm_ctx, dm_session_t *from, dm_session_t *to);
+int dm_move_session_tree_and_ops(dm_ctx_t *dm_ctx, dm_session_t *from, dm_session_t *to, sr_datastore_t ds);
 
 /**
  * @brief Moves data trees from one datastore to another in the session

--- a/src/data_manager.h
+++ b/src/data_manager.h
@@ -417,9 +417,10 @@ int dm_validate_session_data_trees(dm_ctx_t *dm_ctx, dm_session_t *session, sr_e
  * call ::dm_get_data_info will load fresh data.
  * @param [in] dm_ctx
  * @param [in] session
+ * @param [in] module_name Optional module name.
  * @return Error code (SR_ERR_OK on success)
  */
-int dm_discard_changes(dm_ctx_t *dm_ctx, dm_session_t *session);
+int dm_discard_changes(dm_ctx_t *dm_ctx, dm_session_t *session, const char *module_name);
 
 /**
  * @brief Removes the modified flags from session copies of data trees.

--- a/src/request_processor.c
+++ b/src/request_processor.c
@@ -1674,7 +1674,7 @@ rp_switch_datastore_req_process(rp_ctx_t *rp_ctx, rp_session_t *session, Sr__Msg
         return SR_ERR_NOMEM;
     }
 
-    rc = rp_dt_switch_datastore(rp_ctx, session, sr_datastore_gpb_to_sr(msg->request->session_switch_ds_req->datastore));
+    rp_dt_switch_datastore(rp_ctx, session, sr_datastore_gpb_to_sr(msg->request->session_switch_ds_req->datastore));
 
     /* set response code */
     resp->response->result = rc;

--- a/src/request_processor.c
+++ b/src/request_processor.c
@@ -1519,7 +1519,7 @@ rp_discard_changes_req_process(const rp_ctx_t *rp_ctx, const rp_session_t *sessi
         return SR_ERR_NOMEM;
     }
 
-    rc = dm_discard_changes(rp_ctx->dm_ctx, session->dm_session);
+    rc = dm_discard_changes(rp_ctx->dm_ctx, session->dm_session, NULL);
 
     /* set response code */
     resp->response->result = rc;

--- a/src/rp_dt_edit.c
+++ b/src/rp_dt_edit.c
@@ -1088,7 +1088,7 @@ rp_dt_copy_config_to_running(rp_ctx_t *rp_ctx, rp_session_t *session, const char
         rc = dm_move_session_tree_and_ops_all_ds(rp_ctx->dm_ctx, session->dm_session, backup);
         CHECK_RC_MSG_GOTO(rc, cleanup_sess_stop, "Moving session data trees failed");
 
-        rc = rp_dt_switch_datastore(rp_ctx, session, src);
+        rp_dt_switch_datastore(rp_ctx, session, src);
 
         /* load models to be committed to the session */
         if (NULL != module_name) {
@@ -1167,8 +1167,7 @@ rp_dt_copy_config(rp_ctx_t *rp_ctx, rp_session_t *session, const char *module_na
     }
 
     if ((SR_DS_CANDIDATE == src || SR_DS_CANDIDATE == dst) && SR_DS_CANDIDATE != session->datastore) {
-        rc = rp_dt_switch_datastore(rp_ctx, session, SR_DS_CANDIDATE);
-        CHECK_RC_MSG_RETURN(rc, "Datastore switch failed");
+        rp_dt_switch_datastore(rp_ctx, session, SR_DS_CANDIDATE);
     }
 
     if (SR_DS_RUNNING != dst) {
@@ -1190,15 +1189,13 @@ rp_dt_copy_config(rp_ctx_t *rp_ctx, rp_session_t *session, const char *module_na
     return rc;
 }
 
-int
+void
 rp_dt_switch_datastore(rp_ctx_t *rp_ctx, rp_session_t *session, sr_datastore_t ds)
 {
-    CHECK_NULL_ARG3(rp_ctx, session, session->dm_session);
-    int rc = SR_ERR_OK;
+    CHECK_NULL_ARG_VOID3(rp_ctx, session, session->dm_session);
     SR_LOG_INF("Switch datastore request %s -> %s", sr_ds_to_str(session->datastore), sr_ds_to_str(ds));
     session->datastore = ds;
-    rc = dm_session_switch_ds(session->dm_session, ds);
-    return rc;
+    dm_session_switch_ds(session->dm_session, ds);
 }
 
 int

--- a/src/rp_dt_edit.c
+++ b/src/rp_dt_edit.c
@@ -963,7 +963,7 @@ cleanup:
     if (SR_ERR_OK == rc) {
         /* discard changes in session in next get_data_tree call newly committed content will be loaded */
         if (SR_DS_CANDIDATE != session->datastore) {
-            rc = dm_discard_changes(rp_ctx->dm_ctx, session->dm_session);
+            rc = dm_discard_changes(rp_ctx->dm_ctx, session->dm_session, NULL);
         }
         SR_LOG_DBG_MSG("Commit (10/10): finished successfully");
     } else {

--- a/src/rp_dt_edit.h
+++ b/src/rp_dt_edit.h
@@ -157,9 +157,8 @@ int rp_dt_copy_config(rp_ctx_t *rp_ctx, rp_session_t *session, const char *modul
  * @param [in] rp_ctx
  * @param [in] session
  * @param [in] ds
- * @return Error code (SR_ERR_OK on success)
  */
-int rp_dt_switch_datastore(rp_ctx_t *rp_ctx, rp_session_t *session, sr_datastore_t ds);
+void rp_dt_switch_datastore(rp_ctx_t *rp_ctx, rp_session_t *session, sr_datastore_t ds);
 
 /**
  * @brief Locks a model or whole datastore. Lock can not be acquired if the session

--- a/tests/cl_notifications_test.c
+++ b/tests/cl_notifications_test.c
@@ -878,21 +878,21 @@ cl_get_changes_parents_test(void **state)
 
     assert_int_equal(changes.cnt, 4);
 
-    /* /test-module:presence-container/child2/child2-leaf */
+    /* /test-module:presence-container/child2/grandchild2/grandchild2-leaf1 */
     assert_int_equal(changes.oper[0], SR_OP_DELETED);
     assert_non_null(changes.old_values[0]);
-    assert_string_equal(CHILD2_LEAF, changes.old_values[0]->xpath);
+    assert_string_equal(GRANDCHILD2_LEAF1, changes.old_values[0]->xpath);
     assert_int_equal(SR_INT8_T, changes.old_values[0]->type);
-    assert_int_equal(12, changes.old_values[0]->data.int8_val);
+    assert_int_equal(13, changes.old_values[0]->data.int8_val);
     assert_false(changes.old_values[0]->dflt);
     assert_null(changes.new_values[0]);
 
-    /* /test-module:presence-container/child2/grandchild2/grandchild2-leaf1 */
+    /* /test-module:presence-container/child2/child2-leaf */
     assert_int_equal(changes.oper[1], SR_OP_DELETED);
     assert_non_null(changes.old_values[1]);
-    assert_string_equal(GRANDCHILD2_LEAF1, changes.old_values[1]->xpath);
+    assert_string_equal(CHILD2_LEAF, changes.old_values[1]->xpath);
     assert_int_equal(SR_INT8_T, changes.old_values[1]->type);
-    assert_int_equal(13, changes.old_values[1]->data.int8_val);
+    assert_int_equal(12, changes.old_values[1]->data.int8_val);
     assert_false(changes.old_values[1]->dflt);
     assert_null(changes.new_values[1]);
 

--- a/tests/dm_test.c
+++ b/tests/dm_test.c
@@ -308,7 +308,7 @@ dm_discard_changes_test(void **state)
     rc = dm_get_data_info(ctx, ses_ctx, "test-module", &info);
     assert_int_equal(SR_ERR_OK, rc);
 
-    rc = dm_discard_changes(ctx, ses_ctx);
+    rc = dm_discard_changes(ctx, ses_ctx, "test-module");
     assert_int_equal(SR_ERR_OK, rc);
 
     rc = dm_get_data_info(ctx, ses_ctx, "test-module", &info);
@@ -330,7 +330,7 @@ dm_discard_changes_test(void **state)
     assert_int_equal(100, ((struct lyd_node_leaf_list *)info->node->child->next->next->next->next)->value.int8);
 
     /* discard changes to get current datastore value*/
-    rc = dm_discard_changes(ctx, ses_ctx);
+    rc = dm_discard_changes(ctx, ses_ctx, NULL);
     assert_int_equal(SR_ERR_OK, rc);
 
     rc = dm_get_data_info(ctx, ses_ctx, "test-module", &info);

--- a/tests/rp_dt_edit_test.c
+++ b/tests/rp_dt_edit_test.c
@@ -1621,7 +1621,7 @@ edit_discard_changes_test(void **state)
     assert_int_equal(XP_TEST_MODULE_INT64_VALUE_T, valueB->data.int64_val);
     sr_free_val(valueB);
 
-    rc = dm_discard_changes(ctx->dm_ctx, sessionA->dm_session);
+    rc = dm_discard_changes(ctx->dm_ctx, sessionA->dm_session, NULL);
     assert_int_equal(SR_ERR_OK, rc);
 
     sessionA->state = RP_REQ_NEW;
@@ -2316,7 +2316,7 @@ candidate_edit_test(void **state)
     errors = NULL;
     e_cnt = 0;
 
-    rc = dm_discard_changes(ctx->dm_ctx, sessionA->dm_session);
+    rc = dm_discard_changes(ctx->dm_ctx, sessionA->dm_session, NULL);
     assert_int_equal(SR_ERR_OK, rc);
 
     sr_val_t *v = NULL;


### PR DESCRIPTION
### Description
When performing copy-config to running, uncommitted running changes get discarded. Keeping them is quite challenging implementation-wise, but is generally useless and not desired anyway. 

### Closure
Fixes #890 (this replaces the previous commit 580be52e3c48829ddad31a9d8423cdbe28fd9bfd)
