### PR TITLE
bugfix: support "config false" node into choice node

### DIFF
--- a/src/module_dependencies.c
+++ b/src/module_dependencies.c
@@ -1710,8 +1710,8 @@ md_traverse_schema_tree(md_ctx_t *md_ctx, md_module_t *module, md_module_t *main
                         backtracking = false;
                         child = node->child;
                         while ((NULL != child) && (main_module_schema == lys_node_module(child)) && (child != node)) {
-                            assert(!backtracking || (LYS_USES == child->nodetype));
-                            if ((LYS_USES != child->nodetype) && (LYS_CONFIG_R & child->flags)) {
+                            assert(!backtracking || (LYS_USES == child->nodetype) || (LYS_CHOICE == child->nodetype) || (LYS_CASE == child->nodetype));
+                            if ((LYS_USES != child->nodetype && LYS_CHOICE != child->nodetype && LYS_CASE != child->nodetype) && (LYS_CONFIG_R & child->flags)) {
                                 /* child with state data */
                                 rc = SR_ERR_NOT_FOUND;
                                 if (augment) {
@@ -1728,7 +1728,7 @@ md_traverse_schema_tree(md_ctx_t *md_ctx, md_module_t *module, md_module_t *main
                                 }
                             }
                             /* next child */
-                            if ((false == backtracking) && (LYS_USES == child->nodetype) && (NULL != child->child)) {
+                            if ((false == backtracking) && ((LYS_USES == child->nodetype) || (LYS_CHOICE == child->nodetype) || (LYS_CASE == child->nodetype)) && (NULL != child->child)) {
                                 child = child->child;
                             } else if (child->next) {
                                 backtracking = false;

--- a/src/rp_dt_get.c
+++ b/src/rp_dt_get.c
@@ -880,7 +880,7 @@ rp_dt_has_parent_list(struct lys_node *node, struct lys_node **found_list, size_
         size_t dep = 0;
 
         while (NULL != n) {
-            if (0 == (LYS_USES & n->nodetype)) {
+            if (0 == ((LYS_USES & n->nodetype) | (LYS_CHOICE & n->nodetype) | (LYS_CASE & n->nodetype))) {
                 dep++;
             }
             if (LYS_LIST & n->nodetype) {


### PR DESCRIPTION
the pull request can slove two issues:
case 1: if there is a choice node with config false leaf node, the leaf node can not be installed into op-data-subtrees in sysrepo-module-dependencies.xml .
case 2: if the state data is nested in choice/case node, the depth should not be increased. 
