### PR TITLE
C++: remove send_event function

### DIFF
--- a/swig/cpp/src/Session.cpp
+++ b/swig/cpp/src/Session.cpp
@@ -729,20 +729,6 @@ S_Trees Session::action_send(const char *xpath, S_Trees input)
     return output;
 }
 
-void Session::send_event(const char *xpath, S_Vals values, const sr_ev_notif_flag_t options)
-{
-    int ret = sr_event_notif_send(_sess, xpath, values->_vals, values->val_cnt(), options);
-    if (ret != SR_ERR_OK)
-        throw_exception(ret);
-}
-
-void Session::send_event(const char *xpath, S_Trees trees, const sr_ev_notif_flag_t options)
-{
-    int ret = sr_event_notif_send_tree(_sess, xpath, trees->_trees, trees->tree_cnt(), options);
-    if (ret != SR_ERR_OK)
-        throw_exception(ret);
-}
-
 void Session::event_notif_send(const char *xpath, S_Vals values, const sr_ev_notif_flag_t options)
 {
     int ret = sr_event_notif_send(_sess, xpath, values->_vals, values->val_cnt(), options);

--- a/swig/cpp/src/Session.h
+++ b/swig/cpp/src/Session.h
@@ -85,8 +85,6 @@ public:
     S_Trees rpc_send(const char *xpath, S_Trees input);
     S_Vals action_send(const char *xpath, S_Vals input);
     S_Trees action_send(const char *xpath, S_Trees input);
-    void send_event(const char * xpath, S_Vals values, const sr_ev_notif_flag_t options = SR_EV_NOTIF_DEFAULT);
-    void send_event(const char * xpath, S_Trees trees, const sr_ev_notif_flag_t options = SR_EV_NOTIF_DEFAULT);
     void event_notif_send(const char *xpath, S_Vals values, const sr_ev_notif_flag_t options = SR_EV_NOTIF_DEFAULT);
     void event_notif_send(const char *xpath, S_Trees trees, const sr_ev_notif_flag_t options = SR_EV_NOTIF_DEFAULT);
 


### PR DESCRIPTION
### Description
Remove redundant function send_event() made by the pull request #1058.
