### PR TITLE
Identref fix

### DIFF
--- a/src/data_manager.c
+++ b/src/data_manager.c
@@ -1834,6 +1834,10 @@ dm_append_data_tree(dm_ctx_t *dm_ctx, dm_session_t *session, dm_data_info_t *dat
 
         if (NULL == data_info->node) {
             data_info->node = sr_dup_datatree_to_ctx(di->node, data_info->schema->ly_ctx);
+            if (NULL == data_info->node) {
+                SR_LOG_ERR("Failed to duplicate %s data tree into another context", di->schema->module->name);
+                return SR_ERR_INTERNAL;
+            }
         } else {
             ret = lyd_merge_to_ctx(&data_info->node, di->node, LYD_OPT_EXPLICIT, data_info->schema->ly_ctx);
             CHECK_ZERO_LOG_RETURN(ret, SR_ERR_INTERNAL, "Failed to merge %s data tree", di->schema->module->name);

--- a/src/data_manager.c
+++ b/src/data_manager.c
@@ -1830,6 +1830,8 @@ dm_append_data_tree(dm_ctx_t *dm_ctx, dm_session_t *session, dm_data_info_t *dat
 
     /* transform data from one ctx to another */
     if (NULL != di->node) {
+        ly_ctx_set_module_data_clb(data_info->schema->ly_ctx, dm_module_clb, dm_ctx);
+
         if (NULL == data_info->node) {
             data_info->node = sr_dup_datatree_to_ctx(di->node, data_info->schema->ly_ctx);
         } else {

--- a/src/data_manager.c
+++ b/src/data_manager.c
@@ -5299,8 +5299,10 @@ dm_copy_config(dm_ctx_t *dm_ctx, dm_session_t *session, const sr_list_t *module_
         size_t e_cnt = 0;
         rc = dm_validate_session_data_trees(dm_ctx, session, &errors, &e_cnt);
         if (SR_ERR_OK != rc) {
-            rc = dm_report_error(session, errors[0].message, errors[0].xpath, SR_ERR_VALIDATION_FAILED);
-            sr_free_errors(errors, e_cnt);
+            if (NULL != errors) {
+                rc = dm_report_error(session, errors[0].message, errors[0].xpath, SR_ERR_VALIDATION_FAILED);
+                sr_free_errors(errors, e_cnt);
+            }
             SR_LOG_ERR_MSG("There is a invalid data tree, can not be copied");
             goto cleanup;
         }


### PR DESCRIPTION
### Description
Fix of a problem when foreign identity is used in an identityref that is being duplicated into another context, use libyang data callback.

### Closure
Fixes #950 
