### PR TITLE
Improve search times for interconnected yang models.

### DIFF
--- a/src/data_manager.h
+++ b/src/data_manager.h
@@ -272,7 +272,7 @@ void dm_free_schema_info(void *schema_info);
 
 int dm_load_schema_file(const char *schema_filepath, dm_schema_info_t *si, const struct lys_module **mod);
 
-int dm_load_module_deps_r(md_module_t *module, dm_schema_info_t *si, sr_list_t *loaded_deps);
+int dm_load_module_deps_r(md_module_t *module, dm_schema_info_t *si, sr_btree_t *loaded_deps);
 
 /**
  * @brief The function is called to load the requested module into the context.


### PR DESCRIPTION
### Description
When running the sysrepo with a large number of interconnected yang models, we have recently noticed a substantial slowdown during the `dm_load_module` process. We would like to propose the following changes:

#### Change the use of sr_list_t to sr_btree_t
With a large number of installed models and dependencies, the `loaded_deps` list must be traversed a large number of times. We replaced the use of `sr_list_t` with `sr_btree_t` for improved search times.

For the btree comparison function, we compared the pointer values instead of the module names. Are there any forseeable issues with this approach?

#### Move the module-in-context check
Previously, `dm_apply_persist_data_for_model` would check to see if a model was in the target context before attempting to load the persist data. However, before `dm_apply_persist_data_for_model` is called, `dm_apply_persist_data_for_model_imports` already tried to process all of the model's imports. We moved the check into `dm_apply_persist_data_for_model_imports` so the imported models are only processed if the current model is in the target context.

#### Add a completed_deps list
The `dm_apply_persist_data_for_model_imports` function has one recursive call that is not blocked by a check on the `loaded_deps` list. We believe that this is the correct behavior. However, this introduces a way for a single model to be processed by this function many times. To fix this, we added a `completed_deps` list. When the persist data of a model and all of its imported models are completely loaded, the model is added to the `completed_deps` list. If `dm_apply_persist_data_for_model_imports` is called on a model that is already in `completed_deps`, we can safely assume that all of the required persist data has already been loaded and exit the function immediately.

### Test case
All current tests pass. No new functionality added.
