### PR TITLE
Sysrepocfg can now uninstall more modules in one call

### DIFF
--- a/src/data_manager.c
+++ b/src/data_manager.c
@@ -5031,7 +5031,7 @@ dm_uninstall_module(dm_ctx_t *dm_ctx, const char *module_name, const char *revis
         SR_LOG_ERR("Module %s with revision %s was not found", module_name, revision);
         rc = SR_ERR_NOT_FOUND;
     } else {
-        rc = md_remove_module(dm_ctx->md_ctx, module_name, revision, &implicitly_removed);
+        rc = md_remove_modules(dm_ctx->md_ctx, &module_name, &revision, 1, &implicitly_removed);
     }
 
     /* uninstall also modules that were "silently" removed */

--- a/src/executables/sysrepoctl.c
+++ b/src/executables/sysrepoctl.c
@@ -604,7 +604,7 @@ srctl_uninstall(char **module_names, char **revisions, int count)
     md_module_key_t *module_key = NULL;
     sr_list_t *implicitly_removed = NULL;
 
-    if (NULL == module_names) {
+    if (NULL == module_names || NULL == module_names[0]) {
         fprintf(stderr, "Error: Modules must be specified for --uninstall operation.\n");
         return SR_ERR_INVAL_ARG;
     }
@@ -1303,7 +1303,7 @@ main(int argc, char* argv[])
             rc = srctl_install(yang, yin, owner, permissions, search_dirs, search_dir_count);
             break;
         case 'u':
-            if (!strchr(module, ',')) {
+            if (!module || !strchr(module, ',')) {
                 rc = srctl_uninstall(&module, &revision, 1);
             } else {
                 count = 1;

--- a/src/module_dependencies.h
+++ b/src/module_dependencies.h
@@ -257,12 +257,13 @@ int md_insert_module(md_ctx_t *md_ctx, const char *filepath, sr_list_t **implici
  * @note O(|V| * (d_max)^3) where d_max is the maximum degree in both dependency and inverted dependency graph.
  *
  * @param [in] md_ctx Module Dependencies context
- * @param [in] name Name of the module to remove
- * @param [in] revision Revision of the module to remove, can be empty string
+ * @param [in] names Names of the modules to remove
+ * @param [in] revisions Revisions of the modules to remove, can be empty strings
+ * @param [in] count Number of modules to be removed
  * @param [out] implicitly_removed A list of modules (not submodules) that were automatically removed
  *              (previous import-based dependencies). Items are pointers to md_module_key_t.
  */
-int md_remove_module(md_ctx_t *md_ctx, const char *name, const char *revision, sr_list_t **implicitly_removed);
+int md_remove_modules(md_ctx_t *md_ctx, const char * const *names, const char * const *revisions, int count, sr_list_t **implicitly_removed);
 
 /**
  * @brief Output the in-memory stored dependency graph from the given context into the internal data file


### PR DESCRIPTION
### Description
Sysrepocfg can now uninstall more modules simultaneously in one uninstall command so that modules with dependencies on each other can be removed.

### Closure
Fixes #1032