### PR TITLE
make header files includable by c++ implementations

### DIFF
--- a/inc/sysrepo.h
+++ b/inc/sysrepo.h
@@ -59,6 +59,9 @@
     #include <sys/types.h>
 #endif
 
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 ////////////////////////////////////////////////////////////////////////////////
 // Common typedefs and API
@@ -2000,5 +2003,9 @@ void sr_free_tree(sr_node_t *tree);
 void sr_free_trees(sr_node_t *trees, size_t count);
 
 /**@} cl */
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* SYSREPO_H_ */

--- a/inc/sysrepo/plugins.h
+++ b/inc/sysrepo/plugins.h
@@ -30,6 +30,10 @@
 
 #include <sysrepo.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /**
  * @defgroup plugin_utils Plugin Utilities
  * @{
@@ -127,5 +131,9 @@ extern volatile uint8_t sr_ll_syslog;       /**< Holds current level of syslog d
         if (sr_ll_syslog >= LL) \
             SRP_LOG__SYSLOG(LL, MSG, __VA_ARGS__) \
     } while(0)
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* SYSREPO_PLUGINS_H_ */

--- a/inc/sysrepo/trees.h
+++ b/inc/sysrepo/trees.h
@@ -25,6 +25,10 @@
 
 #include <stdio.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /**
  * @defgroup trees Tree Manipulation Utilities
  * @{
@@ -214,5 +218,9 @@ sr_node_t *sr_node_get_next_sibling(sr_session_ctx_t *session, sr_node_t *node);
 sr_node_t *sr_node_get_parent(sr_session_ctx_t *session, sr_node_t *node);
 
 /**@} trees */
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* SYSREPO_TREES_H_ */

--- a/inc/sysrepo/values.h
+++ b/inc/sysrepo/values.h
@@ -25,6 +25,10 @@
 
 #include <stdio.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /**
  * @defgroup values Value Manipulation Utilities
  * @{
@@ -184,5 +188,9 @@ char *sr_val_to_str(const sr_val_t *value);
 int sr_val_to_buff(const sr_val_t *value, char buffer[], size_t size);
 
 /**@} values */
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* SYSREPO_VALUES_H_ */

--- a/inc/sysrepo/xpath.h
+++ b/inc/sysrepo/xpath.h
@@ -24,6 +24,10 @@
 
 #include <stdbool.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /**
  * @defgroup xpath_utils XPath Processing Utilities
  * @{
@@ -219,6 +223,10 @@ bool sr_xpath_node_name_eq(const char *xpath, const char *node_str);
 void sr_xpath_recover(sr_xpath_ctx_t *state);
 
 /**@} xpath_utils */
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* SYSREPO_XPATH_H_ */
 


### PR DESCRIPTION
Hi,
this simple modification ensures that the affected header files can be used in c++ implementations. 

Regards,
Frank