### PR TITLE
Releases 0.7.0 and 0.7.1 added to README.md + fixed typos in SWIG C++ examples' doxygen comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,8 @@ Sysrepo can be easily integrated with management agents such as [NETCONF](https:
 -	(TODO) native client libraries / plugins for other programming languages (Python, Java, ...)
 
 ## Status
+- September 2017: sysrepo [version 0.7.1](https://github.com/sysrepo/sysrepo/releases/tag/v0.7.1) released with many bugfixes and optimizations
+- August 2017: sysrepo [version 0.7.0](https://github.com/sysrepo/sysrepo/releases/tag/v0.7.0) released with several important improvements and changes: full NACM support, (X)Paths for subscriptions unified, candidate datastore changes, `sr_commit` functionality change and many bugfixes and enhancements
 - May 2017: sysrepo [version 0.6.0](https://github.com/sysrepo/sysrepo/releases/tag/v0.6.0) realeased with many bugfixes and improvements including event notification replay.
 - November 2016: sysrepo [version 0.5.0](https://github.com/sysrepo/sysrepo/releases/tag/v0.5.0) realeased with many bugfixes and some minor improvements.
 - October 2016: sysrepo [version 0.4.0](https://github.com/sysrepo/sysrepo/releases/tag/v0.4.0) realeased with lots of new features such as: operational data support, commit verifiers, YANG 1.1 support, subtree-based data retrieval or RPC / event notifications support.

--- a/swig/cpp/examples/cpp_application_changes_example.cpp
+++ b/swig/cpp/examples/cpp_application_changes_example.cpp
@@ -1,5 +1,5 @@
 /**
- * @file application_changes_example.cpp
+ * @file cpp_application_changes_example.cpp
  * @author Mislav Novakovic <mislav.novakovic@sartura.hr>
  * @brief Example application that uses sysrepo as the configuration datastore. It
  * prints the changes made in running data store.

--- a/swig/cpp/examples/cpp_application_example.cpp
+++ b/swig/cpp/examples/cpp_application_example.cpp
@@ -1,5 +1,5 @@
 /**
- * @file application_example.cpp
+ * @file cpp_application_example.cpp
  * @author Mislav Novakovic <mislav.novakovic@sartura.hr>
  * @brief Example application that uses sysrepo as the configuraton datastore.
  *

--- a/swig/cpp/examples/cpp_delete_item_example.cpp
+++ b/swig/cpp/examples/cpp_delete_item_example.cpp
@@ -1,5 +1,5 @@
 /**
- * @file delete_item_example.cpp
+ * @file cpp_delete_item_example.cpp
  * @author Mislav Novakovic <mislav.novakovic@sartura.hr>
  * @brief Example usage of delete_item_example function.
  *

--- a/swig/cpp/examples/cpp_get_item_example.cpp
+++ b/swig/cpp/examples/cpp_get_item_example.cpp
@@ -1,5 +1,5 @@
 /**
- * @file get_item_example.cpp
+ * @file cpp_get_item_example.cpp
  * @author Mislav Novakovic <mislav.novakovic@sartura.hr>
  * @brief Example usage of get_item method
  *

--- a/swig/cpp/examples/cpp_get_items_example.cpp
+++ b/swig/cpp/examples/cpp_get_items_example.cpp
@@ -1,5 +1,5 @@
 /**
- * @file get_items_example.cpp
+ * @file cpp_get_items_example.cpp
  * @author Mislav Novakovic <mislav.novakovic@gmail.com>
  * @brief Example usage of get_items function
  *

--- a/swig/cpp/examples/cpp_get_items_iter_example.cpp
+++ b/swig/cpp/examples/cpp_get_items_iter_example.cpp
@@ -1,5 +1,5 @@
 /**
- * @file get_items_iter_example.cpp
+ * @file cpp_get_items_iter_example.cpp
  * @author Mislav Novakovic <mislav.novakovic@gmail.com>
  * @brief Example usage of get_items_iter function
  *

--- a/swig/cpp/examples/cpp_rpc_example.cpp
+++ b/swig/cpp/examples/cpp_rpc_example.cpp
@@ -1,8 +1,9 @@
 /**
- * @file application_changes_example.cpp
+ * @file cpp_rpc_example.cpp
  * @author Mislav Novakovic <mislav.novakovic@sartura.hr>
- * @brief Example application that uses sysrepo as the configuration datastore. It
- * prints the changes made in running data store.
+ * @brief Example usage of rpc(), rpc_tree(), rpc_subscribe_tree(),
+ * rpc_send() and others related to the Remote procedure call (RPC)
+ * mechanism
  *
  * @copyright
  * Copyright 2016 Deutsche Telekom AG.

--- a/swig/cpp/examples/cpp_set_item_example.cpp
+++ b/swig/cpp/examples/cpp_set_item_example.cpp
@@ -1,5 +1,5 @@
 /**
- * @file set_item_example.cpp
+ * @file cpp_set_item_example.cpp
  * @author Mislav Novakovic <mislav.novakovic@sartura.hr>
  * @brief Example usage of set_item_example function.
  *


### PR DESCRIPTION
This pull request consists of two commits.

**[commit 1] Releases 0.7.0 and 0.7.1 mentioned in README.md**

I've noted that the last two releases of sysrepo are not mentioned in the version list in README.md.

I think this could be confusing, especially for newcomers, who could think that the last release is 0.6.0, several months old.

So I have added those two versions into the list. I don't know if you like the descriptions I have written to them, if not, feel free to change them to anything you want.

**[commit 2] DOC fixed typos in SWIG C++ examples' descriptions**

I've noticed that the C++ SWIG examples (_swig/cpp/examples/*.cpp_), when opened, have incorrect filenames under the "`@file`" doxygen tags - the "cpp_" file prefix is always missing.
I have added this prefix to all the source files.

Moreover, the _cpp_rpc_example.cpp_ file had whole filename and description wrong (obviously copy-pasted from _cpp_application_changes_example.cpp_ file). Here, I have fixed the filename and written my own "`@brief`" description.

Best regards!