### PR TITLE
test case + possible solution for feature enabling issue

### DIFF
--- a/tests/yang/feature-dependencies1.yang
+++ b/tests/yang/feature-dependencies1.yang
@@ -1,0 +1,19 @@
+module feature-dependencies1 {
+
+   namespace "urn:pfe:params:xml:ns:yang:feature-dependencies1";
+   prefix fd1;
+
+   import feature-dependencies2 {
+      prefix fd2;
+   }
+
+   feature issue1;
+
+   container box {
+      leaf abc {
+         if-feature fd2:abc;
+         type string;
+      }
+   }
+
+}

--- a/tests/yang/feature-dependencies2.yang
+++ b/tests/yang/feature-dependencies2.yang
@@ -1,0 +1,16 @@
+module feature-dependencies2 {
+
+   namespace "urn:pfe:params:xml:ns:yang:feature-dependencies2";
+   prefix fd2;
+
+   import feature-dependencies3 {
+      prefix fd3;
+   }
+
+   feature abc {
+      if-feature fd3:xyz;
+   }
+
+   feature issue2;
+
+}

--- a/tests/yang/feature-dependencies3.yang
+++ b/tests/yang/feature-dependencies3.yang
@@ -1,0 +1,8 @@
+module feature-dependencies3 {
+
+   namespace "urn:pfe:params:xml:ns:yang:feature-dependencies3";
+   prefix fd3;
+
+   feature xyz;
+
+}


### PR DESCRIPTION
Hi,

the pull request addresses an issue with feature enabling. Here's the description of the test case, which reflects the problem:

> In the YANG modules "feature-dependencies1/2/3" several features are defined.
   The feature "abc" defined in "feature-dependencies2" depends on feature "xyz"
   defined in "feature-dependency3". Both features can be enabled without problems.
   But if afterwards one tries to enable other features without dependencies
   e.g. "issue1" in "feature-dependencies1" or "issue2" in "feature-dependencies2"
   an error occurs: Feature "abc" is disabled by its 1. if-feature condition.
   The reason is the order in which the persistent data are loaded. The persistent
   data of imported modules should always be loaded before the data of the importer.

We have additionally to the test case made an attempt to fix it in datamanager.c. Please have a look at it.

Btw.: as it seems, there's a little inconsistency with libyang and sysrepo's devel branch. I had to adapt lys_print_mem()'s parameters just to get it compiled. Please check this also for correctness.

Regards,
Frank