### PR TITLE
Fix segfault due to NULL child if module contains augment whose children are contingent on a feature

### DIFF
--- a/src/module_dependencies.c
+++ b/src/module_dependencies.c
@@ -1744,12 +1744,16 @@ md_traverse_schema_tree(md_ctx_t *md_ctx, md_module_t *module, md_module_t *main
                         if (augment) {
                             if (node->nodetype == LYS_AUGMENT) {
                                 child = (struct lys_node *)lys_getnext(NULL, node, NULL, 0);
-                                assert(!(child->nodetype & (LYS_CONTAINER | LYS_LIST)) || (intptr_t)child->priv & PRIV_OP_SUBTREE);
-                                assert(child->nodetype & (LYS_CONTAINER | LYS_LIST) || child->flags & LYS_CONFIG_R);
+                                assert(child == NULL || !(child->nodetype & (LYS_CONTAINER | LYS_LIST)) || (intptr_t)child->priv & PRIV_OP_SUBTREE);
+                                assert(child == NULL || child->nodetype & (LYS_CONTAINER | LYS_LIST) || child->flags & LYS_CONFIG_R);
                             } else {
                                 child = node;
                             }
-                            rc = md_check_op_data_subtree(dest_module, child);
+                            if (child != NULL) {
+                                rc = md_check_op_data_subtree(dest_module, child);
+                            } else {
+                                rc = SR_ERR_OK;
+                            }
                         } else {
                             child = node;
                         }

--- a/tests/md_test.c
+++ b/tests/md_test.c
@@ -1672,6 +1672,36 @@ md_test_insert_module_2(void **state)
     md_destroy(md_ctx);
 }
 
+/*
+ * @brief Test md_insert_module_5().
+ */
+
+static const char * const md_test_insert_module_5_mod1 = TEST_SOURCE_DIR "/yang/augm_container_if_feature_m1" TEST_MODULE_EXT;
+
+static void
+md_test_insert_module_5(void **state)
+{
+    int rc;
+    md_ctx_t *md_ctx = NULL;
+    sr_list_t *implicitly_inserted = NULL;
+
+    rc = md_init(TEST_SOURCE_DIR "/yang", TEST_SCHEMA_SEARCH_DIR "internal",
+                 TEST_DATA_SEARCH_DIR "internal", true, &md_ctx);
+    assert_int_equal(SR_ERR_OK, rc);
+    validate_context(md_ctx);
+
+    rc = md_insert_module(md_ctx, md_test_insert_module_5_mod1, &implicitly_inserted);
+    assert_int_equal(SR_ERR_OK, rc);
+    assert_int_equal(0, implicitly_inserted->count);
+    md_free_module_key_list(implicitly_inserted);
+    validate_context(md_ctx);
+
+    rc = md_flush(md_ctx);
+    assert_int_equal(SR_ERR_OK, rc);
+
+    md_destroy(md_ctx);
+}
+
 static int
 _md_test_remove_modules(md_ctx_t *md_ctx, const char *name, const char *revision, sr_list_t **implicitly_removed)
 {
@@ -1814,6 +1844,12 @@ md_test_remove_modules(void **state)
     implicitly_removed = NULL;
     validate_context(md_ctx);
 
+    rc = _md_test_remove_modules(md_ctx, "augm_container_if_feature_m1", NULL, &implicitly_removed);
+    assert_int_equal(SR_ERR_OK, rc);
+    assert_int_equal(0, implicitly_removed->count);
+    md_free_module_key_list(implicitly_removed);
+    implicitly_removed = NULL;
+
     /* flush changes into the internal data file */
     rc = md_flush(md_ctx);
     assert_int_equal(SR_ERR_OK, rc);
@@ -1952,6 +1988,7 @@ int main(){
             cmocka_unit_test(md_test_init_and_destroy),
             cmocka_unit_test(md_test_insert_module),
             cmocka_unit_test(md_test_insert_module_2),
+            cmocka_unit_test(md_test_insert_module_5),
             cmocka_unit_test(md_test_remove_modules),
             cmocka_unit_test(md_test_grouping_and_uses),
             cmocka_unit_test(md_test_has_data),

--- a/tests/yang/augm_container_if_feature_m1.yang
+++ b/tests/yang/augm_container_if_feature_m1.yang
@@ -1,0 +1,21 @@
+module augm_container_if_feature_m1 {
+  namespace "urn:ietf:params:xml:ns:yang:ietf-interfaces:augm_container_if_feature";
+  prefix acif;
+
+  import ietf-interfaces{
+    prefix if;
+  }
+
+  feature augm_feature;
+
+  augment "/if:interfaces-state/if:interface" {
+    container container1 {
+      if-feature augm_feature;
+      leaf augmented-data-flag {
+          type boolean;
+          description
+            "Flag for test of augmentation into empty container.";
+      }
+    }
+  }
+}


### PR DESCRIPTION
### Description
Installing a YANG module with `sysrepoctl` results in a segmentation fault if the module contains an augment whose children are contingent upon a feature. The same segmentation fault occurs if the module contains an augment with a uses clause where the corresponding grouping’s children are contingent on a feature. Issue #1105 documents this issue. The included test case demonstrates the failure. To address this, `md_traverse_schema_tree()` has been modified to tolerate the return of a null child from the call to the function `lys_getnext()`.

### Test case
The included test case attempts to install a valid model that would previously fail without this fix. The required yang model file is included.

### Closure
closes #1105 