### PR TITLE
Fixing segfault when adding and deleting list row to running config with NACM enabled

### DIFF
--- a/src/data_manager.c
+++ b/src/data_manager.c
@@ -4766,7 +4766,8 @@ dm_perform_netconf_access_control(nacm_ctx_t *nacm_ctx, dm_session_t *session, d
     }
 
     /* start NACM data access validation for this module */
-    rc = nacm_data_validation_start(nacm_ctx, session->user_credentials, new_info->node->schema,
+    struct lys_node *schema = new_info->node == NULL ? prev_info->node->schema : new_info->node->schema;
+    rc = nacm_data_validation_start(nacm_ctx, session->user_credentials, schema,
             &nacm_data_val_ctx);
     CHECK_RC_MSG_GOTO(rc, cleanup, "Failed to start NACM data validation.");
 

--- a/tests/helpers/rp_dt_context_helper.c
+++ b/tests/helpers/rp_dt_context_helper.c
@@ -90,6 +90,27 @@ test_rp_session_create(rp_ctx_t *rp_ctx, sr_datastore_t datastore, rp_session_t 
 }
 
 void
+test_rp_session_create_with_options(rp_ctx_t *rp_ctx, sr_datastore_t datastore,
+        uint32_t options, rp_session_t **rp_session_p)
+{
+    rp_session_t *session = NULL;
+    ac_ucred_t *credentials = NULL;
+    char *user = getenv("USER");
+    int rc = SR_ERR_OK;
+
+    credentials = calloc(1, sizeof(*credentials));
+
+    credentials->r_username = user ? strdup(user) : NULL;
+    credentials->r_uid = getuid();
+    credentials->r_gid = getgid();
+
+    rc = rp_session_start(rp_ctx, 123456, credentials, datastore, options, 0, &session);
+    assert_int_equal(SR_ERR_OK, rc);
+
+    *rp_session_p = session;
+}
+
+void
 test_rp_session_create_user(rp_ctx_t *rp_ctx, sr_datastore_t datastore, const ac_ucred_t user_credentials,
         uint32_t options, rp_session_t **rp_session_p)
 {

--- a/tests/helpers/rp_dt_context_helper.h
+++ b/tests/helpers/rp_dt_context_helper.h
@@ -38,6 +38,12 @@ void test_rp_ctx_cleanup(rp_ctx_t *ctx);
 void test_rp_session_create(rp_ctx_t *rp_ctx, sr_datastore_t datastore, rp_session_t **rp_session_p);
 
 /**
+ * @brief Creates testing RP session with given options.
+ */
+void test_rp_session_create_with_options(rp_ctx_t *rp_ctx, sr_datastore_t datastore,
+        uint32_t options, rp_session_t **rp_session_p);
+
+/**
  * @brief Creates testing RP session for a given (virtual) user.
  */
 void test_rp_session_create_user(rp_ctx_t *rp_ctx, sr_datastore_t datastore, const ac_ucred_t user_credentials,

--- a/tests/yang/commit-nacm-segfault.yang
+++ b/tests/yang/commit-nacm-segfault.yang
@@ -1,0 +1,14 @@
+module commit-nacm-segfault {
+
+  namespace "test:commit-nacm-segfault";
+  prefix commit-seg;
+
+  list test-list {
+    key test-key;
+
+    leaf test-key {
+      type string;
+    }
+  }
+}
+


### PR DESCRIPTION
### Description
When NACM is enabled, creating a row, committing, and deleting a row from a list is causing a segfault.

### Test case
`add_delete_list_row_with_nacm_test` demonstrates the issue which is fixed by the changes in `data_manager.c`
