### PR TITLE
Do not use parent pointer directly in schema nodes

### DIFF
--- a/src/rp_dt_get.c
+++ b/src/rp_dt_get.c
@@ -876,7 +876,7 @@ static bool
 rp_dt_has_parent_list(struct lys_node *node, struct lys_node **found_list, size_t *depth)
 {
     if (NULL != node) {
-        struct lys_node *n = node->parent;
+        struct lys_node *n = lys_parent(node);
         size_t dep = 0;
 
         while (NULL != n) {

--- a/src/rp_dt_get.c
+++ b/src/rp_dt_get.c
@@ -636,7 +636,7 @@ rp_dt_no_parent_list_until(struct lys_node *until, struct lys_node *node)
         return false;
     }
 
-    struct lys_node *n = node->parent;
+    struct lys_node *n = lys_parent(node);
 
     while (NULL != n) {
         if (until == n) {


### PR DESCRIPTION
### Description
Instead using parent pointer in schema nodes, always use lys_parent().

### Closure
Fixes #993
