### PR TITLE
sysrepocfg: Fix memleak when editing lists

### DIFF
--- a/src/executables/sysrepocfg.c
+++ b/src/executables/sysrepocfg.c
@@ -654,6 +654,10 @@ srcfg_convert_lydiff_created(struct lyd_node *node)
                                 goto set_value;
                             } else {
                                 /* create list instance (directly) only once - with the first key */
+                                if (SR_UNKNOWN_T != value.type) {
+                                    sr_free_val_content(&value);
+                                    value.type = SR_UNKNOWN_T;
+                                }
                                 goto next_node;
                             }
                         }


### PR DESCRIPTION
Here's the trace from ASAN without this patch:
```
  ERROR: LeakSanitizer: detected memory leaks

  Direct leak of 64 byte(s) in 8 object(s) allocated from:
    #0 0x7fa3c7b01a20 in __interceptor_strdup /var/tmp/portage/sys-devel/gcc-8.1.0-r1/work/gcc-8.1.0/libsanitizer/asan/asan_interceptors.cc:405
    #1 0x7fa3c6dd52a8 in sr_mem_edit_string /home/jkt/work/cesnet/gerrit/CzechLight/cla-sysrepo/submodules/sysrepo/src/common/sr_mem_mgmt.c:526
    #2 0x7fa3c6d4d0dd in sr_libyang_val_str_to_sr_val /home/jkt/work/cesnet/gerrit/CzechLight/cla-sysrepo/submodules/sysrepo/src/common/sr_utils.c:1048
    #3 0x7fa3c6d50227 in sr_libyang_leaf_copy_value /home/jkt/work/cesnet/gerrit/CzechLight/cla-sysrepo/submodules/sysrepo/src/common/sr_utils.c:1198
    #4 0x55c6071e5e0b in srcfg_convert_lydiff_created /home/jkt/work/cesnet/gerrit/CzechLight/cla-sysrepo/submodules/sysrepo/src/executables/sysrepocfg.c:627
    #5 0x55c6071eaec0 in srcfg_import_datastore /home/jkt/work/cesnet/gerrit/CzechLight/cla-sysrepo/submodules/sysrepo/src/executables/sysrepocfg.c:892
    #6 0x55c6071eefd8 in srcfg_import_operation /home/jkt/work/cesnet/gerrit/CzechLight/cla-sysrepo/submodules/sysrepo/src/executables/sysrepocfg.c:1187
    #7 0x55c6071f68bf in main /home/jkt/work/cesnet/gerrit/CzechLight/cla-sysrepo/submodules/sysrepo/src/executables/sysrepocfg.c:2030
    #8 0x7fa3c35f3c4d in __libc_start_main ../csu/libc-start.c:295
```