### PR TITLE
BUGFIX remove branch devel-cli from dockerfiles

### DIFF
--- a/deploy/docker/sysrepo-netopeer2/Dockerfile.devel
+++ b/deploy/docker/sysrepo-netopeer2/Dockerfile.devel
@@ -100,7 +100,6 @@ RUN \
       make -j2 && \
       make install && \
       cd ../../cli && mkdir build && cd build && \
-      git checkout devel-cli && \
       cmake -DCMAKE_BUILD_TYPE:String="Debug" .. && \
       make -j2 && \
       make install

--- a/deploy/docker/sysrepo-netopeer2/platforms/Dockerfile.arch.devel
+++ b/deploy/docker/sysrepo-netopeer2/platforms/Dockerfile.arch.devel
@@ -103,7 +103,6 @@ RUN \
       make -j2 && \
       make install && \
       cd ../../cli && mkdir build && cd build && \
-      git checkout devel-cli && \
       cmake -DCMAKE_INSTALL_PREFIX=/usr .. && \
       make -j2 && \
       make install

--- a/deploy/docker/sysrepo-netopeer2/platforms/Dockerfile.debian.devel
+++ b/deploy/docker/sysrepo-netopeer2/platforms/Dockerfile.debian.devel
@@ -105,7 +105,6 @@ RUN \
       make -j2 && \
       make install && \
       cd ../../cli && mkdir build && cd build && \
-      git checkout devel-cli && \
       cmake .. && \
       make -j2 && \
       make install

--- a/deploy/docker/sysrepo-netopeer2/platforms/Dockerfile.fedora.devel
+++ b/deploy/docker/sysrepo-netopeer2/platforms/Dockerfile.fedora.devel
@@ -120,7 +120,6 @@ RUN \
       make -j2 && \
       make install && \
       cd ../../cli && mkdir build && cd build && \
-      git checkout devel-cli && \
       cmake -DCMAKE_INSTALL_PREFIX=/usr .. && \
       make -j2 && \
       make install

--- a/deploy/docker/sysrepo-netopeer2/platforms/Dockerfile.gentoo.devel
+++ b/deploy/docker/sysrepo-netopeer2/platforms/Dockerfile.gentoo.devel
@@ -111,7 +111,6 @@ RUN \
       make -j2 && \
       make install && \
       cd ../../cli && mkdir build && cd build && \
-      git checkout devel-cli && \
       cmake -DCMAKE_INSTALL_PREFIX=/usr .. && \
       make -j2 && \
       make install

--- a/deploy/docker/sysrepo-netopeer2/platforms/Dockerfile.ubuntu.devel
+++ b/deploy/docker/sysrepo-netopeer2/platforms/Dockerfile.ubuntu.devel
@@ -116,7 +116,6 @@ RUN \
       make -j2 && \
       make install && \
       cd ../../cli && mkdir build && cd build && \
-      git checkout devel-cli && \
       cmake .. && \
       make -j2 && \
       make install


### PR DESCRIPTION
### Description
The dockerfiles for devel branch do not build any more because there is no longer a `devel-cli` branch in Netopeer2.

### Test case
`docker build -t sysrepo/sysrepo-netopeer2:devel -f deploy/docker/sysrepo-netopeer2/Dockerfile.devel .`

The command will fail without the patch.