### PR TITLE
CHANGE Getting data according to XPath

### DIFF
--- a/src/rp_dt_get.c
+++ b/src/rp_dt_get.c
@@ -698,7 +698,7 @@ rp_dt_xpath_requests_state_data(rp_ctx_t *rp_ctx, rp_session_t *session, dm_sche
     schema_xpath = ly_path_data2schema(schema_info->ly_ctx, xpath);
     if (NULL == schema_xpath) {
         SR_LOG_ERR("Failed to transform data path '%s' to schema path", xpath);
-        rc = SR_ERR_INVAL_ARG;
+        rc = SR_ERR_NOT_FOUND;
         goto cleanup;
     }
 


### PR DESCRIPTION
When the given data path cannot be transformed to the schema path,
better return SR_ERR_NOT_FOUND instead of SR_ERR_INVAL_ARG. The data
path string can be invalid, but in most cases it just refers to some
data that are not present, so SR_ERR_NOT_FOUND is expected for such a
situations.

Netopeer server uses XPaths for filterring get operations. RFC is not
explicit about filters selecting non existing schema nodes, but I
believe it should rather ignore the particular filter and just simply do
not provide output data for such a filter. Ignoring SR_ERR_INVAL_ARG
seems like ignoring any possible internal error (e.g. passing invalid
function arguments), so I would prefer to have SR_ERR_NOT_FOUND for
this.

Maybe the patch actually does not cover all the possible cases corresponding to my description. Please let me know about other suitable cases to change or change my patch.