### PR TITLE
Fix issue where edit-config changes are not reflected in datastore when top-level node within submodule has external dependency

### DIFF
--- a/src/data_manager.c
+++ b/src/data_manager.c
@@ -1987,7 +1987,7 @@ dm_remove_added_data_trees(dm_session_t *session, dm_data_info_t *data_info)
 {
     CHECK_NULL_ARG2(session, data_info);
     if (NULL != data_info->node) {
-        if (data_info->schema->module != data_info->node->schema->module) {
+        if (data_info->schema->module != LYS_MAIN_MODULE(data_info->node->schema)) {
             /* verify that the module referencing others has some data */
             lyd_free_withsiblings(data_info->node);
             data_info->node = NULL;

--- a/tests/rp_dt_edit_test.c
+++ b/tests/rp_dt_edit_test.c
@@ -2607,6 +2607,9 @@ static int set_items_data_and_feature_import_setup(void **state)
     exec_shell_command("../src/sysrepoctl --install --yang=" TEST_SOURCE_DIR "/yang/data-imp-dep-C.yang", ".*", true, 0);
     test_file_exists(TEST_SCHEMA_SEARCH_DIR "data-imp-dep-C.yang", true);
 
+    exec_shell_command("../src/sysrepoctl --install --yang=" TEST_SOURCE_DIR "/yang/data-submodule-main.yang", ".*", true, 0);
+    test_file_exists(TEST_SCHEMA_SEARCH_DIR "data-submodule-main.yang", true);
+
     setup(state);
 
     return 0;
@@ -2631,6 +2634,9 @@ static int set_items_data_and_feature_import_teardown(void **state)
     test_file_exists(TEST_SCHEMA_SEARCH_DIR "data-imp-dep-B.yang", false);
     exec_shell_command("../src/sysrepoctl --uninstall --module=data-imp-dep-C", ".*", true, 0);
     test_file_exists(TEST_SCHEMA_SEARCH_DIR "data-imp-dep-C.yang", false);
+
+    exec_shell_command("../src/sysrepoctl --uninstall --module=data-submodule-main", ".*", true, 0);
+    test_file_exists(TEST_SCHEMA_SEARCH_DIR "data-submodule-main.yang", false);
 
     teardown(state);
 
@@ -2695,6 +2701,35 @@ void set_items_data_and_import_implemented(void **state)
     test_rp_session_cleanup(ctx, session);
 }
 
+void set_and_get_items_from_top_level_in_submodule(void **state)
+{
+    int rc;
+    rp_ctx_t *ctx = *state;
+    rp_session_t *session = NULL;
+    sr_error_info_t *errors = NULL;
+    size_t e_cnt = 0;
+    dm_commit_context_t *c_ctx = NULL;
+    sr_val_t *val = NULL;
+
+    test_rp_session_create(ctx, SR_DS_STARTUP, &session);
+
+    set_item("/data-submodule-main:foo/bar", "test", SR_STRING_T, ctx, session);
+
+    rc = rp_dt_commit(ctx, session, &c_ctx, false, &errors, &e_cnt);
+    assert_int_equal(rc, SR_ERR_OK);
+    assert_int_equal(e_cnt, 0);
+    assert_ptr_equal(errors, NULL);
+    
+    rc = rp_dt_get_value_wrapper(ctx, session, NULL, "/data-submodule-main:foo/bar", &val);
+    assert_int_equal(SR_ERR_OK, rc);
+    assert_non_null(val);
+    assert_int_equal(SR_STRING_T, val->type);
+    assert_string_equal("test", val->data.string_val);
+    sr_free_val(val);
+
+    test_rp_session_cleanup(ctx, session);
+}
+
 int main(){
 
     sr_log_stderr(SR_LL_DBG);
@@ -2737,6 +2772,7 @@ int main(){
             cmocka_unit_test(set_item_id_ref),
             cmocka_unit_test_setup_teardown(set_items_data_and_feature_import, set_items_data_and_feature_import_setup, set_items_data_and_feature_import_teardown),
             cmocka_unit_test_setup_teardown(set_items_data_and_import_implemented, set_items_data_and_feature_import_setup, set_items_data_and_feature_import_teardown),
+            cmocka_unit_test_setup_teardown(set_and_get_items_from_top_level_in_submodule, set_items_data_and_feature_import_setup, set_items_data_and_feature_import_teardown),
     };
 
     watchdog_start(300);

--- a/tests/yang/data-submodule-main.yang
+++ b/tests/yang/data-submodule-main.yang
@@ -1,0 +1,6 @@
+module data-submodule-main {
+    namespace "test:data-submodule-main";
+    prefix dsm;
+
+    include data-submodule-sub;
+}

--- a/tests/yang/data-submodule-sub.yang
+++ b/tests/yang/data-submodule-sub.yang
@@ -1,0 +1,19 @@
+submodule data-submodule-sub {
+    belongs-to data-submodule-main {
+        prefix dsm;
+    }
+
+    import ietf-interfaces {
+        prefix if;
+    }
+
+    container foo {
+        description "Top-level container defined in a submodule";
+
+        leaf bar {
+            when "not(/if:interfaces/if:interface[name='foo'])";
+            description "Leaf with dependency on external module";
+            type string;
+        }
+    }
+}


### PR DESCRIPTION
### Description
When attempting to commit changes to a top-level node defined within a submodule where a child node has some kind of dependency on an external module, the changes will not be applied to the datastore.

### Test case
The test case, `set_and_get_items_from_top_level_in_submodule`, found in `rp_dt_edit_test.c` and accompanying yang models, `data-submodule-main.yang` and `data-submodule-sub.yang` demonstrate the failure.

### Closure
closes #1151 
