### PR TITLE
Remove useless lock for a boolean value

### DIFF
--- a/src/rp_internal.h
+++ b/src/rp_internal.h
@@ -46,8 +46,7 @@ typedef struct rp_ctx_s {
     size_t thread_spin_limit;                /**< Current limit of thread spinning before going to sleep. */
     bool stop_requested;                     /**< Stopping of all threads has been requested. */
 
-    bool block_further_commits;              /**< Flag that allows commit to be processed */
-    pthread_mutex_t commit_block_mutex;      /**< Mutex guarding block_further_commits flag */
+    volatile bool block_further_commits;     /**< Flag that allows commit to be processed */
 
     sr_cbuff_t *request_queue;               /**< Input request queue. */
     pthread_mutex_t request_queue_mutex;     /**< Request queue mutex. */


### PR DESCRIPTION
### Description
There is no need to lock access to a boolean value.

### Closure
Fixes #1195
