### PR TITLE
Removed separate long request timeout

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -176,27 +176,8 @@ set(STORE_CONFIG_CHANGE_NOTIF 1 CACHE BOOL
     "Save config-change notifications (RFC 6470) in the notification store (slows down the commit process).")
 
 # timeouts
-if(REQUEST_TIMEOUT EQUAL "0" OR LONG_REQUEST_TIMEOUT EQUAL "0")
-    message(STATUS "Sysrepo API request Timeouts (REQUEST_TIMEOUT/LONG_REQUEST_TIMEOUT) have been disabled.")
-    set(REQUEST_TIMEOUT 0 CACHE INTEGER
-	"Timeout (in seconds) for standard Sysrepo API requests. Set to 0 for no timeout.")
-    set(LONG_REQUEST_TIMEOUT 0 CACHE INTEGER
-	"Timeout (in seconds) for Sysrepo API requests that can take longer than standard requests (commit, copy-config, rpc, action). Set to 0 for no timeout.")
-endif(REQUEST_TIMEOUT EQUAL "0" OR LONG_REQUEST_TIMEOUT EQUAL "0")
-
-if(NOT DEFINED REQUEST_TIMEOUT)
-    set(REQUEST_TIMEOUT 4 CACHE INTEGER
-	"Timeout (in seconds) for standard Sysrepo API requests. Set to 0 for no timeout.")
-endif(NOT DEFINED REQUEST_TIMEOUT)
-
-if(NOT DEFINED LONG_REQUEST_TIMEOUT)
-    set(LONG_REQUEST_TIMEOUT 15 CACHE INTEGER
-	"Timeout (in seconds) for Sysrepo API requests that can take longer than standard requests (commit, copy-config, rpc, action). Set to 0 for no timeout.")
-endif(NOT DEFINED LONG_REQUEST_TIMEOUT)
-
-if(REQUEST_TIMEOUT GREATER LONG_REQUEST_TIMEOUT)
-    message(FATAL_ERROR "LONG_REQUEST_TIMEOUT (${LONG_REQUEST_TIMEOUT}) must be greater than REQUEST_TIMEOUT (${REQUEST_TIMEOUT})")
-endif(REQUEST_TIMEOUT GREATER LONG_REQUEST_TIMEOUT)
+set(REQUEST_TIMEOUT 15 CACHE INTEGER
+    "Timeout (in seconds) for Sysrepo API requests. Set to 0 for no timeout.")
 
 set(COMMIT_VERIFY_TIMEOUT 10 CACHE INTEGER
     "Timeout (in seconds) that a commit request can wait for answer from commit verifiers and change notification subscribers.")

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -165,7 +165,6 @@ There are several timeouts that can be configured via CMake variables:
 CMake variable              | Default value | Description
 --------------------------- | ------------- | -----------
 `REQUEST_TIMEOUT`           | 3 sec         | Timeout (in seconds) for standard Sysrepo API requests. Set to 0 to disable request timeouts.
-`LONG_REQUEST_TIMEOUT`      | 15 sec        | Timeout (in seconds) for Sysrepo API requests that can take longer than standard requests (commit, copy-config, rpc, action). Set to 0 to disable timeouts.
 `COMMIT_VERIFY_TIMEOUT`     | 10 sec        | Timeout (in seconds) that a commit request can wait for answer from commit verifiers and change notification subscribers.
 `OPER_DATA_PROVIDE_TIMEOUT` | 2 sec         | Timeout (in seconds) that a request can wait for operational data from data providers.
 `NOTIF_AGE_TIMEOUT`         | 60 min        | Timeout (in minutes) after which stored notifications will be aged out and erased from notification store.

--- a/src/clientlib/cl_common.c
+++ b/src/clientlib/cl_common.c
@@ -395,7 +395,7 @@ cl_socket_connect(sr_conn_ctx_t *conn_ctx, const char *socket_path)
     }
 
     /* set timeout for receive operation */
-    if(SR_REQUEST_TIMEOUT > 0) {
+    if (SR_REQUEST_TIMEOUT > 0) {
         tv.tv_sec = SR_REQUEST_TIMEOUT;
         tv.tv_usec = 0;
         rc = setsockopt(fd, SOL_SOCKET, SO_RCVTIMEO, (char *)&tv, sizeof(tv));
@@ -487,24 +487,12 @@ cl_request_process(sr_session_ctx_t *session, Sr__Msg *msg_req, Sr__Msg **msg_re
         sr_mem_ctx_t *sr_mem_resp, const Sr__Operation expected_response_op)
 {
     int rc = SR_ERR_OK;
-    struct timeval tv = { 0, };
 
     CHECK_NULL_ARG4(session, session->conn_ctx, msg_req, msg_resp);
 
     SR_LOG_DBG("Sending %s request.", sr_gpb_operation_name(expected_response_op));
 
     pthread_mutex_lock(&session->conn_ctx->lock);
-    /* some operation may take more time, raise the timeout */
-    if ((SR__OPERATION__COMMIT == expected_response_op || SR__OPERATION__COPY_CONFIG == expected_response_op ||
-            SR__OPERATION__RPC == expected_response_op || SR__OPERATION__ACTION == expected_response_op) &&
-         SR_LONG_REQUEST_TIMEOUT > 0) {
-        tv.tv_sec = SR_LONG_REQUEST_TIMEOUT;
-        tv.tv_usec = 0;
-        rc = setsockopt(session->conn_ctx->fd, SOL_SOCKET, SO_RCVTIMEO, (char *)&tv, sizeof(tv));
-        if (-1 == rc) {
-            SR_LOG_WRN("Unable to set timeout for socket operations: %s", sr_strerror_safe(errno));
-        }
-    }
 
     /* send the request */
     rc = cl_message_send(session->conn_ctx, msg_req);
@@ -524,17 +512,6 @@ cl_request_process(sr_session_ctx_t *session, Sr__Msg *msg_req, Sr__Msg **msg_re
                 session->id, sr_gpb_operation_name(msg_req->request->operation));
         pthread_mutex_unlock(&session->conn_ctx->lock);
         return rc;
-    }
-
-    /* change socket timeout to the standard value */
-    if ((SR__OPERATION__COMMIT == expected_response_op || SR__OPERATION__COPY_CONFIG == expected_response_op ||
-            SR__OPERATION__RPC == expected_response_op || SR__OPERATION__ACTION == expected_response_op) &&
-         SR_LONG_REQUEST_TIMEOUT > 0) {
-        tv.tv_sec = SR_REQUEST_TIMEOUT;
-        rc = setsockopt(session->conn_ctx->fd, SOL_SOCKET, SO_RCVTIMEO, (char *)&tv, sizeof(tv));
-        if (-1 == rc) {
-            SR_LOG_WRN("Unable to set timeout for socket operations: %s", sr_strerror_safe(errno));
-        }
     }
 
     pthread_mutex_unlock(&session->conn_ctx->lock);


### PR DESCRIPTION
### Description
Little use to have 2 separate timeouts so one is used now for all requests.