### PR TITLE
Operational subtree module traversal

### DIFF
--- a/src/module_dependencies.c
+++ b/src/module_dependencies.c
@@ -1743,8 +1743,11 @@ md_traverse_schema_tree(md_ctx_t *md_ctx, md_module_t *module, md_module_t *main
                         rc = SR_ERR_NOT_FOUND;
                         if (augment) {
                             if (node->nodetype == LYS_AUGMENT) {
-                                child = node->child;
-                                assert((intptr_t)child->priv & PRIV_OP_SUBTREE);
+                                child = (struct lys_node *)lys_getnext(NULL, node, NULL, 0);
+                                assert(!(child->nodetype & (LYS_CONTAINER | LYS_LIST)) || (intptr_t)child->priv & PRIV_OP_SUBTREE);
+                                assert(child->nodetype & (LYS_CONTAINER | LYS_LIST) || child->flags & LYS_CONFIG_R);
+                            } else {
+                                child = node;
                             }
                             rc = md_check_op_data_subtree(dest_module, child);
                         } else {


### PR DESCRIPTION
### Description
Uses was not properly handled when traversing a module looking for operational subtrees.

### Closure
Fixes #1011