### PR TITLE
replace cp by install

### DIFF
--- a/src/executables/sysrepoctl.c
+++ b/src/executables/sysrepoctl.c
@@ -758,7 +758,7 @@ srctl_schema_install(const struct lys_module *module, const char *yang_src, cons
                 printf("Schema of the module %s is already installed, skipping...\n", module->name);
             } else {
                 printf("Installing the YANG file to '%s'...\n", yang_dst);
-                snprintf(cmd, PATH_MAX, "cp %s %s", yang_src, yang_dst);
+                snprintf(cmd, PATH_MAX, "install -m 644 %s %s", yang_src, yang_dst);
                 ret = system(cmd);
                 if (0 != ret) {
                     fprintf(stderr, "Error: Unable to install the YANG file to '%s'.\n", yang_dst);
@@ -779,7 +779,7 @@ srctl_schema_install(const struct lys_module *module, const char *yang_src, cons
                 printf("Schema of the module %s is already installed, skipping...\n", module->name);
             } else {
                 printf("Installing the YIN file to '%s'...\n", yin_dst);
-                snprintf(cmd, PATH_MAX, "cp %s %s", yin_src, yin_dst);
+                snprintf(cmd, PATH_MAX, "install -m 644 %s %s", yin_src, yin_dst);
                 ret = system(cmd);
                 if (0 != ret) {
                     fprintf(stderr, "Error: Unable to install the YIN file to '%s'.\n", yin_dst);


### PR DESCRIPTION
Hi,

I made a little change in sysrepoctl: 
When installing modules with sysrepoctl the schema file will be copied to /etc/sysrepo/yang/ by "cp". "cp" copies also the permissions and if the source file has write protection, then a "reinstallation" will fail. Such a "reinstallation" happens for example, if one first installs ietf-interfaces and afterwards a module my-interfaces which imports ietf-interfaces.

I replaced "cp" by "install" with "user read+write permission" and all other with "read permission".

I hope it's ok in that way.

Regards,
Frank

Btw.: 
Do you plan to merge devel into master branch for sysrepo soon? It's already 2 month ahead  and I'd really like to see our recent changes at the master branch :-).