### PR TITLE
make sysrepo connection timeout switchable

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -176,11 +176,27 @@ set(STORE_CONFIG_CHANGE_NOTIF 1 CACHE BOOL
     "Save config-change notifications (RFC 6470) in the notification store (slows down the commit process).")
 
 # timeouts
-set(REQUEST_TIMEOUT 4 CACHE INTEGER
-    "Timeout (in seconds) for standard Sysrepo API requests. Set to 0 for no timeout.")
+if(REQUEST_TIMEOUT EQUAL "0" OR LONG_REQUEST_TIMEOUT EQUAL "0")
+    message(STATUS "Sysrepo API request Timeouts (REQUEST_TIMEOUT/LONG_REQUEST_TIMEOUT) have been disabled.")
+    set(REQUEST_TIMEOUT 0 CACHE INTEGER
+	"Timeout (in seconds) for standard Sysrepo API requests. Set to 0 for no timeout.")
+    set(LONG_REQUEST_TIMEOUT 0 CACHE INTEGER
+	"Timeout (in seconds) for Sysrepo API requests that can take longer than standard requests (commit, copy-config, rpc, action). Set to 0 for no timeout.")
+endif(REQUEST_TIMEOUT EQUAL "0" OR LONG_REQUEST_TIMEOUT EQUAL "0")
 
-set(LONG_REQUEST_TIMEOUT 15 CACHE INTEGER
-    "Timeout (in seconds) for Sysrepo API requests that can take longer than standard requests (commit, copy-config, rpc, action). Set to 0 for no timeout.")
+if(NOT DEFINED REQUEST_TIMEOUT)
+    set(REQUEST_TIMEOUT 4 CACHE INTEGER
+	"Timeout (in seconds) for standard Sysrepo API requests. Set to 0 for no timeout.")
+endif(NOT DEFINED REQUEST_TIMEOUT)
+
+if(NOT DEFINED LONG_REQUEST_TIMEOUT)
+    set(LONG_REQUEST_TIMEOUT 15 CACHE INTEGER
+	"Timeout (in seconds) for Sysrepo API requests that can take longer than standard requests (commit, copy-config, rpc, action). Set to 0 for no timeout.")
+endif(NOT DEFINED LONG_REQUEST_TIMEOUT)
+
+if(REQUEST_TIMEOUT GREATER LONG_REQUEST_TIMEOUT)
+    message(FATAL_ERROR "LONG_REQUEST_TIMEOUT (${LONG_REQUEST_TIMEOUT}) must be greater than REQUEST_TIMEOUT (${REQUEST_TIMEOUT})")
+endif(REQUEST_TIMEOUT GREATER LONG_REQUEST_TIMEOUT)
 
 set(COMMIT_VERIFY_TIMEOUT 10 CACHE INTEGER
     "Timeout (in seconds) that a commit request can wait for answer from commit verifiers and change notification subscribers.")
@@ -193,10 +209,6 @@ set(NOTIF_AGE_TIMEOUT 60 CACHE INTEGER
 
 set(NOTIF_TIME_WINDOW 10 CACHE INTEGER
     "Time window (in minutes) for notifications to be grouped into one data file (larger window produces larger data files).")
-
-if(REQUEST_TIMEOUT EQUAL "0" AND NOT LONG_REQUEST_TIMEOUT EQUAL "0")
-    message(FATAL_ERROR "LONG_REQUEST_TIMEOUT must be 0 when REQUEST_TIMEOUT is 0")
-endif(REQUEST_TIMEOUT EQUAL "0" AND NOT LONG_REQUEST_TIMEOUT EQUAL "0")
 
 # add subdirectories
 add_subdirectory(src)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -177,10 +177,10 @@ set(STORE_CONFIG_CHANGE_NOTIF 1 CACHE BOOL
 
 # timeouts
 set(REQUEST_TIMEOUT 4 CACHE INTEGER
-    "Timeout (in seconds) for standard Sysrepo API requests.")
+    "Timeout (in seconds) for standard Sysrepo API requests. Set to 0 for no timeout.")
 
 set(LONG_REQUEST_TIMEOUT 15 CACHE INTEGER
-    "Timeout (in seconds) for Sysrepo API requests that can take longer than standard requests (commit, copy-config, rpc, action).")
+    "Timeout (in seconds) for Sysrepo API requests that can take longer than standard requests (commit, copy-config, rpc, action). Set to 0 for no timeout.")
 
 set(COMMIT_VERIFY_TIMEOUT 10 CACHE INTEGER
     "Timeout (in seconds) that a commit request can wait for answer from commit verifiers and change notification subscribers.")
@@ -193,6 +193,10 @@ set(NOTIF_AGE_TIMEOUT 60 CACHE INTEGER
 
 set(NOTIF_TIME_WINDOW 10 CACHE INTEGER
     "Time window (in minutes) for notifications to be grouped into one data file (larger window produces larger data files).")
+
+if(REQUEST_TIMEOUT EQUAL "0" AND NOT LONG_REQUEST_TIMEOUT EQUAL "0")
+    message(FATAL_ERROR "LONG_REQUEST_TIMEOUT must be 0 when REQUEST_TIMEOUT is 0")
+endif(REQUEST_TIMEOUT EQUAL "0" AND NOT LONG_REQUEST_TIMEOUT EQUAL "0")
 
 # add subdirectories
 add_subdirectory(src)

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -164,8 +164,8 @@ There are several timeouts that can be configured via CMake variables:
 
 CMake variable              | Default value | Description
 --------------------------- | ------------- | -----------
-`REQUEST_TIMEOUT`           | 3 sec         | Timeout (in seconds) for standard Sysrepo API requests.
-`LONG_REQUEST_TIMEOUT`      | 15 sec        | Timeout (in seconds) for Sysrepo API requests that can take longer than standard requests (commit, copy-config, rpc, action).
+`REQUEST_TIMEOUT`           | 3 sec         | Timeout (in seconds) for standard Sysrepo API requests. Set to 0 to disable request timeouts.
+`LONG_REQUEST_TIMEOUT`      | 15 sec        | Timeout (in seconds) for Sysrepo API requests that can take longer than standard requests (commit, copy-config, rpc, action). Set to 0 to disable timeouts.
 `COMMIT_VERIFY_TIMEOUT`     | 10 sec        | Timeout (in seconds) that a commit request can wait for answer from commit verifiers and change notification subscribers.
 `OPER_DATA_PROVIDE_TIMEOUT` | 2 sec         | Timeout (in seconds) that a request can wait for operational data from data providers.
 `NOTIF_AGE_TIMEOUT`         | 60 min        | Timeout (in minutes) after which stored notifications will be aged out and erased from notification store.


### PR DESCRIPTION
Hi,

please consider this little modification which makes it possible to disable the connection timeout in the sysrepo client library by compiler switch.

Background: 
In low performance environments, sysrepo clients might be too busy to answer in time, if the connection then times out it starts that things get worse. For this reason we want to be able to switch it off (and deal with the consequences, if necessary)

Regards,
Frank
