### PR TITLE
Proper leafref type detection

### DIFF
--- a/src/common/sr_utils.c
+++ b/src/common/sr_utils.c
@@ -789,56 +789,6 @@ sr_ly_data_type_to_sr(LY_DATA_TYPE type)
         }
 }
 
-static sr_type_t
-sr_libyang_leaf_get_type_sch(const struct lys_node_leaf *leaf)
-{
-    if (NULL == leaf || !((LYS_LEAF | LYS_LEAFLIST) & leaf->nodetype)) {
-        return SR_UNKNOWN_T;
-    }
-
-    switch(leaf->type.base){
-        case LY_TYPE_BINARY:
-            return SR_BINARY_T;
-        case LY_TYPE_BITS:
-            return SR_BITS_T;
-        case LY_TYPE_BOOL:
-            return SR_BOOL_T;
-        case LY_TYPE_DEC64:
-            return SR_DECIMAL64_T;
-        case LY_TYPE_EMPTY:
-            return SR_LEAF_EMPTY_T;
-        case LY_TYPE_ENUM:
-            return SR_ENUM_T;
-        case LY_TYPE_IDENT:
-            return SR_IDENTITYREF_T;
-        case LY_TYPE_INST:
-            return SR_INSTANCEID_T;
-        case LY_TYPE_LEAFREF:
-            return sr_libyang_leaf_get_type_sch(leaf->type.info.lref.target);
-        case LY_TYPE_STRING:
-            return SR_STRING_T;
-        case LY_TYPE_INT8:
-            return SR_INT8_T;
-        case LY_TYPE_UINT8:
-            return SR_UINT8_T;
-        case LY_TYPE_INT16:
-            return SR_INT16_T;
-        case LY_TYPE_UINT16:
-            return SR_UINT16_T;
-        case LY_TYPE_INT32:
-            return SR_INT32_T;
-        case LY_TYPE_UINT32:
-            return SR_UINT32_T;
-        case LY_TYPE_INT64:
-            return SR_INT64_T;
-        case LY_TYPE_UINT64:
-            return SR_UINT64_T;
-        default:
-            return SR_UNKNOWN_T;
-            //LY_DERIVED
-        }
-}
-
 sr_type_t
 sr_libyang_leaf_get_type(const struct lyd_node_leaf_list *leaf)
 {
@@ -860,7 +810,7 @@ sr_libyang_leaf_get_type(const struct lyd_node_leaf_list *leaf)
         case LY_TYPE_INST:
             return SR_INSTANCEID_T;
         case LY_TYPE_LEAFREF:
-            return sr_libyang_leaf_get_type_sch(((struct lys_node_leaf *)leaf->schema)->type.info.lref.target);
+            return sr_libyang_leaf_get_type((struct lyd_node_leaf_list *)leaf->value.leafref);
         case LY_TYPE_STRING:
             return SR_STRING_T;
         case LY_TYPE_INT8:

--- a/src/common/sr_utils.c
+++ b/src/common/sr_utils.c
@@ -789,6 +789,56 @@ sr_ly_data_type_to_sr(LY_DATA_TYPE type)
         }
 }
 
+static sr_type_t
+sr_libyang_leaf_get_type_sch(const struct lys_node_leaf *leaf)
+{
+    if (NULL == leaf || !((LYS_LEAF | LYS_LEAFLIST) & leaf->nodetype)) {
+        return SR_UNKNOWN_T;
+    }
+
+    switch(leaf->type.base){
+        case LY_TYPE_BINARY:
+            return SR_BINARY_T;
+        case LY_TYPE_BITS:
+            return SR_BITS_T;
+        case LY_TYPE_BOOL:
+            return SR_BOOL_T;
+        case LY_TYPE_DEC64:
+            return SR_DECIMAL64_T;
+        case LY_TYPE_EMPTY:
+            return SR_LEAF_EMPTY_T;
+        case LY_TYPE_ENUM:
+            return SR_ENUM_T;
+        case LY_TYPE_IDENT:
+            return SR_IDENTITYREF_T;
+        case LY_TYPE_INST:
+            return SR_INSTANCEID_T;
+        case LY_TYPE_LEAFREF:
+            return sr_libyang_leaf_get_type_sch(leaf->type.info.lref.target);
+        case LY_TYPE_STRING:
+            return SR_STRING_T;
+        case LY_TYPE_INT8:
+            return SR_INT8_T;
+        case LY_TYPE_UINT8:
+            return SR_UINT8_T;
+        case LY_TYPE_INT16:
+            return SR_INT16_T;
+        case LY_TYPE_UINT16:
+            return SR_UINT16_T;
+        case LY_TYPE_INT32:
+            return SR_INT32_T;
+        case LY_TYPE_UINT32:
+            return SR_UINT32_T;
+        case LY_TYPE_INT64:
+            return SR_INT64_T;
+        case LY_TYPE_UINT64:
+            return SR_UINT64_T;
+        default:
+            return SR_UNKNOWN_T;
+            //LY_DERIVED
+        }
+}
+
 sr_type_t
 sr_libyang_leaf_get_type(const struct lyd_node_leaf_list *leaf)
 {
@@ -810,7 +860,12 @@ sr_libyang_leaf_get_type(const struct lyd_node_leaf_list *leaf)
         case LY_TYPE_INST:
             return SR_INSTANCEID_T;
         case LY_TYPE_LEAFREF:
-            return sr_libyang_leaf_get_type((struct lyd_node_leaf_list *)leaf->value.leafref);
+            /* if the target leafref was disconnected there is a problem in case the leaf is actually a union */
+            if ((struct lyd_node_leaf_list *)leaf->value.leafref) {
+                return sr_libyang_leaf_get_type((struct lyd_node_leaf_list *)leaf->value.leafref);
+            } else {
+                return sr_libyang_leaf_get_type_sch(((struct lys_node_leaf *)leaf->schema)->type.info.lref.target);
+            }
         case LY_TYPE_STRING:
             return SR_STRING_T;
         case LY_TYPE_INT8:


### PR DESCRIPTION
### Description
libyang always detects and stores actual type of union values. sysrepo must always use this information to learn a value type, schema node types cannot be used because of unions.
