### PR TITLE
Resolve module installation assertion error when augmenting into empty container

### DIFF
--- a/src/module_dependencies.c
+++ b/src/module_dependencies.c
@@ -1785,10 +1785,11 @@ next_node:
                     } else {
                         /* if processing augment, we must be able to go back through
                          * the augments from the same module */
-                        if (parent && main_module_schema == lys_node_module(parent)) {
-                            node = parent;
-                        } else {
-                            node = node->parent; /* should be NULL */
+                        node = node->parent;
+                        if (node == NULL) {
+                            if (parent && main_module_schema == lys_node_module(parent)) {
+                                node = parent;
+                            } 
                         }
                     }
                     process_children = false;

--- a/tests/md_test.c
+++ b/tests/md_test.c
@@ -1672,6 +1672,36 @@ md_test_insert_module_2(void **state)
     md_destroy(md_ctx);
 }
 
+/*
+ * @brief Test md_insert_module_4().
+ */
+
+static const char * const md_test_insert_module_4_mod1 = TEST_SOURCE_DIR "/yang/augm_empty_container_m1" TEST_MODULE_EXT;
+
+static void
+md_test_insert_module_4(void **state)
+{
+    int rc;
+    md_ctx_t *md_ctx = NULL;
+    sr_list_t *implicitly_inserted = NULL;
+
+    rc = md_init(TEST_SOURCE_DIR "/yang", TEST_SCHEMA_SEARCH_DIR "internal",
+                 TEST_DATA_SEARCH_DIR "internal", true, &md_ctx);
+    assert_int_equal(SR_ERR_OK, rc);
+    validate_context(md_ctx);
+
+    rc = md_insert_module(md_ctx, md_test_insert_module_4_mod1, &implicitly_inserted);
+    assert_int_equal(SR_ERR_OK, rc);
+    assert_int_equal(0, implicitly_inserted->count);
+    md_free_module_key_list(implicitly_inserted);
+    validate_context(md_ctx);
+
+    rc = md_flush(md_ctx);
+    assert_int_equal(SR_ERR_OK, rc);
+
+    md_destroy(md_ctx);
+}
+
 static int
 _md_test_remove_modules(md_ctx_t *md_ctx, const char *name, const char *revision, sr_list_t **implicitly_removed)
 {
@@ -1814,6 +1844,12 @@ md_test_remove_modules(void **state)
     implicitly_removed = NULL;
     validate_context(md_ctx);
 
+    rc = _md_test_remove_modules(md_ctx, "augm_empty_container_m1", NULL, &implicitly_removed);
+    assert_int_equal(SR_ERR_OK, rc);
+    assert_int_equal(0, implicitly_removed->count);
+    md_free_module_key_list(implicitly_removed);
+    implicitly_removed = NULL;
+
     /* flush changes into the internal data file */
     rc = md_flush(md_ctx);
     assert_int_equal(SR_ERR_OK, rc);
@@ -1952,6 +1988,7 @@ int main(){
             cmocka_unit_test(md_test_init_and_destroy),
             cmocka_unit_test(md_test_insert_module),
             cmocka_unit_test(md_test_insert_module_2),
+            cmocka_unit_test(md_test_insert_module_4),
             cmocka_unit_test(md_test_remove_modules),
             cmocka_unit_test(md_test_grouping_and_uses),
             cmocka_unit_test(md_test_has_data),

--- a/tests/yang/augm_empty_container_m1.yang
+++ b/tests/yang/augm_empty_container_m1.yang
@@ -1,0 +1,23 @@
+module augm_empty_container_m1 {
+  namespace "urn:ietf:params:xml:ns:yang:ietf-interfaces:augm_empty_container";
+  prefix aec;
+
+  import ietf-interfaces{
+    prefix if;
+  }
+
+  augment "/if:interfaces-state/if:interface" {
+    container container1 {
+    }
+  }
+
+  augment "/if:interfaces-state/if:interface/container1" {
+    leaf augmented-data-flag {
+        config false;
+        type boolean;
+        description
+          "Flag for test of augmentation into empty container.";
+    }
+  }
+
+}


### PR DESCRIPTION
### Description
Installing a YANG module with sysrepoctl results in a failure due to an assertion if an otherwise empty container has children added by augmentation.  While backtracking augment nodes, existing code assumes that node->parent is NULL and uses the parent returned from lys_parent(node).  This is the wrong parent in the test case when node->parent is not NULL.  This code modification establishes preference for a non-NULL node->parent.

### Test case
The test case, `md_insert_module_4`, found in `md_test.c` and accompanying yang model, `augm_empty_container_m1`, demonstrate the failure.

### Closure
closes #1106
