### PR TITLE
Use stable cmocka version

### DIFF
--- a/deploy/travis/install-libs.sh
+++ b/deploy/travis/install-libs.sh
@@ -18,8 +18,9 @@ if [ ! -d "$INSTALL_PREFIX_DIR/lib" ]; then
     cd ~
 
     # CMocka
-    git clone git://git.cryptomilk.org/projects/cmocka.git
-    cd cmocka ; mkdir build; cd build
+    wget https://cmocka.org/files/1.1/cmocka-1.1.2.tar.xz
+    tar -xf cmocka-1.1.2.tar.xz
+    cd cmocka-1.1.2; mkdir build; cd build
     cmake -DCMAKE_INSTALL_PREFIX=$INSTALL_PREFIX_DIR -DCMAKE_C_FLAGS="-DUNIT_TESTING_DEBUG" ..
     make -j2 > /dev/null && make install
     cd ../..


### PR DESCRIPTION
### Description
Master cmocka was compiled as `cmocka_shared.so` and could not be find by tests.