### PR TITLE
C++: fix segfaults on std::string(nullptr) and an associated cleanup

### DIFF
--- a/swig/cpp/src/Internal.cpp
+++ b/swig/cpp/src/Internal.cpp
@@ -105,5 +105,4 @@ Deleter::~Deleter() {
     v._sess = nullptr;
     break;
     }
-    return;
 }

--- a/swig/cpp/src/Session.cpp
+++ b/swig/cpp/src/Session.cpp
@@ -140,24 +140,26 @@ S_Yang_Schemas Session::list_schemas()
     }
 }
 
-S_String Session::get_schema(const char *module_name, const char *revision,\
+std::string Session::get_schema(const char *module_name, const char *revision,\
                                const char *submodule_name, sr_schema_format_t format)
 {
     char *mem = nullptr;
 
     int ret = sr_get_schema(_sess, module_name, revision, submodule_name, format, &mem);
     if (SR_ERR_OK == ret) {
-        if (mem == nullptr)
-            return nullptr;
-        S_String string_val = mem;
+        if (mem == nullptr) {
+            return std::string();
+        }
+        std::string string_val = mem;
         free(mem);
         return string_val;
-    } else if (SR_ERR_NOT_FOUND == ret) {
-        return nullptr;
-    } else {
-        throw_exception(ret);
-        return nullptr;
     }
+
+    if (SR_ERR_NOT_FOUND == ret) {
+        return std::string();
+    }
+
+    throw_exception(ret);
 }
 
 S_Val Session::get_item(const char *xpath)

--- a/swig/cpp/src/Session.cpp
+++ b/swig/cpp/src/Session.cpp
@@ -66,7 +66,6 @@ Session::Session(S_Connection conn, sr_datastore_t datastore, const sr_sess_opti
 
 cleanup:
     throw_exception(ret);
-    return;
 }
 
 Session::Session(sr_session_ctx_t *sess, sr_sess_options_t opts, S_Deleter deleter)
@@ -101,12 +100,11 @@ S_Error Session::get_last_error()
     int ret = sr_get_last_error(_sess, &error->_info);
     if (SR_ERR_OK == ret) {
         return error;
-    } else if (SR_ERR_NOT_FOUND == ret) {
-        return nullptr;
-    } else {
-        throw_exception(ret);
+    }
+    if (SR_ERR_NOT_FOUND == ret) {
         return nullptr;
     }
+    throw_exception(ret);
 }
 
 S_Errors Session::get_last_errors()
@@ -116,12 +114,11 @@ S_Errors Session::get_last_errors()
     int ret = sr_get_last_errors(_sess, &errors->_info, &errors->_cnt);
     if (SR_ERR_OK == ret) {
         return errors;
-    } else if (SR_ERR_NOT_FOUND == ret) {
-        return nullptr;
-    } else {
-        throw_exception(ret);
+    }
+    if (SR_ERR_NOT_FOUND == ret) {
         return nullptr;
     }
+    throw_exception(ret);
 }
 
 S_Yang_Schemas Session::list_schemas()
@@ -132,12 +129,11 @@ S_Yang_Schemas Session::list_schemas()
     if (SR_ERR_OK == ret) {
         schema->_deleter = std::make_shared<Deleter>(schema->_sch, schema->_cnt);
         return schema;
-    } else if (SR_ERR_NOT_FOUND == ret) {
-        return nullptr;
-    } else {
-        throw_exception(ret);
+    }
+    if (SR_ERR_NOT_FOUND == ret) {
         return nullptr;
     }
+    throw_exception(ret);
 }
 
 std::string Session::get_schema(const char *module_name, const char *revision,\
@@ -154,11 +150,9 @@ std::string Session::get_schema(const char *module_name, const char *revision,\
         free(mem);
         return string_val;
     }
-
     if (SR_ERR_NOT_FOUND == ret) {
         return std::string();
     }
-
     throw_exception(ret);
 }
 
@@ -170,12 +164,11 @@ S_Val Session::get_item(const char *xpath)
     if (SR_ERR_OK == ret) {
         value->_deleter = std::make_shared<Deleter>(value->_val);
         return value;
-    } else if (SR_ERR_NOT_FOUND == ret) {
-        return nullptr;
-    } else {
-        throw_exception(ret);
+    }
+    if (SR_ERR_NOT_FOUND == ret) {
         return nullptr;
     }
+    throw_exception(ret);
 }
 S_Vals Session::get_items(const char *xpath)
 {
@@ -185,12 +178,11 @@ S_Vals Session::get_items(const char *xpath)
     if (SR_ERR_OK == ret) {
         values->_deleter = std::make_shared<Deleter>(values->_vals, values->_cnt);
         return values;
-    } else if (SR_ERR_NOT_FOUND == ret) {
-        return nullptr;
-    } else {
-        throw_exception(ret);
+    }
+    if (SR_ERR_NOT_FOUND == ret) {
         return nullptr;
     }
+    throw_exception(ret);
 }
 
 S_Iter_Value Session::get_items_iter(const char *xpath)
@@ -200,12 +192,11 @@ S_Iter_Value Session::get_items_iter(const char *xpath)
     int ret = sr_get_items_iter(_sess, xpath, &iter->_iter);
     if (SR_ERR_OK == ret) {
         return iter;
-    } else if (SR_ERR_NOT_FOUND == ret) {
-        return nullptr;
-    } else {
-        throw_exception(ret);
+    }
+    if (SR_ERR_NOT_FOUND == ret) {
         return nullptr;
     }
+    throw_exception(ret);
 }
 
 S_Val Session::get_item_next(S_Iter_Value iter)
@@ -216,12 +207,11 @@ S_Val Session::get_item_next(S_Iter_Value iter)
     if (SR_ERR_OK == ret) {
         value->_deleter = std::make_shared<Deleter>(value->_val);
         return value;
-    } else if (SR_ERR_NOT_FOUND == ret) {
-        return nullptr;
-    } else {
-        throw_exception(ret);
-    return nullptr;
     }
+    if (SR_ERR_NOT_FOUND == ret) {
+        return nullptr;
+    }
+    throw_exception(ret);
 }
 
 S_Tree Session::get_subtree(const char *xpath, sr_get_subtree_options_t opts)
@@ -232,14 +222,11 @@ S_Tree Session::get_subtree(const char *xpath, sr_get_subtree_options_t opts)
     if (SR_ERR_OK == ret) {
         tree->_deleter = std::make_shared<Deleter>(tree->_node);
         return tree;
-    } else if (SR_ERR_NOT_FOUND == ret) {
-        return nullptr;
-    } else {
-        throw_exception(ret);
-    return nullptr;
     }
-
-    return tree;
+    if (SR_ERR_NOT_FOUND == ret) {
+        return nullptr;
+    }
+    throw_exception(ret);
 }
 
 S_Trees Session::get_subtrees(const char *xpath, sr_get_subtree_options_t opts)
@@ -250,14 +237,11 @@ S_Trees Session::get_subtrees(const char *xpath, sr_get_subtree_options_t opts)
     if (SR_ERR_OK == ret) {
         trees->_deleter = std::make_shared<Deleter>(trees->_trees, trees->_cnt);
         return trees;
-    } else if (SR_ERR_NOT_FOUND == ret) {
-        return nullptr;
-    } else {
-        throw_exception(ret);
-    return nullptr;
     }
-
-    return trees;
+    if (SR_ERR_NOT_FOUND == ret) {
+        return nullptr;
+    }
+    throw_exception(ret);
 }
 
 S_Tree Session::get_child(S_Tree in_tree)
@@ -398,12 +382,11 @@ S_Iter_Change Session::get_changes_iter(const char *xpath)
     int ret = sr_get_changes_iter(_sess, xpath, &iter->_iter);
     if (SR_ERR_OK == ret) {
         return iter;
-    } else if (SR_ERR_NOT_FOUND == ret) {
-        return nullptr;
-    } else {
-        throw_exception(ret);
+    }
+    if (SR_ERR_NOT_FOUND == ret) {
         return nullptr;
     }
+    throw_exception(ret);
 }
 
 S_Change Session::get_change_next(S_Iter_Change iter)
@@ -413,12 +396,11 @@ S_Change Session::get_change_next(S_Iter_Change iter)
     int ret = sr_get_change_next(_sess, iter->_iter, &change->_oper, &change->_old, &change->_new);
     if (SR_ERR_OK == ret) {
         return change;
-    } else if (SR_ERR_NOT_FOUND == ret) {
-        return nullptr;
-    } else {
-        throw_exception(ret);
+    }
+    if (SR_ERR_NOT_FOUND == ret) {
         return nullptr;
     }
+    throw_exception(ret);
 }
 
 Session::~Session() {}

--- a/swig/cpp/src/Session.h
+++ b/swig/cpp/src/Session.h
@@ -50,8 +50,8 @@ public:
     S_Error get_last_error();
     S_Errors get_last_errors();
     S_Yang_Schemas list_schemas();
-    S_String get_schema(const char *module_name, const char *revision,\
-                               const char *submodule_name, sr_schema_format_t format);
+    std::string get_schema(const char *module_name, const char *revision,
+                           const char *submodule_name, sr_schema_format_t format);
     S_Val get_item(const char *xpath);
     S_Vals get_items(const char *xpath);
     S_Iter_Value get_items_iter(const char *xpath);

--- a/swig/cpp/src/Struct.cpp
+++ b/swig/cpp/src/Struct.cpp
@@ -479,30 +479,29 @@ void Val::set(const char *xpath, uint64_t uint64_val, sr_type_t type) {
 
     _val->type = type;
 }
-S_String Val::to_string() {
+std::string Val::to_string() {
     char *mem = nullptr;
 
     int ret = sr_print_val_mem(&mem, _val);
     if (SR_ERR_OK == ret) {
-        if (mem == nullptr)
-            return nullptr;
-        S_String string_val = mem;
+        if (!mem) {
+            return std::string();
+        }
+        std::string string_val = mem;
         free(mem);
         return string_val;
-    } else if (SR_ERR_NOT_FOUND == ret) {
-        return nullptr;
-    } else {
-        throw_exception(ret);
+    }
+    if (SR_ERR_NOT_FOUND == ret) {
         return nullptr;
     }
+    throw_exception(ret);
 }
-S_String Val::val_to_string() {
+std::string Val::val_to_string() {
     char *value = sr_val_to_str(_val);
     if (value == nullptr) {
         throw_exception(SR_ERR_OPERATION_FAILED);
-        return nullptr;
     }
-    S_String string_val = value;
+    std::string string_val = value;
     free(value);
 
     return string_val;

--- a/swig/cpp/src/Struct.h
+++ b/swig/cpp/src/Struct.h
@@ -96,8 +96,8 @@ public:
     bool dflt() {return _val->dflt;};
     void dflt_set(bool data) {_val->dflt = data;};
     S_Data data() {S_Data data(new Data(_val->data, _val->type, _deleter)); return data;};
-    S_String to_string();
-    S_String val_to_string();
+    std::string to_string();
+    std::string val_to_string();
     S_Val dup();
 
     friend class Session;

--- a/swig/cpp/src/Sysrepo.h
+++ b/swig/cpp/src/Sysrepo.h
@@ -50,7 +50,6 @@
     #define S_Change           Change*
     #define S_Counter          std::shared_ptr<Counter>
     #define S_Callback         Callback*
-    #define S_String           std::string
 #else
     #define S_Iter_Value       std::shared_ptr<Iter_Value>
     #define S_Iter_Change      std::shared_ptr<Iter_Change>
@@ -79,7 +78,6 @@
     #define S_Change           std::shared_ptr<Change>
     #define S_Counter          std::shared_ptr<Counter>
     #define S_Callback         std::shared_ptr<Callback>
-    #define S_String           std::string
 #endif
 
 #define SESS_DEFAULT 0

--- a/swig/cpp/src/Sysrepo.h
+++ b/swig/cpp/src/Sysrepo.h
@@ -98,7 +98,12 @@ extern "C" {
 #include "sysrepo.h"
 }
 
-void throw_exception(int error);
+#ifdef SWIG
+// https://github.com/swig/swig/issues/1158
+void throw_exception (int error);
+#else
+void throw_exception [[noreturn]] (int error);
+#endif
 
 class sysrepo_exception : public std::runtime_error
 {

--- a/swig/cpp/src/Tree.cpp
+++ b/swig/cpp/src/Tree.cpp
@@ -113,24 +113,24 @@ S_Tree Tree::last_child() {
     S_Tree node(new Tree(_node->last_child, _deleter));
     return node;
 }
-S_String Tree::to_string(int depth_limit) {
+std::string Tree::to_string(int depth_limit) {
     char *mem = nullptr;
 
     int ret = sr_print_tree_mem(&mem, _node, depth_limit);
     if (SR_ERR_OK == ret) {
-        if (mem == nullptr)
-            return nullptr;
-        S_String string_val = mem;
+        if (!mem) {
+            return std::string();
+        }
+        std::string string_val = mem;
         free(mem);
         return string_val;
-    } else if (SR_ERR_NOT_FOUND == ret) {
-        return nullptr;
-    } else {
-        throw_exception(ret);
-        return nullptr;
     }
+    if (SR_ERR_NOT_FOUND == ret) {
+        return std::string();
+    }
+    throw_exception(ret);
 }
-S_String Tree::value_to_string() {
+std::string Tree::value_to_string() {
     char *mem = nullptr;
 
     if (_node == nullptr) throw_exception(SR_ERR_DATA_MISSING);
@@ -139,17 +139,17 @@ S_String Tree::value_to_string() {
 
     int ret = sr_print_val_mem(&mem, val);
     if (SR_ERR_OK == ret) {
-        if (mem == nullptr)
-            return nullptr;
-        S_String string_val = mem;
+        if (!mem) {
+            return std::string();
+        }
+        std::string string_val = mem;
         free(mem);
         return string_val;
-    } else if (SR_ERR_NOT_FOUND == ret) {
-        return nullptr;
-    } else {
-        throw_exception(ret);
+    }
+    if (SR_ERR_NOT_FOUND == ret) {
         return nullptr;
     }
+    throw_exception(ret);
 }
 void Tree::set_name(const char *name) {
     if (_node == nullptr) throw_exception(SR_ERR_DATA_MISSING);

--- a/swig/cpp/src/Tree.h
+++ b/swig/cpp/src/Tree.h
@@ -48,8 +48,8 @@ public:
     S_Tree prev();
     S_Tree first_child();
     S_Tree last_child();
-    S_String to_string(int depth_limit);
-    S_String value_to_string();
+    std::string to_string(int depth_limit);
+    std::string value_to_string();
     void set_name(const char *name);
     void set_module(const char *module_name);
     void set_str_data(sr_type_t type, const char *string_val);


### PR DESCRIPTION
The C++ bindings were returning a `std::string` instance from `nullptr` which results in a crash. While fixing this I got rid of the `S_String` typedef which is not needed, and it actively confusing because it suggests that it's a shared pointer. It is not. While at it :), I also removed some extra returns which followed the exception-throwing wrapper, and cleaned some warnings.

Reported-by: @syyyr