### PR TITLE
[RFC] access-control: disable identity change when nacm is enabled (DO NOT MERGE)

### DIFF
--- a/src/access_control.c
+++ b/src/access_control.c
@@ -112,6 +112,7 @@ ac_module_info_free_cb(void *item)
     free(info);
 }
 
+#ifndef ENABLE_NACM
 /**
  * @brief Checks if the current user is able to access provided file for specified operation.
  */
@@ -194,6 +195,7 @@ ac_check_file_access_with_eid(ac_ctx_t *ac_ctx, const char *file_name,
 
     CHECK_NULL_ARG2(ac_ctx, file_name);
 
+#ifndef ENABLE_NACM
     pthread_mutex_lock(&ac_ctx->lock);
 
     rc_tmp = ac_set_identity(euid, egid);
@@ -205,9 +207,11 @@ ac_check_file_access_with_eid(ac_ctx_t *ac_ctx, const char *file_name,
     }
 
     pthread_mutex_unlock(&ac_ctx->lock);
+#endif
 
     return (SR_ERR_OK == rc_tmp) ? rc : rc_tmp;
 }
+#endif
 
 /**
  * @brief Checks if the session is authorized to perform specified operation
@@ -410,6 +414,7 @@ ac_check_file_permissions(ac_session_t *session, const char *file_name, const ac
 
     CHECK_NULL_ARG4(session, session->ac_ctx, session->user_credentials, file_name);
 
+#ifndef ENABLE_NACM
     if (!session->ac_ctx->priviledged_process) {
         /* sysrepo engine DOES NOT run within a privileged process */
         if ((session->user_credentials->r_uid != session->ac_ctx->proc_euid) ||
@@ -458,6 +463,7 @@ ac_check_file_permissions(ac_session_t *session, const char *file_name, const ac
                     (AC_OPER_READ == operation ? "read" : "write"), file_name);
         }
     }
+#endif
 
     return rc;
 }
@@ -469,6 +475,7 @@ ac_set_user_identity(ac_ctx_t *ac_ctx, const ac_ucred_t *user_credentials)
 
     CHECK_NULL_ARG(ac_ctx);
 
+#ifndef ENABLE_NACM
     if (NULL != user_credentials) {
         if (!ac_ctx->priviledged_process) {
             /* sysrepo engine DOES NOT run within a privileged process - skip identity switch */
@@ -488,6 +495,7 @@ ac_set_user_identity(ac_ctx_t *ac_ctx, const ac_ucred_t *user_credentials)
             rc = ac_set_identity(user_credentials->r_uid, user_credentials->r_gid);
         }
     }
+#endif
 
     return rc;
 }
@@ -499,6 +507,7 @@ ac_unset_user_identity(ac_ctx_t *ac_ctx, const ac_ucred_t *user_credentials)
 
     CHECK_NULL_ARG(ac_ctx);
 
+#ifndef ENABLE_NACM
     if (!ac_ctx->priviledged_process) {
         /* sysrepo engine DOES NOT run within a privileged process - skip identity switch */
         return SR_ERR_OK;
@@ -510,6 +519,7 @@ ac_unset_user_identity(ac_ctx_t *ac_ctx, const ac_ucred_t *user_credentials)
     if (NULL != user_credentials) {
         pthread_mutex_unlock(&ac_ctx->lock);
     }
+#endif
 
     return rc;
 }


### PR DESCRIPTION
DISCLAIMER: THIS IS NOT A PROPER FIX BUT MORE OF A WORKAROUND.
I propose this patch as a starting point to base the discussion on.

Sysrepo has two different mechanisms to manage what user may access which data:

- **"access control"**: based on UNIX file system permissions. The user which is identified by sysrepo must have read (and/or write) permissions to the files in `/etc/sysrepo/data`. This is suitable for local access via the sysrepocfg tool but not quite for remote NETCONF access (where there might not even be a corresponding UNIX user).
- **"nacm"**: based on RFC [8341](https://tools.ietf.org/html/rfc8341), it is implemented by sysrepo and uses the `ietf-netconf-acm` YANG module as configuration data. It allows more fine grained control over what parts of the configuration a user has access to (read/write/execute).

NACM is disabled by default and must be enabled at compile time. Surprisingly, enabling NACM does not disable the file system permissions based "access control".

When relying on NACM for access control and sysrepo is a backend for Netopeer2, if the NETCONF user does not have UNIX permissions to modify the files under `/etc/sysrepo/data`, he/she cannot modify parts of the configuration (even though the NACM rules says he/she can). Here is an example:

```
root@localhost:/home/admin# id -a admin
uid=10002(admin) gid=10002(admin) groups=10002(admin)
root@localhost:/home/admin# ls -l /etc/sysrepo/data/ietf-netconf-acm*
-rw-r--r-- 1 root root   0 Jul  3 10:48 /etc/sysrepo/data/ietf-netconf-acm.persist
-rw-r--r-- 1 root root 438 Jul  3 10:51 /etc/sysrepo/data/ietf-netconf-acm.running
-rw-r--r-- 1 root root   0 Jul  3 10:48 /etc/sysrepo/data/ietf-netconf-acm.running.lock
-rw-r--r-- 1 root root 438 Jul  3 10:50 /etc/sysrepo/data/ietf-netconf-acm.startup
-rw-r--r-- 1 root root   0 Jul  3 10:48 /etc/sysrepo/data/ietf-netconf-acm.startup.lock
root@localhost:~# sysrepocfg -x - -f xml ietf-netconf-acm
<nacm xmlns="urn:ietf:params:xml:ns:yang:ietf-netconf-acm">
  <groups>
    <group>
      <name>admin</name>
      <user-name>admin</user-name>
    </group>
  </groups>
  <rule-list>
    <name>admin</name>
    <group>admin</group>
    <rule>
      <name>allow-all</name>
      <module-name>*</module-name>
      <access-operations>*</access-operations>
      <path>/</path>
      <action>permit</action>
    </rule>
  </rule-list>
</nacm>
root@localhost:~# cat > /tmp/test.xml
<nacm xmlns="urn:ietf:params:xml:ns:yang:ietf-netconf-acm">
  <groups>
    <group>
      <name>admin</name>
      <user-name>janitor</user-name>
    </group>
  </groups>
</nacm>
^D
root@localhost:~# cd /home/admin
root@localhost:/home/admin# sudo -u admin netopeer2-cli 
> connect --ssh 
Interactive SSH Authentication
Type your password:
Password: 
nc ERROR: Session 2: unexpected data in reply to a yang-library <get> RPC.
ly ERROR: Module "ietf-netconf-acm" parsing failed.
ly ERROR: Module "ietf-netconf-acm@2018-02-14" in another revision "2012-02-22" already implemented.
ly ERROR: Invalid arguments (lys_features_change()).
> get 
DATA
<nacm xmlns="urn:ietf:params:xml:ns:yang:ietf-netconf-acm">
  <groups>
    <group>
      <name>admin</name>
      <user-name>admin</user-name>
    </group>
  </groups>
  <rule-list>
    <name>admin</name>
    <group>admin</group>
    <rule>
      <name>allow-all</name>
      <module-name>*</module-name>
      <access-operations>*</access-operations>
      <path>/</path>
      <action>permit</action>
    </rule>
  </rule-list>
  <denied-operations>0</denied-operations>
  <denied-data-writes>0</denied-data-writes>
  <denied-notifications>0</denied-notifications>
</nacm>
....
> edit-config --defop merge --config=/tmp/test.xml --target running
ERROR
        type:     protocol
        tag:      access-denied
        severity: error
        path:     /ietf-netconf-acm:nacm/groups/group[name='admin']
        message:  Access to the requested protocol operation or data model is denied because authorization failed.

        type:     application
        tag:      operation-failed
        severity: error
        message:  Operation not authorized
>  ^D
root@localhost:/home/admin# journalctl | tail
Jul 03 11:27:53 localhost sysrepod[13464]: [ERR] Access control check failed for xpath '/ietf-netconf-acm:nacm/groups/group[name='admin']'
Jul 03 11:27:53 localhost sysrepod[13464]: [ERR] Set item failed for '/ietf-netconf-acm:nacm/groups/group[name='admin']', session id=1930371751.
Jul 03 11:27:53 localhost sysrepod[13464]: [ERR] Insufficient permissions to lock the file '/etc/sysrepo/data/ietf-netconf-acm.running.lock'
Jul 03 11:27:53 localhost sysrepod[13464]: [ERR] Module ietf-netconf-acm can not be locked
Jul 03 11:27:53 localhost sysrepod[13464]: [ERR] Loading of modified models failed
```

Giving filesystem write access to every user that need to modify part of the configuration is redundant with adding access rules in `ietf-netconf-acm`. Also, it allows a coarser grained access control and it may not be desirable for security reasons.

Disable identity switch for file system checks so that they always succeed when NACM is enabled at compile time.

A proper way to do it would be to disable the identity switch only when the user is connected via NETCONF and that NACM is enabled (and enforced). However, this involves changing the API of multiple functions in `access_control.h` and I don't know the code well enough to do that without breaking everything.