### PR TITLE
Use different return value for non-existing schema node

### DIFF
--- a/src/rp_dt_get.c
+++ b/src/rp_dt_get.c
@@ -698,7 +698,7 @@ rp_dt_xpath_requests_state_data(rp_ctx_t *rp_ctx, rp_session_t *session, dm_sche
     schema_xpath = ly_path_data2schema(schema_info->ly_ctx, xpath);
     if (NULL == schema_xpath) {
         SR_LOG_ERR("Failed to transform data path '%s' to schema path", xpath);
-        rc = SR_ERR_INVAL_ARG;
+        rc = SR_ERR_BAD_ELEMENT;
         goto cleanup;
     }
 

--- a/tests/sysrepocfg_test.c
+++ b/tests/sysrepocfg_test.c
@@ -433,7 +433,7 @@ srcfg_test_xpath(void **state)
         printf("Error by sr_session_refresh %s\n", sr_strerror(rc));
     };
     rc = sr_get_item(srcfg_test_session, "/ietf-interfaces:interfaces/interface[name='eth0']/ietf-ip:ipv4/fakeleaf", &rvalue);
-    assert_int_equal(rc, SR_ERR_INVAL_ARG);
+    assert_int_equal(rc, SR_ERR_BAD_ELEMENT);
     sr_free_val(rvalue);
     rvalue = NULL;
 


### PR DESCRIPTION
### Description
This differentiation is required for netopeer2-server.