### PR TITLE
Support notifications tied to data nodes

### DIFF
--- a/inc/sysrepo.h
+++ b/inc/sysrepo.h
@@ -94,6 +94,7 @@ typedef enum sr_type_e {
     SR_CONTAINER_T,            /**< Non-presence container. ([RFC 6020 sec 7.5](http://tools.ietf.org/html/rfc6020#section-7.5)) */
     SR_CONTAINER_PRESENCE_T,   /**< Presence container. ([RFC 6020 sec 7.5.1](http://tools.ietf.org/html/rfc6020#section-7.5.1)) */
     SR_LEAF_EMPTY_T,           /**< A leaf that does not hold any value ([RFC 6020 sec 9.11](http://tools.ietf.org/html/rfc6020#section-9.11)) */
+    SR_NOTIFICATION_T,         /**< Notification instance ([RFC 7095 sec 7.16](https://tools.ietf.org/html/rfc7950#section-7.16)) */
 
     /* types containing some data */
     SR_BINARY_T,       /**< Base64-encoded binary data ([RFC 6020 sec 9.8](http://tools.ietf.org/html/rfc6020#section-9.8)) */

--- a/src/common/sr_utils.c
+++ b/src/common/sr_utils.c
@@ -1537,6 +1537,9 @@ sr_copy_node_to_tree_internal(const struct lyd_node *top_parent, const struct ly
         case LYS_LIST:
             sr_tree->type = SR_LIST_T;
             break;
+        case LYS_NOTIF:
+            sr_tree->type = SR_NOTIFICATION_T;
+            break;
         case LYS_ANYXML:
         case LYS_ANYDATA:
             sch_any = (struct lyd_node_anydata *) node;

--- a/src/rp_dt_get.c
+++ b/src/rp_dt_get.c
@@ -100,6 +100,9 @@ rp_dt_get_value_from_node(struct lyd_node *node, sr_val_t *val)
         val->type = sch_cont->presence == NULL ? SR_CONTAINER_T : SR_CONTAINER_PRESENCE_T;
         val->dflt = node->dflt;
         break;
+    case LYS_NOTIF:
+        val->type = SR_NOTIFICATION_T;
+        break;
     case LYS_LIST:
         val->type = SR_LIST_T;
         break;
@@ -151,20 +154,20 @@ rp_dt_get_values_from_nodes(sr_mem_ctx_t *sr_mem, struct ly_set *nodes, sr_val_t
     }
 
     for (size_t i = 0; i < nodes->number; i++) {
-        vals[i]._sr_mem = sr_mem;
+        vals[cnt]._sr_mem = sr_mem;
         node = nodes->set.d[i];
         if (NULL == node || NULL == node->schema || LYS_RPC == node->schema->nodetype ||
             LYS_NOTIF == node->schema->nodetype || LYS_ACTION == node->schema->nodetype) {
             /* ignore this node */
             continue;
         }
-        rc = rp_dt_get_value_from_node(node, &vals[i]);
+        rc = rp_dt_get_value_from_node(node, &vals[cnt]);
         if (SR_ERR_OK != rc) {
             SR_LOG_ERR("Getting value from node %s failed", node->schema->name);
             if (sr_mem) {
                 sr_mem_restore(&snapshot);
             } else {
-                sr_free_values(vals, i);
+                sr_free_values(vals, cnt);
             }
             return SR_ERR_INTERNAL;
         }


### PR DESCRIPTION
### Description
These changes fix a few cases where _sysrepo_ was not processing notifications connected to a data node. (Support for this was added beginning in RFC 7950.)

Summary of changes:

* `LYS_NOTIF` cases were added to `sr_copy_node_to_tree_internal()` and `rp_dt_get_value_from_node()`. Previously, these functions were treating this node type as unsupported and returning with an error.

* `rp_dt_get_values_from_nodes()` was modified so that it does not produce a `values` array with blank entries for skipped nodes (like notifications). Prior to this fix, it was correctly reporting the number of non-blank values in the array via `value_cnt`, but the array itself would actually be larger due to the blank (skipped) entries.

### Test cases
We've written integration tests that demonstrate these types of notifications. This commit, together with https://github.com/CESNET/libnetconf2/pull/70, will allow those failing test cases to pass. (See [CI results], lines 7282-7284, or [test source code].) These test cases cover several different variations of notifications tied to data nodes.

[CI results]: https://travis-ci.org/ADTRAN/netopeer2-integration-tests/builds/414144146#L7282
[test source code]: https://github.com/ADTRAN/netopeer2-integration-tests/blob/master/tests/test_notif.py#L233

### Closure
Fixes #1261 