### PR TITLE
persistence_manager: only write <enable-running /> for supported subscriptions

### DIFF
--- a/src/persistence_manager.c
+++ b/src/persistence_manager.c
@@ -1138,7 +1138,10 @@ pm_add_subscription(pm_ctx_t *pm_ctx, const ac_ucred_t *user_cred, const char *m
     CHECK_RC_MSG_GOTO(rc, cleanup, "Unable to add new subscription into the data tree.");
 
     /* set subscription details */
-    if (subscription->enable_running) {
+    if (subscription->enable_running && (
+            SR__SUBSCRIPTION_TYPE__MODULE_CHANGE_SUBS == subscription->type ||
+            SR__SUBSCRIPTION_TYPE__SUBTREE_CHANGE_SUBS == subscription->type ||
+            SR__SUBSCRIPTION_TYPE__DP_GET_ITEMS_SUBS == subscription->type)) {
         snprintf(xpath, PATH_MAX, PM_XPATH_SUBSCRIPTION_ENABLE_RUNNING, module_name,
                 sr_subscription_type_gpb_to_str(subscription->type), subscription->dst_address, subscription->dst_id);
         rc = pm_modify_persist_data_tree(pm_ctx, &data_tree, xpath, NULL, true, true, NULL);


### PR DESCRIPTION
When accessing the sysrepo protobuf API without using the client library, it is possible to send a `RPC_SUBS` message with `->enable_running = true`. Sysrepo accepts the subscription and adds it in the persistant-data with a `<enable-running />` tag.

This leads to an error when sysrepo tries to read the file again and parse it with libyang:

```
[ERR] libyang error: When condition "../type = 'module-change' or ../type = 'subtree-change' or ../type = 'dp-get-items'" not satisfied.
[ERR] Parsing persist data from file '/etc/sysrepo/data/example.persist' failed: When condition "../type = 'module-change' or ../type = 'subtree-change' or ../type = 'dp-get-items'" not satisfied.
```

Make sure to respect the condition in the yang module.

This fixes the second part of #1208 but the problem with RPCs in yang modules that have no data nodes still remains. I did not find a way to fix it.