### PR TITLE
Pass the commit error code to client

### DIFF
--- a/src/clientlib/client_library.c
+++ b/src/clientlib/client_library.c
@@ -2084,14 +2084,8 @@ sr_commit(sr_session_ctx_t *session)
 
     /* send the request and receive the response */
     rc = cl_request_process(session, msg_req, &msg_resp, NULL, SR__OPERATION__COMMIT);
-    if ((SR_ERR_OK != rc) && (SR_ERR_OPERATION_FAILED != rc) && (SR_ERR_VALIDATION_FAILED != rc) &&
-        (SR_ERR_UNAUTHORIZED != rc)) {
-        SR_LOG_ERR_MSG("Error by processing of commit request.");
-        goto cleanup;
-    }
-
     commit_resp = msg_resp->response->commit_resp;
-    if ((SR_ERR_OPERATION_FAILED == rc) || (SR_ERR_VALIDATION_FAILED == rc) || (SR_ERR_UNAUTHORIZED == rc)) {
+    if (rc != SR_ERR_OK) {
         SR_LOG_ERR("Commit operation failed with %zu error(s).", commit_resp->n_errors);
 
         /* store commit errors within the session */
@@ -2184,14 +2178,8 @@ sr_copy_config(sr_session_ctx_t *session, const char *module_name,
 
     /* send the request and receive the response */
     rc = cl_request_process(session, msg_req, &msg_resp, NULL, SR__OPERATION__COPY_CONFIG);
-    if ((SR_ERR_OK != rc) && (SR_ERR_OPERATION_FAILED != rc) && (SR_ERR_VALIDATION_FAILED != rc) &&
-        (SR_ERR_UNAUTHORIZED != rc)) {
-        SR_LOG_ERR_MSG("Error by processing of copy_config request.");
-        goto cleanup;
-    }
-
     copy_config_resp = msg_resp->response->copy_config_resp;
-    if ((SR_ERR_OPERATION_FAILED == rc) || (SR_ERR_VALIDATION_FAILED == rc) || (SR_ERR_UNAUTHORIZED == rc)) {
+    if (rc != SR_ERR_OK) {
         SR_LOG_ERR("Copy_config operation failed with %zu error(s).", copy_config_resp->n_errors);
 
         /* store commit errors within the session */

--- a/src/data_manager.h
+++ b/src/data_manager.h
@@ -231,6 +231,7 @@ typedef struct dm_commit_context_s {
     bool nacm_edited;           /**< flag whether the running NACM configuration was edited. */
     bool in_btree;              /**< set to tree if the context was inserted into btree */
     bool should_be_removed;     /**< flag denoting whether c_ctx can be removed from btree */
+    int result;                 /**< result of verify or apply commit phase */
     dm_session_t *backup_session; /**< session with backed up modifications from before the commit */
 } dm_commit_context_t;
 

--- a/src/notification_processor.c
+++ b/src/notification_processor.c
@@ -1535,13 +1535,8 @@ np_commit_notification_ack(np_ctx_t *np_ctx, uint32_t commit_id, char *subs_xpat
     if (NULL != commit) {
         if (SR_EV_VERIFY == event && SR_ERR_OK != result) {
             /* error returned from the verifier */
-            if (SR_ERR_OK == commit->result) {
-                /* if there isn't any previous error stored within the commit context, store there this one */
-                commit->result = result;
-            }
-            if (SR_ERR_OK != result) {
-                np_commit_error_add(commit, subs_xpath, do_not_send_abort, err_msg, err_xpath);
-            }
+            commit->result = result;
+            np_commit_error_add(commit, subs_xpath, do_not_send_abort, err_msg, err_xpath);
             SR_LOG_ERR("Verifier for '%s' returned an error (msg: '%s', xpath: '%s'), commit will be aborted.",
                     subs_xpath, err_msg, err_xpath);
         }

--- a/src/request_processor.c
+++ b/src/request_processor.c
@@ -4247,10 +4247,9 @@ rp_all_notifications_received(rp_ctx_t *rp_ctx, uint32_t commit_id, bool finishe
 
     pthread_mutex_lock(&c_ctx->mutex);
     SR_LOG_DBG("Commit context in state %d", c_ctx->state);
+    c_ctx->result = result;
 
-    if (!finished && DM_COMMIT_WAIT_FOR_NOTIFICATIONS == c_ctx->state &&
-        NULL != c_ctx->init_session) {
-
+    if (!finished && DM_COMMIT_WAIT_FOR_NOTIFICATIONS == c_ctx->state && NULL != c_ctx->init_session) {
         switch (c_ctx->init_session->req->request->operation) {
         case SR__OPERATION__COPY_CONFIG:
             op_str = "copy_config";
@@ -4291,7 +4290,7 @@ rp_all_notifications_received(rp_ctx_t *rp_ctx, uint32_t commit_id, bool finishe
         c_ctx->init_session->req = NULL;
         pthread_mutex_unlock(&c_ctx->mutex);
         pthread_rwlock_unlock(&dm_ctxs->lock);
-    } else if (finished && DM_COMMIT_FINISHED == c_ctx->state){
+    } else if (finished && DM_COMMIT_FINISHED == c_ctx->state) {
         pthread_mutex_unlock(&c_ctx->mutex);
         pthread_rwlock_unlock(&dm_ctxs->lock);
         locked = false;

--- a/src/rp_dt_edit.c
+++ b/src/rp_dt_edit.c
@@ -938,7 +938,7 @@ rp_dt_commit(rp_ctx_t *rp_ctx, rp_session_t *session, dm_commit_context_t **c_ct
             commit_ctx->errors = NULL;
             commit_ctx->err_cnt = 0;
             SR_LOG_DBG_MSG("Commit (9/10): abort notifications sent");
-            rc = SR_ERR_OPERATION_FAILED;
+            rc = commit_ctx->result;
             goto cleanup;
         default:
             break;

--- a/tests/cl_notifications_test.c
+++ b/tests/cl_notifications_test.c
@@ -1785,7 +1785,8 @@ cl_refused_by_verifier(void **state)
     rc = sr_commit(session);
     assert_int_equal(rc, SR_ERR_OK);
     rc = sr_copy_config(session, NULL, SR_DS_CANDIDATE, SR_DS_RUNNING);
-    assert_int_equal(rc, SR_ERR_OPERATION_FAILED);
+    /* error code from the verifier */
+    assert_int_equal(rc, SR_ERR_INVAL_ARG);
 
     sr_clock_get_time(CLOCK_REALTIME, &ts);
     ts.tv_sec += COND_WAIT_SEC;
@@ -1893,7 +1894,7 @@ cl_no_abort_notifications(void **state)
     rc = sr_commit(session);
     assert_int_equal(rc, SR_ERR_OK);
     rc = sr_copy_config(session, "example-module", SR_DS_CANDIDATE, SR_DS_RUNNING);
-    assert_int_equal(rc, SR_ERR_OPERATION_FAILED);
+    assert_int_equal(rc, SR_ERR_INVAL_ARG);
 
     assert_int_equal(changes.cnt, 0);
 
@@ -1967,7 +1968,7 @@ cl_one_abort_notification(void **state)
     rc = sr_commit(session);
     assert_int_equal(rc, SR_ERR_OK);
     rc = sr_copy_config(session, "example-module", SR_DS_CANDIDATE, SR_DS_RUNNING);
-    assert_int_equal(rc, SR_ERR_OPERATION_FAILED);
+    assert_int_equal(rc, SR_ERR_INVAL_ARG);
 
     sr_clock_get_time(CLOCK_REALTIME, &ts);
     ts.tv_sec += COND_WAIT_SEC;


### PR DESCRIPTION
### Description
The most relevant commit error code should be passed to client instead of just generic SR_ERR_OP_FAILED.