### PR TITLE
Failed copy-config on verifier callback did not rollback changes

### DIFF
--- a/src/data_manager.c
+++ b/src/data_manager.c
@@ -3602,6 +3602,9 @@ dm_free_commit_context(void *commit_ctx)
         }
         c_ctx->session = NULL;
         sr_btree_cleanup(c_ctx->difflists);
+        if (NULL != c_ctx->backup_session) {
+            dm_session_stop(c_ctx->backup_session->dm_ctx, c_ctx->backup_session);
+        }
         free(c_ctx);
     }
 }

--- a/src/data_manager.h
+++ b/src/data_manager.h
@@ -231,6 +231,7 @@ typedef struct dm_commit_context_s {
     bool nacm_edited;           /**< flag whether the running NACM configuration was edited. */
     bool in_btree;              /**< set to tree if the context was inserted into btree */
     bool should_be_removed;     /**< flag denoting whether c_ctx can be removed from btree */
+    dm_session_t *backup_session; /**< session with backed up modifications from before the commit */
 } dm_commit_context_t;
 
 /**

--- a/src/request_processor.c
+++ b/src/request_processor.c
@@ -1464,7 +1464,7 @@ rp_commit_req_process(rp_ctx_t *rp_ctx, rp_session_t *session, Sr__Msg *msg, boo
 
     if (SR_ERR_OK == rc ) {
         session->req = msg;
-        rc = rp_dt_commit(rp_ctx, session, c_ctx, false, &errors, &err_cnt);
+        rc = rp_dt_commit(rp_ctx, session, &c_ctx, false, &errors, &err_cnt);
     }
     if (SR_ERR_OK == rc && RP_REQ_WAITING_FOR_VERIFIERS == session->state) {
         SR_LOG_DBG_MSG("Commit request paused, waiting for verifiers");

--- a/src/rp_dt_edit.c
+++ b/src/rp_dt_edit.c
@@ -794,14 +794,14 @@ rp_dt_reload_nacm(rp_ctx_t *rp_ctx)
 }
 
 int
-rp_dt_commit(rp_ctx_t *rp_ctx, rp_session_t *session, dm_commit_context_t *c_ctx, bool copy_config,
+rp_dt_commit(rp_ctx_t *rp_ctx, rp_session_t *session, dm_commit_context_t **c_ctx, bool copy_config,
         sr_error_info_t **errors, size_t *err_cnt)
 {
     int rc = SR_ERR_OK;
-    CHECK_NULL_ARG_NORET4(rc, rp_ctx, session, errors, err_cnt);
+    CHECK_NULL_ARG_NORET5(rc, rp_ctx, session, c_ctx, errors, err_cnt);
     if (SR_ERR_OK != rc) {
-        if (NULL != c_ctx) {
-            pthread_mutex_unlock(&c_ctx->mutex);
+        if (NULL != *c_ctx) {
+            pthread_mutex_unlock(&(*c_ctx)->mutex);
         }
         return rc;
     }
@@ -809,7 +809,7 @@ rp_dt_commit(rp_ctx_t *rp_ctx, rp_session_t *session, dm_commit_context_t *c_ctx
     bool remove_ctx = false;
     bool free_ctx = false;
     uint32_t c_id = 0;
-    dm_commit_context_t *commit_ctx = c_ctx;
+    dm_commit_context_t *commit_ctx = *c_ctx;
     dm_commit_state_t state = NULL != commit_ctx ? commit_ctx->state : DM_COMMIT_STARTED;
     nacm_ctx_t *nacm_ctx = NULL;
 
@@ -838,9 +838,9 @@ rp_dt_commit(rp_ctx_t *rp_ctx, rp_session_t *session, dm_commit_context_t *c_ctx
                 if (SR_DS_CANDIDATE != session->datastore) {
                     /* we still need to discard changes (operations), it is possible there are some operations that
                      * did not modify the data (so no model was modified) */
-                    rc = dm_discard_changes(rp_ctx->dm_ctx, session->dm_session, NULL);
+                    dm_discard_changes(rp_ctx->dm_ctx, session->dm_session, NULL);
                 }
-                return rc;
+                return SR_ERR_OK;
             }
             pthread_mutex_lock(&commit_ctx->mutex);
             commit_ctx->disabled_config_change = rp_ctx->do_not_generate_config_change;
@@ -901,7 +901,8 @@ rp_dt_commit(rp_ctx_t *rp_ctx, rp_session_t *session, dm_commit_context_t *c_ctx
             SR_LOG_DBG("Commit %"PRIu32" processing paused waiting for replies from verifiers", commit_ctx->id);
             session->state = RP_REQ_WAITING_FOR_VERIFIERS;
             pthread_mutex_unlock(&commit_ctx->mutex);
-            return rc;
+            *c_ctx = commit_ctx;
+            return SR_ERR_OK;
         case DM_COMMIT_WRITE:
             rc = dm_commit_writelock_fds(session->dm_session, commit_ctx);
             if (SR_ERR_OK == rc ) {
@@ -932,10 +933,10 @@ rp_dt_commit(rp_ctx_t *rp_ctx, rp_session_t *session, dm_commit_context_t *c_ctx
         case DM_COMMIT_NOTIFY_ABORT:
             rc = dm_commit_notify(rp_ctx->dm_ctx, session->dm_session, SR_EV_ABORT, commit_ctx);
             session->state = RP_REQ_FINISHED;
-            *errors = c_ctx->errors;
-            *err_cnt = c_ctx->err_cnt;
-            c_ctx->errors = NULL;
-            c_ctx->err_cnt = 0;
+            *errors = commit_ctx->errors;
+            *err_cnt = commit_ctx->err_cnt;
+            commit_ctx->errors = NULL;
+            commit_ctx->err_cnt = 0;
             SR_LOG_DBG_MSG("Commit (9/10): abort notifications sent");
             rc = SR_ERR_OPERATION_FAILED;
             goto cleanup;
@@ -943,6 +944,7 @@ rp_dt_commit(rp_ctx_t *rp_ctx, rp_session_t *session, dm_commit_context_t *c_ctx
             break;
         }
     }
+
 cleanup:
     if (NULL != commit_ctx) {
         remove_ctx = commit_ctx->should_be_removed;
@@ -972,7 +974,7 @@ cleanup:
     if (SR_ERR_OK == rc) {
         /* discard changes in session in next get_data_tree call newly committed content will be loaded */
         if (SR_DS_CANDIDATE != session->datastore) {
-            rc = dm_discard_changes(rp_ctx->dm_ctx, session->dm_session, NULL);
+            dm_discard_changes(rp_ctx->dm_ctx, session->dm_session, NULL);
         }
         SR_LOG_DBG_MSG("Commit (10/10): finished successfully");
     } else {
@@ -1079,81 +1081,115 @@ rp_dt_copy_config_to_running(rp_ctx_t *rp_ctx, rp_session_t *session, const char
     dm_session_t *backup = NULL;
     dm_commit_context_t *c_ctx = NULL;
     dm_data_info_t *info = NULL;
-    int first_err = SR_ERR_OK;
-    bool enabled = false, changes_backed = false, trees_moved = false;
+    bool enabled = false;
 
-    /* are we resuming a copy_config commit? */
-    if (RP_REQ_RESUMED == session->state) {
-        rc = dm_get_commit_context(rp_ctx->dm_ctx, session->commit_id, &c_ctx);
-        CHECK_RC_LOG_GOTO(rc, cleanup, "Failed to resume copy_config, commit ctx with id %"PRIu32" not found.", session->commit_id);
-        pthread_mutex_lock(&c_ctx->mutex);
-    } else {
-        /* copy to running is running commit behind the scenes */
-        rc = dm_session_start(rp_ctx->dm_ctx, session->user_credentials, src, &backup);
-        CHECK_RC_MSG_RETURN(rc, "Session start of temporary session failed");
+    assert(RP_REQ_RESUMED != session->state);
 
-        /* backup the running ds changes to restore them if something goes wrong */
-        rc = dm_move_session_tree_and_ops(rp_ctx->dm_ctx, session->dm_session, backup, SR_DS_RUNNING);
-        CHECK_RC_MSG_GOTO(rc, cleanup, "Moving session data trees failed");
-        changes_backed = true;
+    /*
+     * copy to running is running commit behind the scenes
+     */
 
-        rp_dt_switch_datastore(rp_ctx, session, src);
+    /* backup the running ds changes to restore them if something goes wrong */
+    rc = dm_session_start(rp_ctx->dm_ctx, session->user_credentials, src, &backup);
+    CHECK_RC_MSG_GOTO(rc, cleanup1, "Session start of temporary session failed");
 
-        /* load models to be committed to the session */
-        if (NULL != module_name) {
-            /* is the module enabled? */
-            rc = dm_has_enabled_subtree(rp_ctx->dm_ctx, module_name, NULL, &enabled);
-            CHECK_RC_LOG_GOTO(rc, cleanup, "Has enabled subtree failed %s", module_name);
-            if (!enabled) {
-                SR_LOG_ERR("Cannot copy module '%s', it is not enabled.", module_name);
-                rc = SR_ERR_OPERATION_FAILED;
-                goto cleanup;
-            }
+    rc = dm_move_session_tree_and_ops(rp_ctx->dm_ctx, session->dm_session, backup, SR_DS_RUNNING);
+    CHECK_RC_MSG_GOTO(rc, cleanup2, "Moving session data trees failed");
 
-            /* load data tree if it was not copied from backup session */
-            rc = dm_get_data_info(rp_ctx->dm_ctx, session->dm_session, module_name, &info);
-            CHECK_RC_MSG_GOTO(rc, cleanup, "Get data info failed");
-            info->modified = true;
-        } else {
-            /* load all enabled models */
-            rc = dm_get_all_modules(rp_ctx->dm_ctx, session->dm_session, true, &modules);
-            CHECK_RC_MSG_GOTO(rc, cleanup, "Get all modules failed");
-            for (size_t i = 0; i < modules->count; i++) {
-                char *module = modules->data[i];
-                rc = dm_get_data_info(rp_ctx->dm_ctx, session->dm_session, module, &info);
-                CHECK_RC_LOG_GOTO(rc, cleanup, "Get data info failed %s", module);
-                info->modified = true;
-            }
+    rp_dt_switch_datastore(rp_ctx, session, src);
+
+    /* load models to be committed to the session */
+    if (NULL != module_name) {
+        /* is the module enabled? */
+        rc = dm_has_enabled_subtree(rp_ctx->dm_ctx, module_name, NULL, &enabled);
+        CHECK_RC_LOG_GOTO(rc, cleanup3, "Has enabled subtree failed %s", module_name);
+        if (!enabled) {
+            SR_LOG_ERR("Cannot copy module '%s', it is not enabled.", module_name);
+            rc = SR_ERR_OPERATION_FAILED;
+            goto cleanup3;
         }
 
-        /* move changes to running datastore */
-        rc = dm_move_session_trees_in_session(rp_ctx->dm_ctx, session->dm_session, src, SR_DS_RUNNING);
-        CHECK_RC_MSG_GOTO(rc, cleanup, "Data tree move failed");
-        trees_moved = true;
+        /* load data tree if it was not copied from backup session */
+        rc = dm_get_data_info(rp_ctx->dm_ctx, session->dm_session, module_name, &info);
+        CHECK_RC_MSG_GOTO(rc, cleanup3, "Get data info failed");
+        info->modified = true;
+    } else {
+        /* load all enabled models */
+        rc = dm_get_all_modules(rp_ctx->dm_ctx, session->dm_session, true, &modules);
+        CHECK_RC_MSG_GOTO(rc, cleanup3, "Get all modules failed");
+        for (size_t i = 0; i < modules->count; i++) {
+            char *module = modules->data[i];
+            rc = dm_get_data_info(rp_ctx->dm_ctx, session->dm_session, module, &info);
+            CHECK_RC_LOG_GOTO(rc, cleanup3, "Get data info failed %s", module);
+            info->modified = true;
+        }
     }
+
+    /* move changes to running datastore */
+    rc = dm_move_session_trees_in_session(rp_ctx->dm_ctx, session->dm_session, src, SR_DS_RUNNING);
+    CHECK_RC_MSG_GOTO(rc, cleanup3, "Data tree move failed");
 
     /* commit running changes */
     rp_dt_switch_datastore(rp_ctx, session, SR_DS_RUNNING);
-    rc = rp_dt_commit(rp_ctx, session, c_ctx, true, errors, err_cnt);
+    rc = rp_dt_commit(rp_ctx, session, &c_ctx, true, errors, err_cnt);
 
-cleanup:
-    first_err = rc;
-    rc = SR_ERR_OK;
-    if (NULL != backup) {
-        if (changes_backed && SR_ERR_OK != first_err) {
-            /* restore the session running changes if something went wrong */
-            if (trees_moved) {
-                rc = dm_move_session_trees_in_session(rp_ctx->dm_ctx, session->dm_session, SR_DS_RUNNING, src);
-            }
-            if (SR_ERR_OK == rc) {
-                rc = dm_move_session_tree_and_ops(rp_ctx->dm_ctx, backup, session->dm_session, SR_DS_RUNNING);
-            }
-        }
-        dm_session_stop(rp_ctx->dm_ctx, backup);
+    if (c_ctx != NULL) {
+        /* waiting for notifications, store backup session */
+        c_ctx->backup_session = backup;
     }
-    sr_list_cleanup(modules);
 
-    return first_err == SR_ERR_OK ? rc : first_err;
+    if (rc == SR_ERR_OK) {
+        if (c_ctx != NULL) {
+            goto cleanup1;
+        } else {
+            /* commit succeeded and finished */
+            goto cleanup2;
+        }
+    }
+    /* else fail */
+
+    dm_move_session_trees_in_session(rp_ctx->dm_ctx, session->dm_session, SR_DS_RUNNING, src);
+cleanup3:
+    /* restore the session running changes if something went wrong */
+    dm_move_session_tree_and_ops(rp_ctx->dm_ctx, session->dm_session, backup, SR_DS_RUNNING);
+cleanup2:
+    dm_session_stop(rp_ctx->dm_ctx, backup);
+cleanup1:
+    sr_list_cleanup(modules);
+    return rc;
+}
+
+static int
+rp_dt_copy_config_to_running_resume(rp_ctx_t *rp_ctx, rp_session_t *session, const char *module_name, sr_datastore_t src,
+                                    sr_error_info_t **errors, size_t *err_cnt)
+{
+    CHECK_NULL_ARG2(rp_ctx, session);
+    int rc = SR_ERR_OK;
+    dm_session_t *backup = NULL;
+    dm_commit_context_t *c_ctx = NULL;
+
+    assert(RP_REQ_RESUMED == session->state);
+
+    rc = dm_get_commit_context(rp_ctx->dm_ctx, session->commit_id, &c_ctx);
+    CHECK_RC_LOG_RETURN(rc, "Failed to resume copy_config, commit ctx with id %"PRIu32" not found.", session->commit_id);
+    pthread_mutex_lock(&c_ctx->mutex);
+
+    backup = c_ctx->backup_session;
+    c_ctx->backup_session = NULL;
+
+    /* commit running changes */
+    rp_dt_switch_datastore(rp_ctx, session, SR_DS_RUNNING);
+    rc = rp_dt_commit(rp_ctx, session, &c_ctx, true, errors, err_cnt);
+
+    if (rc != SR_ERR_OK) {
+        /* restore the session running changes if something went wrong */
+        dm_move_session_trees_in_session(rp_ctx->dm_ctx, session->dm_session, SR_DS_RUNNING, src);
+        dm_move_session_tree_and_ops(rp_ctx->dm_ctx, session->dm_session, backup, SR_DS_RUNNING);
+    } else {
+        dm_move_session_tree_and_ops(rp_ctx->dm_ctx, backup, session->dm_session, SR_DS_RUNNING);
+    }
+    dm_session_stop(rp_ctx->dm_ctx, backup);
+    return rc;
 }
 
 int
@@ -1184,7 +1220,11 @@ rp_dt_copy_config(rp_ctx_t *rp_ctx, rp_session_t *session, const char *module_na
         }
 
     } else {
-        rc = rp_dt_copy_config_to_running(rp_ctx, session, module_name, src, errors, err_cnt);
+        if (session->state == RP_REQ_RESUMED) {
+            rc = rp_dt_copy_config_to_running_resume(rp_ctx, session, module_name, src, errors, err_cnt);
+        } else {
+            rc = rp_dt_copy_config_to_running(rp_ctx, session, module_name, src, errors, err_cnt);
+        }
     }
 
     rp_dt_switch_datastore(rp_ctx, session, prev_ds);

--- a/src/rp_dt_edit.h
+++ b/src/rp_dt_edit.h
@@ -124,7 +124,7 @@ int rp_dt_delete_item_wrapper(rp_ctx_t *rp_ctx, rp_session_t *session, const cha
  * @param [out] err_cnt
  * @return Error code (SR_ERR_OK on success), SR_ERR_COMMIT_FAILED, SR_ERR_VALIDATION_FAILED, SR_ERR_IO
  */
-int rp_dt_commit(rp_ctx_t *rp_ctx, rp_session_t *session, dm_commit_context_t *c_ctx, bool copy_config,
+int rp_dt_commit(rp_ctx_t *rp_ctx, rp_session_t *session, dm_commit_context_t **c_ctx, bool copy_config,
         sr_error_info_t **errors, size_t *err_cnt);
 
 /**

--- a/tests/rp_datatree_test.c
+++ b/tests/rp_datatree_test.c
@@ -1525,6 +1525,7 @@ default_nodes_test(void **state)
     int rc = 0;
     rp_ctx_t *ctx = *state;
     rp_session_t *ses_ctx = NULL;
+    dm_commit_context_t *c_ctx = NULL;
 
     test_rp_session_create(ctx, SR_DS_STARTUP, &ses_ctx);
     sr_val_t *val = NULL;
@@ -1535,7 +1536,7 @@ default_nodes_test(void **state)
     /* cleanup - remove all list instances */
     rc = rp_dt_delete_item_wrapper(ctx, ses_ctx, "/test-module:with_def", SR_EDIT_DEFAULT);
     assert_int_equal(SR_ERR_OK, rc);
-    rc = rp_dt_commit(ctx, ses_ctx, NULL, false, &errors, &e_cnt);
+    rc = rp_dt_commit(ctx, ses_ctx, &c_ctx, false, &errors, &e_cnt);
     assert_int_equal(SR_ERR_OK, rc);
 
 
@@ -1710,7 +1711,7 @@ default_nodes_test(void **state)
     assert_false(tree->dflt);
     sr_free_tree(tree);
 
-    rc = rp_dt_commit(ctx, ses_ctx, NULL, false, &errors, &e_cnt);
+    rc = rp_dt_commit(ctx, ses_ctx, &c_ctx, false, &errors, &e_cnt);
     assert_int_equal(SR_ERR_OK, rc);
 
     /* check after commit */
@@ -1801,7 +1802,7 @@ default_nodes_test(void **state)
     /* clean up*/
     rc = rp_dt_delete_item_wrapper(ctx, ses_ctx, "/test-module:with_def", SR_EDIT_DEFAULT);
     assert_int_equal(SR_ERR_OK, rc);
-    rc = rp_dt_commit(ctx, ses_ctx, NULL, false, &errors, &e_cnt);
+    rc = rp_dt_commit(ctx, ses_ctx, &c_ctx, false, &errors, &e_cnt);
     assert_int_equal(SR_ERR_OK, rc);
 
     test_rp_session_cleanup(ctx, ses_ctx);
@@ -1816,6 +1817,7 @@ default_nodes_toplevel_test(void **state)
     sr_val_t *val = NULL;
     sr_error_info_t *errors = NULL;
     size_t e_cnt = 0;
+    dm_commit_context_t *c_ctx = NULL;
 
     test_rp_session_create(ctx, SR_DS_STARTUP, &ses_ctx);
 
@@ -1849,7 +1851,7 @@ default_nodes_toplevel_test(void **state)
     assert_int_equal(SR_ERR_OK, rc);
     rc = rp_dt_delete_item_wrapper(ctx, ses_ctx, "/referenced-data:*", SR_EDIT_DEFAULT);
     assert_int_equal(SR_ERR_OK, rc);
-    rc = rp_dt_commit(ctx, ses_ctx, NULL, false, &errors, &e_cnt);
+    rc = rp_dt_commit(ctx, ses_ctx, &c_ctx, false, &errors, &e_cnt);
     assert_int_equal(SR_ERR_OK, rc);
 
     ses_ctx->state = RP_REQ_NEW;

--- a/tests/rp_dt_edit_test.c
+++ b/tests/rp_dt_edit_test.c
@@ -1141,6 +1141,7 @@ void edit_instance_id_test(void **state) {
     sr_val_t *new_val = NULL;
     sr_error_info_t *errors = NULL;
     size_t e_cnt = 0;
+    dm_commit_context_t *c_ctx = NULL;
 
     test_rp_session_create(ctx, SR_DS_STARTUP, &session);
     /* leaf */
@@ -1153,7 +1154,7 @@ void edit_instance_id_test(void **state) {
     rc = rp_dt_set_item_wrapper(ctx, session, "/test-module:main/instance_id", value, NULL, SR_EDIT_DEFAULT);
     assert_int_equal(SR_ERR_OK, rc);
 
-    rc = rp_dt_commit(ctx, session, NULL, false, &errors, &e_cnt);
+    rc = rp_dt_commit(ctx, session, &c_ctx, false, &errors, &e_cnt);
     assert_int_equal(SR_ERR_OK, rc);
 
     rc = rp_dt_refresh_session(ctx, session, &errors, &e_cnt);
@@ -1176,7 +1177,7 @@ void edit_instance_id_test(void **state) {
     rc = rp_dt_set_item_wrapper(ctx, session, "/test-module:main/instance_id", value, NULL, SR_EDIT_DEFAULT);
     assert_int_equal(SR_ERR_OK, rc);
 
-    rc = rp_dt_commit(ctx, session, NULL, false, &errors, &e_cnt);
+    rc = rp_dt_commit(ctx, session, &c_ctx, false, &errors, &e_cnt);
     assert_int_equal(SR_ERR_OK, rc);
 
     rc = rp_dt_refresh_session(ctx, session, &errors, &e_cnt);
@@ -1199,7 +1200,7 @@ void edit_instance_id_test(void **state) {
     rc = rp_dt_set_item_wrapper(ctx, session, "/test-module:main/instance_id", value, NULL, SR_EDIT_DEFAULT);
     assert_int_equal(SR_ERR_OK, rc);
 
-    rc = rp_dt_commit(ctx, session, NULL, false, &errors, &e_cnt);
+    rc = rp_dt_commit(ctx, session, &c_ctx, false, &errors, &e_cnt);
     assert_int_equal(SR_ERR_OK, rc);
 
     rc = rp_dt_refresh_session(ctx, session, &errors, &e_cnt);
@@ -1222,7 +1223,7 @@ void edit_instance_id_test(void **state) {
     rc = rp_dt_set_item_wrapper(ctx, session, "/test-module:main/instance_id", value, NULL, SR_EDIT_DEFAULT);
     assert_int_equal(SR_ERR_OK, rc);
 
-    rc = rp_dt_commit(ctx, session, NULL, false, &errors, &e_cnt);
+    rc = rp_dt_commit(ctx, session, &c_ctx, false, &errors, &e_cnt);
     assert_int_equal(SR_ERR_OK, rc);
 
     rc = rp_dt_refresh_session(ctx, session, &errors, &e_cnt);
@@ -1643,12 +1644,13 @@ empty_commit_test(void **state)
     rp_ctx_t *ctx = *state;
     rp_session_t *session = NULL;
     dm_data_info_t *info = NULL;
+    dm_commit_context_t *c_ctx = NULL;
     test_rp_session_create(ctx, SR_DS_STARTUP, &session);
 
     /* no session copy made*/
     sr_error_info_t *errors = NULL;
     size_t err_cnt = 0;
-    rc = rp_dt_commit(ctx, session, NULL, false, &errors, &err_cnt);
+    rc = rp_dt_commit(ctx, session, &c_ctx, false, &errors, &err_cnt);
     assert_int_equal(SR_ERR_OK, rc);
     sr_free_errors(errors, err_cnt);
 
@@ -1656,7 +1658,7 @@ empty_commit_test(void **state)
     rc = dm_get_data_info(ctx->dm_ctx, session->dm_session, "test-module", &info);
     assert_int_equal(SR_ERR_OK, rc);
 
-    rc = rp_dt_commit(ctx, session, NULL, false, &errors, &err_cnt);
+    rc = rp_dt_commit(ctx, session, &c_ctx, false, &errors, &err_cnt);
     assert_int_equal(SR_ERR_OK, rc);
     sr_free_errors(errors, err_cnt);
 
@@ -1664,7 +1666,7 @@ empty_commit_test(void **state)
     assert_int_equal(SR_ERR_OK, rc);
     info->modified = true;
 
-    rc = rp_dt_commit(ctx, session, NULL, false, &errors, &err_cnt);
+    rc = rp_dt_commit(ctx, session, &c_ctx, false, &errors, &err_cnt);
     assert_int_equal(SR_ERR_OK, rc);
     sr_free_errors(errors, err_cnt);
 
@@ -1679,6 +1681,7 @@ edit_commit_test(void **state)
     rp_ctx_t *ctx = *state;
     rp_session_t *sessionA = NULL, *sessionB = NULL;
     sr_val_t *valueA = NULL, *valueB = NULL;
+    dm_commit_context_t *c_ctx = NULL;
 
     test_rp_session_create(ctx, SR_DS_STARTUP, &sessionA);
     test_rp_session_create(ctx, SR_DS_STARTUP, &sessionB);
@@ -1721,7 +1724,7 @@ edit_commit_test(void **state)
     sr_error_info_t *errors = NULL;
     size_t e_cnt = 0;
 
-    rc = rp_dt_commit(ctx, sessionA, NULL, false, &errors, &e_cnt);
+    rc = rp_dt_commit(ctx, sessionA, &c_ctx, false, &errors, &e_cnt);
     assert_int_equal(SR_ERR_OK, rc);
     sr_free_errors(errors, e_cnt);
 
@@ -1758,7 +1761,7 @@ edit_commit_test(void **state)
     rc = rp_dt_set_item_wrapper(ctx, sessionA, XP_TEST_MODULE_INT64, valueA, NULL, SR_EDIT_DEFAULT);
     assert_int_equal(SR_ERR_OK, rc);
 
-    rc = rp_dt_commit(ctx, sessionA, NULL, false, &errors, &e_cnt);
+    rc = rp_dt_commit(ctx, sessionA, &c_ctx, false, &errors, &e_cnt);
     assert_int_equal(SR_ERR_OK, rc);
     sr_free_errors(errors, e_cnt);
 
@@ -1772,6 +1775,7 @@ edit_commit2_test(void **state)
     int rc = 0;
     rp_ctx_t *ctx = *state;
     rp_session_t *session = NULL, *sessionB = NULL;
+    dm_commit_context_t *c_ctx = NULL;
 
     test_rp_session_create(ctx, SR_DS_STARTUP, &session);
     test_rp_session_create(ctx, SR_DS_STARTUP, &sessionB);
@@ -1784,11 +1788,11 @@ edit_commit2_test(void **state)
 
     sr_error_info_t *errors = NULL;
     size_t e_cnt = 0;
-    rc = rp_dt_commit(ctx, session, NULL, false, &errors, &e_cnt);
+    rc = rp_dt_commit(ctx, session, &c_ctx, false, &errors, &e_cnt);
     assert_int_equal(SR_ERR_OK, rc);
 
     /*this commit should failed because main container is already deleted */
-    rc = rp_dt_commit(ctx, sessionB, NULL, false, &errors, &e_cnt);
+    rc = rp_dt_commit(ctx, sessionB, &c_ctx, false, &errors, &e_cnt);
     assert_int_equal(SR_ERR_DATA_MISSING, rc);
     sr_free_errors(errors, e_cnt);
 
@@ -1803,6 +1807,7 @@ edit_commit3_test(void **state)
     int rc = 0;
     rp_ctx_t *ctx = *state;
     rp_session_t *session = NULL, *sessionB = NULL;
+    dm_commit_context_t *c_ctx = NULL;
 
     test_rp_session_create(ctx, SR_DS_STARTUP, &session);
     test_rp_session_create(ctx, SR_DS_STARTUP, &sessionB);
@@ -1829,11 +1834,11 @@ edit_commit3_test(void **state)
     sr_error_info_t *errors = NULL;
     size_t e_cnt = 0;
 
-    rc = rp_dt_commit(ctx, session, NULL, false, &errors, &e_cnt);
+    rc = rp_dt_commit(ctx, session, &c_ctx, false, &errors, &e_cnt);
     assert_int_equal(SR_ERR_OK, rc);
 
     /* the leaf-list value was committed during the first commit */
-    rc = rp_dt_commit(ctx, sessionB, NULL, false, &errors, &e_cnt);
+    rc = rp_dt_commit(ctx, sessionB, &c_ctx, false, &errors, &e_cnt);
     assert_int_equal(SR_ERR_DATA_EXISTS, rc);
     sr_free_errors(errors, e_cnt);
 
@@ -1849,6 +1854,7 @@ edit_commit4_test(void **state)
     int rc = 0;
     rp_ctx_t *ctx = *state;
     rp_session_t *session = NULL;
+    dm_commit_context_t *c_ctx = NULL;
 
     test_rp_session_create(ctx, SR_DS_STARTUP, &session);
 
@@ -1865,7 +1871,7 @@ edit_commit4_test(void **state)
 
     sr_error_info_t *errors = NULL;
     size_t e_cnt = 0;
-    rc = rp_dt_commit(ctx, session, NULL, false, &errors, &e_cnt);
+    rc = rp_dt_commit(ctx, session, &c_ctx, false, &errors, &e_cnt);
     assert_int_equal(SR_ERR_OK, rc);
 
     test_rp_session_cleanup(ctx, session);
@@ -2212,6 +2218,7 @@ lock_commit_test(void **state)
    int rc = 0;
    rp_ctx_t *ctx = *state;
    rp_session_t *sessionA = NULL, *sessionB = NULL;
+   dm_commit_context_t *c_ctx = NULL;
 
    test_rp_session_create(ctx, SR_DS_STARTUP, &sessionA);
    test_rp_session_create(ctx, SR_DS_STARTUP, &sessionB);
@@ -2234,7 +2241,7 @@ lock_commit_test(void **state)
    /* commit A should fail */
    size_t e_cnt = 0;
    sr_error_info_t *errors = NULL;
-   rc = rp_dt_commit(ctx, sessionA, NULL, false, &errors, &e_cnt);
+   rc = rp_dt_commit(ctx, sessionA, &c_ctx, false, &errors, &e_cnt);
    assert_int_equal(SR_ERR_LOCKED, rc);
 
    /* unlock B */
@@ -2242,7 +2249,7 @@ lock_commit_test(void **state)
    assert_int_equal(SR_ERR_OK, rc);
 
    /* commit A should succeed */
-   rc = rp_dt_commit(ctx, sessionA, NULL, false, &errors, &e_cnt);
+   rc = rp_dt_commit(ctx, sessionA, &c_ctx, false, &errors, &e_cnt);
    assert_int_equal(SR_ERR_OK, rc);
 
    /* should be still locked even after commit */
@@ -2260,6 +2267,7 @@ empty_string_leaf_test(void **state)
    int rc = 0;
    rp_ctx_t *ctx = *state;
    rp_session_t *sessionA = NULL, *sessionB = NULL;
+   dm_commit_context_t *c_ctx = NULL;
 
    test_rp_session_create(ctx, SR_DS_STARTUP, &sessionA);
    test_rp_session_create(ctx, SR_DS_STARTUP, &sessionB);
@@ -2274,7 +2282,7 @@ empty_string_leaf_test(void **state)
 
    size_t e_cnt = 0;
    sr_error_info_t *errors = NULL;
-   rc = rp_dt_commit(ctx, sessionA, NULL, false, &errors, &e_cnt);
+   rc = rp_dt_commit(ctx, sessionA, &c_ctx, false, &errors, &e_cnt);
    assert_int_equal(SR_ERR_OK, rc);
 
    sr_val_t *retrieved = NULL;
@@ -2392,6 +2400,7 @@ candidate_copy_config_lock_test(void **state)
     sr_error_info_t *errors = NULL;
     size_t e_cnt = 0;
     sr_val_t *value = NULL;
+    dm_commit_context_t *c_ctx = NULL;
 
     test_rp_session_create(ctx, SR_DS_CANDIDATE, &sessionA);
     test_rp_session_create(ctx, SR_DS_RUNNING, &sessionB);
@@ -2415,7 +2424,7 @@ candidate_copy_config_lock_test(void **state)
     assert_int_equal(SR_ERR_OK, rc);
 
     /* copy-config failed running locked */
-    rc = rp_dt_commit(ctx, sessionA, NULL, false, &errors, &e_cnt);
+    rc = rp_dt_commit(ctx, sessionA, &c_ctx, false, &errors, &e_cnt);
     assert_int_equal(SR_ERR_OK, rc);
     rc = rp_dt_copy_config(ctx, sessionA, NULL, SR_DS_CANDIDATE, SR_DS_RUNNING, &errors, &e_cnt);
     assert_int_equal(SR_ERR_LOCKED, rc);
@@ -2425,7 +2434,7 @@ candidate_copy_config_lock_test(void **state)
     assert_int_equal(SR_ERR_OK, rc);
 
     /* already committed... */
-    rc = rp_dt_commit(ctx, sessionA, NULL, false, &errors, &e_cnt);
+    rc = rp_dt_commit(ctx, sessionA, &c_ctx, false, &errors, &e_cnt);
     assert_int_equal(SR_ERR_OK, rc);
     rc = rp_dt_copy_config(ctx, sessionA, NULL, SR_DS_CANDIDATE, SR_DS_RUNNING, &errors, &e_cnt);
     assert_int_equal(SR_ERR_OK, rc);


### PR DESCRIPTION
### Description
Seems this functionality was accidentally completely removed some time ago when fixing another issue and optimizing the copy-config to running process.

### Test case
Affected tests modified.

### Closure
Fixes #1026
