### PR TITLE
Fixed moved operation display

### DIFF
--- a/swig/cpp/examples/cpp_application_changes_example.cpp
+++ b/swig/cpp/examples/cpp_application_changes_example.cpp
@@ -61,8 +61,15 @@ print_change(sysrepo::S_Change change) {
         }
     break;
     case SR_OP_MOVED:
-        if (nullptr != change->new_val()) {
-        cout<<"MOVED: " << change->new_val()->xpath() << " after " << change->old_val()->xpath() << endl;
+        if (nullptr != change->old_val() && nullptr != change->new_val()) {
+           cout << "MOVED: ";
+           cout << change->new_val()->xpath();
+           cout << " after ";
+           cout << change->old_val()->xpath();
+        } else if (nullptr != change->new_val()) {
+           cout << "MOVED: ";
+           cout << change->new_val()->xpath();
+           cout << " first";
         }
     break;
     }


### PR DESCRIPTION
### Description
The cpp_application_changes_example.cpp crashes on a moved operation to the first place of the list by using the old value which is null in this case.

Fix is trivial. I took the occasion to reformat the moved case code in the style of other cases. Note if the term "first" is not good enough please replace it by a better one.

### Test case
Create a list with int id and string name leaves. Use id as the key and set the by user (vs system) ordering. Create 2 entries: id=1 name="foo" and id=2 name="bar". Launch cpp_application_changes_example and with sysrepocfg changes the id of the first entry from 1 to 10.

The system will produce some changes: delete the first entry, create a new one with id=10 name="foo" and what will cause the crash move the new entry to the first place in the list.

### Closure
None.