### PR TITLE
Tests and models to verify successful installation when submodule contains a leafref

### DIFF
--- a/tests/md_test.c
+++ b/tests/md_test.c
@@ -1673,6 +1673,36 @@ md_test_insert_module_2(void **state)
 }
 
 /*
+ * @brief Test md_insert_module().
+ */
+
+static const char * const md_test_insert_module_3_mod1 = TEST_SOURCE_DIR "/yang/mws-main-module" TEST_MODULE_EXT;
+
+static void
+md_test_insert_module_3(void **state)
+{
+    int rc;
+    md_ctx_t *md_ctx = NULL;
+    sr_list_t *implicitly_inserted = NULL;
+
+    rc = md_init(TEST_SOURCE_DIR "/yang", TEST_SCHEMA_SEARCH_DIR "internal",
+                 TEST_DATA_SEARCH_DIR "internal", true, &md_ctx);
+    assert_int_equal(SR_ERR_OK, rc);
+    validate_context(md_ctx);
+
+    rc = md_insert_module(md_ctx, md_test_insert_module_3_mod1, &implicitly_inserted);
+    assert_int_equal(SR_ERR_OK, rc);
+    assert_int_equal(1, implicitly_inserted->count);
+    md_free_module_key_list(implicitly_inserted);
+    validate_context(md_ctx);
+
+    rc = md_flush(md_ctx);
+    assert_int_equal(SR_ERR_OK, rc);
+
+    md_destroy(md_ctx);
+}
+
+/*
  * @brief Test md_insert_module_4().
  */
 
@@ -1870,6 +1900,13 @@ md_test_remove_modules(void **state)
     implicitly_removed = NULL;
     validate_context(md_ctx);
 
+    rc = _md_test_remove_modules(md_ctx, "mws-main-module", NULL, &implicitly_removed);
+    assert_int_equal(SR_ERR_OK, rc);
+    assert_int_equal(1, implicitly_removed->count);
+    md_free_module_key_list(implicitly_removed);
+    implicitly_removed = NULL;
+    validate_context(md_ctx);
+
     rc = _md_test_remove_modules(md_ctx, "augm_empty_container_m1", NULL, &implicitly_removed);
     assert_int_equal(SR_ERR_OK, rc);
     assert_int_equal(0, implicitly_removed->count);
@@ -2020,6 +2057,7 @@ int main(){
             cmocka_unit_test(md_test_init_and_destroy),
             cmocka_unit_test(md_test_insert_module),
             cmocka_unit_test(md_test_insert_module_2),
+            cmocka_unit_test(md_test_insert_module_3),
             cmocka_unit_test(md_test_insert_module_4),
             cmocka_unit_test(md_test_insert_module_5),
             cmocka_unit_test(md_test_remove_modules),

--- a/tests/yang/mws-main-module.yang
+++ b/tests/yang/mws-main-module.yang
@@ -1,0 +1,14 @@
+module mws-main-module {
+    prefix mws-main;
+
+    namespace "modulewithsub:main";
+
+    include mws-main-submodule1;
+    include mws-main-submodule2;
+
+    container main {
+        leaf top {
+            type string;
+        }
+    }
+}

--- a/tests/yang/mws-main-submodule1.yang
+++ b/tests/yang/mws-main-submodule1.yang
@@ -1,0 +1,11 @@
+submodule mws-main-submodule1 {
+    belongs-to mws-main-module {
+        prefix mws-main;
+    }
+
+    augment "/mws-main:main" {
+        leaf first {
+            type string;
+        }
+    }
+}

--- a/tests/yang/mws-main-submodule2.yang
+++ b/tests/yang/mws-main-submodule2.yang
@@ -1,0 +1,17 @@
+submodule mws-main-submodule2 {
+    belongs-to mws-main-module {
+        prefix mws-main;
+    }
+
+    import mws-other-module {
+        prefix mws-other;
+    }
+
+    augment "/mws-main:main" {
+        leaf second {
+            type leafref {
+                path "/mws-other:foo/mws-other:bar";
+            }
+        }
+    }
+}

--- a/tests/yang/mws-other-module.yang
+++ b/tests/yang/mws-other-module.yang
@@ -1,0 +1,11 @@
+module mws-other-module {
+    prefix mws-other;
+
+    namespace "modulewithsub:other";
+
+    container foo {
+        leaf bar {
+            type string;
+        }
+    }
+}


### PR DESCRIPTION
### Description
This is a follow-on pull request as requested by @michalvasko that contains only the test case and models which should now pass due to #1125 .  This PR is associated with issue #1116 

### Test case
The included test case attempts to install a valid model that would previously fail without @michalvasko 
fix in #1125 . This yang model is the same one attached to issue #1116

### Closure
Tests support PR #1125
Closes issue #1116 
