### PR TITLE
CHANGE option for changing file format

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -175,6 +175,16 @@ set(ENABLE_CONFIG_CHANGE_NOTIF 1 CACHE BOOL
 set(STORE_CONFIG_CHANGE_NOTIF 1 CACHE BOOL
     "Save config-change notifications (RFC 6470) in the notification store (slows down the commit process).")
 
+set(FILE_FORMAT_EXT "xml" CACHE STRING
+    "Datastore file format extension used. Can be either json or xml.")
+if (FILE_FORMAT_EXT STREQUAL "json")
+    set(FILE_FORMAT_LY "LYD_JSON")
+elseif (FILE_FORMAT_EXT STREQUAL "xml")
+    set(FILE_FORMAT_LY "LYD_XML")
+else()
+    message(FATAL_ERROR "Unknown file format \"${FILE_FORMAT_EXT}\", must be either json or xml.")
+endif()
+
 # timeouts
 set(REQUEST_TIMEOUT 15 CACHE INTEGER
     "Timeout (in seconds) for Sysrepo API requests. Set to 0 for no timeout.")

--- a/src/common/sr_constants.h.in
+++ b/src/common/sr_constants.h.in
@@ -168,4 +168,12 @@
  *  of higher memory usage peaks. */
 #define SR_GET_SUBTREE_CHUNK_CHILD_LIMIT @GET_SUBTREE_CHUNK_CHILD_LIMIT@
 
+/** Datastore file format extension used.
+ */
+#define SR_FILE_FORMAT_EXT "@FILE_FORMAT_EXT@"
+
+/** libyang format flag.
+ */
+#define SR_FILE_FORMAT_LY @FILE_FORMAT_LY@
+
 #endif /* SRC_SR_CONSTANTS_H_IN_ */

--- a/src/common/sr_utils.h
+++ b/src/common/sr_utils.h
@@ -338,9 +338,10 @@ int sr_get_peer_eid(int fd, uid_t *uid, gid_t *gid);
  * @brief Saves the data tree into file. Workaround function that adds the root element to data_tree.
  * @param [in] file_name
  * @param [in] data_tree
+ * @param [in] format
  * @return err_code
  */
-int sr_save_data_tree_file(const char *file_name, const struct lyd_node *data_tree);
+int sr_save_data_tree_file(const char *file_name, const struct lyd_node *data_tree, LYD_FORMAT format);
 
 /**
  * @brief Check if the set contains the specified object.

--- a/src/executables/sysrepocfg.c
+++ b/src/executables/sysrepocfg.c
@@ -1640,7 +1640,7 @@ srcfg_print_help()
     printf("  -d, --datastore <datastore>  Datastore to be operated on\n");
     printf("                               (either \"running\" or \"startup\", \"running\" is default).\n");
     printf("  -f, --format <format>        Data format to be used for configuration editing/importing/exporting\n");
-    printf("                               (\"xml\" or \"json\", \"xml\" is default).\n");
+    printf("                               (\"xml\" or \"json\", \"" SR_FILE_FORMAT_EXT "\" is default).\n");
     printf("  -e, --editor <editor>        Text editor to be used for editing datastore data\n");
     printf("                               (default editor is defined by $VISUAL or $EDITOR env. variables).\n");
     printf("  -i, --import [<path>]        Read and replace entire configuration from a supplied file\n");
@@ -1688,10 +1688,10 @@ main(int argc, char* argv[])
     int c = 0;
     srcfg_operation_t operation = SRCFG_OP_EDIT;
     char *module_name = NULL, *datastore_name = "running";
-    char *format_name = "xml", *editor = NULL;
+    char *format_name = SR_FILE_FORMAT_EXT, *editor = NULL;
     char *filepath = NULL;
     srcfg_datastore_t datastore = SRCFG_STORE_RUNNING;
-    LYD_FORMAT format = LYD_XML;
+    LYD_FORMAT format = SR_FILE_FORMAT_LY;
     bool enabled = false, keep = false, permanent = false, strict = true;
     int log_level = -1;
     char local_schema_search_dir[PATH_MAX] = { 0, }, local_internal_schema_search_dir[PATH_MAX] = { 0, };

--- a/src/module_dependencies.c
+++ b/src/module_dependencies.c
@@ -34,7 +34,7 @@
 //! @cond doxygen_suppress
 #define MD_MODULE_NAME      "sysrepo-module-dependencies"
 #define MD_SCHEMA_FILENAME  MD_MODULE_NAME ".yang"
-#define MD_DATA_FILENAME    MD_MODULE_NAME ".xml"
+#define MD_DATA_FILENAME    MD_MODULE_NAME "." SR_FILE_FORMAT_EXT
 //! @endcond
 
 /* A list of frequently used xpaths for the internal module with dependency info */
@@ -1093,7 +1093,7 @@ md_init(const char *schema_search_dir,
 
     /* parse the data file */
     ly_errno = LY_SUCCESS;
-    ctx->data_tree = lyd_parse_fd(ctx->ly_ctx, ctx->fd, LYD_XML, LYD_OPT_STRICT | LYD_OPT_CONFIG);
+    ctx->data_tree = lyd_parse_fd(ctx->ly_ctx, ctx->fd, SR_FILE_FORMAT_LY, LYD_OPT_STRICT | LYD_OPT_CONFIG);
     if (NULL == ctx->data_tree && LY_SUCCESS != ly_errno) {
         SR_LOG_ERR("Unable to parse " MD_DATA_FILENAME " data file: %s", ly_errmsg(ctx->ly_ctx));
         goto fail;
@@ -1744,8 +1744,8 @@ md_traverse_schema_tree(md_ctx_t *md_ctx, md_module_t *module, struct lys_node *
                                 child = (struct lys_node *)lys_getnext(NULL, node, NULL, 0);
                                 if (child != NULL) {
                                     if (child->nodetype & (LYS_CONTAINER | LYS_LIST)) {
-                                        /* All op data means containers/lists containing children will have 
-                                           PRIV_OP_SUBTREE set. Empty containers/lists will not have this set. 
+                                        /* All op data means containers/lists containing children will have
+                                           PRIV_OP_SUBTREE set. Empty containers/lists will not have this set.
                                            Neither will containers that only have children from a different schema. */
                                         assert(((intptr_t)child->priv & PRIV_OP_SUBTREE) || child->child == NULL || main_module_schema != lys_node_module(child->child));
                                     } else {
@@ -2843,7 +2843,7 @@ md_flush(md_ctx_t *md_ctx)
     ret = ftruncate(md_ctx->fd, 0);
     CHECK_ZERO_MSG_RETURN(ret, SR_ERR_INTERNAL, "Failed to truncate the internal data file '" MD_DATA_FILENAME"'.");
 
-    ret = lyd_print_fd(md_ctx->fd, md_ctx->data_tree, LYD_XML, LYP_WITHSIBLINGS | LYP_FORMAT);
+    ret = lyd_print_fd(md_ctx->fd, md_ctx->data_tree, SR_FILE_FORMAT_LY, LYP_WITHSIBLINGS | LYP_FORMAT);
     if (0 != ret) {
         SR_LOG_ERR("Unable to export data tree with dependencies: %s", ly_errmsg(md_ctx->data_tree->schema->module->ctx));
         return SR_ERR_INTERNAL;

--- a/src/nacm.c
+++ b/src/nacm.c
@@ -493,7 +493,7 @@ nacm_load_config(nacm_ctx_t *nacm_ctx, const sr_datastore_t ds)
     ly_ctx_set_module_data_clb(nacm_ctx->schema_info->ly_ctx, dm_module_clb, nacm_ctx->dm_ctx);
 
     ly_errno = 0;
-    data_tree = lyd_parse_fd(nacm_ctx->schema_info->ly_ctx, fd, LYD_XML, LYD_OPT_TRUSTED | LYD_OPT_CONFIG);
+    data_tree = lyd_parse_fd(nacm_ctx->schema_info->ly_ctx, fd, SR_FILE_FORMAT_LY, LYD_OPT_TRUSTED | LYD_OPT_CONFIG);
     if (NULL == data_tree && LY_SUCCESS != ly_errno) {
         SR_LOG_ERR("Parsing of data tree from file %s failed: %s", ds_filepath, ly_errmsg(nacm_ctx->schema_info->ly_ctx));
         goto cleanup;

--- a/src/notification_processor.h
+++ b/src/notification_processor.h
@@ -66,6 +66,7 @@ typedef enum np_ev_notif_data_type_s {
     NP_EV_NOTIF_DATA_NONE,             /**< No data. */
     NP_EV_NOTIF_DATA_XML,              /**< Data in XML format. */
     NP_EV_NOTIF_DATA_STRING,           /**< Data in string xml format */
+    NP_EV_NOTIF_DATA_JSON,             /**< Data in string JSON format */
     NP_EV_NOTIF_DATA_VALUES,           /**< Data in st_val_t format. */
     NP_EV_NOTIF_DATA_TREES,            /**< Data in sr_node_t format. */
 } np_ev_notif_data_type_t;

--- a/src/persistence_manager.c
+++ b/src/persistence_manager.c
@@ -161,7 +161,7 @@ pm_save_data_tree(struct lyd_node *data_tree, int fd)
     CHECK_ZERO_LOG_RETURN(ret, SR_ERR_INTERNAL, "File truncate failed: %s", sr_strerror_safe(errno));
 
     /* print data tree to file */
-    ret = lyd_print_fd(fd, data_tree, LYD_XML, LYP_WITHSIBLINGS | LYP_FORMAT);
+    ret = lyd_print_fd(fd, data_tree, SR_FILE_FORMAT_LY, LYP_WITHSIBLINGS | LYP_FORMAT);
     CHECK_ZERO_LOG_RETURN(ret, SR_ERR_INTERNAL, "Saving persist data tree failed: %s", ly_errmsg(data_tree->schema->module->ctx));
 
     /* flush in-core data to the disc */
@@ -259,7 +259,7 @@ pm_load_data_tree(pm_ctx_t *pm_ctx, const ac_ucred_t *user_cred, const char *mod
     CHECK_RC_LOG_GOTO(rc, cleanup, "Unable to lock persist data file for '%s'.", module_name);
 
     ly_errno = LY_SUCCESS;
-    *data_tree = lyd_parse_fd(pm_ctx->ly_ctx, fd, LYD_XML, LYD_OPT_STRICT | LYD_OPT_CONFIG | LYD_OPT_NOAUTODEL);
+    *data_tree = lyd_parse_fd(pm_ctx->ly_ctx, fd, SR_FILE_FORMAT_LY, LYD_OPT_STRICT | LYD_OPT_CONFIG | LYD_OPT_NOAUTODEL);
     if (NULL == *data_tree && LY_SUCCESS != ly_errno) {
         SR_LOG_ERR("Parsing persist data from file '%s' failed: %s", data_filename, ly_errmsg(pm_ctx->ly_ctx));
         rc = SR_ERR_INTERNAL;

--- a/tests/helpers/nacm_module_helper.c
+++ b/tests/helpers/nacm_module_helper.c
@@ -50,7 +50,7 @@ save_nacm_config(test_nacm_cfg_t *nacm_config)
 {
     /* validate & save */
     assert_int_equal(0, lyd_validate(&nacm_config->root, LYD_OPT_STRICT | LYD_OPT_CONFIG, nacm_config->ly_ctx));
-    assert_int_equal(SR_ERR_OK, sr_save_data_tree_file(NACM_MODULE_DATA_FILE_NAME, nacm_config->root));
+    assert_int_equal(SR_ERR_OK, sr_save_data_tree_file(NACM_MODULE_DATA_FILE_NAME, nacm_config->root, SR_FILE_FORMAT_LY));
 }
 
 void

--- a/tests/helpers/test_module_helper.c
+++ b/tests/helpers/test_module_helper.c
@@ -278,7 +278,7 @@ createDataTreeTestModule()
 
     /* validate & save */
     assert_int_equal(0, lyd_validate(&r, LYD_OPT_STRICT | LYD_OPT_CONFIG, NULL));
-    assert_int_equal(SR_ERR_OK, sr_save_data_tree_file(TEST_MODULE_DATA_FILE_NAME, r));
+    assert_int_equal(SR_ERR_OK, sr_save_data_tree_file(TEST_MODULE_DATA_FILE_NAME, r, SR_FILE_FORMAT_LY));
 
     lyd_free_withsiblings(r);
 
@@ -302,7 +302,7 @@ createDataTreeExampleModule()
 
     root = lyd_new_path(NULL, ctx, XPATH, "Leaf value", 0, 0);
     assert_int_equal(0, lyd_validate(&root, LYD_OPT_STRICT | LYD_OPT_CONFIG, NULL));
-    assert_int_equal(SR_ERR_OK, sr_save_data_tree_file(EXAMPLE_MODULE_DATA_FILE_NAME, root));
+    assert_int_equal(SR_ERR_OK, sr_save_data_tree_file(EXAMPLE_MODULE_DATA_FILE_NAME, root, SR_FILE_FORMAT_LY));
 
     lyd_free_withsiblings(root);
     ly_ctx_destroy(ctx, NULL);
@@ -335,7 +335,7 @@ createDataTreeLargeExampleModule(int list_count)
     lyd_new_path(root, ctx, "/example-module:container/list[key1='key1'][key2='key2']/leaf", "Leaf value", 0, 0);
 
     assert_int_equal(0, lyd_validate(&root, LYD_OPT_STRICT | LYD_OPT_CONFIG, NULL));
-    assert_int_equal(SR_ERR_OK, sr_save_data_tree_file(EXAMPLE_MODULE_DATA_FILE_NAME, root));
+    assert_int_equal(SR_ERR_OK, sr_save_data_tree_file(EXAMPLE_MODULE_DATA_FILE_NAME, root, SR_FILE_FORMAT_LY));
 
     lyd_free_withsiblings(root);
     ly_ctx_destroy(ctx, NULL);
@@ -392,7 +392,7 @@ createDataTreeLargeIETFinterfacesModule(size_t if_count)
 
 
     assert_int_equal(0, lyd_validate(&root, LYD_OPT_STRICT | LYD_OPT_CONFIG, NULL));
-    assert_int_equal(SR_ERR_OK, sr_save_data_tree_file(TEST_DATA_SEARCH_DIR"ietf-interfaces"SR_STARTUP_FILE_EXT, root));
+    assert_int_equal(SR_ERR_OK, sr_save_data_tree_file(TEST_DATA_SEARCH_DIR"ietf-interfaces"SR_STARTUP_FILE_EXT, root, SR_FILE_FORMAT_LY));
 
     lyd_free_withsiblings(root);
     ly_ctx_destroy(ctx, NULL);
@@ -444,7 +444,7 @@ createDataTreeIETFinterfacesModule(){
     lyd_new_leaf(node, module_interfaces, "enabled", "false");
 
     assert_int_equal(0, lyd_validate(&root, LYD_OPT_STRICT | LYD_OPT_CONFIG, NULL));
-    assert_int_equal(SR_ERR_OK, sr_save_data_tree_file(TEST_DATA_SEARCH_DIR"ietf-interfaces"SR_STARTUP_FILE_EXT, root));
+    assert_int_equal(SR_ERR_OK, sr_save_data_tree_file(TEST_DATA_SEARCH_DIR"ietf-interfaces"SR_STARTUP_FILE_EXT, root, SR_FILE_FORMAT_LY));
 
     lyd_free_withsiblings(root);
     ly_ctx_destroy(ctx, NULL);
@@ -484,7 +484,7 @@ createDataTreeIETFinterfacesModuleMerge(){
     lyd_new_leaf(node, module_ip, "mtu", "1500");
 
     assert_int_equal(0, lyd_validate(&root, LYD_OPT_STRICT | LYD_OPT_CONFIG, NULL));
-    assert_int_equal(SR_ERR_OK, sr_save_data_tree_file(TEST_DATA_SEARCH_DIR"ietf-interfaces.merge.xml", root));
+    assert_int_equal(SR_ERR_OK, sr_save_data_tree_file(TEST_DATA_SEARCH_DIR"ietf-interfaces.merge." SR_FILE_FORMAT_EXT, root, SR_FILE_FORMAT_LY));
 
     lyd_free_withsiblings(root);
     ly_ctx_destroy(ctx, NULL);
@@ -514,7 +514,7 @@ createDataTreeReferencedModule(int8_t magic_number)
 
     /* validate & save */
     assert_int_equal(0, lyd_validate(&r1, LYD_OPT_STRICT | LYD_OPT_CONFIG, NULL));
-    assert_int_equal(SR_ERR_OK, sr_save_data_tree_file(REFERENCED_MODULE_DATA_FILE_NAME, r1));
+    assert_int_equal(SR_ERR_OK, sr_save_data_tree_file(REFERENCED_MODULE_DATA_FILE_NAME, r1, SR_FILE_FORMAT_LY));
 
     lyd_free_withsiblings(r1);
 
@@ -548,7 +548,7 @@ createDataTreeStateModule()
 
     /* validate & save */
     assert_int_equal(0, lyd_validate(&r1, LYD_OPT_STRICT | LYD_OPT_CONFIG, NULL));
-    assert_int_equal(SR_ERR_OK, sr_save_data_tree_file(STATE_MODULE_DATA_FILE_NAME, r1));
+    assert_int_equal(SR_ERR_OK, sr_save_data_tree_file(STATE_MODULE_DATA_FILE_NAME, r1, SR_FILE_FORMAT_LY));
 
     lyd_free_withsiblings(r1);
 

--- a/tests/sysrepocfg_test.c
+++ b/tests/sysrepocfg_test.c
@@ -88,7 +88,7 @@ srcfg_test_cmp_data_file_content(const char *file_path, LYD_FORMAT file_format, 
         assert_true_bt(exp_data || LY_SUCCESS == ly_errno);
     }
 
-    diff = lyd_diff(file_data, exp_data, LYD_DIFFOPT_WITHDEFAULTS);
+    diff = lyd_diff(file_data, exp_data, 0);
     assert_non_null_bt(diff);
 
     while (diff->type && LYD_DIFF_END != diff->type[count]) {
@@ -276,82 +276,82 @@ srcfg_test_export(void **state)
     /* ietf-interfaces */
     /*  startup, xml */
     exec_shell_command("../src/sysrepocfg --export --datastore=startup --format=xml ietf-interfaces > /tmp/ietf-interfaces.startup.xml", ".*", true, 0);
-    assert_int_equal(0, srcfg_test_cmp_data_files("/tmp/ietf-interfaces.startup.xml", LYD_XML, TEST_DATA_SEARCH_DIR "ietf-interfaces.startup", LYD_XML));
+    assert_int_equal(0, srcfg_test_cmp_data_files("/tmp/ietf-interfaces.startup.xml", LYD_XML, TEST_DATA_SEARCH_DIR "ietf-interfaces.startup", SR_FILE_FORMAT_LY));
     /*  startup, json */
     exec_shell_command("../src/sysrepocfg --export=/tmp/ietf-interfaces.startup.json --datastore=startup --format=json ietf-interfaces", ".*", true, 0);
-    assert_int_equal(0, srcfg_test_cmp_data_files("/tmp/ietf-interfaces.startup.json", LYD_JSON, TEST_DATA_SEARCH_DIR "ietf-interfaces.startup", LYD_XML));
+    assert_int_equal(0, srcfg_test_cmp_data_files("/tmp/ietf-interfaces.startup.json", LYD_JSON, TEST_DATA_SEARCH_DIR "ietf-interfaces.startup", SR_FILE_FORMAT_LY));
     /*  running, xml */
     exec_shell_command("../src/sysrepocfg --export --datastore=running --format=xml ietf-interfaces", "no active subscriptions", true, 1);
     assert_int_equal(0, srcfg_test_subscribe("ietf-interfaces"));
     exec_shell_command("../src/sysrepocfg --export --datastore=running --format=xml ietf-interfaces > /tmp/ietf-interfaces.running.xml", ".*", true, 0);
-    assert_int_equal(0, srcfg_test_cmp_data_files("/tmp/ietf-interfaces.running.xml", LYD_XML, TEST_DATA_SEARCH_DIR "ietf-interfaces.running", LYD_XML));
+    assert_int_equal(0, srcfg_test_cmp_data_files("/tmp/ietf-interfaces.running.xml", LYD_XML, TEST_DATA_SEARCH_DIR "ietf-interfaces.running", SR_FILE_FORMAT_LY));
     /*  running, json */
     exec_shell_command("../src/sysrepocfg --export=/tmp/ietf-interfaces.running.json --datastore=running --format=json ietf-interfaces", ".*", true, 0);
-    assert_int_equal(0, srcfg_test_cmp_data_files("/tmp/ietf-interfaces.running.json", LYD_JSON, TEST_DATA_SEARCH_DIR "ietf-interfaces.running", LYD_XML));
+    assert_int_equal(0, srcfg_test_cmp_data_files("/tmp/ietf-interfaces.running.json", LYD_JSON, TEST_DATA_SEARCH_DIR "ietf-interfaces.running", SR_FILE_FORMAT_LY));
 
     /* test-module */
     /*  startup, xml */
     exec_shell_command("../src/sysrepocfg --export --datastore=startup --format=xml test-module > /tmp/test-module.startup.xml", ".*", true, 0);
-    assert_int_equal(0, srcfg_test_cmp_data_files("/tmp/test-module.startup.xml", LYD_XML, TEST_DATA_SEARCH_DIR "test-module.startup", LYD_XML));
+    assert_int_equal(0, srcfg_test_cmp_data_files("/tmp/test-module.startup.xml", LYD_XML, TEST_DATA_SEARCH_DIR "test-module.startup", SR_FILE_FORMAT_LY));
     /*  startup, json */
     exec_shell_command("../src/sysrepocfg --export=/tmp/test-module.startup.json --datastore=startup --format=json test-module", ".*", true, 0);
-    assert_int_equal(0, srcfg_test_cmp_data_files("/tmp/test-module.startup.json", LYD_JSON, TEST_DATA_SEARCH_DIR "test-module.startup", LYD_XML));
+    assert_int_equal(0, srcfg_test_cmp_data_files("/tmp/test-module.startup.json", LYD_JSON, TEST_DATA_SEARCH_DIR "test-module.startup", SR_FILE_FORMAT_LY));
     /*  running, xml */
     exec_shell_command("../src/sysrepocfg --export --datastore=running --format=xml test-module", "no active subscriptions", true, 1);
     assert_int_equal(0, srcfg_test_subscribe("test-module"));
     exec_shell_command("../src/sysrepocfg --export --datastore=running --format=xml test-module > /tmp/test-module.running.xml", ".*", true, 0);
-    assert_int_equal(0, srcfg_test_cmp_data_files("/tmp/test-module.running.xml", LYD_XML, TEST_DATA_SEARCH_DIR "test-module.running", LYD_XML));
+    assert_int_equal(0, srcfg_test_cmp_data_files("/tmp/test-module.running.xml", LYD_XML, TEST_DATA_SEARCH_DIR "test-module.running", SR_FILE_FORMAT_LY));
     /*  running, json */
     exec_shell_command("../src/sysrepocfg --export=/tmp/test-module.running.json --datastore=running --format=json test-module", ".*", true, 0);
-    assert_int_equal(0, srcfg_test_cmp_data_files("/tmp/test-module.running.json", LYD_JSON, TEST_DATA_SEARCH_DIR "test-module.running", LYD_XML));
+    assert_int_equal(0, srcfg_test_cmp_data_files("/tmp/test-module.running.json", LYD_JSON, TEST_DATA_SEARCH_DIR "test-module.running", SR_FILE_FORMAT_LY));
 
     /* example-module */
     /*  startup, xml */
     exec_shell_command("../src/sysrepocfg --export --datastore=startup --format=xml example-module > /tmp/example-module.startup.xml", ".*", true, 0);
-    assert_int_equal(0, srcfg_test_cmp_data_files("/tmp/example-module.startup.xml", LYD_XML, TEST_DATA_SEARCH_DIR "example-module.startup", LYD_XML));
+    assert_int_equal(0, srcfg_test_cmp_data_files("/tmp/example-module.startup.xml", LYD_XML, TEST_DATA_SEARCH_DIR "example-module.startup", SR_FILE_FORMAT_LY));
     /*  startup, json */
     exec_shell_command("../src/sysrepocfg --export=/tmp/example-module.startup.json --datastore=startup --format=json example-module", ".*", true, 0);
-    assert_int_equal(0, srcfg_test_cmp_data_files("/tmp/example-module.startup.json", LYD_JSON, TEST_DATA_SEARCH_DIR "example-module.startup", LYD_XML));
+    assert_int_equal(0, srcfg_test_cmp_data_files("/tmp/example-module.startup.json", LYD_JSON, TEST_DATA_SEARCH_DIR "example-module.startup", SR_FILE_FORMAT_LY));
     /*  running, xml */
     exec_shell_command("../src/sysrepocfg --export --datastore=running --format=xml example-module", "no active subscriptions", true, 1);
     assert_int_equal(0, srcfg_test_subscribe("example-module"));
     exec_shell_command("../src/sysrepocfg --export --datastore=running --format=xml example-module > /tmp/example-module.running.xml", ".*", true, 0);
-    assert_int_equal(0, srcfg_test_cmp_data_files("/tmp/example-module.running.xml", LYD_XML, TEST_DATA_SEARCH_DIR "example-module.running", LYD_XML));
+    assert_int_equal(0, srcfg_test_cmp_data_files("/tmp/example-module.running.xml", LYD_XML, TEST_DATA_SEARCH_DIR "example-module.running", SR_FILE_FORMAT_LY));
     /*  running, json */
     exec_shell_command("../src/sysrepocfg --export=/tmp/example-module.running.json --datastore=running --format=json example-module", ".*", true, 0);
-    assert_int_equal(0, srcfg_test_cmp_data_files("/tmp/example-module.running.json", LYD_JSON, TEST_DATA_SEARCH_DIR "example-module.running", LYD_XML));
+    assert_int_equal(0, srcfg_test_cmp_data_files("/tmp/example-module.running.json", LYD_JSON, TEST_DATA_SEARCH_DIR "example-module.running", SR_FILE_FORMAT_LY));
 
     /* cross-module */
     /*  startup, xml */
     exec_shell_command("../src/sysrepocfg --export --datastore=startup --format=xml cross-module > /tmp/cross-module.startup.xml", ".*", true, 0);
-    assert_int_equal(0, srcfg_test_cmp_data_files("/tmp/cross-module.startup.xml", LYD_XML, TEST_DATA_SEARCH_DIR "cross-module.startup", LYD_XML));
+    assert_int_equal(0, srcfg_test_cmp_data_files("/tmp/cross-module.startup.xml", LYD_XML, TEST_DATA_SEARCH_DIR "cross-module.startup", SR_FILE_FORMAT_LY));
     /*  startup, json */
     exec_shell_command("../src/sysrepocfg --export=/tmp/cross-module.startup.json --datastore=startup --format=json cross-module", ".*", true, 0);
-    assert_int_equal(0, srcfg_test_cmp_data_files("/tmp/cross-module.startup.json", LYD_JSON, TEST_DATA_SEARCH_DIR "cross-module.startup", LYD_XML));
+    assert_int_equal(0, srcfg_test_cmp_data_files("/tmp/cross-module.startup.json", LYD_JSON, TEST_DATA_SEARCH_DIR "cross-module.startup", SR_FILE_FORMAT_LY));
     /*  running, xml */
     exec_shell_command("../src/sysrepocfg --export --datastore=running --format=xml cross-module", "no active subscriptions", true, 1);
     assert_int_equal(0, srcfg_test_subscribe("cross-module"));
     exec_shell_command("../src/sysrepocfg --export --datastore=running --format=xml cross-module > /tmp/cross-module.running.xml", ".*", true, 0);
-    assert_int_equal(0, srcfg_test_cmp_data_files("/tmp/cross-module.running.xml", LYD_XML, TEST_DATA_SEARCH_DIR "cross-module.running", LYD_XML));
+    assert_int_equal(0, srcfg_test_cmp_data_files("/tmp/cross-module.running.xml", LYD_XML, TEST_DATA_SEARCH_DIR "cross-module.running", SR_FILE_FORMAT_LY));
     /*  running, json */
     exec_shell_command("../src/sysrepocfg --export=/tmp/cross-module.running.json --datastore=running --format=json cross-module", ".*", true, 0);
-    assert_int_equal(0, srcfg_test_cmp_data_files("/tmp/cross-module.running.json", LYD_JSON, TEST_DATA_SEARCH_DIR "cross-module.running", LYD_XML));
+    assert_int_equal(0, srcfg_test_cmp_data_files("/tmp/cross-module.running.json", LYD_JSON, TEST_DATA_SEARCH_DIR "cross-module.running", SR_FILE_FORMAT_LY));
 
     /* referenced-data */
     /*  startup, xml */
     exec_shell_command("../src/sysrepocfg --export --datastore=startup --format=xml referenced-data > /tmp/referenced-data.startup.xml", ".*", true, 0);
-    assert_int_equal(0, srcfg_test_cmp_data_files("/tmp/referenced-data.startup.xml", LYD_XML, TEST_DATA_SEARCH_DIR "referenced-data.startup", LYD_XML));
+    assert_int_equal(0, srcfg_test_cmp_data_files("/tmp/referenced-data.startup.xml", LYD_XML, TEST_DATA_SEARCH_DIR "referenced-data.startup", SR_FILE_FORMAT_LY));
     /*  startup, json */
     exec_shell_command("../src/sysrepocfg --export=/tmp/referenced-data.startup.json --datastore=startup --format=json referenced-data", ".*", true, 0);
-    assert_int_equal(0, srcfg_test_cmp_data_files("/tmp/referenced-data.startup.json", LYD_JSON, TEST_DATA_SEARCH_DIR "referenced-data.startup", LYD_XML));
+    assert_int_equal(0, srcfg_test_cmp_data_files("/tmp/referenced-data.startup.json", LYD_JSON, TEST_DATA_SEARCH_DIR "referenced-data.startup", SR_FILE_FORMAT_LY));
     /*  running, xml */
     exec_shell_command("../src/sysrepocfg --export --datastore=running --format=xml referenced-data", "no active subscriptions", true, 1);
     assert_int_equal(0, srcfg_test_subscribe("referenced-data"));
     exec_shell_command("../src/sysrepocfg --export --datastore=running --format=xml referenced-data > /tmp/referenced-data.running.xml", ".*", true, 0);
-    assert_int_equal(0, srcfg_test_cmp_data_files("/tmp/referenced-data.running.xml", LYD_XML, TEST_DATA_SEARCH_DIR "referenced-data.running", LYD_XML));
+    assert_int_equal(0, srcfg_test_cmp_data_files("/tmp/referenced-data.running.xml", LYD_XML, TEST_DATA_SEARCH_DIR "referenced-data.running", SR_FILE_FORMAT_LY));
     /*  running, json */
     exec_shell_command("../src/sysrepocfg --export=/tmp/referenced-data.running.json --datastore=running --format=json referenced-data", ".*", true, 0);
-    assert_int_equal(0, srcfg_test_cmp_data_files("/tmp/referenced-data.running.json", LYD_JSON, TEST_DATA_SEARCH_DIR "referenced-data.running", LYD_XML));
+    assert_int_equal(0, srcfg_test_cmp_data_files("/tmp/referenced-data.running.json", LYD_JSON, TEST_DATA_SEARCH_DIR "referenced-data.running", SR_FILE_FORMAT_LY));
 
     /* restore pre-test state */
     assert_int_equal(0, srcfg_test_unsubscribe("ietf-interfaces"));
@@ -370,19 +370,19 @@ srcfg_test_xpath(void **state)
     /* export ietf-interfaces, in both xml and json formats */
 
     /*  startup, xml */
-    exec_shell_command("../src/sysrepocfg -d startup -g /ietf-interfaces:*//* > /tmp/ietf-interfaces.startup.xml", ".*", true, 0);
-    assert_int_equal(0, srcfg_test_cmp_data_files("/tmp/ietf-interfaces.startup.xml", LYD_XML, TEST_DATA_SEARCH_DIR "ietf-interfaces.startup", LYD_XML));
+    exec_shell_command("../src/sysrepocfg -d startup -f xml -g /ietf-interfaces:*//* > /tmp/ietf-interfaces.startup.xml", ".*", true, 0);
+    assert_int_equal(0, srcfg_test_cmp_data_files("/tmp/ietf-interfaces.startup.xml", LYD_XML, TEST_DATA_SEARCH_DIR "ietf-interfaces.startup", SR_FILE_FORMAT_LY));
     /*  startup, json */
-    exec_shell_command("../src/sysrepocfg -d startup --format json -g /ietf-interfaces:*//* > /tmp/ietf-interfaces.startup.json", ".*", true, 0);
-    assert_int_equal(0, srcfg_test_cmp_data_files("/tmp/ietf-interfaces.startup.json", LYD_JSON, TEST_DATA_SEARCH_DIR "ietf-interfaces.startup", LYD_XML));
+    exec_shell_command("../src/sysrepocfg -d startup -f json -g /ietf-interfaces:*//* > /tmp/ietf-interfaces.startup.json", ".*", true, 0);
+    assert_int_equal(0, srcfg_test_cmp_data_files("/tmp/ietf-interfaces.startup.json", LYD_JSON, TEST_DATA_SEARCH_DIR "ietf-interfaces.startup", SR_FILE_FORMAT_LY));
     /*  running, xml */
     exec_shell_command("../src/sysrepocfg -d running -g /ietf-interfaces:*//*", "no active subscriptions", true, 1);
     assert_int_equal(0, srcfg_test_subscribe("ietf-interfaces"));
     exec_shell_command("../src/sysrepocfg -g /ietf-interfaces:*//* --datastore=running --format=xml ietf-interfaces > /tmp/ietf-interfaces.running.xml", ".*", true, 0);
-    assert_int_equal(0, srcfg_test_cmp_data_files("/tmp/ietf-interfaces.running.xml", LYD_XML, TEST_DATA_SEARCH_DIR "ietf-interfaces.running", LYD_XML));
+    assert_int_equal(0, srcfg_test_cmp_data_files("/tmp/ietf-interfaces.running.xml", LYD_XML, TEST_DATA_SEARCH_DIR "ietf-interfaces.running", SR_FILE_FORMAT_LY));
     /*  running, json */
     exec_shell_command("../src/sysrepocfg -g /ietf-interfaces:*//* --datastore=running --format=json ietf-interfaces > /tmp/ietf-interfaces.running.json", ".*", true, 0);
-    assert_int_equal(0, srcfg_test_cmp_data_files("/tmp/ietf-interfaces.running.json", LYD_JSON, TEST_DATA_SEARCH_DIR "ietf-interfaces.running", LYD_XML));
+    assert_int_equal(0, srcfg_test_cmp_data_files("/tmp/ietf-interfaces.running.json", LYD_JSON, TEST_DATA_SEARCH_DIR "ietf-interfaces.running", SR_FILE_FORMAT_LY));
 
     /* set a string value */
     exec_shell_command("../src/sysrepocfg -s \"/ietf-interfaces:interfaces/interface[name='eth0']/description\" -w 'description eth0' --datastore=running", ".*", true, 0);
@@ -510,9 +510,9 @@ srcfg_test_merge(void **state)
     sr_val_t *rvalue = { 0 };
     int rc = 0;
 
-    exec_shell_command("../src/sysrepocfg -d running -g /ietf-interfaces:*//*", "no active subscriptions", true, 1);
+    exec_shell_command("../src/sysrepocfg -d running -f " SR_FILE_FORMAT_EXT " -g /ietf-interfaces:*//*", "no active subscriptions", true, 1);
     assert_int_equal(0, srcfg_test_subscribe("ietf-interfaces"));
-    exec_shell_command("../src/sysrepocfg -m " TEST_DATA_SEARCH_DIR "ietf-interfaces.merge.xml -d running ietf-interfaces", ".*", true, 0);
+    exec_shell_command("../src/sysrepocfg -m " TEST_DATA_SEARCH_DIR "ietf-interfaces.merge." SR_FILE_FORMAT_EXT " -d running ietf-interfaces", ".*", true, 0);
     assert_int_equal(rc, SR_ERR_OK);
     rc = sr_session_refresh(srcfg_test_session);
     if (rc != SR_ERR_OK) {
@@ -567,20 +567,20 @@ srcfg_test_import(void **state)
     /* ietf-interfaces */
     /*  startup, xml */
     exec_shell_command("../src/sysrepocfg --import --datastore=startup --format=xml ietf-interfaces < /tmp/ietf-interfaces.startup.xml", ".*", true, 0);
-    assert_int_equal(0, srcfg_test_cmp_data_files("/tmp/ietf-interfaces.startup.xml", LYD_XML, TEST_DATA_SEARCH_DIR "ietf-interfaces.startup", LYD_XML));
+    assert_int_equal(0, srcfg_test_cmp_data_files("/tmp/ietf-interfaces.startup.xml", LYD_XML, TEST_DATA_SEARCH_DIR "ietf-interfaces.startup", SR_FILE_FORMAT_LY));
     /*  startup, json */
     exec_shell_command("../src/sysrepocfg --import=/tmp/ietf-interfaces.startup.json --datastore=startup --format=json ietf-interfaces", ".*", true, 0);
-    assert_int_equal(0, srcfg_test_cmp_data_files("/tmp/ietf-interfaces.startup.json", LYD_JSON, TEST_DATA_SEARCH_DIR "ietf-interfaces.startup", LYD_XML));
+    assert_int_equal(0, srcfg_test_cmp_data_files("/tmp/ietf-interfaces.startup.json", LYD_JSON, TEST_DATA_SEARCH_DIR "ietf-interfaces.startup", SR_FILE_FORMAT_LY));
     /*  running, xml */
     exec_shell_command("../src/sysrepocfg --import --datastore=running --format=xml ietf-interfaces < /tmp/ietf-interfaces.running.xml",
                        "no active subscriptions", true, 1);
     assert_int_equal(0, srcfg_test_subscribe("ietf-interfaces"));
     exec_shell_command("../src/sysrepocfg --import --datastore=running --format=xml ietf-interfaces < /tmp/ietf-interfaces.running.xml", ".*", true, 0);
-    assert_int_equal(0, srcfg_test_cmp_data_files("/tmp/ietf-interfaces.running.xml", LYD_XML, TEST_DATA_SEARCH_DIR "ietf-interfaces.running", LYD_XML));
+    assert_int_equal(0, srcfg_test_cmp_data_files("/tmp/ietf-interfaces.running.xml", LYD_XML, TEST_DATA_SEARCH_DIR "ietf-interfaces.running", SR_FILE_FORMAT_LY));
     /*  running, json, permanent */
     exec_shell_command("../src/sysrepocfg --permanent --import=/tmp/ietf-interfaces.running.json --datastore=running --format=json ietf-interfaces", ".*", true, 0);
-    assert_int_equal(0, srcfg_test_cmp_data_files("/tmp/ietf-interfaces.running.json", LYD_JSON, TEST_DATA_SEARCH_DIR "ietf-interfaces.running", LYD_XML));
-    assert_int_equal(0, srcfg_test_cmp_data_files("/tmp/ietf-interfaces.running.json", LYD_JSON, TEST_DATA_SEARCH_DIR "ietf-interfaces.startup", LYD_XML));
+    assert_int_equal(0, srcfg_test_cmp_data_files("/tmp/ietf-interfaces.running.json", LYD_JSON, TEST_DATA_SEARCH_DIR "ietf-interfaces.running", SR_FILE_FORMAT_LY));
+    assert_int_equal(0, srcfg_test_cmp_data_files("/tmp/ietf-interfaces.running.json", LYD_JSON, TEST_DATA_SEARCH_DIR "ietf-interfaces.startup", SR_FILE_FORMAT_LY));
     /* check the internal data file with module dependencies (just in case) */
     rc = md_init(TEST_SCHEMA_SEARCH_DIR, TEST_SCHEMA_SEARCH_DIR "internal/", TEST_DATA_SEARCH_DIR "internal/",
                  false, &md_ctx);
@@ -592,10 +592,10 @@ srcfg_test_import(void **state)
     /* test-module */
     /*  startup, xml */
     exec_shell_command("../src/sysrepocfg --import --datastore=startup --format=xml test-module < /tmp/test-module.startup.xml", ".*", true, 0);
-    assert_int_equal(0, srcfg_test_cmp_data_files("/tmp/test-module.startup.xml", LYD_XML, TEST_DATA_SEARCH_DIR "test-module.startup", LYD_XML));
+    assert_int_equal(0, srcfg_test_cmp_data_files("/tmp/test-module.startup.xml", LYD_XML, TEST_DATA_SEARCH_DIR "test-module.startup", SR_FILE_FORMAT_LY));
     /*  startup, json */
     exec_shell_command("../src/sysrepocfg --import=/tmp/test-module.startup.json --datastore=startup --format=json test-module", ".*", true, 0);
-    assert_int_equal(0, srcfg_test_cmp_data_files("/tmp/test-module.startup.json", LYD_JSON, TEST_DATA_SEARCH_DIR "test-module.startup", LYD_XML));
+    assert_int_equal(0, srcfg_test_cmp_data_files("/tmp/test-module.startup.json", LYD_JSON, TEST_DATA_SEARCH_DIR "test-module.startup", SR_FILE_FORMAT_LY));
     /*  running, xml */
     exec_shell_command("../src/sysrepocfg --import --datastore=running --format=xml test-module < /tmp/test-module.running.xml",
                        "no active subscriptions", true, 1);
@@ -604,11 +604,11 @@ srcfg_test_import(void **state)
                        "Cannot read data from module 'referenced-data' .* no active subscriptions", true, 1);
     assert_int_equal(0, srcfg_test_subscribe("referenced-data"));
     exec_shell_command("../src/sysrepocfg --import --datastore=running --format=xml test-module < /tmp/test-module.running.xml", ".*", true, 0);
-    assert_int_equal(0, srcfg_test_cmp_data_files("/tmp/test-module.running.xml", LYD_XML, TEST_DATA_SEARCH_DIR "test-module.running", LYD_XML));
+    assert_int_equal(0, srcfg_test_cmp_data_files("/tmp/test-module.running.xml", LYD_XML, TEST_DATA_SEARCH_DIR "test-module.running", SR_FILE_FORMAT_LY));
     /*  running, json, permanent */
     exec_shell_command("../src/sysrepocfg --permanent --import=/tmp/test-module.running.json --datastore=running --format=json test-module", ".*", true, 0);
-    assert_int_equal(0, srcfg_test_cmp_data_files("/tmp/test-module.running.json", LYD_JSON, TEST_DATA_SEARCH_DIR "test-module.running", LYD_XML));
-    assert_int_equal(0, srcfg_test_cmp_data_files("/tmp/test-module.running.json", LYD_JSON, TEST_DATA_SEARCH_DIR "test-module.startup", LYD_XML));
+    assert_int_equal(0, srcfg_test_cmp_data_files("/tmp/test-module.running.json", LYD_JSON, TEST_DATA_SEARCH_DIR "test-module.running", SR_FILE_FORMAT_LY));
+    assert_int_equal(0, srcfg_test_cmp_data_files("/tmp/test-module.running.json", LYD_JSON, TEST_DATA_SEARCH_DIR "test-module.startup", SR_FILE_FORMAT_LY));
     /* check the internal data file with module dependencies (just in case) */
     rc = md_init(TEST_SCHEMA_SEARCH_DIR, TEST_SCHEMA_SEARCH_DIR "internal/", TEST_DATA_SEARCH_DIR "internal/",
                  false, &md_ctx);
@@ -621,20 +621,20 @@ srcfg_test_import(void **state)
     /* example-module */
     /*  startup, xml */
     exec_shell_command("../src/sysrepocfg --import --datastore=startup --format=xml example-module < /tmp/example-module.startup.xml", ".*", true, 0);
-    assert_int_equal(0, srcfg_test_cmp_data_files("/tmp/example-module.startup.xml", LYD_XML, TEST_DATA_SEARCH_DIR "example-module.startup", LYD_XML));
+    assert_int_equal(0, srcfg_test_cmp_data_files("/tmp/example-module.startup.xml", LYD_XML, TEST_DATA_SEARCH_DIR "example-module.startup", SR_FILE_FORMAT_LY));
     /*  startup, json */
     exec_shell_command("../src/sysrepocfg --import=/tmp/example-module.startup.json --datastore=startup --format=json example-module", ".*", true, 0);
-    assert_int_equal(0, srcfg_test_cmp_data_files("/tmp/example-module.startup.json", LYD_JSON, TEST_DATA_SEARCH_DIR "example-module.startup", LYD_XML));
+    assert_int_equal(0, srcfg_test_cmp_data_files("/tmp/example-module.startup.json", LYD_JSON, TEST_DATA_SEARCH_DIR "example-module.startup", SR_FILE_FORMAT_LY));
     /*  running, xml */
     exec_shell_command("../src/sysrepocfg --import --datastore=running --format=xml example-module < /tmp/example-module.running.xml",
                        "no active subscriptions", true, 1);
     assert_int_equal(0, srcfg_test_subscribe("example-module"));
     exec_shell_command("../src/sysrepocfg --import --datastore=running --format=xml example-module < /tmp/example-module.running.xml", ".*", true, 0);
-    assert_int_equal(0, srcfg_test_cmp_data_files("/tmp/example-module.running.xml", LYD_XML, TEST_DATA_SEARCH_DIR "example-module.running", LYD_XML));
+    assert_int_equal(0, srcfg_test_cmp_data_files("/tmp/example-module.running.xml", LYD_XML, TEST_DATA_SEARCH_DIR "example-module.running", SR_FILE_FORMAT_LY));
     /*  running, json, permanent */
     exec_shell_command("../src/sysrepocfg --permanent --import=/tmp/example-module.running.json --datastore=running --format=json example-module", ".*", true, 0);
-    assert_int_equal(0, srcfg_test_cmp_data_files("/tmp/example-module.running.json", LYD_JSON, TEST_DATA_SEARCH_DIR "example-module.running", LYD_XML));
-    assert_int_equal(0, srcfg_test_cmp_data_files("/tmp/example-module.running.json", LYD_JSON, TEST_DATA_SEARCH_DIR "example-module.startup", LYD_XML));
+    assert_int_equal(0, srcfg_test_cmp_data_files("/tmp/example-module.running.json", LYD_JSON, TEST_DATA_SEARCH_DIR "example-module.running", SR_FILE_FORMAT_LY));
+    assert_int_equal(0, srcfg_test_cmp_data_files("/tmp/example-module.running.json", LYD_JSON, TEST_DATA_SEARCH_DIR "example-module.startup", SR_FILE_FORMAT_LY));
     /* check the internal data file with module dependencies (just in case) */
     rc = md_init(TEST_SCHEMA_SEARCH_DIR, TEST_SCHEMA_SEARCH_DIR "internal/", TEST_DATA_SEARCH_DIR "internal/",
                  false, &md_ctx);
@@ -646,10 +646,10 @@ srcfg_test_import(void **state)
     /* cross-module */
     /*  startup, xml */
     exec_shell_command("../src/sysrepocfg --import --datastore=startup --format=xml cross-module < /tmp/cross-module.startup.xml", ".*", true, 0);
-    assert_int_equal(0, srcfg_test_cmp_data_files("/tmp/cross-module.startup.xml", LYD_XML, TEST_DATA_SEARCH_DIR "cross-module.startup", LYD_XML));
+    assert_int_equal(0, srcfg_test_cmp_data_files("/tmp/cross-module.startup.xml", LYD_XML, TEST_DATA_SEARCH_DIR "cross-module.startup", SR_FILE_FORMAT_LY));
     /*  startup, json */
     exec_shell_command("../src/sysrepocfg --import=/tmp/cross-module.startup.json --datastore=startup --format=json cross-module", ".*", true, 0);
-    assert_int_equal(0, srcfg_test_cmp_data_files("/tmp/cross-module.startup.json", LYD_JSON, TEST_DATA_SEARCH_DIR "cross-module.startup", LYD_XML));
+    assert_int_equal(0, srcfg_test_cmp_data_files("/tmp/cross-module.startup.json", LYD_JSON, TEST_DATA_SEARCH_DIR "cross-module.startup", SR_FILE_FORMAT_LY));
     /*  running, xml */
     exec_shell_command("../src/sysrepocfg --import --datastore=running --format=xml cross-module < /tmp/cross-module.running.xml",
                        "no active subscriptions", true, 1);
@@ -658,11 +658,11 @@ srcfg_test_import(void **state)
                        "Cannot read data from module 'referenced-data' .* no active subscriptions", true, 1);
     assert_int_equal(0, srcfg_test_subscribe("referenced-data"));
     exec_shell_command("../src/sysrepocfg --import --datastore=running --format=xml cross-module < /tmp/cross-module.running.xml", ".*", true, 0);
-    assert_int_equal(0, srcfg_test_cmp_data_files("/tmp/cross-module.running.xml", LYD_XML, TEST_DATA_SEARCH_DIR "cross-module.running", LYD_XML));
+    assert_int_equal(0, srcfg_test_cmp_data_files("/tmp/cross-module.running.xml", LYD_XML, TEST_DATA_SEARCH_DIR "cross-module.running", SR_FILE_FORMAT_LY));
     /*  running, json, permanent */
     exec_shell_command("../src/sysrepocfg --permanent --import=/tmp/cross-module.running.json --datastore=running --format=json cross-module", ".*", true, 0);
-    assert_int_equal(0, srcfg_test_cmp_data_files("/tmp/cross-module.running.json", LYD_JSON, TEST_DATA_SEARCH_DIR "cross-module.running", LYD_XML));
-    assert_int_equal(0, srcfg_test_cmp_data_files("/tmp/cross-module.running.json", LYD_JSON, TEST_DATA_SEARCH_DIR "cross-module.startup", LYD_XML));
+    assert_int_equal(0, srcfg_test_cmp_data_files("/tmp/cross-module.running.json", LYD_JSON, TEST_DATA_SEARCH_DIR "cross-module.running", SR_FILE_FORMAT_LY));
+    assert_int_equal(0, srcfg_test_cmp_data_files("/tmp/cross-module.running.json", LYD_JSON, TEST_DATA_SEARCH_DIR "cross-module.startup", SR_FILE_FORMAT_LY));
     /* check the internal data file with module dependencies (just in case) */
     rc = md_init(TEST_SCHEMA_SEARCH_DIR, TEST_SCHEMA_SEARCH_DIR "internal/", TEST_DATA_SEARCH_DIR "internal/",
                  false, &md_ctx);
@@ -675,20 +675,20 @@ srcfg_test_import(void **state)
     /* referenced-data */
     /*  startup, xml */
     exec_shell_command("../src/sysrepocfg --import --datastore=startup --format=xml referenced-data < /tmp/referenced-data.startup.xml", ".*", true, 0);
-    assert_int_equal(0, srcfg_test_cmp_data_files("/tmp/referenced-data.startup.xml", LYD_XML, TEST_DATA_SEARCH_DIR "referenced-data.startup", LYD_XML));
+    assert_int_equal(0, srcfg_test_cmp_data_files("/tmp/referenced-data.startup.xml", LYD_XML, TEST_DATA_SEARCH_DIR "referenced-data.startup", SR_FILE_FORMAT_LY));
     /*  startup, json */
     exec_shell_command("../src/sysrepocfg --import=/tmp/referenced-data.startup.json --datastore=startup --format=json referenced-data", ".*", true, 0);
-    assert_int_equal(0, srcfg_test_cmp_data_files("/tmp/referenced-data.startup.json", LYD_JSON, TEST_DATA_SEARCH_DIR "referenced-data.startup", LYD_XML));
+    assert_int_equal(0, srcfg_test_cmp_data_files("/tmp/referenced-data.startup.json", LYD_JSON, TEST_DATA_SEARCH_DIR "referenced-data.startup", SR_FILE_FORMAT_LY));
     /*  running, xml */
     exec_shell_command("../src/sysrepocfg --import --datastore=running --format=xml referenced-data < /tmp/referenced-data.running.xml",
                        "no active subscriptions", true, 1);
     assert_int_equal(0, srcfg_test_subscribe("referenced-data"));
     exec_shell_command("../src/sysrepocfg --import --datastore=running --format=xml referenced-data < /tmp/referenced-data.running.xml", ".*", true, 0);
-    assert_int_equal(0, srcfg_test_cmp_data_files("/tmp/referenced-data.running.xml", LYD_XML, TEST_DATA_SEARCH_DIR "referenced-data.running", LYD_XML));
+    assert_int_equal(0, srcfg_test_cmp_data_files("/tmp/referenced-data.running.xml", LYD_XML, TEST_DATA_SEARCH_DIR "referenced-data.running", SR_FILE_FORMAT_LY));
     /*  running, json, permanent */
     exec_shell_command("../src/sysrepocfg --permanent --import=/tmp/referenced-data.running.json --datastore=running --format=json referenced-data", ".*", true, 0);
-    assert_int_equal(0, srcfg_test_cmp_data_files("/tmp/referenced-data.running.json", LYD_JSON, TEST_DATA_SEARCH_DIR "referenced-data.running", LYD_XML));
-    assert_int_equal(0, srcfg_test_cmp_data_files("/tmp/referenced-data.running.json", LYD_JSON, TEST_DATA_SEARCH_DIR "referenced-data.startup", LYD_XML));
+    assert_int_equal(0, srcfg_test_cmp_data_files("/tmp/referenced-data.running.json", LYD_JSON, TEST_DATA_SEARCH_DIR "referenced-data.running", SR_FILE_FORMAT_LY));
+    assert_int_equal(0, srcfg_test_cmp_data_files("/tmp/referenced-data.running.json", LYD_JSON, TEST_DATA_SEARCH_DIR "referenced-data.startup", SR_FILE_FORMAT_LY));
     /* check the internal data file with module dependencies (just in case) */
     rc = md_init(TEST_SCHEMA_SEARCH_DIR, TEST_SCHEMA_SEARCH_DIR "internal/", TEST_DATA_SEARCH_DIR "internal/",
                  false, &md_ctx);
@@ -739,7 +739,7 @@ srcfg_test_editing(void **state)
     /* prepare command to execute sysrepocfg */
     strcat(cmd, "cat " FILENAME_USER_INPUT " | PATH=");
     assert_non_null(getcwd(cmd + strlen(cmd), PATH_MAX - strlen(cmd)));
-    strcat(cmd, ":$PATH ../src/sysrepocfg --editor=sysrepocfg_test_editor.sh --datastore=");
+    strcat(cmd, ":$PATH ../src/sysrepocfg --editor=sysrepocfg_test_editor.sh --format=xml --datastore=");
     strcat(cmd, srcfg_test_datastore);
     strcat(cmd, " ");
     args = cmd + strlen(cmd);

--- a/tests/sysrepoctl_test.c
+++ b/tests/sysrepoctl_test.c
@@ -276,7 +276,7 @@ sysrepoctl_test_feature(void **state)
                        "Enabling feature 'if-mib' in the module 'ietf-interfaces'.\n"
                        "Operation completed successfully.", true, 0);
     test_file_content(TEST_DATA_SEARCH_DIR "ietf-interfaces.persist",
-                      "<enabled-features>.*<feature-name>if-mib</feature-name>.*</enabled-features>", true);
+                      "enabled-features.*feature-name.*if-mib", true);
     snprintf(buff, PATH_MAX, "ietf-interfaces[[:space:]]*\\| 2014-05-08 \\| Installed[[:space:]]*\\| %s:[-_[:alnum:]]*[[:space:]]*\\| 664[[:space:]]*\\|[[:space:]]*\\| if-mib[[:space:]]*\n", user);
     exec_shell_command("../src/sysrepoctl -l", buff, true, 0);
 
@@ -285,7 +285,7 @@ sysrepoctl_test_feature(void **state)
                        "Enabling feature 'if-mib' in the module 'ietf-interfaces'.\n"
                        "Operation completed successfully.", true, 0);
     test_file_content(TEST_DATA_SEARCH_DIR "ietf-interfaces.persist",
-                      "<enabled-features>.*<feature-name>if-mib</feature-name>.*</enabled-features>", true);
+                      "enabled-features.*feature-name.*if-mib", true);
     exec_shell_command("../src/sysrepoctl -l", buff, true, 0);
 
     /* disable */
@@ -293,7 +293,7 @@ sysrepoctl_test_feature(void **state)
                        "Disabling feature 'if-mib' in the module 'ietf-interfaces'.\n"
                        "Operation completed successfully.", true, 0);
     test_file_content(TEST_DATA_SEARCH_DIR "ietf-interfaces.persist",
-                      "!<enabled-features>.*<feature-name>if-mib</feature-name>.*</enabled-features>", true);
+                      "!enabled-features.*feature-name.*if-mib", true);
     snprintf(buff, PATH_MAX, "ietf-interfaces[[:space:]]*\\| 2014-05-08 \\| Installed[[:space:]]*\\| %s:[-_[:alnum:]]*[[:space:]]*\\| 664[[:space:]]*\\|[[:space:]]*\\|[[:space:]]*\n", user);
     exec_shell_command("../src/sysrepoctl -l", buff, true, 0);
 
@@ -302,7 +302,7 @@ sysrepoctl_test_feature(void **state)
                        "Disabling feature 'if-mib' in the module 'ietf-interfaces'.\n"
                        "Operation completed successfully.", true, 0);
     test_file_content(TEST_DATA_SEARCH_DIR "ietf-interfaces.persist",
-                      "!<enabled-features>.*<feature-name>if-mib</feature-name>.*</enabled-features>", true);
+                      "!enabled-features.*feature-name.*if-mib", true);
     exec_shell_command("../src/sysrepoctl -l", buff, true, 0);
 }
 


### PR DESCRIPTION
### Description
It is now also possible to use JSON as the main format for datastores, notifications, and everything else. XML is the default for now, but will likely be changed because of significantly more efficient libyang JSON parser than XML parser.

New `cmake` option is `FILE_FORMAT_EXT` and accepts values `xml` or `json`.
