### PR TITLE
Add Session::set_error()

### DIFF
--- a/swig/cpp/src/Session.cpp
+++ b/swig/cpp/src/Session.cpp
@@ -417,6 +417,14 @@ void Session::set_options(const sr_sess_options_t opts)
     }
 }
 
+void Session::set_error(const char *message, const char *xpath)
+{
+    int ret = sr_set_error(_sess, message, xpath);
+    if (ret != SR_ERR_OK) {
+        throw_exception(ret);
+    }
+}
+
 Subscribe::Subscribe(S_Session sess)
 {
     _sub = nullptr;

--- a/swig/cpp/src/Session.hpp
+++ b/swig/cpp/src/Session.hpp
@@ -120,6 +120,8 @@ public:
     void copy_config(const char *module_name, sr_datastore_t src_datastore, sr_datastore_t dst_datastore);
     /** Wrapper for [sr_session_set_options](@ref sr_session_set_options) */
     void set_options(const sr_sess_options_t opts);
+    /** Wrapper for [sr_set_error](@ref sr_set_error) */
+    void set_error(const char *message, const char *xpath);
     /** Wrapper for [sr_get_changes_iter](@ref sr_get_changes_iter) */
     S_Iter_Change get_changes_iter(const char *xpath);
     /** Wrapper for [sr_get_change_next](@ref sr_get_change_next) */


### PR DESCRIPTION

### Description
Adds set_error() to Session class for returning validation error details

### Test case
It works with Netopeer2. Constructing a test required exposing clientlib internals which involved more hacks than I was comfortable with, so I gave up. I can offer help (on a limited basis) to build out the test infrastructure to enable this, but would need more info about philosophy, etc., plus more experience in general...

### Closure
Closes #1218 

