### PR TITLE
Stop sysrepo-plugind from auto-launching the daemon, and fix systemd integration

### DIFF
--- a/deploy/systemd/sysrepo-plugind.service
+++ b/deploy/systemd/sysrepo-plugind.service
@@ -1,6 +1,7 @@
 [Unit]
 Description=Sysrepo YANG configuration storage and management
 Requires=sysrepod.service
+After=sysrepod.service
 
 [Service]
 Type=forking


### PR DESCRIPTION
Check commit messages for details. In a nutshell, this stops `sysrepo-plugind` from auto-launching the main `sysrepod` daemon because that's something which is better handled by the init system.