### PR TITLE
Fix for features not loading when defined within submodules that augments external module element

### DIFF
--- a/tests/yang/feature-submodule-main.yang
+++ b/tests/yang/feature-submodule-main.yang
@@ -1,0 +1,6 @@
+module feature-submodule-main {
+    namespace "test:feature-submodule-main";
+    prefix fsm;
+
+    include feature-submodule-sub;
+}

--- a/tests/yang/feature-submodule-mod.yang
+++ b/tests/yang/feature-submodule-mod.yang
@@ -1,0 +1,14 @@
+module feature-submodule-mod {
+    namespace "test:feature-submodule-mod";
+    prefix fsmod;
+
+    container mod-container {
+        description "Top-level container defined in a module";
+
+        leaf leaf1 {
+            description "Leaf of external module";
+            type string;
+        }
+    }
+    
+}

--- a/tests/yang/feature-submodule-sub.yang
+++ b/tests/yang/feature-submodule-sub.yang
@@ -1,0 +1,23 @@
+submodule feature-submodule-sub {
+    belongs-to feature-submodule-main {
+        prefix fsm;
+    }
+
+    import feature-submodule-mod {
+        prefix fsmod;
+    }
+
+    feature test-submodule-feature {
+      description
+        "Submodule feature used for tests.";
+    }
+
+    augment "/fsmod:mod-container" {
+      leaf augmented-data-val {
+        if-feature test-submodule-feature;
+        type string;
+        description
+          "Test data for feature dependent leaf.";
+      }
+    }
+}


### PR DESCRIPTION
### Description
Sysrepo does not load features that are defined within a submodule that augments an element of an external module.

### Test case
The test case, `set_and_get_items_from_feature_of_submodule`, found in `rp_dt_edit_test.c` and accompanying yang models, `feature-submodule-main.yang`, `feature-submodule-mod.yang`, and `feature-submodule-sub.yang` demonstrate the failure.

### Closure
closes #1156 
