### PR TITLE
Store relative paths in sysrepo-module-dependencies

### DIFF
--- a/src/common/sr_utils.h
+++ b/src/common/sr_utils.h
@@ -26,9 +26,6 @@
 #include <stdarg.h>
 #include <stdio.h>
 #include <stdbool.h>
-//! @cond doxygen_suppress
-#define __USE_XOPEN
-//! @endcond
 #include <time.h>
 
 #include <libyang/libyang.h>


### PR DESCRIPTION
Cross-compiles typically build sysrepo twice -- once for the host system (the machien doing the build), and once for the target (the machine which will run sysrepod in the end). The host build often runs with the repository location set to something like `${TARGET}/etc/sysrepo` where `${TARGET}` is a directory which will become the target's root filesystem.

Sysrepo creates one private data file which contains absolute paths to YANG schemas of all known modules. If we therefore use host's binaries to manage the target's upcoming repository, sysrepo stores host's paths in there. This makes sysrepod explode on target later on.

Previously, with the XML backend, I used to simply `sed` away the host's paths at image creation time. That way I could always use host's tools prior to finishing the image, and then execute a simple fixup just prior to deploying the image on the target. This no longer works when using the LYB serialization which is a new default.

This patch ensures that the paths stored in the repository are relative to the schema search dir. They are still being converted to an absolute path right after reading so that the rest of the code doesn't have to change.

The actual code cannot use `asprintf` because the existing code doesn't define neither `_BSD_SOURCE` nor `_GNU_SOURCE` and I'm too afraid to add that.

Fixes: #1274