### PR TITLE
Missing include

### DIFF
--- a/inc/sysrepo/values.h
+++ b/inc/sysrepo/values.h
@@ -23,6 +23,8 @@
 #ifndef SYSREPO_VALUES_H_
 #define SYSREPO_VALUES_H_
 
+#include <stdio.h>
+
 /**
  * @defgroup values Value Manipulation Utilities
  * @{


### PR DESCRIPTION
### Description
Missing stdio include in values.h.

### Closure
Fixes #956 