### PR TITLE
Add request id in data provide items callback

### DIFF
--- a/doc/start.dox
+++ b/doc/start.dox
@@ -204,7 +204,7 @@ the specific changed values.
 @subsection state State Data
 ~~~{.c}
 static int
-oven_state_cb(const char *xpath, sr_val_t **values, size_t *values_cnt, void *private_ctx)
+oven_state_cb(const char *xpath, sr_val_t **values, size_t *values_cnt, uint64_t request_id, void *private_ctx)
 {
     sr_val_t *vals;
     int rc;
@@ -230,7 +230,8 @@ oven_state_cb(const char *xpath, sr_val_t **values, size_t *values_cnt, void *pr
 ~~~
 The state data callback is self-explaining. It should create and return direct children of the `xpath` parent
 (more in @ref data_providers). As the subscription was only for one container with 2 leaves as children, the `xpath`
-can only have one value and will hence be always the same.
+can only have one value and will hence be always the same. `request_id` identifies the initial request which
+triggered this callback.
 
 @subsection rpc RPC Subscriptions
 ~~~{.c}

--- a/examples/oper_data_example.c
+++ b/examples/oper_data_example.c
@@ -33,7 +33,7 @@
 volatile int exit_application = 0;
 
 static int
-data_provider_cb(const char *xpath, sr_val_t **values, size_t *values_cnt, void *private_ctx)
+data_provider_cb(const char *xpath, sr_val_t **values, size_t *values_cnt, uint64_t request_id, void *private_ctx)
 {
     sr_val_t *v = NULL;
     sr_xpath_ctx_t xp_ctx = {0};

--- a/examples/plugins/oven.c
+++ b/examples/plugins/oven.c
@@ -121,7 +121,7 @@ sys_error:
 }
 
 static int
-oven_state_cb(const char *xpath, sr_val_t **values, size_t *values_cnt, void *private_ctx)
+oven_state_cb(const char *xpath, sr_val_t **values, size_t *values_cnt, uint64_t request_id, void *private_ctx)
 {
     sr_val_t *vals;
     int rc;

--- a/inc/sysrepo.h
+++ b/inc/sysrepo.h
@@ -1837,11 +1837,12 @@ int sr_event_notif_replay(sr_session_ctx_t *session, sr_subscription_ctx_t *subs
  * @param[in] xpath @ref xp_page "Data Path" identifying the level under which the nodes are requested.
  * @param[out] values Array of values at the selected level (allocated by the provider).
  * @param[out] values_cnt Number of values returned.
+ * @param[in] request_id An ID identifying the originating request.
  * @param[in] private_ctx Private context opaque to sysrepo, as passed to ::sr_dp_get_items_subscribe call.
  *
  * @return Error code (SR_ERR_OK on success).
  */
-typedef int (*sr_dp_get_items_cb)(const char *xpath, sr_val_t **values, size_t *values_cnt, void *private_ctx);
+typedef int (*sr_dp_get_items_cb)(const char *xpath, sr_val_t **values, size_t *values_cnt, uint64_t request_id, void *private_ctx);
 
 /**
  * @brief Registers for providing of operational data under given xpath.

--- a/src/clientlib/cl_subscription_manager.c
+++ b/src/clientlib/cl_subscription_manager.c
@@ -817,6 +817,7 @@ cl_sm_dp_request_process(cl_sm_ctx_t *sm_ctx, cl_sm_conn_ctx_t *conn, Sr__Msg *m
     cb_rc = subscription->callback.dp_get_items_cb(
             msg->request->data_provide_req->xpath,
             &values, &values_cnt,
+            msg->request->data_provide_req->request_id,
             subscription->private_ctx);
 
     pthread_mutex_unlock(&sm_ctx->subscriptions_lock);

--- a/src/rp_internal.h
+++ b/src/rp_internal.h
@@ -58,6 +58,10 @@ typedef struct rp_ctx_s {
 
     pthread_rwlock_t commit_lock;            /**< Lock to synchronize commit in this instance */
     bool do_not_generate_config_change;      /**< Config-change notification will not be generated */
+
+    /* request ID generator */
+    uint64_t total_req_cnt;                  /**< Total number of received requests for this context. */
+    pthread_mutex_t total_req_cnt_mutex;     /**< Mutex protecting total_req_cnt. */
 } rp_ctx_t;
 
 /**

--- a/swig/cpp/src/Session.cpp
+++ b/swig/cpp/src/Session.cpp
@@ -515,10 +515,10 @@ static void event_notif_tree_cb(const sr_ev_notif_type_t notif_type, const char 
     Callback *wrap = (Callback*) private_ctx;
     return wrap->event_notif_tree(notif_type, xpath, vals, timestamp, wrap->private_ctx["event_notif_tree"]);
 }
-static int dp_get_items_cb(const char *xpath, sr_val_t **values, size_t *values_cnt, void *private_ctx) {
+static int dp_get_items_cb(const char *xpath, sr_val_t **values, size_t *values_cnt, uint64_t request_id, void *private_ctx) {
     S_Vals_Holder vals(new Vals_Holder(values, values_cnt));
     Callback *wrap = (Callback*) private_ctx;
-    return wrap->dp_get_items(xpath, vals, wrap->private_ctx["dp_get_items"]);
+    return wrap->dp_get_items(xpath, vals, request_id, wrap->private_ctx["dp_get_items"]);
 }
 
 void Subscribe::module_change_subscribe(const char *module_name, S_Callback callback, \

--- a/swig/cpp/src/Session.h
+++ b/swig/cpp/src/Session.h
@@ -112,7 +112,7 @@ public:
     virtual int action(const char *xpath, const S_Vals input, S_Vals_Holder output, void *private_ctx) {return SR_ERR_OK;};
     virtual int rpc_tree(const char *xpath, const S_Trees input, S_Trees_Holder output, void *private_ctx) {return SR_ERR_OK;};
     virtual int action_tree(const char *xpath, const S_Trees input, S_Trees_Holder output, void *private_ctx) {return SR_ERR_OK;};
-    virtual int dp_get_items(const char *xpath, S_Vals_Holder vals, void *private_ctx) {return SR_ERR_OK;};
+    virtual int dp_get_items(const char *xpath, S_Vals_Holder vals, uint64_t request_id, void *private_ctx) {return SR_ERR_OK;};
     virtual void event_notif(const sr_ev_notif_type_t notif_type, const char *xpath, S_Vals vals, time_t timestamp, void *private_ctx) {return;};
     virtual void event_notif_tree(const sr_ev_notif_type_t notif_type, const char *xpath, S_Trees trees, time_t timestamp, void *private_ctx) {return;};
     Callback *get() {return this;};

--- a/swig/lua/libsysrepoLua.i
+++ b/swig/lua/libsysrepoLua.i
@@ -192,7 +192,7 @@ public:
         return ret;
     }
 
-    int dp_get_items(const char *xpath, sr_val_t **values, size_t *values_cnt, void *private_ctx) {
+    int dp_get_items(const char *xpath, sr_val_t **values, size_t *values_cnt, uint64_t request_id, void *private_ctx) {
         swiglua_ref_get(&fn);
         if (!lua_isfunction(fn.L,-1)) {
             throw std::runtime_error("Lua error in function callback");
@@ -200,6 +200,7 @@ public:
         Vals_Holder *out_vals =(Vals_Holder *)new Vals_Holder(values, values_cnt);
         lua_pushstring(fn.L, xpath);
         SWIG_NewPointerObj(fn.L, out_vals, SWIGTYPE_p_Vals_Holder, 0);
+        lua_pushnumber(fn.L, request_id);
         SWIG_NewPointerObj(fn.L, private_ctx, SWIGTYPE_p_void, 0);
         lua_call(fn.L, 3, 1);
         out_vals->~Vals_Holder();

--- a/swig/python/sysrepo.i
+++ b/swig/python/sysrepo.i
@@ -264,14 +264,14 @@ public:
     }
 
 
-    int dp_get_items(const char *xpath, sr_val_t **values, size_t *values_cnt, PyObject *private_ctx) {
+    int dp_get_items(const char *xpath, sr_val_t **values, size_t *values_cnt, uint64_t request_id, PyObject *private_ctx) {
         PyObject *arglist;
 
         Vals_Holder *out_vals =(Vals_Holder *)new Vals_Holder(values, values_cnt);
         std::shared_ptr<Vals_Holder> *shared_out_vals = out_vals ? new std::shared_ptr<Vals_Holder>(out_vals) : 0;
         PyObject *out = SWIG_NewPointerObj(SWIG_as_voidptr(shared_out_vals), SWIGTYPE_p_std__shared_ptrT_Vals_Holder_t, SWIG_POINTER_DISOWN);
 
-        arglist = Py_BuildValue("(sOO)", xpath, out, private_ctx);
+        arglist = Py_BuildValue("(sOiO)", xpath, out, request_id, private_ctx);
         PyObject *result = PyEval_CallObject(_callback, arglist);
         Py_DECREF(arglist);
         if (result == nullptr) {
@@ -386,10 +386,10 @@ static int g_action_tree_cb(const char *xpath, const sr_node_t *input, const siz
     return ctx->action_tree_cb(xpath, input, input_cnt, output, output_cnt, ctx->private_ctx);
 }
 
-static int g_dp_get_items_cb(const char *xpath, sr_val_t **values, size_t *values_cnt, void *private_ctx)
+static int g_dp_get_items_cb(const char *xpath, sr_val_t **values, size_t *values_cnt, uint64_t request_id, void *private_ctx)
 {
     Wrap_cb *ctx = (Wrap_cb *) private_ctx;
-    return ctx->dp_get_items(xpath, values, values_cnt, ctx->private_ctx);
+    return ctx->dp_get_items(xpath, values, values_cnt, request_id, ctx->private_ctx);
 }
 
 static void g_event_notif_cb(const sr_ev_notif_type_t notif_type, const char *xpath, const sr_val_t *values, const size_t values_cnt, time_t timestamp, void *private_ctx)

--- a/tests/cl_state_data_test.c
+++ b/tests/cl_state_data_test.c
@@ -293,7 +293,7 @@ provide_seats_reserved(const char *xpath, sr_val_t **values, size_t *values_cnt,
     return 0;
 }
 
-int cl_dp_cpu_load (const char *xpath, sr_val_t **values, size_t *values_cnt, void *private_ctx)
+int cl_dp_cpu_load (const char *xpath, sr_val_t **values, size_t *values_cnt, uint64_t request_id, void *private_ctx)
 {
     const char *expected_xpath = "/state-module:cpu_load";
     if (0 == strcmp(xpath, expected_xpath)) {
@@ -318,7 +318,7 @@ int cl_dp_cpu_load (const char *xpath, sr_val_t **values, size_t *values_cnt, vo
     return -1;
 }
 
-int cl_dp_bus (const char *xpath, sr_val_t **values, size_t *values_cnt, void *private_ctx)
+int cl_dp_bus (const char *xpath, sr_val_t **values, size_t *values_cnt, uint64_t request_id, void *private_ctx)
 {
     if (0 == strcmp(xpath, "/state-module:bus/distance_travelled"))
     {
@@ -332,7 +332,16 @@ int cl_dp_bus (const char *xpath, sr_val_t **values, size_t *values_cnt, void *p
     return -1;
 }
 
-int cl_dp_distance_travelled (const char *xpath, sr_val_t **values, size_t *values_cnt, void *private_ctx)
+int cl_dp_bus_req_id (const char *xpath, sr_val_t **values, size_t *values_cnt, uint64_t request_id, void *private_ctx)
+{
+    sr_list_t *l = (sr_list_t *) private_ctx;
+    if (0 != sr_list_add(l, (char *)request_id)) {
+        SR_LOG_ERR_MSG("Error while adding into list");
+    }
+    return 0;
+}
+
+int cl_dp_distance_travelled (const char *xpath, sr_val_t **values, size_t *values_cnt, uint64_t request_id, void *private_ctx)
 {
     const char *expected_xpath = "/state-module:bus/distance_travelled";
     if (0 == strcmp(xpath, expected_xpath)) {
@@ -342,7 +351,7 @@ int cl_dp_distance_travelled (const char *xpath, sr_val_t **values, size_t *valu
     return -1;
 }
 
-int cl_dp_gps_located (const char *xpath, sr_val_t **values, size_t *values_cnt, void *private_ctx)
+int cl_dp_gps_located (const char *xpath, sr_val_t **values, size_t *values_cnt, uint64_t request_id, void *private_ctx)
 {
     const char *expected_xpath = "/state-module:bus/gps_located";
     if (0 == strcmp(xpath, "/state-module:bus/gps_located")) {
@@ -352,7 +361,7 @@ int cl_dp_gps_located (const char *xpath, sr_val_t **values, size_t *values_cnt,
     return -1;
 }
 
-int cl_dp_seats_reserved (const char *xpath, sr_val_t **values, size_t *values_cnt, void *private_ctx)
+int cl_dp_seats_reserved (const char *xpath, sr_val_t **values, size_t *values_cnt, uint64_t request_id, void *private_ctx)
 {
     const char *expected_xpath = "/state-module:bus/seats/reserved";
     if (sr_xpath_node_name_eq(xpath, "reserved")) {
@@ -362,7 +371,7 @@ int cl_dp_seats_reserved (const char *xpath, sr_val_t **values, size_t *values_c
     return -1;
 }
 
-int cl_dp_missing_type_bus (const char *xpath, sr_val_t **values, size_t *values_cnt, void *private_ctx)
+int cl_dp_missing_type_bus (const char *xpath, sr_val_t **values, size_t *values_cnt, uint64_t request_id, void *private_ctx)
 {
     if (0 == strcmp(xpath, "/state-module:bus/distance_travelled"))
     {
@@ -377,7 +386,7 @@ int cl_dp_missing_type_bus (const char *xpath, sr_val_t **values, size_t *values
 }
 
 int
-cl_dp_incorrect_data(const char *xpath, sr_val_t **values, size_t *values_cnt, void *private_ctx)
+cl_dp_incorrect_data(const char *xpath, sr_val_t **values, size_t *values_cnt, uint64_t request_id, void *private_ctx)
 {
     sr_list_t *l = (sr_list_t *) private_ctx;
     if (0 != sr_list_add(l, strdup(xpath))) {
@@ -397,12 +406,12 @@ cl_dp_incorrect_data(const char *xpath, sr_val_t **values, size_t *values_cnt, v
     return 0;
 }
 
-int cl_dp_weather (const char *xpath, sr_val_t **values, size_t *values_cnt, void *private_ctx)
+int cl_dp_weather (const char *xpath, sr_val_t **values, size_t *values_cnt, uint64_t request_id, void *private_ctx)
 {
     return SR_ERR_OK;
 }
 
-int cl_dp_sky (const char *xpath, sr_val_t **values, size_t *values_cnt, void *private_ctx)
+int cl_dp_sky (const char *xpath, sr_val_t **values, size_t *values_cnt, uint64_t request_id, void *private_ctx)
 {
     const char *expected_xpath = "/state-module:weather/sky";
     if (0 == strcmp(xpath, expected_xpath)) {
@@ -421,7 +430,7 @@ int cl_dp_sky (const char *xpath, sr_val_t **values, size_t *values_cnt, void *p
     return -1;
 }
 
-int cl_dp_humidity (const char *xpath, sr_val_t **values, size_t *values_cnt, void *private_ctx)
+int cl_dp_humidity (const char *xpath, sr_val_t **values, size_t *values_cnt, uint64_t request_id, void *private_ctx)
 {
     const char *expected_xpath = "/state-module:weather/humidity";
     if (0 == strcmp(xpath, expected_xpath)) {
@@ -449,7 +458,7 @@ cl_whole_module_cb(sr_session_ctx_t *session, const char *module_name, sr_notif_
 }
 
 int
-cl_dp_traffic_stats(const char *xpath, sr_val_t **values, size_t *values_cnt, void *private_ctx)
+cl_dp_traffic_stats(const char *xpath, sr_val_t **values, size_t *values_cnt, uint64_t request_id, void *private_ctx)
 {
     sr_list_t *l = (sr_list_t *) private_ctx;
     int rc = SR_ERR_OK;
@@ -570,7 +579,7 @@ cl_dp_traffic_stats(const char *xpath, sr_val_t **values, size_t *values_cnt, vo
 }
 
 int
-cl_dp_cross_road(const char *xpath, sr_val_t **values, size_t *values_cnt, void *private_ctx)
+cl_dp_cross_road(const char *xpath, sr_val_t **values, size_t *values_cnt, uint64_t request_id, void *private_ctx)
 {
     sr_list_t *l = (sr_list_t *) private_ctx;
     if (0 != sr_list_add(l, strdup(xpath))) {
@@ -611,7 +620,7 @@ cl_dp_cross_road(const char *xpath, sr_val_t **values, size_t *values_cnt, void 
 }
 
 int
-cl_dp_wind(const char *xpath, sr_val_t **values, size_t *values_cnt, void *private_ctx)
+cl_dp_wind(const char *xpath, sr_val_t **values, size_t *values_cnt, uint64_t request_id, void *private_ctx)
 {
     sr_list_t *l = (sr_list_t *) private_ctx;
     if (0 != sr_list_add(l, strdup(xpath))) {
@@ -642,7 +651,7 @@ cl_dp_wind(const char *xpath, sr_val_t **values, size_t *values_cnt, void *priva
 }
 
 int
-cl_dp_wind_speed(const char *xpath, sr_val_t **values, size_t *values_cnt, void *private_ctx)
+cl_dp_wind_speed(const char *xpath, sr_val_t **values, size_t *values_cnt, uint64_t request_id, void *private_ctx)
 {
     sr_list_t *l = (sr_list_t *) private_ctx;
     if (0 != sr_list_add(l, strdup(xpath))) {
@@ -669,7 +678,7 @@ cl_dp_wind_speed(const char *xpath, sr_val_t **values, size_t *values_cnt, void 
 }
 
 int
-cl_dp_traffic_light(const char *xpath, sr_val_t **values, size_t *values_cnt, void *private_ctx)
+cl_dp_traffic_light(const char *xpath, sr_val_t **values, size_t *values_cnt, uint64_t request_id, void *private_ctx)
 {
     sr_list_t *l = (sr_list_t *) private_ctx;
     if (0 != sr_list_add(l, strdup(xpath))) {
@@ -715,7 +724,7 @@ cl_dp_traffic_light(const char *xpath, sr_val_t **values, size_t *values_cnt, vo
 }
 
 static int
-cl_dp_card_state(const char *xpath, sr_val_t **values, size_t *values_cnt, void *private_ctx)
+cl_dp_card_state(const char *xpath, sr_val_t **values, size_t *values_cnt, uint64_t request_id, void *private_ctx)
 {
     sr_val_t *v = NULL;
     int rc = SR_ERR_OK;
@@ -2446,6 +2455,62 @@ cl_all_state_data(void **state)
 }
 
 static void
+cl_request_id(void **state)
+{
+    sr_conn_ctx_t *conn = *state;
+    assert_non_null(conn);
+    sr_session_ctx_t *session = NULL;
+    sr_subscription_ctx_t *subscription = NULL;
+    sr_list_t *reqid_retrieved = NULL;
+    sr_val_t *values = NULL;
+    size_t cnt = 0;
+    uint32_t count = 0;
+    int rc = SR_ERR_OK;
+
+    rc = sr_list_init(&reqid_retrieved);
+    assert_int_equal(rc, SR_ERR_OK);
+
+    /* start session */
+    rc = sr_session_start(conn, SR_DS_RUNNING, SR_SESS_DEFAULT, &session);
+    assert_int_equal(rc, SR_ERR_OK);
+
+    rc = sr_module_change_subscribe(session, "state-module", cl_whole_module_cb, NULL,
+            0, SR_SUBSCR_DEFAULT, &subscription);
+    assert_int_equal(rc, SR_ERR_OK);
+
+    /* subscribe data providers */
+    rc = sr_dp_get_items_subscribe(session, "/state-module:bus", cl_dp_bus_req_id, reqid_retrieved, SR_SUBSCR_CTX_REUSE, &subscription);
+    assert_int_equal(rc, SR_ERR_OK);
+
+    /* retrieve data once */
+    rc = sr_get_items(session, "/state-module:*//*", &values, &cnt);
+    assert_int_equal(rc, SR_ERR_OK);
+
+    sr_free_values(values, cnt);
+
+    /* check that reqid is always the same */
+    for (size_t i = 1; i < reqid_retrieved->count; i++) {
+        assert_int_equal(reqid_retrieved->data[i - 1], reqid_retrieved->data[i]);
+    }
+    count = reqid_retrieved->count;
+
+    /* retrieve data a second time */
+    rc = sr_get_items(session, "/state-module:*//*", &values, &cnt);
+    assert_int_equal(rc, SR_ERR_OK);
+
+    sr_free_values(values, cnt);
+
+    /* check that reqids are different for the first and second request */
+    assert_int_not_equal(reqid_retrieved->data[0], reqid_retrieved->data[count]);
+
+    sr_list_cleanup(reqid_retrieved);
+
+    /* cleanup */
+    sr_unsubscribe(session, subscription);
+    sr_session_stop(session);
+}
+
+static void
 cl_partial_covered_dp_subtree(void **state)
 {
     sr_conn_ctx_t *conn = *state;
@@ -3072,6 +3137,7 @@ main()
         cmocka_unit_test_setup_teardown(cl_nested_data_subscription2, sysrepo_setup, sysrepo_teardown),
         cmocka_unit_test_setup_teardown(cl_nested_data_subscription2_tree, sysrepo_setup, sysrepo_teardown),
         cmocka_unit_test_setup_teardown(cl_all_state_data, sysrepo_setup, sysrepo_teardown),
+        cmocka_unit_test_setup_teardown(cl_request_id, sysrepo_setup, sysrepo_teardown),
         cmocka_unit_test_setup_teardown(cl_partial_covered_dp_subtree, sysrepo_setup, sysrepo_teardown),
         cmocka_unit_test_setup_teardown(cl_missing_list_dp, sysrepo_setup, sysrepo_teardown),
         cmocka_unit_test_setup_teardown(cl_subscribe_list_in_state_container_dp, sysrepo_setup, sysrepo_teardown),

--- a/tests/cl_test.c
+++ b/tests/cl_test.c
@@ -4151,7 +4151,7 @@ cl_enable_empty_startup(void **state)
 }
 
 static int
-dp_get_items_cb(const char *xpath, sr_val_t **values, size_t *values_cnt, void *private_ctx)
+dp_get_items_cb(const char *xpath, sr_val_t **values, size_t *values_cnt, uint64_t request_id, void *private_ctx)
 {
     printf("operational data for '%s' requested.\n", xpath);
 

--- a/tests/measure_performance.c
+++ b/tests/measure_performance.c
@@ -181,7 +181,7 @@ typedef struct dp_setup_s {
 
 
 int
-data_provide_cb(const char *xpath, sr_val_t **values, size_t *values_cnt, void *private_ctx)
+data_provide_cb(const char *xpath, sr_val_t **values, size_t *values_cnt, uint64_t request_id, void *private_ctx)
 {
     size_t if_count = *((size_t *) private_ctx);
     int rc = SR_ERR_OK;


### PR DESCRIPTION
### Description
 When a data request is made, sysrepo will ask to a subscriber for each level under the subscription, calling the subscriber's callback once per layer.

There are cases when this is a problem, because we can not be sure if the data is consistent, as it was asked for in several separate requests.

This patch series adds the request_id from the originating get_item request to the sr_dp_get_items_cb prototype. Then, the subscriber can know if his callback is called for one state data request or several by checking the given request id. The subscriber can take the necessary mesure to ensure the data is consistent.
It also changes the way data request message id are calculated. It is now increasing with the global number of messages sent, and is not per session.

Note that those patches breaks the API, as the sr_dp_get_items_cb prototype has a new request id argument.

### Test case
A new test has been added, named cl_request_id, part of cl_state_data_test. This test checks that several callbacks called for one request have the same request id, and that another request has another request id.
The sysrepo unit tests are 100% after this patch series, including the new test. I have not made other tests.