### PR TITLE
Fix for variant of #1190

### DIFF
--- a/src/data_manager.c
+++ b/src/data_manager.c
@@ -962,6 +962,14 @@ dm_apply_persist_data_for_model_imports(dm_ctx_t *dm_ctx, dm_session_t *session,
                 rc = dm_apply_persist_data_for_model_imports(dm_ctx, session, si, dep->dest, loaded_deps);
                 CHECK_RC_LOG_GOTO(rc, cleanup, "Failed to apply features from persist data for module %s", dep->dest->name);
             }
+            if (dep->type == MD_DEP_EXTENSION && !dm_load_module_deps_in_list(dep->dest, loaded_deps)) {
+                /* add the dep to list to track any already accounted deps */
+                rc = sr_list_add(loaded_deps, dep->dest);
+                CHECK_RC_LOG_GOTO(rc, cleanup, "Failed to add module %s to list", dep->dest->name);
+
+                rc = dm_apply_persist_data_for_model_imports(dm_ctx, session, si, dep->dest, loaded_deps);
+                CHECK_RC_LOG_GOTO(rc, cleanup, "Failed to apply features from persist data for module %s", dep->dest->name);
+            }
         }
 
         ll_node2 = dep->dest->deps->first;

--- a/tests/yang/data-imp-per-A.yang
+++ b/tests/yang/data-imp-per-A.yang
@@ -1,0 +1,19 @@
+module data-imp-per-A {
+    namespace "urn:test:data-imp-per-A";
+    prefix dip-A;
+
+    description
+        "Base model for data import persistence test";
+
+    typedef a-type {
+        type leafref {
+            path "/dip-A:a-cont/dip-A:a-leaf";
+        }
+    }
+
+    container a-cont {
+        leaf a-leaf {
+            type string;
+        }
+    }
+}

--- a/tests/yang/data-imp-per-B.yang
+++ b/tests/yang/data-imp-per-B.yang
@@ -1,0 +1,30 @@
+module data-imp-per-B {
+    namespace "urn:test:data-imp-per-B";
+    prefix dip-B;
+
+
+    import data-imp-per-A {
+        prefix dip-A;
+    }
+
+    description
+        "Non-submodule example for data import persistence test";
+
+    typedef b-type {
+        type leafref {
+            path "/dip-B:b-cont/dip-B:b-leaf";
+        }
+    }
+
+    container b-cont {
+        leaf b-leaf {
+            type string;
+        }
+    }
+
+    augment "/dip-A:a-cont" {
+        leaf b-augleaf {
+            type b-type;
+        }
+    }
+}

--- a/tests/yang/data-imp-per-C.yang
+++ b/tests/yang/data-imp-per-C.yang
@@ -1,0 +1,24 @@
+module data-imp-per-C {
+    namespace "urn:test:data-imp-per-C";
+    prefix dip-C;
+
+    import data-imp-per-A {
+        prefix dip-A;
+    }
+
+    description
+        "Augment for data import persistence test";
+
+    feature c-feature;
+
+    augment "/dip-A:a-cont" {
+        container c-cont {
+            if-feature c-feature;
+            presence "presence";
+
+            leaf c-leaf {
+                type string;
+            }
+        }
+    }
+}

--- a/tests/yang/data-imp-per-D-with-identity.yang
+++ b/tests/yang/data-imp-per-D-with-identity.yang
@@ -1,0 +1,27 @@
+module data-imp-per-D-with-identity {
+    namespace "urn:test:data-imp-per-D";
+    prefix dip-D;
+
+    import data-imp-per-A {
+        prefix dip-A;
+    }
+
+    import test-module {
+        prefix tm;
+    }
+
+    description
+        "Model to import dip-A for data import persistence test
+
+        Includes use of imported identity";
+
+    identity d-identity {
+        base tm:base_id;
+    }
+
+    container d-cont {
+        leaf d-leaf {
+            type dip-A:a-type;
+        }
+    }
+}

--- a/tests/yang/data-imp-per-D.yang
+++ b/tests/yang/data-imp-per-D.yang
@@ -1,0 +1,17 @@
+module data-imp-per-D {
+    namespace "urn:test:data-imp-per-D";
+    prefix dip-D;
+
+    import data-imp-per-A {
+        prefix dip-A;
+    }
+
+    description
+        "Model to import dip-A for data import persistence test";
+
+    container d-cont {
+        leaf d-leaf {
+            type dip-A:a-type;
+        }
+    }
+}


### PR DESCRIPTION
### Description
This is a proposed fix to issue #1190. Pull request #1192 fixed the example yang models that were provided in the issue, but we found another, slightly more complicated variant that still showed the same issue. We are proposing this fix as an alternative or addition to #1192.

While running `dm_apply_persist_data_for_model_imports`, we want to make sure that persist data is applied for any models that augment the current model.

### Test case
A cmocka test for the original, fixed scenario and a test for the new, modified scenario are provided.

### Closure
closes #1190
