### PR TITLE
Modify rp_dt_reload_nacm() to wait for request to be processed

### DIFF
--- a/src/common/sr_data_structs.c
+++ b/src/common/sr_data_structs.c
@@ -534,6 +534,23 @@ sr_cbuff_dequeue(sr_cbuff_t *buffer, void *item)
     return true;
 }
 
+bool
+sr_cbuff_search(sr_cbuff_t *buffer, void *item)
+{
+    if (NULL == buffer || 0 == buffer->count) {
+        return false;
+    }
+
+    for (size_t i = 0; i < buffer->count; ++i) {
+        if (item == ((uint8_t*)buffer->data + (buffer->head * buffer->elem_size * i))) {
+            SR_LOG_DBG("item: %p found in buffer: %p", item, (void*)buffer);
+            return true;
+        }
+    }
+    SR_LOG_DBG("item: %p not found in buffer: %p", item, (void*)buffer);
+    return false;
+}
+
 size_t
 sr_cbuff_items_in_queue(sr_cbuff_t *buffer)
 {

--- a/src/common/sr_data_structs.h
+++ b/src/common/sr_data_structs.h
@@ -315,6 +315,18 @@ int sr_cbuff_enqueue(sr_cbuff_t *buffer, void *item);
 bool sr_cbuff_dequeue(sr_cbuff_t *buffer, void *item);
 
 /**
+ * @brief Searches for an element in the circular buffer.
+ *
+ * @note O(n).
+ *
+ * @param[in] buffer Circular buffer queue context.
+ * @param[in] item The element that is to be searched for in the buffer.
+ *
+ * @return true if an element was found, false if the element is not found.
+ */
+bool sr_cbuff_search(sr_cbuff_t *buffer, void *item);
+
+/**
  * @brief Return number of elements currently stored in the queue.
  *
  * @note O(1).

--- a/src/connection_manager.c
+++ b/src/connection_manager.c
@@ -2084,6 +2084,20 @@ cm_msg_send(cm_ctx_t *cm_ctx, Sr__Msg *msg)
     return rc;
 }
 
+bool
+cm_msg_search(cm_ctx_t *cm_ctx, Sr__Msg *msg)
+{
+    bool search_result = false;
+
+    if (cm_ctx != NULL && msg != NULL) {
+        pthread_mutex_lock(&cm_ctx->msg_queue_mutex);
+        search_result = sr_cbuff_search(cm_ctx->msg_queue, &msg);
+        pthread_mutex_unlock(&cm_ctx->msg_queue_mutex);
+    }
+
+    return search_result;
+}
+
 int
 cm_watch_signal(cm_ctx_t *cm_ctx, int signum, cm_signal_cb callback)
 {

--- a/src/connection_manager.h
+++ b/src/connection_manager.h
@@ -44,6 +44,7 @@
 
 #include "sysrepo.pb-c.h"
 #include "cm_session_manager.h"
+#include <stdbool.h>
 
 /**
  * @brief Connection Manager context used to identify particular instance of
@@ -137,6 +138,19 @@ int cm_stop(cm_ctx_t *cm_ctx);
  * @return Error code (SR_ERR_OK on success).
  */
 int cm_msg_send(cm_ctx_t *cm_ctx, Sr__Msg *msg);
+
+/**
+ * @brief Checks the Connection Manager context to see if the message
+ * is still in the buffer.
+ *
+ * @note This function is thread safe, can be called from any thread.
+ *
+ * @param[in] cm_ctx Connection Manager context.
+ * @param[in] msg Message to search for.
+ *
+ * @return true if the msg exists in the buffer, false if it does not exist.
+ */
+bool cm_msg_search(cm_ctx_t *cm_ctx, Sr__Msg *msg);
 
 /**
  * @brief Callback to be called when a watched signal (registered with

--- a/src/rp_dt_edit.c
+++ b/src/rp_dt_edit.c
@@ -771,7 +771,8 @@ cleanup:
 }
 
 /**
- * @brief Reload NACM configuration (asynchronous, sends a request to the request processor).
+ * @brief Reload NACM configuration (sends a request to the request processor
+ * and waits for it to be fully processed).
  */
 static int
 rp_dt_reload_nacm(rp_ctx_t *rp_ctx)
@@ -788,6 +789,11 @@ rp_dt_reload_nacm(rp_ctx_t *rp_ctx)
     }
     if (SR_ERR_OK != rc) {
         SR_LOG_ERR_MSG("Unable to send a request to reload the running NACM configuration.");
+    }
+
+    /* wait until the NACM ctx has been reloaded */
+    while (cm_msg_search(rp_ctx->cm_ctx, req)) {
+        usleep(250);
     }
 
     return rc;

--- a/src/rp_dt_edit.c
+++ b/src/rp_dt_edit.c
@@ -29,6 +29,7 @@
 #include <pthread.h>
 #include <libyang/libyang.h>
 #include <inttypes.h>
+#include <time.h>
 
 /**
  * @brief Checks if the schema node has a key node with the specified name
@@ -779,6 +780,7 @@ rp_dt_reload_nacm(rp_ctx_t *rp_ctx)
 {
     Sr__Msg *req = NULL;
     int rc = SR_ERR_OK;
+    struct timespec ts;
     CHECK_NULL_ARG(rp_ctx);
 
     /* setup the timer */
@@ -793,7 +795,9 @@ rp_dt_reload_nacm(rp_ctx_t *rp_ctx)
 
     /* wait until the NACM ctx has been reloaded */
     while (cm_msg_search(rp_ctx->cm_ctx, req)) {
-        usleep(250);
+        ts.tv_sec = 0;
+        ts.tv_nsec = 250000;
+        nanosleep(&ts, NULL);
     }
 
     return rc;


### PR DESCRIPTION
Fixes #1278

This commit modifies `rp_dt_reload_nacm()` to wait until the NACM request has been fully processed before returning.

(Patch by @bhart3.)