### PR TITLE
Portable printing of size_t

### DIFF
--- a/src/clientlib/client_library.c
+++ b/src/clientlib/client_library.c
@@ -1617,7 +1617,7 @@ sr_get_subtree_next_chunk(sr_session_ctx_t *session, sr_node_t *parent)
             }
             prev = prev->prev;
         }
-        snprintf(indices[i], BUF_LEN, "%lu", index);
+        snprintf(indices[i], BUF_LEN, "%zu", index);
         node = node->parent;
     }
     /* -> xpath length */


### PR DESCRIPTION
Without this warning, GCC 6.4.1 complains when cross-building for ARM Cortex A9:
```
src/clientlib/client_library.c:1620:42: warning: format ‘%lu’ expects argument of type ‘long unsigned int’, but argument 4 has type ‘size_t {aka unsigned int}’ [-Wformat=]
         snprintf(indices[i], BUF_LEN, "%lu", index);
                                          ^
```