### PR TITLE
Load modules with derived identities of a used identity

### DIFF
--- a/src/data_manager.c
+++ b/src/data_manager.c
@@ -270,7 +270,7 @@ dm_free_lys_private_data(const struct lys_node *node, void *private)
     }
 }
 
-static void
+void
 dm_free_schema_info(void *schema_info)
 {
     CHECK_NULL_ARG_VOID(schema_info);
@@ -459,7 +459,7 @@ dm_enable_features_with_imports(dm_ctx_t *dm_ctx, md_module_t *module, const str
 }
 
 static int
-dm_mark_deps_as_implemented(dm_ctx_t *dm_ctx, md_module_t *module, struct ly_ctx *target_ctx)
+dm_mark_deps_as_implemented(md_module_t *module, struct ly_ctx *target_ctx)
 {
     const struct lys_module *dest_module = NULL;
     int ret = 0;
@@ -537,7 +537,7 @@ dm_module_clb(struct ly_ctx *ctx, const char *name, const char *ns, int options,
         return NULL;
     }
 
-    rc = dm_mark_deps_as_implemented(dm_ctx, module, ctx);
+    rc = dm_mark_deps_as_implemented(module, ctx);
     if (SR_ERR_OK != rc) {
         SR_LOG_ERR("Failed mark imports of module %s as implemented", module->name);
         return NULL;
@@ -649,7 +649,7 @@ dm_release_tmp_ly_ctx(dm_ctx_t *dm_ctx, dm_tmp_ly_ctx_t *tmp_ctx)
     return rc;
 }
 
-static int
+int
 dm_schema_info_init(const char *schema_search_dir, dm_schema_info_t **schema_info)
 {
     CHECK_NULL_ARG2(schema_search_dir, schema_info);
@@ -930,7 +930,7 @@ dm_apply_persist_data_for_model_imports(dm_ctx_t *dm_ctx, dm_session_t *session,
 {
     int rc = SR_ERR_OK;
     md_dep_t *dep = NULL;
-    sr_llist_node_t *ll_node = NULL;
+    sr_llist_node_t *ll_node = NULL, *ll_node2 = NULL, *ll_node3 = NULL;
 
     ll_node = module->deps->first;
     while (ll_node) {
@@ -941,6 +941,26 @@ dm_apply_persist_data_for_model_imports(dm_ctx_t *dm_ctx, dm_session_t *session,
                 CHECK_RC_LOG_GOTO(rc, cleanup, "Failed to apply features from persist data for module %s", dep->dest->name);
             }
         }
+
+        ll_node2 = dep->dest->deps->first;
+        while (ll_node2) {
+            dep = (md_dep_t *)ll_node2->data;
+            if (dep->type == MD_DEP_EXTENSION && dep->dest->implemented) {
+                ll_node3 = dep->dest->deps->first;
+                while (ll_node3) {
+                    dep = (md_dep_t *)ll_node3->data;
+                    if (dm_module_has_persist(dep->dest)) {
+                        if (dep->type == MD_DEP_EXTENSION || dep->type == MD_DEP_DATA) {
+                            rc = dm_apply_persist_data_for_model_imports(dm_ctx, session, si, dep->dest);
+                            CHECK_RC_LOG_GOTO(rc, cleanup, "Failed to apply features from persist data for module %s", dep->dest->name);
+                        }
+                    }
+                    ll_node3 = ll_node3->next;
+                }
+            }
+            ll_node2 = ll_node2->next;
+        }
+
         ll_node = ll_node->next;
     }
     rc = dm_apply_persist_data_for_model(dm_ctx, session, module->name, si, true);
@@ -962,48 +982,89 @@ cleanup:
  * @param [out] schema_info
  * @return Error code (SR_ERR_OK on success)
  */
-static int
-dm_load_schema_file(dm_ctx_t *dm_ctx, const char *schema_filepath, bool append, dm_schema_info_t **schema_info)
+int
+dm_load_schema_file(const char *schema_filepath, dm_schema_info_t *si, const struct lys_module **mod)
 {
-    CHECK_NULL_ARG3(dm_ctx, schema_filepath, schema_info);
+    CHECK_NULL_ARG2(schema_filepath, si);
     const struct lys_module *module = NULL;
-
-    dm_schema_info_t *si = NULL;
-    int rc = SR_ERR_OK;
-
-    if (append) {
-        /* schemas will be loaded into provided context */
-        CHECK_NULL_ARG(*schema_info);
-        si = *schema_info;
-    } else {
-        /* allocate new structure where schemas will be loaded*/
-        rc = dm_schema_info_init(dm_ctx->schema_search_dir, &si);
-        CHECK_RC_MSG_RETURN(rc, "Schema info init failed");
-    }
 
     /* load schema tree */
     LYS_INFORMAT fmt = sr_str_ends_with(schema_filepath, SR_SCHEMA_YIN_FILE_EXT) ? LYS_IN_YIN : LYS_IN_YANG;
     module = lys_parse_path(si->ly_ctx, schema_filepath, fmt);
     if (module == NULL) {
         SR_LOG_WRN("Unable to parse a schema file: %s", schema_filepath);
-        if (!append) {
-            dm_free_schema_info(si);
-        }
         return SR_ERR_INTERNAL;
     }
 
-    if (!append) {
-        si->module_name = strdup(module->name);
-        CHECK_NULL_NOMEM_GOTO(si->module_name, rc, cleanup);
-        si->module = module;
+    if (mod) {
+        *mod = module;
     }
 
-    *schema_info = si;
     return SR_ERR_OK;
+}
 
-cleanup:
-    dm_free_schema_info(si);
-    return rc;
+int
+dm_load_module_deps_r(md_module_t *module, dm_schema_info_t *si)
+{
+    int rc = SR_ERR_OK;
+    md_dep_t *dep = NULL;
+    sr_llist_node_t *ll_node = NULL, *ll_node2 = NULL, *ll_node3 = NULL;
+
+    ll_node = module->deps->first;
+    while (ll_node) {
+        dep = (md_dep_t *)ll_node->data;
+        if (dep->type == MD_DEP_EXTENSION || dep->type == MD_DEP_DATA) {
+            if (dep->type == MD_DEP_DATA) {
+                /* mark this module as dependent on data from other modules */
+                si->cross_module_data_dependency = true;
+            }
+            /**
+             * Note:
+             *  - imports are automatically loaded by libyang
+             *  - module write lock is not required because schema info is not added into schema tree yet
+             */
+            rc = dm_load_schema_file(dep->dest->filepath, si, NULL);
+            if (SR_ERR_OK != rc) {
+                return rc;
+            }
+
+            rc = dm_mark_deps_as_implemented(dep->dest, si->ly_ctx);
+            if (SR_ERR_OK != rc) {
+                return rc;
+            }
+
+            /* we must check EXTENSION deps of this dep IMPORT deps because of possible derived implemented identities */
+            ll_node2 = dep->dest->deps->first;
+            while (ll_node2) {
+                dep = (md_dep_t *)ll_node2->data;
+                if (dep->type == MD_DEP_IMPORT) {
+                    ll_node3 = dep->dest->deps->first;
+                    while (ll_node3) {
+                        dep = (md_dep_t *)ll_node3->data;
+                        if (dep->type == MD_DEP_EXTENSION && dep->dest->implemented) {
+
+                            /* load the module schema and all its dependencies */
+                            rc = dm_load_schema_file(dep->dest->filepath, si, NULL);
+                            CHECK_RC_LOG_RETURN(rc, "Failed to load schema %s", dep->dest->filepath);
+
+                            rc = dm_load_module_deps_r(dep->dest, si);
+                            if (SR_ERR_OK != rc) {
+                                return rc;
+                            }
+                        }
+                        ll_node3 = ll_node3->next;
+                    }
+                }
+                ll_node2 = ll_node2->next;
+            }
+        }
+        ll_node = ll_node->next;
+    }
+
+    rc = dm_mark_deps_as_implemented(module, si->ly_ctx);
+    CHECK_RC_LOG_RETURN(rc, "Failed to mark imports as implemented for module %s", module->name);
+
+    return SR_ERR_OK;
 }
 
 /**
@@ -1023,6 +1084,7 @@ dm_load_module(dm_ctx_t *dm_ctx, const char *module_name, const char *revision, 
     md_module_t *module = NULL;
     md_dep_t *dep = NULL;
     sr_llist_node_t *ll_node = NULL;
+    const struct lys_module *ly_mod = NULL;
 
     /* search for the module to use */
     md_ctx_lock(dm_ctx->md_ctx, false);
@@ -1039,44 +1101,22 @@ dm_load_module(dm_ctx_t *dm_ctx, const char *module_name, const char *revision, 
         goto cleanup;
     }
 
-    /* load the module schema and all its dependencies */
-    rc = dm_load_schema_file(dm_ctx, module->filepath, false, &si);
-    CHECK_RC_LOG_GOTO(rc, cleanup, "Failed to load schema %s", module->filepath);
+    /* allocate new structure where schemas will be loaded*/
+    rc = dm_schema_info_init(dm_ctx->schema_search_dir, &si);
+    CHECK_RC_MSG_RETURN(rc, "Schema info init failed");
 
+    /* load the module schema and all its dependencies */
+    rc = dm_load_schema_file(module->filepath, si, &ly_mod);
+    CHECK_RC_LOG_RETURN(rc, "Failed to load schema %s", dep->dest->filepath);
+
+    si->module_name = strdup(ly_mod->name);
+    CHECK_NULL_NOMEM_GOTO(si->module_name, rc, cleanup);
+    si->module = ly_mod;
     si->has_instance_id = module->inst_ids->first != NULL;
 
-    ll_node = module->deps->first;
-    while (ll_node) {
-        dep = (md_dep_t *)ll_node->data;
-        if (dep->type == MD_DEP_EXTENSION || dep->type == MD_DEP_DATA) {
-            /**
-             * Note:
-             *  - imports are automatically loaded by libyang
-             *  - module write lock is not required because schema info is not added into schema tree yet
-             */
-            rc = dm_load_schema_file(dm_ctx, dep->dest->filepath, true, &si);
-            if (SR_ERR_OK != rc) {
-                *schema_info = NULL;
-                md_ctx_unlock(dm_ctx->md_ctx);
-                return rc;
-            }
-
-            rc = dm_mark_deps_as_implemented(dm_ctx, dep->dest, si->ly_ctx);
-            if (SR_ERR_OK != rc) {
-                *schema_info = NULL;
-                md_ctx_unlock(dm_ctx->md_ctx);
-                return rc;
-            }
-        }
-        if (dep->type == MD_DEP_DATA) {
-            /* mark this module as dependent on data from other modules */
-            si->cross_module_data_dependency = true;
-        }
-        ll_node = ll_node->next;
-    }
-
-    rc = dm_mark_deps_as_implemented(dm_ctx, module, si->ly_ctx);
-    CHECK_RC_LOG_GOTO(rc, cleanup, "Failed to mark imports as implemented for module %s", module->name);
+    /* load the module schema and all its dependencies */
+    rc = dm_load_module_deps_r(module, si);
+    CHECK_RC_LOG_GOTO(rc, cleanup, "Failed to load dependencies for module %s", module->name);
 
     /* compute xpath hashes for all schema nodes (referenced from data tree) */
     rc = dm_init_missing_node_priv_data(si);
@@ -5054,7 +5094,7 @@ dm_install_module(dm_ctx_t *dm_ctx, dm_session_t *session, const char *module_na
         si->ly_ctx = ly_ctx_new(dm_ctx->schema_search_dir, 0);
         CHECK_NULL_NOMEM_GOTO(si->ly_ctx, rc, unlock);
 
-        rc = dm_load_schema_file(dm_ctx, module->filepath, true, &si);
+        rc = dm_load_schema_file(module->filepath, si, NULL);
         CHECK_RC_LOG_GOTO(rc, unlock, "Failed to load schema %s", module->filepath);
 
         si->module = ly_ctx_get_module(si->ly_ctx, module_name, NULL, 1);
@@ -5103,7 +5143,7 @@ unlock:
             lookup.module_name = (char *)dep->dest->name;
             si_ext = sr_btree_search(dm_ctx->schema_info_tree, &lookup);
             if (NULL != si_ext && NULL != si_ext->ly_ctx) {
-                rc = dm_load_schema_file(dm_ctx, module->filepath, true, &si_ext);
+                rc = dm_load_schema_file(module->filepath, si_ext, NULL);
                 CHECK_RC_LOG_GOTO(rc, unlock, "Failed to load schema %s", module->filepath);
 
                 /* compute xpath hashes for all newly added schema nodes (through augment) */

--- a/src/data_manager.h
+++ b/src/data_manager.h
@@ -266,6 +266,14 @@ typedef struct dm_commit_context_s {
         }                                                                     \
     }while(0)
 
+int dm_schema_info_init(const char *schema_search_dir, dm_schema_info_t **schema_info);
+
+void dm_free_schema_info(void *schema_info);
+
+int dm_load_schema_file(const char *schema_filepath, dm_schema_info_t *si, const struct lys_module **mod);
+
+int dm_load_module_deps_r(md_module_t *module, dm_schema_info_t *si);
+
 /**
  * @brief The function is called to load the requested module into the context.
  */

--- a/src/executables/sysrepocfg.c
+++ b/src/executables/sysrepocfg.c
@@ -36,6 +36,7 @@
 #include "sr_common.h"
 #include "client_library.h"
 #include "module_dependencies.h"
+#include "data_manager.h"
 #include "sysrepo/xpath.h"
 
 #define EXPECTED_MAX_INPUT_FILE_SIZE  4096
@@ -154,32 +155,6 @@ srcfg_report_error(int rc)
     }
 }
 
-/*
- * @brief Load schema file at the given path into the libyang context and enable all features.
- */
-static int
-srcfg_load_module_schema(struct ly_ctx *ly_ctx, const char *filepath)
-{
-    const struct lys_module *module_schema = NULL;
-
-    CHECK_NULL_ARG2(ly_ctx, filepath);
-
-    SR_LOG_DBG("Loading module schema: '%s'.", filepath);
-    module_schema = lys_parse_path(ly_ctx, filepath,
-                                   sr_str_ends_with(filepath, SR_SCHEMA_YANG_FILE_EXT) ? LYS_IN_YANG : LYS_IN_YIN);
-    if (NULL == module_schema) {
-        fprintf(stderr, "Error: Failed to load the schema file at: %s.\n", filepath);
-        return SR_ERR_INTERNAL;
-    }
-
-    /* also enable all features */
-    for (uint8_t i = 0; i < module_schema->features_size; i++) {
-        lys_features_enable(module_schema, module_schema->features[i].name);
-    }
-
-    return SR_ERR_OK;
-}
-
 /**
  * @brief Initializes libyang ctx with all schemas installed for specified module in sysrepo.
  */
@@ -187,40 +162,42 @@ static int
 srcfg_ly_init(struct ly_ctx **ly_ctx, md_module_t *module)
 {
     int rc = SR_ERR_OK;
-    sr_llist_node_t *dep_node = NULL;
-    md_dep_t *dep = NULL;
+    dm_schema_info_t *si = NULL;
+    uint32_t mod_idx = 0;
+    const struct lys_module *mod = NULL;
 
     CHECK_NULL_ARG2(ly_ctx, module);
 
-    /* init libyang context */
-    *ly_ctx = ly_ctx_new(srcfg_schema_search_dir, 0);
-    if (NULL == *ly_ctx) {
-        SR_LOG_ERR_MSG("Unable to initialize libyang context");
-        return SR_ERR_INTERNAL;
-    }
+    /* allocate new structure where schemas will be loaded */
+    rc = dm_schema_info_init(srcfg_schema_search_dir, &si);
+    CHECK_RC_MSG_GOTO(rc, cleanup, "Schema info init failed");
+
     ly_set_log_clb(srcfg_ly_log_cb, 1);
 
-    /* load the module schema and all its dependencies */
-    rc = srcfg_load_module_schema(*ly_ctx, module->filepath);
-    if (SR_ERR_OK != rc) {
+    SR_LOG_DBG("Loading module schema: '%s'.", module->filepath);
+    rc = dm_load_schema_file(module->filepath, si, NULL);
+    if (rc != SR_ERR_OK) {
         goto cleanup;
     }
-    dep_node = module->deps->first;
-    while (dep_node) {
-        dep = (md_dep_t *)dep_node->data;
-        if (dep->type == MD_DEP_EXTENSION || dep->type == MD_DEP_DATA) {
-            /* imports and includes are automatically loaded by libyang */
-            rc = srcfg_load_module_schema(*ly_ctx, dep->dest->filepath);
-            if (SR_ERR_OK != rc) {
-                goto cleanup;
-            }
+
+    /* load the module schema and all its dependencies */
+    rc = dm_load_module_deps_r(module, si);
+    CHECK_RC_LOG_GOTO(rc, cleanup, "Failed to load dependencies for module %s", module->name);
+
+    /* also enable all features of all models */
+    mod_idx = ly_ctx_internal_modules_count(si->ly_ctx);
+    while ((mod = ly_ctx_get_module_iter(si->ly_ctx, &mod_idx))) {
+        for (uint8_t i = 0; i < mod->features_size; i++) {
+            lys_features_enable(mod, mod->features[i].name);
         }
-        dep_node = dep_node->next;
     }
 
+    *ly_ctx = si->ly_ctx;
+    si->ly_ctx = NULL;
     rc = SR_ERR_OK;
 
 cleanup:
+    dm_free_schema_info(si);
     return rc;
 }
 

--- a/tests/rp_dt_edit_test.c
+++ b/tests/rp_dt_edit_test.c
@@ -2726,7 +2726,7 @@ void set_and_get_items_from_top_level_in_submodule(void **state)
     assert_int_equal(rc, SR_ERR_OK);
     assert_int_equal(e_cnt, 0);
     assert_ptr_equal(errors, NULL);
-    
+
     rc = rp_dt_get_value_wrapper(ctx, session, NULL, "/data-submodule-main:foo/bar", &val);
     assert_int_equal(SR_ERR_OK, rc);
     assert_non_null(val);
@@ -2754,7 +2754,7 @@ void set_and_get_items_from_feature_of_submodule(void **state)
     assert_int_equal(rc, SR_ERR_OK);
     assert_int_equal(e_cnt, 0);
     assert_ptr_equal(errors, NULL);
-    
+
     rc = rp_dt_get_value_wrapper(ctx, session, NULL, "/feature-submodule-mod:mod-container/feature-submodule-main:augmented-data-val", &val);
     assert_int_equal(SR_ERR_OK, rc);
     assert_non_null(val);


### PR DESCRIPTION
### Description
Handle situations when an implemented model imports a model with base identity used in some of the original model identityref and there are other implemented models with derived identities that should be possible to use as that identityref's values.

### Closure
Fixes #1166 