### PR TITLE
add java package support

### DIFF
--- a/swig/java/CMakeLists.txt
+++ b/swig/java/CMakeLists.txt
@@ -12,9 +12,9 @@ set(CMAKE_SWIG_FLAGS "-c++")
 set(CMAKE_SWIG_FLAGS "-I${PROJECT_SOURCE_DIR}")
 set(CMAKE_SWIG_OUTDIR "${CMAKE_CURRENT_BINARY_DIR}")
 
-set_source_files_properties(${JAVA_SWIG_BINDING}.i PROPERTIES CPLUSPLUS ON)
+set_source_files_properties(${JAVA_SWIG_BINDING}.i PROPERTIES CPLUSPLUS ON SWIG_FLAGS "-package;com.sysrepo")
 
-file(MAKE_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/classes")
+file(MAKE_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/com/sysrepo")
 
 swig_add_module(${JAVA_SWIG_BINDING} java ${JAVA_SWIG_BINDING}.i)
 set_target_properties(${SWIG_MODULE_${JAVA_SWIG_BINDING}_REAL_NAME} PROPERTIES PREFIX "")
@@ -22,7 +22,7 @@ swig_link_libraries(${JAVA_SWIG_BINDING} ${JAVA_LIBRARIES} Sysrepo-cpp)
 
 file(COPY "examples" DESTINATION "${CMAKE_CURRENT_BINARY_DIR}")
 
-add_custom_command(TARGET ${JAVA_SWIG_BINDING} POST_BUILD COMMAND "${Java_JAVAC_EXECUTABLE}" -d classes *.java COMMAND "${Java_JAR_EXECUTABLE}" -cfM Sysrepo.jar -C classes . )
+add_custom_command(TARGET ${JAVA_SWIG_BINDING} POST_BUILD COMMAND "${Java_JAVAC_EXECUTABLE}" *.java -d . COMMAND "${Java_JAR_EXECUTABLE}" -cvf Sysrepo.jar com)
 set(NATIVE_JAR "${CMAKE_CURRENT_BINARY_DIR}/Sysrepo.jar")
 
 # install so file

--- a/swig/java/examples/javaApplicationChangesExample.java
+++ b/swig/java/examples/javaApplicationChangesExample.java
@@ -18,6 +18,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import com.sysrepo.*;
 
 import java.io.*;
 import java.util.Scanner;
@@ -108,7 +109,8 @@ class My_Callback extends Callback {
  * Here it is useful because `Conenction`, `Session` and `Subscribe` could throw an exception. */
 public class javaApplicationChangesExample {
 	static {
-		System.loadLibrary("libsysrepoJava");
+		System.loadLibrary("sysrepoJava");
+		// System.loadLibrary("libsysrepoJava");
 	}
 	public static void main(String argv[]) {
 		try {

--- a/swig/java/examples/javaApplicationExample.java
+++ b/swig/java/examples/javaApplicationExample.java
@@ -18,6 +18,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import com.sysrepo.*;
 
 import java.io.*;
 import java.util.Scanner;
@@ -51,7 +52,8 @@ class My_Callback extends Callback {
  * Here it is useful because `Conenction`, `Session` and `Subscribe` could throw an exception. */
 public class javaApplicationExample {
 	static {
-		System.loadLibrary("libsysrepoJava");
+		System.loadLibrary("sysrepoJava");
+		// System.loadLibrary("libsysrepoJava");
 	}
 	public static void main(String argv[]) {
 		try {

--- a/swig/java/tests/Changes.java
+++ b/swig/java/tests/Changes.java
@@ -1,3 +1,5 @@
+import com.sysrepo.*;
+
 import java.io.*;
 import org.junit.Test;
 import java.util.Scanner;

--- a/swig/java/tests/Operations.java
+++ b/swig/java/tests/Operations.java
@@ -1,3 +1,5 @@
+import com.sysrepo.*;
+
 import java.io.*;
 import org.junit.Test;
 import java.util.Scanner;

--- a/swig/swig_base/java_base.i
+++ b/swig/swig_base/java_base.i
@@ -19,27 +19,27 @@
 %warnfilter(477);
 
 %typemap(javadirectorin) std::shared_ptr<Session> "new $typemap(jstype, Session)($1,false)";
-%typemap(directorin,descriptor="L$typemap(jstype, Session);") std::shared_ptr<Session> %{
+%typemap(directorin,descriptor="L$packagepath/$typemap(jstype, Session);") std::shared_ptr<Session> %{
   *($&1_type*)&j$1 = &$1;
 %}
 
 %typemap(javadirectorin) std::shared_ptr<Vals> "new $typemap(jstype, Vals)($1,false)";
-%typemap(directorin,descriptor="L$typemap(jstype, Vals);") std::shared_ptr<Vals> %{
+%typemap(directorin,descriptor="L$packagepath/$typemap(jstype, Vals);") std::shared_ptr<Vals> %{
   *($&1_type*)&j$1 = &$1;
 %}
 
 %typemap(javadirectorin) std::shared_ptr<Vals_Holder> "new $typemap(jstype, Vals_Holder)($1,false)";
-%typemap(directorin,descriptor="L$typemap(jstype, Vals_Holder);") std::shared_ptr<Vals_Holder> %{
+%typemap(directorin,descriptor="L$packagepath/$typemap(jstype, Vals_Holder);") std::shared_ptr<Vals_Holder> %{
   *($&1_type*)&j$1 = &$1;
 %}
 
 %typemap(javadirectorin) std::shared_ptr<Trees> "new $typemap(jstype, Trees)($1,false)";
-%typemap(directorin,descriptor="L$typemap(jstype, Trees);") std::shared_ptr<Trees> %{
+%typemap(directorin,descriptor="L$packagepath/$typemap(jstype, Trees);") std::shared_ptr<Trees> %{
   *($&1_type*)&j$1 = &$1;
 %}
 
 %typemap(javadirectorin) std::shared_ptr<Trees_Holder> "new $typemap(jstype, Trees_Holder)($1,false)";
-%typemap(directorin,descriptor="L$typemap(jstype, Trees_Holder);") std::shared_ptr<Trees_Holder> %{
+%typemap(directorin,descriptor="L$packagepath/$typemap(jstype, Trees_Holder);") std::shared_ptr<Trees_Holder> %{
   *($&1_type*)&j$1 = &$1;
 %}
 


### PR DESCRIPTION
Because most Java applications have packages, it is necessary to add packages to the swig extension of Java.
The example and test cases are running correctly.
