### PR TITLE
add originating xpath to sr_dp_get_items_cb

### DIFF
--- a/doc/start.dox
+++ b/doc/start.dox
@@ -204,7 +204,7 @@ the specific changed values.
 @subsection state State Data
 ~~~{.c}
 static int
-oven_state_cb(const char *xpath, sr_val_t **values, size_t *values_cnt, uint64_t request_id, void *private_ctx)
+oven_state_cb(const char *xpath, sr_val_t **values, size_t *values_cnt, uint64_t request_id, const char* original_xpath, void *private_ctx)
 {
     sr_val_t *vals;
     int rc;
@@ -231,7 +231,7 @@ oven_state_cb(const char *xpath, sr_val_t **values, size_t *values_cnt, uint64_t
 The state data callback is self-explaining. It should create and return direct children of the `xpath` parent
 (more in @ref data_providers). As the subscription was only for one container with 2 leaves as children, the `xpath`
 can only have one value and will hence be always the same. `request_id` identifies the initial request which
-triggered this callback.
+triggered this callback. `original_xpath` gives the xpath that was requested in the initial request which triggered this callback.
 
 @subsection rpc RPC Subscriptions
 ~~~{.c}

--- a/examples/oper_data_example.c
+++ b/examples/oper_data_example.c
@@ -33,7 +33,8 @@
 volatile int exit_application = 0;
 
 static int
-data_provider_cb(const char *xpath, sr_val_t **values, size_t *values_cnt, uint64_t request_id, void *private_ctx)
+data_provider_cb(const char *xpath, sr_val_t **values, size_t *values_cnt,
+        uint64_t request_id, const char *original_xpath, void *private_ctx)
 {
     sr_val_t *v = NULL;
     sr_xpath_ctx_t xp_ctx = {0};

--- a/examples/plugins/oven.c
+++ b/examples/plugins/oven.c
@@ -121,7 +121,8 @@ sys_error:
 }
 
 static int
-oven_state_cb(const char *xpath, sr_val_t **values, size_t *values_cnt, uint64_t request_id, void *private_ctx)
+oven_state_cb(const char *xpath, sr_val_t **values, size_t *values_cnt,
+        uint64_t request_id, const char *original_xpath, void *private_ctx)
 {
     sr_val_t *vals;
     int rc;

--- a/inc/sysrepo.h
+++ b/inc/sysrepo.h
@@ -1840,11 +1840,12 @@ int sr_event_notif_replay(sr_session_ctx_t *session, sr_subscription_ctx_t *subs
  * @param[out] values Array of values at the selected level (allocated by the provider).
  * @param[out] values_cnt Number of values returned.
  * @param[in] request_id An ID identifying the originating request.
+ * @param[in] original_xpath The xpath that was asked for in the originating request.
  * @param[in] private_ctx Private context opaque to sysrepo, as passed to ::sr_dp_get_items_subscribe call.
  *
  * @return Error code (SR_ERR_OK on success).
  */
-typedef int (*sr_dp_get_items_cb)(const char *xpath, sr_val_t **values, size_t *values_cnt, uint64_t request_id, void *private_ctx);
+typedef int (*sr_dp_get_items_cb)(const char *xpath, sr_val_t **values, size_t *values_cnt, uint64_t request_id, const char *original_xpath, void *private_ctx);
 
 /**
  * @brief Registers for providing of operational data under given xpath.

--- a/src/clientlib/cl_subscription_manager.c
+++ b/src/clientlib/cl_subscription_manager.c
@@ -818,6 +818,7 @@ cl_sm_dp_request_process(cl_sm_ctx_t *sm_ctx, cl_sm_conn_ctx_t *conn, Sr__Msg *m
             msg->request->data_provide_req->xpath,
             &values, &values_cnt,
             msg->request->data_provide_req->request_id,
+            msg->request->data_provide_req->original_xpath,
             subscription->private_ctx);
 
     pthread_mutex_unlock(&sm_ctx->subscriptions_lock);

--- a/src/notification_processor.c
+++ b/src/notification_processor.c
@@ -1459,6 +1459,40 @@ np_data_provider_request(np_ctx_t *np_ctx, np_subscription_t *subscription, rp_s
             CHECK_NULL_NOMEM_ERROR(req->request->data_provide_req->subscriber_address, rc);
             /* identification of the request that asked for data */
             req->request->data_provide_req->request_id = session->req->request->_id;
+            switch (session->req->request->operation) {
+            case SR__OPERATION__GET_ITEM:
+                if (session->req->request->get_item_req->xpath) {
+                    req->request->data_provide_req->original_xpath = strdup(session->req->request->get_item_req->xpath);
+                    CHECK_NULL_NOMEM_ERROR(req->request->data_provide_req->original_xpath, rc);
+                }
+                break;
+            case SR__OPERATION__GET_ITEMS:
+                if (session->req->request->get_items_req->xpath) {
+                    req->request->data_provide_req->original_xpath = strdup(session->req->request->get_items_req->xpath);
+                    CHECK_NULL_NOMEM_ERROR(req->request->data_provide_req->original_xpath, rc);
+                }
+                break;
+            case SR__OPERATION__GET_SUBTREE:
+                if (session->req->request->get_subtree_req->xpath) {
+                    req->request->data_provide_req->original_xpath = strdup(session->req->request->get_subtree_req->xpath);
+                    CHECK_NULL_NOMEM_ERROR(req->request->data_provide_req->original_xpath, rc);
+                }
+                break;
+            case SR__OPERATION__GET_SUBTREES:
+                if (session->req->request->get_subtrees_req->xpath) {
+                    req->request->data_provide_req->original_xpath = strdup(session->req->request->get_subtrees_req->xpath);
+                    CHECK_NULL_NOMEM_ERROR(req->request->data_provide_req->original_xpath, rc);
+                }
+                break;
+            case SR__OPERATION__GET_SUBTREE_CHUNK:
+                if (session->req->request->get_subtree_chunk_req->xpath) {
+                    req->request->data_provide_req->original_xpath = strdup(session->req->request->get_subtree_chunk_req->xpath);
+                    CHECK_NULL_NOMEM_ERROR(req->request->data_provide_req->original_xpath, rc);
+                }
+                break;
+            default:
+                break;
+            }
         }
     }
 

--- a/src/sysrepo.proto
+++ b/src/sysrepo.proto
@@ -836,6 +836,7 @@ message DataProvideReq {
   required uint32 subscription_id = 11;
 
   required uint64 request_id = 20;
+  required string original_xpath = 21;
 }
 
 /**

--- a/swig/cpp/src/Session.cpp
+++ b/swig/cpp/src/Session.cpp
@@ -495,10 +495,10 @@ static void event_notif_tree_cb(const sr_ev_notif_type_t notif_type, const char 
     Callback *wrap = (Callback*) private_ctx;
     return wrap->event_notif_tree(notif_type, xpath, vals, timestamp, wrap->private_ctx["event_notif_tree"]);
 }
-static int dp_get_items_cb(const char *xpath, sr_val_t **values, size_t *values_cnt, uint64_t request_id, void *private_ctx) {
+static int dp_get_items_cb(const char *xpath, sr_val_t **values, size_t *values_cnt, uint64_t request_id, const char *original_xpath, void *private_ctx) {
     S_Vals_Holder vals(new Vals_Holder(values, values_cnt));
     Callback *wrap = (Callback*) private_ctx;
-    return wrap->dp_get_items(xpath, vals, request_id, wrap->private_ctx["dp_get_items"]);
+    return wrap->dp_get_items(xpath, vals, request_id, original_xpath, wrap->private_ctx["dp_get_items"]);
 }
 
 void Subscribe::module_change_subscribe(const char *module_name, S_Callback callback, \

--- a/swig/cpp/src/Session.hpp
+++ b/swig/cpp/src/Session.hpp
@@ -176,7 +176,7 @@ public:
     /** Wrapper for [sr_action_tree_cb](@ref sr_action_tree_cb) callback.*/
     virtual int action_tree(const char *xpath, const S_Trees input, S_Trees_Holder output, void *private_ctx) {return SR_ERR_OK;};
     /** Wrapper for [sr_dp_get_items_cb](@ref sr_dp_get_items_cb) callback.*/
-    virtual int dp_get_items(const char *xpath, S_Vals_Holder vals, uint64_t request_id, void *private_ctx) {return SR_ERR_OK;};
+    virtual int dp_get_items(const char *xpath, S_Vals_Holder vals, uint64_t request_id, const char *original_xpath, void *private_ctx) {return SR_ERR_OK;};
     /** Wrapper for [sr_event_notif_cb](@ref sr_event_notif_cb) callback.*/
     virtual void event_notif(const sr_ev_notif_type_t notif_type, const char *xpath, S_Vals vals, time_t timestamp, void *private_ctx) {return;};
     /** Wrapper for [sr_event_notif_tree_cb](@ref sr_event_notif_tree_cb) callback.*/

--- a/swig/lua/libsysrepoLua.i
+++ b/swig/lua/libsysrepoLua.i
@@ -192,7 +192,7 @@ public:
         return ret;
     }
 
-    int dp_get_items(const char *xpath, sr_val_t **values, size_t *values_cnt, uint64_t request_id, void *private_ctx) {
+    int dp_get_items(const char *xpath, sr_val_t **values, size_t *values_cnt, uint64_t request_id, const char *original_xpath, void *private_ctx) {
         swiglua_ref_get(&fn);
         if (!lua_isfunction(fn.L,-1)) {
             throw std::runtime_error("Lua error in function callback");
@@ -201,6 +201,7 @@ public:
         lua_pushstring(fn.L, xpath);
         SWIG_NewPointerObj(fn.L, out_vals, SWIGTYPE_p_Vals_Holder, 0);
         lua_pushnumber(fn.L, request_id);
+        lua_pushstring(fn.L, original_xpath);
         SWIG_NewPointerObj(fn.L, private_ctx, SWIGTYPE_p_void, 0);
         lua_call(fn.L, 3, 1);
         out_vals->~Vals_Holder();

--- a/swig/python/sysrepo.i
+++ b/swig/python/sysrepo.i
@@ -264,14 +264,14 @@ public:
     }
 
 
-    int dp_get_items(const char *xpath, sr_val_t **values, size_t *values_cnt, uint64_t request_id, PyObject *private_ctx) {
+    int dp_get_items(const char *xpath, sr_val_t **values, size_t *values_cnt, uint64_t request_id, const char *original_xpath, PyObject *private_ctx) {
         PyObject *arglist;
 
         sysrepo::Vals_Holder *out_vals =(sysrepo::Vals_Holder *)new sysrepo::Vals_Holder(values, values_cnt);
         std::shared_ptr<sysrepo::Vals_Holder> *shared_out_vals = out_vals ? new std::shared_ptr<sysrepo::Vals_Holder>(out_vals) : 0;
         PyObject *out = SWIG_NewPointerObj(SWIG_as_voidptr(shared_out_vals), SWIGTYPE_p_std__shared_ptrT_sysrepo__Vals_Holder_t, SWIG_POINTER_DISOWN);
 
-        arglist = Py_BuildValue("(sOiO)", xpath, out, request_id, private_ctx);
+        arglist = Py_BuildValue("(sOisO)", xpath, out, request_id, original_xpath, private_ctx);
         PyObject *result = PyEval_CallObject(_callback, arglist);
         Py_DECREF(arglist);
         if (result == nullptr) {
@@ -386,10 +386,10 @@ static int g_action_tree_cb(const char *xpath, const sr_node_t *input, const siz
     return ctx->action_tree_cb(xpath, input, input_cnt, output, output_cnt, ctx->private_ctx);
 }
 
-static int g_dp_get_items_cb(const char *xpath, sr_val_t **values, size_t *values_cnt, uint64_t request_id, void *private_ctx)
+static int g_dp_get_items_cb(const char *xpath, sr_val_t **values, size_t *values_cnt, uint64_t request_id, const char *original_xpath, void *private_ctx)
 {
     Wrap_cb *ctx = (Wrap_cb *) private_ctx;
-    return ctx->dp_get_items(xpath, values, values_cnt, request_id, ctx->private_ctx);
+    return ctx->dp_get_items(xpath, values, values_cnt, request_id, original_xpath, ctx->private_ctx);
 }
 
 static void g_event_notif_cb(const sr_ev_notif_type_t notif_type, const char *xpath, const sr_val_t *values, const size_t values_cnt, time_t timestamp, void *private_ctx)

--- a/tests/cl_state_data_test.c
+++ b/tests/cl_state_data_test.c
@@ -293,7 +293,7 @@ provide_seats_reserved(const char *xpath, sr_val_t **values, size_t *values_cnt,
     return 0;
 }
 
-int cl_dp_cpu_load (const char *xpath, sr_val_t **values, size_t *values_cnt, uint64_t request_id, void *private_ctx)
+int cl_dp_cpu_load (const char *xpath, sr_val_t **values, size_t *values_cnt, uint64_t request_id, const char *original_xpath, void *private_ctx)
 {
     const char *expected_xpath = "/state-module:cpu_load";
     if (0 == strcmp(xpath, expected_xpath)) {
@@ -318,7 +318,7 @@ int cl_dp_cpu_load (const char *xpath, sr_val_t **values, size_t *values_cnt, ui
     return -1;
 }
 
-int cl_dp_bus (const char *xpath, sr_val_t **values, size_t *values_cnt, uint64_t request_id, void *private_ctx)
+int cl_dp_bus (const char *xpath, sr_val_t **values, size_t *values_cnt, uint64_t request_id, const char *original_xpath, void *private_ctx)
 {
     if (0 == strcmp(xpath, "/state-module:bus/distance_travelled"))
     {
@@ -332,7 +332,7 @@ int cl_dp_bus (const char *xpath, sr_val_t **values, size_t *values_cnt, uint64_
     return -1;
 }
 
-int cl_dp_bus_req_id (const char *xpath, sr_val_t **values, size_t *values_cnt, uint64_t request_id, void *private_ctx)
+int cl_dp_bus_req_id (const char *xpath, sr_val_t **values, size_t *values_cnt, uint64_t request_id, const char *original_xpath, void *private_ctx)
 {
     sr_list_t *l = (sr_list_t *) private_ctx;
     if (0 != sr_list_add(l, (char *)request_id)) {
@@ -341,7 +341,7 @@ int cl_dp_bus_req_id (const char *xpath, sr_val_t **values, size_t *values_cnt, 
     return 0;
 }
 
-int cl_dp_distance_travelled (const char *xpath, sr_val_t **values, size_t *values_cnt, uint64_t request_id, void *private_ctx)
+int cl_dp_distance_travelled (const char *xpath, sr_val_t **values, size_t *values_cnt, uint64_t request_id, const char *original_xpath, void *private_ctx)
 {
     const char *expected_xpath = "/state-module:bus/distance_travelled";
     if (0 == strcmp(xpath, expected_xpath)) {
@@ -351,7 +351,7 @@ int cl_dp_distance_travelled (const char *xpath, sr_val_t **values, size_t *valu
     return -1;
 }
 
-int cl_dp_gps_located (const char *xpath, sr_val_t **values, size_t *values_cnt, uint64_t request_id, void *private_ctx)
+int cl_dp_gps_located (const char *xpath, sr_val_t **values, size_t *values_cnt, uint64_t request_id, const char *original_xpath, void *private_ctx)
 {
     const char *expected_xpath = "/state-module:bus/gps_located";
     if (0 == strcmp(xpath, "/state-module:bus/gps_located")) {
@@ -361,7 +361,7 @@ int cl_dp_gps_located (const char *xpath, sr_val_t **values, size_t *values_cnt,
     return -1;
 }
 
-int cl_dp_seats_reserved (const char *xpath, sr_val_t **values, size_t *values_cnt, uint64_t request_id, void *private_ctx)
+int cl_dp_seats_reserved (const char *xpath, sr_val_t **values, size_t *values_cnt, uint64_t request_id, const char *original_xpath, void *private_ctx)
 {
     const char *expected_xpath = "/state-module:bus/seats/reserved";
     if (sr_xpath_node_name_eq(xpath, "reserved")) {
@@ -371,7 +371,7 @@ int cl_dp_seats_reserved (const char *xpath, sr_val_t **values, size_t *values_c
     return -1;
 }
 
-int cl_dp_missing_type_bus (const char *xpath, sr_val_t **values, size_t *values_cnt, uint64_t request_id, void *private_ctx)
+int cl_dp_missing_type_bus (const char *xpath, sr_val_t **values, size_t *values_cnt, uint64_t request_id, const char *original_xpath, void *private_ctx)
 {
     if (0 == strcmp(xpath, "/state-module:bus/distance_travelled"))
     {
@@ -386,7 +386,7 @@ int cl_dp_missing_type_bus (const char *xpath, sr_val_t **values, size_t *values
 }
 
 int
-cl_dp_incorrect_data(const char *xpath, sr_val_t **values, size_t *values_cnt, uint64_t request_id, void *private_ctx)
+cl_dp_incorrect_data(const char *xpath, sr_val_t **values, size_t *values_cnt, uint64_t request_id, const char *original_xpath, void *private_ctx)
 {
     sr_list_t *l = (sr_list_t *) private_ctx;
     if (0 != sr_list_add(l, strdup(xpath))) {
@@ -406,12 +406,12 @@ cl_dp_incorrect_data(const char *xpath, sr_val_t **values, size_t *values_cnt, u
     return 0;
 }
 
-int cl_dp_weather (const char *xpath, sr_val_t **values, size_t *values_cnt, uint64_t request_id, void *private_ctx)
+int cl_dp_weather (const char *xpath, sr_val_t **values, size_t *values_cnt, uint64_t request_id, const char *original_xpath, void *private_ctx)
 {
     return SR_ERR_OK;
 }
 
-int cl_dp_sky (const char *xpath, sr_val_t **values, size_t *values_cnt, uint64_t request_id, void *private_ctx)
+int cl_dp_sky (const char *xpath, sr_val_t **values, size_t *values_cnt, uint64_t request_id, const char *original_xpath, void *private_ctx)
 {
     const char *expected_xpath = "/state-module:weather/sky";
     if (0 == strcmp(xpath, expected_xpath)) {
@@ -430,7 +430,7 @@ int cl_dp_sky (const char *xpath, sr_val_t **values, size_t *values_cnt, uint64_
     return -1;
 }
 
-int cl_dp_humidity (const char *xpath, sr_val_t **values, size_t *values_cnt, uint64_t request_id, void *private_ctx)
+int cl_dp_humidity (const char *xpath, sr_val_t **values, size_t *values_cnt, uint64_t request_id, const char *original_xpath, void *private_ctx)
 {
     const char *expected_xpath = "/state-module:weather/humidity";
     if (0 == strcmp(xpath, expected_xpath)) {
@@ -458,7 +458,7 @@ cl_whole_module_cb(sr_session_ctx_t *session, const char *module_name, sr_notif_
 }
 
 int
-cl_dp_traffic_stats(const char *xpath, sr_val_t **values, size_t *values_cnt, uint64_t request_id, void *private_ctx)
+cl_dp_traffic_stats(const char *xpath, sr_val_t **values, size_t *values_cnt, uint64_t request_id, const char *original_xpath, void *private_ctx)
 {
     sr_list_t *l = (sr_list_t *) private_ctx;
     int rc = SR_ERR_OK;
@@ -579,7 +579,7 @@ cl_dp_traffic_stats(const char *xpath, sr_val_t **values, size_t *values_cnt, ui
 }
 
 int
-cl_dp_cross_road(const char *xpath, sr_val_t **values, size_t *values_cnt, uint64_t request_id, void *private_ctx)
+cl_dp_cross_road(const char *xpath, sr_val_t **values, size_t *values_cnt, uint64_t request_id, const char *original_xpath, void *private_ctx)
 {
     sr_list_t *l = (sr_list_t *) private_ctx;
     if (0 != sr_list_add(l, strdup(xpath))) {
@@ -620,7 +620,7 @@ cl_dp_cross_road(const char *xpath, sr_val_t **values, size_t *values_cnt, uint6
 }
 
 int
-cl_dp_wind(const char *xpath, sr_val_t **values, size_t *values_cnt, uint64_t request_id, void *private_ctx)
+cl_dp_wind(const char *xpath, sr_val_t **values, size_t *values_cnt, uint64_t request_id, const char *original_xpath, void *private_ctx)
 {
     sr_list_t *l = (sr_list_t *) private_ctx;
     if (0 != sr_list_add(l, strdup(xpath))) {
@@ -651,7 +651,7 @@ cl_dp_wind(const char *xpath, sr_val_t **values, size_t *values_cnt, uint64_t re
 }
 
 int
-cl_dp_wind_speed(const char *xpath, sr_val_t **values, size_t *values_cnt, uint64_t request_id, void *private_ctx)
+cl_dp_wind_speed(const char *xpath, sr_val_t **values, size_t *values_cnt, uint64_t request_id, const char *original_xpath, void *private_ctx)
 {
     sr_list_t *l = (sr_list_t *) private_ctx;
     if (0 != sr_list_add(l, strdup(xpath))) {
@@ -678,7 +678,7 @@ cl_dp_wind_speed(const char *xpath, sr_val_t **values, size_t *values_cnt, uint6
 }
 
 int
-cl_dp_traffic_light(const char *xpath, sr_val_t **values, size_t *values_cnt, uint64_t request_id, void *private_ctx)
+cl_dp_traffic_light(const char *xpath, sr_val_t **values, size_t *values_cnt, uint64_t request_id, const char *original_xpath, void *private_ctx)
 {
     sr_list_t *l = (sr_list_t *) private_ctx;
     if (0 != sr_list_add(l, strdup(xpath))) {
@@ -724,7 +724,7 @@ cl_dp_traffic_light(const char *xpath, sr_val_t **values, size_t *values_cnt, ui
 }
 
 static int
-cl_dp_card_state(const char *xpath, sr_val_t **values, size_t *values_cnt, uint64_t request_id, void *private_ctx)
+cl_dp_card_state(const char *xpath, sr_val_t **values, size_t *values_cnt, uint64_t request_id, const char *original_xpath, void *private_ctx)
 {
     sr_val_t *v = NULL;
     int rc = SR_ERR_OK;

--- a/tests/cl_test2.c
+++ b/tests/cl_test2.c
@@ -733,7 +733,7 @@ cl_enable_empty_startup(void **state)
 }
 
 static int
-dp_get_items_cb(const char *xpath, sr_val_t **values, size_t *values_cnt, uint64_t request_id, void *private_ctx)
+dp_get_items_cb(const char *xpath, sr_val_t **values, size_t *values_cnt, uint64_t request_id, const char *original_xpath, void *private_ctx)
 {
     printf("operational data for '%s' requested.\n", xpath);
 

--- a/tests/measure_performance.c
+++ b/tests/measure_performance.c
@@ -181,7 +181,7 @@ typedef struct dp_setup_s {
 
 
 int
-data_provide_cb(const char *xpath, sr_val_t **values, size_t *values_cnt, uint64_t request_id, void *private_ctx)
+data_provide_cb(const char *xpath, sr_val_t **values, size_t *values_cnt, uint64_t request_id, const char *original_xpath, void *private_ctx)
 {
     size_t if_count = *((size_t *) private_ctx);
     int rc = SR_ERR_OK;


### PR DESCRIPTION
When a data request is made, sysrepo will ask to a subscriber for each level under the subscription, calling the subscriber's callback once per layer. When a lot of state nodes are present, it can trigger performance problems in the subscriber.

This patch adds the xpath from the originating get_item request to the sr_dp_get_items_cb prototype. Then, the subscriber can know what it has to answer, and can filter beforehand what it should return to sysrepo, lowering the load needed to get the informations, and the number of requests between sysrepo and the subscriber.

Note that those patches breaks the API, as the sr_dp_get_items_cb prototype has a new original_xpath argument.