### PR TITLE
Validate inverse data dependencies on commit

### DIFF
--- a/tests/cl_test.c
+++ b/tests/cl_test.c
@@ -5426,6 +5426,16 @@ cl_cross_module_dependency(void **state)
     rc = sr_validate(session);
     assert_int_equal(SR_ERR_OK, rc);
 
+    /* clean data */
+    rc = sr_delete_item(session, "/referenced-data:*", SR_EDIT_DEFAULT);
+    assert_int_equal(rc, SR_ERR_OK);
+
+    rc = sr_delete_item(session, "/cross-module:*", SR_EDIT_DEFAULT);
+    assert_int_equal(rc, SR_ERR_OK);
+
+    rc = sr_commit(session);
+    assert_int_equal(SR_ERR_OK, rc);
+
     sr_session_stop(session);
 }
 


### PR DESCRIPTION
### Description
Whenever a module is changed, any other modules that have data dependencies on that module should also be checked to ensure their data references are still valid.

There is a bit of a performance penalty for doing this, and ideally one would only check the inverse deps if the specific nodes being referenced were changed. That is an optimization that could be done in the future.

### Test case
These changes will cause the failing test case `test_create_resolved_data_and_removing_referenced_data_is_error` in https://github.com/ADTRAN/netopeer2-integration-tests to pass.

### Closure
Fixes #1242
