### PR TITLE
Resolve module installation assertion when empty container in augment and double augments

### DIFF
--- a/src/module_dependencies.c
+++ b/src/module_dependencies.c
@@ -1742,8 +1742,16 @@ md_traverse_schema_tree(md_ctx_t *md_ctx, md_module_t *module, struct lys_node *
                         if (augment) {
                             if (node->nodetype == LYS_AUGMENT) {
                                 child = (struct lys_node *)lys_getnext(NULL, node, NULL, 0);
-                                assert(child == NULL || !(child->nodetype & (LYS_CONTAINER | LYS_LIST)) || (intptr_t)child->priv & PRIV_OP_SUBTREE);
-                                assert(child == NULL || child->nodetype & (LYS_CONTAINER | LYS_LIST) || child->flags & LYS_CONFIG_R);
+                                if (child != NULL) {
+                                    if (child->nodetype & (LYS_CONTAINER | LYS_LIST)) {
+                                        /* All op data means containers/lists containing children will have 
+                                           PRIV_OP_SUBTREE set. Empty containers/lists will not have this set. 
+                                           Neither will containers that only have children from a different schema. */
+                                        assert(((intptr_t)child->priv & PRIV_OP_SUBTREE) || child->child == NULL || main_module_schema != lys_node_module(child->child));
+                                    } else {
+                                        assert(child->flags & LYS_CONFIG_R);
+                                    }
+                                }
                             } else {
                                 child = node;
                             }

--- a/tests/md_test.c
+++ b/tests/md_test.c
@@ -1758,6 +1758,32 @@ md_test_insert_module_5(void **state)
     md_destroy(md_ctx);
 }
 
+static const char * const md_test_insert_module_double_aug_mod = TEST_SOURCE_DIR "/yang/mwa-aug2" TEST_MODULE_EXT;
+
+static void
+md_test_insert_module_double_aug(void **state)
+{
+    int rc;
+    md_ctx_t *md_ctx = NULL;
+    sr_list_t *implicitly_inserted = NULL;
+
+    rc = md_init(TEST_SOURCE_DIR "/yang", TEST_SCHEMA_SEARCH_DIR "internal",
+                 TEST_DATA_SEARCH_DIR "internal", true, &md_ctx);
+    assert_int_equal(SR_ERR_OK, rc);
+    validate_context(md_ctx);
+
+    rc = md_insert_module(md_ctx, md_test_insert_module_double_aug_mod, &implicitly_inserted);
+    assert_int_equal(SR_ERR_OK, rc);
+    assert_int_equal(1, implicitly_inserted->count);
+    md_free_module_key_list(implicitly_inserted);
+    validate_context(md_ctx);
+
+    rc = md_flush(md_ctx);
+    assert_int_equal(SR_ERR_OK, rc);
+
+    md_destroy(md_ctx);
+}
+
 static int
 _md_test_remove_modules(md_ctx_t *md_ctx, const char *name, const char *revision, sr_list_t **implicitly_removed)
 {
@@ -1918,6 +1944,12 @@ md_test_remove_modules(void **state)
     assert_int_equal(0, implicitly_removed->count);
     md_free_module_key_list(implicitly_removed);
     implicitly_removed = NULL;
+  
+    rc = _md_test_remove_modules(md_ctx, "mwa-aug2", NULL, &implicitly_removed);
+    assert_int_equal(SR_ERR_OK, rc);
+    assert_int_equal(1, implicitly_removed->count);
+    md_free_module_key_list(implicitly_removed);
+    implicitly_removed = NULL;
 
     /* flush changes into the internal data file */
     rc = md_flush(md_ctx);
@@ -2060,6 +2092,7 @@ int main(){
             cmocka_unit_test(md_test_insert_module_3),
             cmocka_unit_test(md_test_insert_module_4),
             cmocka_unit_test(md_test_insert_module_5),
+            cmocka_unit_test(md_test_insert_module_double_aug),
             cmocka_unit_test(md_test_remove_modules),
             cmocka_unit_test(md_test_grouping_and_uses),
             cmocka_unit_test(md_test_has_data),

--- a/tests/yang/mwa-aug1.yang
+++ b/tests/yang/mwa-aug1.yang
@@ -1,0 +1,14 @@
+module mwa-aug1 {
+    namespace "modulewithaug:aug1";
+    prefix mwa1;
+
+    import ietf-interfaces {
+        prefix if;
+    }
+
+    augment "/if:interfaces-state/if:interface" {
+        container foo {
+            
+        }
+    }
+}

--- a/tests/yang/mwa-aug2.yang
+++ b/tests/yang/mwa-aug2.yang
@@ -1,0 +1,17 @@
+module mwa-aug2 {
+    namespace "modulewithaug:aug2";
+    prefix mwa2;
+
+    import ietf-interfaces {
+        prefix if;
+    }
+    import mwa-aug1 {
+        prefix mwa1;
+    }
+
+    augment "/if:interfaces-state/if:interface/mwa1:foo" {
+        container bar {
+            leaf baz { type string; }
+        }
+    }
+}


### PR DESCRIPTION
### Description
Installing a YANG module with sysrepoctl results in a failure due to an assertion when the module contains an augment containing an empty container.  This was very similar to #1106, but with the second augmentation layer in a different model.

### Test case
The test case, `md_test_insert_module_double_aug`, found in `md_test.c` and accompanying yang model, `mwa-aug2`, demonstrate the failure.

### Closure
closes #1128 
