### PR TITLE
Do not consider operations in modules as data

### DIFF
--- a/src/common/sr_utils.c
+++ b/src/common/sr_utils.c
@@ -2689,7 +2689,7 @@ sr_lys_module_has_data(const struct lys_module *module)
     /* iterate through top-level nodes */
     LY_TREE_FOR(module->data, iter) {
         if (((LYS_CONFIG_R & iter->flags) /* operational data */ ||
-             ((LYS_CONTAINER | LYS_LIST | LYS_LEAF | LYS_LEAFLIST | LYS_CHOICE | LYS_RPC | LYS_NOTIF | LYS_ACTION | LYS_USES) & iter->nodetype))) {
+             ((LYS_CONTAINER | LYS_LIST | LYS_LEAF | LYS_LEAFLIST | LYS_CHOICE | LYS_USES) & iter->nodetype))) {
             /* data-carrying */
             return true;
         }

--- a/src/module_dependencies.h
+++ b/src/module_dependencies.h
@@ -79,7 +79,8 @@ typedef struct md_module_s {
     bool submodule;               /**< "true" if this is actually a submodule, "false" in case of a proper module. */
     bool installed;               /**< "true" if the module was explicitly installed, not just imported (but can be implemented even if not installed) */
     bool implemented;             /**< flag if the module is implemented, not just imported */
-    bool has_data;                /**< "true" if this module defines any data-carrying elements and not only data types and identities. */
+    bool has_data;                /**< "true" if this module defines any data-carrying elements and not only operations,
+                                       data types, and identities. */
     bool has_persist;             /**< "true" if this module has data or features. */
 
     sr_llist_t *inst_ids;         /**< List of xpaths referencing all instance-identifiers in the module.


### PR DESCRIPTION
### Description
Changed the meaning of has_data flag, operations are no longer considered as such.