### PR TITLE
Bugfixes

### DIFF
--- a/src/executables/sysrepocfg.c
+++ b/src/executables/sysrepocfg.c
@@ -597,7 +597,7 @@ srcfg_convert_lydiff_created(struct lyd_node *node)
     do {
         /* go as deep as possible */
         if (process_children) {
-            while (!(elem->schema->nodetype & (LYS_LEAF | LYS_LEAFLIST | LYS_ANYXML)) && elem->child) {
+            while (!(elem->schema->nodetype & (LYS_LEAF | LYS_LEAFLIST | LYS_ANYDATA)) && elem->child) {
                 elem = elem->child;
             }
         }

--- a/src/persistence_manager.c
+++ b/src/persistence_manager.c
@@ -37,17 +37,18 @@
 #include <sys/xattr.h>
 #endif
 
-#define PM_SCHEMA_FILE "sysrepo-persistent-data.yang"  /**< Schema of module's persistent data. */
+#define PM_MODULE_NAME "sysrepo-persistent-data"
+#define PM_SCHEMA_FILE PM_MODULE_NAME ".yang"  /**< Schema of module's persistent data. */
 
 //! @cond doxygen_suppress
-#define PM_XPATH_MODULE                      "/sysrepo-persistent-data:module[name='%s']"
+#define PM_XPATH_MODULE                      "/" PM_MODULE_NAME ":module[name='%s']"
 
 #define PM_XPATH_FEATURES                     PM_XPATH_MODULE "/enabled-features/feature-name"
 #define PM_XPATH_FEATURES_BY_NAME             PM_XPATH_MODULE "/enabled-features/feature-name[.='%s']"
 
 #define PM_XPATH_SUBSCRIPTION_LIST            PM_XPATH_MODULE "/subscriptions/subscription"
 
-#define PM_XPATH_SUBSCRIPTION                 PM_XPATH_SUBSCRIPTION_LIST "[type='%s'][destination-address='%s'][destination-id='%"PRIu32"']"
+#define PM_XPATH_SUBSCRIPTION                 PM_XPATH_SUBSCRIPTION_LIST "[type='" PM_MODULE_NAME ":%s'][destination-address='%s'][destination-id='%"PRIu32"']"
 #define PM_XPATH_SUBSCRIPTION_XPATH           PM_XPATH_SUBSCRIPTION      "/xpath"
 #define PM_XPATH_SUBSCRIPTION_USERNAME        PM_XPATH_SUBSCRIPTION      "/username"
 #define PM_XPATH_SUBSCRIPTION_EVENT           PM_XPATH_SUBSCRIPTION      "/event"
@@ -56,8 +57,8 @@
 #define PM_XPATH_SUBSCRIPTION_ENABLE_NACM     PM_XPATH_SUBSCRIPTION      "/enable-nacm"
 #define PM_XPATH_SUBSCRIPTION_API_VARIANT     PM_XPATH_SUBSCRIPTION      "/api-variant"
 
-#define PM_XPATH_SUBSCRIPTIONS_BY_TYPE        PM_XPATH_SUBSCRIPTION_LIST "[type='%s']"
-#define PM_XPATH_SUBSCRIPTIONS_BY_TYPE_XPATH  PM_XPATH_SUBSCRIPTION_LIST "[type='%s'][xpath='%s']"
+#define PM_XPATH_SUBSCRIPTIONS_BY_TYPE        PM_XPATH_SUBSCRIPTION_LIST "[type='" PM_MODULE_NAME ":%s']"
+#define PM_XPATH_SUBSCRIPTIONS_BY_TYPE_XPATH  PM_XPATH_SUBSCRIPTION_LIST "[type='" PM_MODULE_NAME ":%s'][xpath='%s']"
 #define PM_XPATH_SUBSCRIPTIONS_BY_DST_ADDR    PM_XPATH_SUBSCRIPTION_LIST "[destination-address='%s']"
 #define PM_XPATH_SUBSCRIPTIONS_BY_DST_ID      PM_XPATH_SUBSCRIPTION_LIST "[destination-address='%s'][destination-id='%"PRIu32"']"
 #define PM_XPATH_SUBSCRIPTIONS_WITH_E_RUNNING PM_XPATH_SUBSCRIPTION_LIST "[enable-running=true()]"

--- a/src/rp_dt_get.c
+++ b/src/rp_dt_get.c
@@ -1556,9 +1556,10 @@ rp_dt_add_changes_for_children(sr_list_t *changes, LYD_DIFFTYPE type, struct lyd
     bool added = false, added_child = false;
     size_t orig_len =  changes->count;
 
-    child = node->child;
-    if (node->schema->nodetype & (LYS_LEAF | LYS_LEAFLIST | LYS_ANYXML)) {
+    if (node->schema->nodetype & (LYS_LEAF | LYS_LEAFLIST | LYS_ANYDATA)) {
         child = NULL;
+    } else {
+        child = node->child;
     }
     while (child) {
         rc = rp_dt_add_changes_for_children(changes, type, child, &added);
@@ -1632,9 +1633,10 @@ rp_has_only_empty_np_containers(struct lyd_node *root, sr_list_t *deleted, struc
         return false;
     }
 
-    child = root->child;
-    if (root->schema->nodetype & (LYS_LEAF | LYS_LEAFLIST | LYS_ANYXML)) {
+    if (root->schema->nodetype & (LYS_LEAF | LYS_LEAFLIST | LYS_ANYDATA)) {
         child = NULL;
+    } else {
+        child = root->child;
     }
     while (child) {
         if (!rp_has_only_empty_np_containers(child, deleted, skip)) {


### PR DESCRIPTION
### Description
Never access `child` pointer of anyxml or anydata nodes and always use module name as prefix for identityref values in predicates.

### Closure
Refs cesnet/libyang#506
