### PR TITLE
travis: release branches must use master libyang

### DIFF
--- a/deploy/travis/install-libs.sh
+++ b/deploy/travis/install-libs.sh
@@ -47,7 +47,7 @@ fi
 # libraries that we don't want to cache
 
 # libyang
-if [[ (("$TRAVIS_BRANCH" == *"master"*)) || (("$TRAVIS_BRANCH" == "v"[0-9]"."[0-9]"."[0-9])) ]]; then
+if [[ (( "$TRAVIS_BRANCH" == *"master"* )) || (( "$TRAVIS_TAG" =~ "v"[0-9]+"."[0-9]+"."[0-9]+ )) ]]; then
     git clone https://github.com/CESNET/libyang.git
 else
     git clone -b devel https://github.com/CESNET/libyang.git

--- a/deploy/travis/install-libs.sh
+++ b/deploy/travis/install-libs.sh
@@ -47,7 +47,7 @@ fi
 # libraries that we don't want to cache
 
 # libyang
-if [[ "$TRAVIS_BRANCH" == *"master"* ]]; then
+if [[ (("$TRAVIS_BRANCH" == *"master"*)) || (("$TRAVIS_BRANCH" == "v"[0-9]"."[0-9]"."[0-9])) ]]; then
     git clone https://github.com/CESNET/libyang.git
 else
     git clone -b devel https://github.com/CESNET/libyang.git


### PR DESCRIPTION
### Description
Regex for master libyang branch should include release branches.
