### PR TITLE
Reduce scope of test module installs from #1131

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -189,16 +189,6 @@ INSTALL_YANG_FOR_TESTS("ietf-netconf-notifications")
 INSTALL_YANG_FOR_TESTS("nc-notifications")
 INSTALL_YANG_FOR_TESTS("servers")
 
-INSTALL_YANG_FOR_TESTS("data-feat-enable-A")
-INSTALL_YANG_FOR_TESTS("data-feat-enable-B")
-INSTALL_YANG_FOR_TESTS("data-feat-enable-C")
-INSTALL_YANG_FOR_TESTS("data-feat-enable-D")
-ENABLE_FEATURE_FOR_TESTS("data-feat-enable-C" "c-feature")
-
-INSTALL_YANG_FOR_TESTS("data-imp-dep-A")
-INSTALL_YANG_FOR_TESTS("data-imp-dep-B")
-INSTALL_YANG_FOR_TESTS("data-imp-dep-C")
-
 
 # dummy testing plugins
 add_library(dummy-plugin-1 SHARED ${TEST_HELPERS_DIR}dummy_plugin.c)

--- a/tests/cl_test.c
+++ b/tests/cl_test.c
@@ -2106,9 +2106,6 @@ cl_notification_test(void **state)
         if (0 == strcmp("ietf-interfaces", schemas[s].module_name)){
             assert_true(schemas[s].enabled_feature_cnt > 0);
             assert_string_equal("pre-provisioning", schemas[s].enabled_features[0]);
-        } else if(0 != strstr(schemas[s].module_name, "data-feat-enable-C")) {
-            assert_true(schemas[s].enabled_feature_cnt > 0);
-            assert_string_equal("c-feature", schemas[s].enabled_features[0]);
         } else {
             assert_int_equal(0, schemas[s].enabled_feature_cnt);
         }

--- a/tests/rp_dt_edit_test.c
+++ b/tests/rp_dt_edit_test.c
@@ -2587,6 +2587,56 @@ static void set_item(const char *path, const char *value, sr_type_t type, rp_ctx
     assert_int_equal(SR_ERR_OK, rc);
 }
 
+static int set_items_data_and_feature_import_setup(void **state)
+{
+    exec_shell_command("../src/sysrepoctl --install --yang=" TEST_SOURCE_DIR "/yang/data-feat-enable-A.yang", ".*", true, 0);
+    test_file_exists(TEST_SCHEMA_SEARCH_DIR "data-feat-enable-A.yang", true);
+    exec_shell_command("../src/sysrepoctl --install --yang=" TEST_SOURCE_DIR "/yang/data-feat-enable-B.yang", ".*", true, 0);
+    test_file_exists(TEST_SCHEMA_SEARCH_DIR "data-feat-enable-B.yang", true);
+    exec_shell_command("../src/sysrepoctl --install --yang=" TEST_SOURCE_DIR "/yang/data-feat-enable-C.yang", ".*", true, 0);
+    test_file_exists(TEST_SCHEMA_SEARCH_DIR "data-feat-enable-C.yang", true);
+    exec_shell_command("../src/sysrepoctl --install --yang=" TEST_SOURCE_DIR "/yang/data-feat-enable-D.yang", ".*", true, 0);
+    test_file_exists(TEST_SCHEMA_SEARCH_DIR "data-feat-enable-D.yang", true);
+
+    exec_shell_command("../src/sysrepoctl --feature-enable c-feature --module data-feat-enable-C", ".*", true, 0);
+
+    exec_shell_command("../src/sysrepoctl --install --yang=" TEST_SOURCE_DIR "/yang/data-imp-dep-A.yang", ".*", true, 0);
+    test_file_exists(TEST_SCHEMA_SEARCH_DIR "data-imp-dep-A.yang", true);
+    exec_shell_command("../src/sysrepoctl --install --yang=" TEST_SOURCE_DIR "/yang/data-imp-dep-B.yang", ".*", true, 0);
+    test_file_exists(TEST_SCHEMA_SEARCH_DIR "data-imp-dep-B.yang", true);
+    exec_shell_command("../src/sysrepoctl --install --yang=" TEST_SOURCE_DIR "/yang/data-imp-dep-C.yang", ".*", true, 0);
+    test_file_exists(TEST_SCHEMA_SEARCH_DIR "data-imp-dep-C.yang", true);
+
+    setup(state);
+
+    return 0;
+}
+
+static int set_items_data_and_feature_import_teardown(void **state)
+{
+    exec_shell_command("../src/sysrepoctl --feature-disable c-feature --module data-feat-enable-C", ".*", true, 0);
+
+    exec_shell_command("../src/sysrepoctl --uninstall --module=data-feat-enable-A", ".*", true, 0);
+    test_file_exists(TEST_SCHEMA_SEARCH_DIR "data-feat-enable-A.yang", false);
+    exec_shell_command("../src/sysrepoctl --uninstall --module=data-feat-enable-B", ".*", true, 0);
+    test_file_exists(TEST_SCHEMA_SEARCH_DIR "data-feat-enable-B.yang", false);
+    exec_shell_command("../src/sysrepoctl --uninstall --module=data-feat-enable-C", ".*", true, 0);
+    test_file_exists(TEST_SCHEMA_SEARCH_DIR "data-feat-enable-C.yang", false);
+    exec_shell_command("../src/sysrepoctl --uninstall --module=data-feat-enable-D", ".*", true, 0);
+    test_file_exists(TEST_SCHEMA_SEARCH_DIR "data-feat-enable-D.yang", false);
+
+    exec_shell_command("../src/sysrepoctl --uninstall --module=data-imp-dep-A", ".*", true, 0);
+    test_file_exists(TEST_SCHEMA_SEARCH_DIR "data-imp-dep-A.yang", false);
+    exec_shell_command("../src/sysrepoctl --uninstall --module=data-imp-dep-B", ".*", true, 0);
+    test_file_exists(TEST_SCHEMA_SEARCH_DIR "data-imp-dep-B.yang", false);
+    exec_shell_command("../src/sysrepoctl --uninstall --module=data-imp-dep-C", ".*", true, 0);
+    test_file_exists(TEST_SCHEMA_SEARCH_DIR "data-imp-dep-C.yang", false);
+
+    teardown(state);
+
+    return 0;
+}
+
 void set_items_data_and_feature_import(void **state)
 {
     int rc;
@@ -2685,8 +2735,8 @@ int main(){
             cmocka_unit_test_setup(edit_union_type, createData),
             cmocka_unit_test_setup(validaton_of_multiple_models, createData),
             cmocka_unit_test(set_item_id_ref),
-            cmocka_unit_test(set_items_data_and_feature_import),
-            cmocka_unit_test(set_items_data_and_import_implemented),
+            cmocka_unit_test_setup_teardown(set_items_data_and_feature_import, set_items_data_and_feature_import_setup, set_items_data_and_feature_import_teardown),
+            cmocka_unit_test_setup_teardown(set_items_data_and_import_implemented, set_items_data_and_feature_import_setup, set_items_data_and_feature_import_teardown),
     };
 
     watchdog_start(300);


### PR DESCRIPTION
This is a small adjustment to the tests we submitted in #1131. I moved the module installation and feature enabling calls out of tests/CMakeLists.txt, where they would apply to all test cases, and instead added them to a setup function so that they only happen before the two `rp_dt_edit_test` test cases that actually need those modules. (This is similar to how the `cl_test` tests work.)