### PR TITLE
Resolve module installation error when submodule contains a leafref

### DIFF
--- a/tests/md_test.c
+++ b/tests/md_test.c
@@ -1672,6 +1672,36 @@ md_test_insert_module_2(void **state)
     md_destroy(md_ctx);
 }
 
+/*
+ * @brief Test md_insert_module().
+ */
+
+static const char * const md_test_insert_module_3_mod1 = TEST_SOURCE_DIR "/yang/mws-main-module" TEST_MODULE_EXT;
+
+static void
+md_test_insert_module_3(void **state)
+{
+    int rc;
+    md_ctx_t *md_ctx = NULL;
+    sr_list_t *implicitly_inserted = NULL;
+
+    rc = md_init(TEST_SOURCE_DIR "/yang", TEST_SCHEMA_SEARCH_DIR "internal",
+                 TEST_DATA_SEARCH_DIR "internal", true, &md_ctx);
+    assert_int_equal(SR_ERR_OK, rc);
+    validate_context(md_ctx);
+
+    rc = md_insert_module(md_ctx, md_test_insert_module_3_mod1, &implicitly_inserted);
+    assert_int_equal(SR_ERR_OK, rc);
+    assert_int_equal(1, implicitly_inserted->count);
+    md_free_module_key_list(implicitly_inserted);
+    validate_context(md_ctx);
+
+    rc = md_flush(md_ctx);
+    assert_int_equal(SR_ERR_OK, rc);
+
+    md_destroy(md_ctx);
+}
+
 static int
 _md_test_remove_modules(md_ctx_t *md_ctx, const char *name, const char *revision, sr_list_t **implicitly_removed)
 {
@@ -1814,6 +1844,14 @@ md_test_remove_modules(void **state)
     implicitly_removed = NULL;
     validate_context(md_ctx);
 
+    /* remove all mws modules */
+    rc = _md_test_remove_modules(md_ctx, "mws-main-module", NULL, &implicitly_removed);
+    assert_int_equal(SR_ERR_OK, rc);
+    assert_int_equal(1, implicitly_removed->count);
+    md_free_module_key_list(implicitly_removed);
+    implicitly_removed = NULL;
+    validate_context(md_ctx);
+
     /* flush changes into the internal data file */
     rc = md_flush(md_ctx);
     assert_int_equal(SR_ERR_OK, rc);
@@ -1952,6 +1990,7 @@ int main(){
             cmocka_unit_test(md_test_init_and_destroy),
             cmocka_unit_test(md_test_insert_module),
             cmocka_unit_test(md_test_insert_module_2),
+            cmocka_unit_test(md_test_insert_module_3),
             cmocka_unit_test(md_test_remove_modules),
             cmocka_unit_test(md_test_grouping_and_uses),
             cmocka_unit_test(md_test_has_data),

--- a/tests/yang/mws-main-module.yang
+++ b/tests/yang/mws-main-module.yang
@@ -1,0 +1,14 @@
+module mws-main-module {
+    prefix mws-main;
+
+    namespace "modulewithsub:main";
+
+    include mws-main-submodule1;
+    include mws-main-submodule2;
+
+    container main {
+        leaf top {
+            type string;
+        }
+    }
+}

--- a/tests/yang/mws-main-submodule1.yang
+++ b/tests/yang/mws-main-submodule1.yang
@@ -1,0 +1,11 @@
+submodule mws-main-submodule1 {
+    belongs-to mws-main-module {
+        prefix mws-main;
+    }
+
+    augment "/mws-main:main" {
+        leaf first {
+            type string;
+        }
+    }
+}

--- a/tests/yang/mws-main-submodule2.yang
+++ b/tests/yang/mws-main-submodule2.yang
@@ -1,0 +1,17 @@
+submodule mws-main-submodule2 {
+    belongs-to mws-main-module {
+        prefix mws-main;
+    }
+
+    import mws-other-module {
+        prefix mws-other;
+    }
+
+    augment "/mws-main:main" {
+        leaf second {
+            type leafref {
+                path "/mws-other:foo/mws-other:bar";
+            }
+        }
+    }
+}

--- a/tests/yang/mws-other-module.yang
+++ b/tests/yang/mws-other-module.yang
@@ -1,0 +1,11 @@
+module mws-other-module {
+    prefix mws-other;
+
+    namespace "modulewithsub:other";
+
+    container foo {
+        leaf bar {
+            type string;
+        }
+    }
+}


### PR DESCRIPTION
### Description
When installing a module using sysrepoctl, certain functions, such as md_traverse_schema_tree and md_collect_data_dependencies expect any modules that are referenced to appear in the being_parsed list of modules while building the module dependency graph. In some cases, this may not be the case. The included test case (and issue #1116) demonstrate a case where this is not true.To fix this issue, a new list, expected_modules, is used to keep track of module names (and revisions) that we expect to see but have not yet been added to being_parsed. This allows us to continue to build up module dependencies. When a new module is added to the being_parsed list, this fix first checks the list of expected_modules to see if the new module was previously expected. If the dependency graph is complete, but there are still items in the expected_modules list, we assume an error has occurred.

### Test case
The included test case attempts to install a valid model that would previously fail without this fix. This yang model is the same one attached to issue #1116

### Closure
closes #1116



