### PR TITLE
sysrepoctl: Fix memory leak

### DIFF
--- a/src/executables/sysrepoctl.c
+++ b/src/executables/sysrepoctl.c
@@ -1047,7 +1047,10 @@ cleanup:
     md_destroy(md_ctx);
     ly_ctx_destroy(ly_ctx, NULL);
     if (local_search_dir) {
-        free((char*)search_dirs);
+        for (int i = 0; i < search_dir_count; ++i) {
+            free(search_dirs[i]);
+        }
+        free(search_dirs);
     }
     return rc;
 }


### PR DESCRIPTION
Commit d119b61a introduced a memory leak by forgetting to free the individual members of that array.

Discovered by ASAN; a simply `make install` was failing.