### PR TITLE
Application receive information from which netconf client (session-id) specific rpc has been sent.

### DIFF
--- a/examples/plugins/oven.c
+++ b/examples/plugins/oven.c
@@ -148,7 +148,7 @@ oven_state_cb(const char *xpath, sr_val_t **values, size_t *values_cnt,
 }
 
 static int
-oven_insert_food_cb(const char *xpath, const sr_val_t *input, const size_t input_cnt,
+oven_insert_food_cb(sr_session_ctx_t *session, const char *xpath, const sr_val_t *input, const size_t input_cnt,
         sr_val_t **output, size_t *output_cnt, void *private_ctx)
 {
     if (food_inside) {
@@ -172,7 +172,7 @@ oven_insert_food_cb(const char *xpath, const sr_val_t *input, const size_t input
 }
 
 static int
-oven_remove_food_cb(const char *xpath, const sr_val_t *input, const size_t input_cnt,
+oven_remove_food_cb(sr_session_ctx_t *session, const char *xpath, const sr_val_t *input, const size_t input_cnt,
         sr_val_t **output, size_t *output_cnt, void *private_ctx)
 {
     if (!food_inside) {

--- a/examples/plugins/turing-machine.c
+++ b/examples/plugins/turing-machine.c
@@ -58,7 +58,7 @@ module_change_cb(sr_session_ctx_t *session, const char *module_name, sr_notif_ev
 }
 
 static int
-rpc_initialize_cb(const char *xpath, const sr_val_t *input, const size_t input_cnt,
+rpc_initialize_cb(sr_session_ctx_t *session, const char *xpath, const sr_val_t *input, const size_t input_cnt,
         sr_val_t **output, size_t *output_cnt, void *private_ctx)
 {
     SRP_LOG_DBG_MSG("turing-machine 'initialize' RPC called.");
@@ -71,7 +71,7 @@ rpc_initialize_cb(const char *xpath, const sr_val_t *input, const size_t input_c
 }
 
 static int
-rpc_run_cb(const char *xpath, const sr_val_t *input, const size_t input_cnt,
+rpc_run_cb(sr_session_ctx_t *session, const char *xpath, const sr_val_t *input, const size_t input_cnt,
         sr_val_t **output, size_t *output_cnt, void *private_ctx)
 {
     SRP_LOG_DBG_MSG("turing-machine 'run' RPC called.");

--- a/examples/rpc_example.c
+++ b/examples/rpc_example.c
@@ -32,12 +32,11 @@
 volatile int exit_application = 0;
 
 static int
-rpc_cb(const char *xpath, const sr_val_t *input, const size_t input_cnt,
+rpc_cb(sr_session_ctx_t *session, const char *xpath, const sr_val_t *input, const size_t input_cnt,
        sr_val_t **output, size_t *output_cnt, void *private_ctx)
 {
     int rc = SR_ERR_OK;
     sr_val_t *notif = NULL;
-    sr_session_ctx_t *session = (sr_session_ctx_t *)private_ctx;
 
     /* print input values */
     printf("\n\n ========== RECEIVED RPC REQUEST ==========\n\n");

--- a/examples/rpc_tree_example.c
+++ b/examples/rpc_tree_example.c
@@ -33,11 +33,10 @@
 volatile int exit_application = 0;
 
 static int
-rpc_cb(const char *xpath, const sr_node_t *input, const size_t input_cnt,
-       sr_node_t **output, size_t *output_cnt, void *private_ctx)
+rpc_cb(sr_session_ctx_t *session, const char *xpath, const sr_node_t *input, 
+       const size_t input_cnt, sr_node_t **output, size_t *output_cnt, void *private_ctx)
 {
     int rc = SR_ERR_OK;
-    sr_session_ctx_t *session = (sr_session_ctx_t *)private_ctx;
 
     /* print input data */
     printf("\n\n ========== RECEIVED RPC REQUEST ==========\n\n");

--- a/inc/sysrepo.h
+++ b/inc/sysrepo.h
@@ -1466,6 +1466,7 @@ int sr_check_exec_permission(sr_session_ctx_t *session, const char *xpath, bool 
  * @brief Callback to be called by the delivery of RPC specified by xpath.
  * Subscribe to it by ::sr_rpc_subscribe call.
  *
+ * @param[in] session Session context acquired with ::sr_session_start call.
  * @param[in] xpath @ref xp_page "Data Path" identifying the RPC.
  * @param[in] input Array of input parameters.
  * @param[in] input_cnt Number of input parameters.
@@ -1476,14 +1477,15 @@ int sr_check_exec_permission(sr_session_ctx_t *session, const char *xpath, bool 
  *
  * @return Error code (SR_ERR_OK on success).
  */
-typedef int (*sr_rpc_cb)(const char *xpath, const sr_val_t *input, const size_t input_cnt,
-        sr_val_t **output, size_t *output_cnt, void *private_ctx);
+typedef int (*sr_rpc_cb)(sr_session_ctx_t *session, const char *xpath, const sr_val_t *input, 
+        const size_t input_cnt, sr_val_t **output, size_t *output_cnt, void *private_ctx);
 
 /**
  * @brief Callback to be called by the delivery of RPC specified by xpath.
  * This RPC callback variant operates with sysrepo trees rather than with sysrepo values,
  * use it with ::sr_rpc_subscribe_tree and ::sr_rpc_send_tree.
  *
+ * @param[in] session Session context acquired with ::sr_session_start call.
  * @param[in] xpath @ref xp_page "Data Path" identifying the RPC.
  * @param[in] input Array of input parameters (represented as trees).
  * @param[in] input_cnt Number of input parameters.
@@ -1494,8 +1496,8 @@ typedef int (*sr_rpc_cb)(const char *xpath, const sr_val_t *input, const size_t 
  *
  * @return Error code (SR_ERR_OK on success).
  */
-typedef int (*sr_rpc_tree_cb)(const char *xpath, const sr_node_t *input, const size_t input_cnt,
-        sr_node_t **output, size_t *output_cnt, void *private_ctx);
+typedef int (*sr_rpc_tree_cb)(sr_session_ctx_t *session, const char *xpath, const sr_node_t *input, 
+        const size_t input_cnt, sr_node_t **output, size_t *output_cnt, void *private_ctx);
 
 /**
  * @brief Subscribes for delivery of RPC specified by xpath.
@@ -2006,6 +2008,21 @@ void sr_free_tree(sr_node_t *tree);
  * @param[in] count length of array
  */
 void sr_free_trees(sr_node_t *trees, size_t count);
+
+/**
+ * @brief Store netconf session id in sr_session_ctx_t.
+ *
+ * @param[in] session
+ * @param[in] netconf_id
+ */
+void sr_set_netconf_id(sr_session_ctx_t *session, uint32_t netconf_id);
+
+ /**
+ * @brief Receive netconf sid from sr_session_ctx_t.
+ *
+ * @param[in] session
+ */
+uint32_t sr_get_netconf_id(sr_session_ctx_t *session);
 
 /**@} cl */
 

--- a/src/clientlib/cl_common.h
+++ b/src/clientlib/cl_common.h
@@ -53,6 +53,7 @@ typedef struct sr_conn_ctx_s {
 typedef struct sr_session_ctx_s {
     sr_conn_ctx_t *conn_ctx;      /**< Associated connection context. */
     uint32_t id;                  /**< Assigned session identifier. */
+    uint32_t netconf_id;          /**< Assigned netconf server session. */
     pthread_mutex_t lock;         /**< Mutex for the session context content. */
     sr_error_t last_error;        /**< Latest error code returned from an API call. */
     sr_error_info_t *error_info;  /**< Array of detailed error information from last API call. */

--- a/src/request_processor.c
+++ b/src/request_processor.c
@@ -2159,7 +2159,7 @@ rp_rpc_req_process(rp_ctx_t *rp_ctx, rp_session_t *session, Sr__Msg *msg, bool *
     np_subscription_t *subscription = NULL;
     Sr__Msg *req = NULL, *resp = NULL;
     sr_mem_ctx_t *sr_mem = NULL;
-    const char *op_name = NULL;
+    const char *op_name = NULL, *netconf_id = NULL;
     bool action = false;
     nacm_ctx_t *nacm_ctx = NULL;
     nacm_action_t nacm_action = NACM_ACTION_PERMIT;
@@ -2173,6 +2173,7 @@ rp_rpc_req_process(rp_ctx_t *rp_ctx, rp_session_t *session, Sr__Msg *msg, bool *
 
     xpath = msg->request->rpc_req->xpath;
     action = msg->request->rpc_req->action;
+    netconf_id = msg->request->rpc_req->netconf_id;
     op_name = (action ? "Action" : "RPC");
     SR_LOG_DBG("Processing %s request (%s).", op_name, xpath);
 
@@ -2331,6 +2332,9 @@ rp_rpc_req_process(rp_ctx_t *rp_ctx, rp_session_t *session, Sr__Msg *msg, bool *
             CHECK_NULL_NOMEM_GOTO(req->request->rpc_req->subscriber_address, rc, finalize);
             req->request->rpc_req->subscription_id = subscription->dst_id;
             req->request->rpc_req->has_subscription_id = true;
+            if (netconf_id) {
+                sr_mem_edit_string(sr_mem, &req->request->rpc_req->netconf_id, netconf_id);
+            }
             subscription_match = true;
             break;
         }

--- a/src/sysrepo.proto
+++ b/src/sysrepo.proto
@@ -739,6 +739,7 @@ message RPCReq {
 
   optional string subscriber_address = 10;
   optional uint32 subscription_id = 11;
+  optional string netconf_id = 12;
 }
 
 /**

--- a/swig/cpp/examples/cpp_rpc_example.cpp
+++ b/swig/cpp/examples/cpp_rpc_example.cpp
@@ -162,7 +162,7 @@ print_value(sysrepo::S_Val value)
 }
 
 class My_Callback:public sysrepo::Callback {
-    int rpc(const char *xpath, const sysrepo::S_Vals in_vals, sysrepo::S_Vals_Holder holder, void *private_ctx) {
+    int rpc(sysrepo::S_Session session, const char *xpath, const sysrepo::S_Vals in_vals, sysrepo::S_Vals_Holder holder, void *private_ctx) {
         cout << "\n ========== RPC CALLED ==========\n" << endl;
 
         auto out_vals = holder->allocate(3);
@@ -183,7 +183,7 @@ class My_Callback:public sysrepo::Callback {
     return SR_ERR_OK;
     }
 
-    int rpc_tree(const char *xpath, const sysrepo::S_Trees in_trees, sysrepo::S_Trees_Holder holder, void *private_ctx) {
+    int rpc_tree(sysrepo::S_Session session, const char *xpath, const sysrepo::S_Trees in_trees, sysrepo::S_Trees_Holder holder, void *private_ctx) {
         cout << "\n ========== RPC TREE CALLED ==========\n" << endl;
 
         auto out_trees = holder->allocate(3);

--- a/swig/cpp/examples/cpp_turing_rpc_example.cpp
+++ b/swig/cpp/examples/cpp_turing_rpc_example.cpp
@@ -33,7 +33,7 @@
 volatile int exit_application = 0;
 
 class My_Callback:public sysrepo::Callback {
-    int rpc(const char *xpath, const sysrepo::S_Vals input, sysrepo::S_Vals_Holder holder, void *private_ctx) {
+    int rpc(sysrepo::S_Session session, const char *xpath, const sysrepo::S_Vals input, sysrepo::S_Vals_Holder holder, void *private_ctx) {
         int rc = SR_ERR_OK;
         try {
             sysrepo::S_Session *session = (sysrepo::S_Session *)private_ctx;

--- a/swig/cpp/src/Session.cpp
+++ b/swig/cpp/src/Session.cpp
@@ -469,29 +469,33 @@ static int subtree_change_cb(sr_session_ctx_t *session, const char *xpath, sr_no
     Callback *wrap = (Callback*) private_ctx;
     return wrap->subtree_change(sess, xpath, event, wrap->private_ctx["subtree_change"]);
 }
-static int rpc_cb(const char *xpath, const sr_val_t *input, const size_t input_cnt, sr_val_t **output, size_t *output_cnt, void *private_ctx) {
+static int rpc_cb(sr_session_ctx_t *session, const char *xpath, const sr_val_t *input, const size_t input_cnt, sr_val_t **output, size_t *output_cnt, void *private_ctx) {
+    S_Session sess(new Session(session));
     S_Vals in_vals(new Vals(input, input_cnt, nullptr));
     S_Vals_Holder out_vals(new Vals_Holder(output, output_cnt));
     Callback *wrap = (Callback*) private_ctx;
-    return wrap->rpc(xpath, in_vals, out_vals, wrap->private_ctx["rpc_cb"]);
+    return wrap->rpc(sess, xpath, in_vals, out_vals, wrap->private_ctx["rpc_cb"]);
 }
-static int action_cb(const char *xpath, const sr_val_t *input, const size_t input_cnt, sr_val_t **output, size_t *output_cnt, void *private_ctx) {
+static int action_cb(sr_session_ctx_t *session, const char *xpath, const sr_val_t *input, const size_t input_cnt, sr_val_t **output, size_t *output_cnt, void *private_ctx) {
+    S_Session sess(new Session(session));
     S_Vals in_vals(new Vals(input, input_cnt, nullptr));
     S_Vals_Holder out_vals(new Vals_Holder(output, output_cnt));
     Callback *wrap = (Callback*) private_ctx;
-    return wrap->action(xpath, in_vals, out_vals, wrap->private_ctx["action_cb"]);
+    return wrap->action(sess, xpath, in_vals, out_vals, wrap->private_ctx["action_cb"]);
 }
-static int rpc_tree_cb(const char *xpath, const sr_node_t *input, const size_t input_cnt, sr_node_t **output, size_t *output_cnt, void *private_ctx) {
+static int rpc_tree_cb(sr_session_ctx_t *session, const char *xpath, const sr_node_t *input, const size_t input_cnt, sr_node_t **output, size_t *output_cnt, void *private_ctx) {
+    S_Session sess(new Session(session));
     S_Trees in_tree(new Trees(input, input_cnt, nullptr));
     S_Trees_Holder out_tree(new Trees_Holder(output, output_cnt));
     Callback *wrap = (Callback*) private_ctx;
-    return wrap->rpc_tree(xpath, in_tree, out_tree, wrap->private_ctx["rpc_tree"]);
+    return wrap->rpc_tree(sess, xpath, in_tree, out_tree, wrap->private_ctx["rpc_tree"]);
 }
-static int action_tree_cb(const char *xpath, const sr_node_t *input, const size_t input_cnt, sr_node_t **output, size_t *output_cnt, void *private_ctx) {
+static int action_tree_cb(sr_session_ctx_t *session, const char *xpath, const sr_node_t *input, const size_t input_cnt, sr_node_t **output, size_t *output_cnt, void *private_ctx) {
+    S_Session sess(new Session(session));
     S_Trees in_tree(new Trees(input, input_cnt, nullptr));
     S_Trees_Holder out_tree(new Trees_Holder(output, output_cnt));
     Callback *wrap = (Callback*) private_ctx;
-    return wrap->action_tree(xpath, in_tree, out_tree, wrap->private_ctx["action_tree"]);
+    return wrap->action_tree(sess, xpath, in_tree, out_tree, wrap->private_ctx["action_tree"]);
 }
 static void event_notif_cb(const sr_ev_notif_type_t notif_type, const char *xpath, const sr_val_t *values, const size_t values_cnt, time_t timestamp, void *private_ctx) {
     S_Vals vals(new Vals(values, values_cnt, nullptr));

--- a/swig/cpp/src/Session.hpp
+++ b/swig/cpp/src/Session.hpp
@@ -170,13 +170,13 @@ public:
     /** Wrapper for [sr_feature_enable_cb](@ref sr_feature_enable_cb) callback.*/
     virtual void feature_enable(const char *module_name, const char *feature_name, bool enabled, void *private_ctx) {return;};
     /** Wrapper for [sr_rpc_cb](@ref sr_rpc_cb) callback.*/
-    virtual int rpc(const char *xpath, const S_Vals input, S_Vals_Holder output, void *private_ctx) {return SR_ERR_OK;};
+    virtual int rpc(S_Session session, const char *xpath, const S_Vals input, S_Vals_Holder output, void *private_ctx) {return SR_ERR_OK;};
     /** Wrapper for [sr_action_cb](@ref sr_action_cb) callback.*/
-    virtual int action(const char *xpath, const S_Vals input, S_Vals_Holder output, void *private_ctx) {return SR_ERR_OK;};
+    virtual int action(S_Session session, const char *xpath, const S_Vals input, S_Vals_Holder output, void *private_ctx) {return SR_ERR_OK;};
     /** Wrapper for [sr_rpc_tree_cb](@ref sr_rpc_tree_cb) callback.*/
-    virtual int rpc_tree(const char *xpath, const S_Trees input, S_Trees_Holder output, void *private_ctx) {return SR_ERR_OK;};
+    virtual int rpc_tree(S_Session session, const char *xpath, const S_Trees input, S_Trees_Holder output, void *private_ctx) {return SR_ERR_OK;};
     /** Wrapper for [sr_action_tree_cb](@ref sr_action_tree_cb) callback.*/
-    virtual int action_tree(const char *xpath, const S_Trees input, S_Trees_Holder output, void *private_ctx) {return SR_ERR_OK;};
+    virtual int action_tree(S_Session session, const char *xpath, const S_Trees input, S_Trees_Holder output, void *private_ctx) {return SR_ERR_OK;};
     /** Wrapper for [sr_dp_get_items_cb](@ref sr_dp_get_items_cb) callback.*/
     virtual int dp_get_items(const char *xpath, S_Vals_Holder vals, uint64_t request_id, const char *original_xpath, void *private_ctx) {return SR_ERR_OK;};
     /** Wrapper for [sr_event_notif_cb](@ref sr_event_notif_cb) callback.*/

--- a/swig/lua/libsysrepoLua.i
+++ b/swig/lua/libsysrepoLua.i
@@ -106,7 +106,7 @@ public:
         lua_call(fn.L, 4, 0);
     }
 
-    int rpc_cb(const char *xpath, const sr_val_t *input, const size_t input_cnt, sr_val_t **output,\
+    int rpc_cb(sr_session_ctx_t *session, const char *xpath, const sr_val_t *input, const size_t input_cnt, sr_val_t **output,\
                size_t *output_cnt, void *private_ctx) {
         swiglua_ref_get(&fn);
         if (!lua_isfunction(fn.L,-1)) {
@@ -128,7 +128,7 @@ public:
         return ret;
     }
 
-    int action_cb(const char *xpath, const sr_val_t *input, const size_t input_cnt, sr_val_t **output,\
+    int action_cb(sr_session_ctx_t *session, const char *xpath, const sr_val_t *input, const size_t input_cnt, sr_val_t **output,\
                size_t *output_cnt, void *private_ctx) {
         swiglua_ref_get(&fn);
         if (!lua_isfunction(fn.L,-1)) {
@@ -150,7 +150,7 @@ public:
         return ret;
     }
 
-    int rpc_tree_cb(const char *xpath, const sr_node_t *input, const size_t input_cnt,\
+    int rpc_tree_cb(sr_session_ctx_t *session, const char *xpath, const sr_node_t *input, const size_t input_cnt,\
                          sr_node_t **output, size_t *output_cnt, void *private_ctx) {
         swiglua_ref_get(&fn);
         if (!lua_isfunction(fn.L,-1)) {
@@ -172,7 +172,7 @@ public:
         return ret;
     }
 
-    int action_tree_cb(const char *xpath, const sr_node_t *input, const size_t input_cnt,\
+    int action_tree_cb(sr_session_ctx_t *session, const char *xpath, const sr_node_t *input, const size_t input_cnt,\
                          sr_node_t **output, size_t *output_cnt, void *private_ctx) {
         swiglua_ref_get(&fn);
         if (!lua_isfunction(fn.L,-1)) {
@@ -280,32 +280,32 @@ static void g_feature_enable_cb(const char *module_name, const char *feature_nam
     ctx->feature_enable(module_name, feature_name, enabled, ctx->private_ctx);
 }
 
-static int g_rpc_cb(const char *xpath, const sr_val_t *input, const size_t input_cnt, sr_val_t **output,\
+static int g_rpc_cb(sr_session_ctx_t *session, const char *xpath, const sr_val_t *input, const size_t input_cnt, sr_val_t **output,\
                      size_t *output_cnt, void *private_ctx)
 {
     sysrepo::Wrap_cb *ctx = (sysrepo::Wrap_cb *) private_ctx;
-    return ctx->rpc_cb(xpath, input, input_cnt, output, output_cnt, ctx->private_ctx);
+    return ctx->rpc_cb(session, xpath, input, input_cnt, output, output_cnt, ctx->private_ctx);
 }
 
-static int g_action_cb(const char *xpath, const sr_val_t *input, const size_t input_cnt, sr_val_t **output,\
+static int g_action_cb(sr_session_ctx_t *session, const char *xpath, const sr_val_t *input, const size_t input_cnt, sr_val_t **output,\
                      size_t *output_cnt, void *private_ctx)
 {
     sysrepo::Wrap_cb *ctx = (sysrepo::Wrap_cb *) private_ctx;
-    return ctx->action_cb(xpath, input, input_cnt, output, output_cnt, ctx->private_ctx);
+    return ctx->action_cb(session, xpath, input, input_cnt, output, output_cnt, ctx->private_ctx);
 }
 
-static int g_rpc_tree_cb(const char *xpath, const sr_node_t *input, const size_t input_cnt,\
+static int g_rpc_tree_cb(sr_session_ctx_t *session, const char *xpath, const sr_node_t *input, const size_t input_cnt,\
                          sr_node_t **output, size_t *output_cnt, void *private_ctx)
 {
     sysrepo::Wrap_cb *ctx = (sysrepo::Wrap_cb *) private_ctx;
-    return ctx->rpc_tree_cb(xpath, input, input_cnt, output, output_cnt, ctx->private_ctx);
+    return ctx->rpc_tree_cb(session, xpath, input, input_cnt, output, output_cnt, ctx->private_ctx);
 }
 
-static int g_action_tree_cb(const char *xpath, const sr_node_t *input, const size_t input_cnt,\
+static int g_action_tree_cb(sr_session_ctx_t *session, const char *xpath, const sr_node_t *input, const size_t input_cnt,\
                          sr_node_t **output, size_t *output_cnt, void *private_ctx)
 {
     sysrepo::Wrap_cb *ctx = (sysrepo::Wrap_cb *) private_ctx;
-    return ctx->action_tree_cb(xpath, input, input_cnt, output, output_cnt, ctx->private_ctx);
+    return ctx->action_tree_cb(session, xpath, input, input_cnt, output, output_cnt, ctx->private_ctx);
 }
 
 static int g_dp_get_items_cb(const char *xpath, sr_val_t **values, size_t *values_cnt, uint64_t request_id, const char *original_xpath, void *private_ctx)

--- a/swig/python/examples/rpc_example.py
+++ b/swig/python/examples/rpc_example.py
@@ -20,7 +20,7 @@ __license__ = "Apache 2.0"
 import sysrepo as sr
 import sys
 
-def test_rpc_cb(xpath, in_vals, holder, private_ctx):
+def test_rpc_cb(session, xpath, in_vals, holder, private_ctx):
     try:
         print ("\n\n ========== RPC CALLED ==========")
         out_vals = holder.allocate(3)
@@ -38,7 +38,7 @@ def test_rpc_cb(xpath, in_vals, holder, private_ctx):
     except Exception as e:
         print (e)
 
-def test_rpc_tree_cb(xpath, in_trees, holder, private_ctx):
+def test_rpc_tree_cb(session, xpath, in_trees, holder, private_ctx):
     try:
         print ("\n ========== RPC TREE CALLED ==========\n")
 

--- a/swig/python/sysrepo.i
+++ b/swig/python/sysrepo.i
@@ -137,7 +137,7 @@ public:
             Py_DECREF(result);
     }
 
-    int rpc_cb(const char *xpath, const sr_val_t *input, const size_t input_cnt, sr_val_t **output,\
+    int rpc_cb(sr_session_ctx_t *session, const char *xpath, const sr_val_t *input, const size_t input_cnt, sr_val_t **output,\
                size_t *output_cnt, PyObject *private_ctx) {
         PyObject *arglist;
 
@@ -169,7 +169,7 @@ public:
         }
      }
 
-    int action_cb(const char *xpath, const sr_val_t *input, const size_t input_cnt, sr_val_t **output,\
+    int action_cb(sr_session_ctx_t *session, const char *xpath, const sr_val_t *input, const size_t input_cnt, sr_val_t **output,\
                size_t *output_cnt, PyObject *private_ctx) {
         PyObject *arglist;
 
@@ -201,7 +201,7 @@ public:
         }
      }
 
-    int rpc_tree_cb(const char *xpath, const sr_node_t *input, const size_t input_cnt,\
+    int rpc_tree_cb(sr_session_ctx_t *session, const char *xpath, const sr_node_t *input, const size_t input_cnt,\
                          sr_node_t **output, size_t *output_cnt, PyObject *private_ctx) {
         PyObject *arglist;
 
@@ -232,7 +232,7 @@ public:
         }
     }
 
-    int action_tree_cb(const char *xpath, const sr_node_t *input, const size_t input_cnt,\
+    int action_tree_cb(sr_session_ctx_t *session, const char *xpath, const sr_node_t *input, const size_t input_cnt,\
                          sr_node_t **output, size_t *output_cnt, PyObject *private_ctx) {
         PyObject *arglist;
 
@@ -358,32 +358,32 @@ static void g_feature_enable_cb(const char *module_name, const char *feature_nam
     ctx->feature_enable(module_name, feature_name, enabled, ctx->private_ctx);
 }
 
-static int g_rpc_cb(const char *xpath, const sr_val_t *input, const size_t input_cnt, sr_val_t **output,\
+static int g_rpc_cb(sr_session_ctx_t *session, const char *xpath, const sr_val_t *input, const size_t input_cnt, sr_val_t **output,\
                      size_t *output_cnt, void *private_ctx)
 {
     Wrap_cb *ctx = (Wrap_cb *) private_ctx;
-    return ctx->rpc_cb(xpath, input, input_cnt, output, output_cnt, ctx->private_ctx);
+    return ctx->rpc_cb(session, xpath, input, input_cnt, output, output_cnt, ctx->private_ctx);
 }
 
-static int g_action_cb(const char *xpath, const sr_val_t *input, const size_t input_cnt, sr_val_t **output,\
+static int g_action_cb(sr_session_ctx_t *session, const char *xpath, const sr_val_t *input, const size_t input_cnt, sr_val_t **output,\
                      size_t *output_cnt, void *private_ctx)
 {
     Wrap_cb *ctx = (Wrap_cb *) private_ctx;
-    return ctx->action_cb(xpath, input, input_cnt, output, output_cnt, ctx->private_ctx);
+    return ctx->action_cb(session, xpath, input, input_cnt, output, output_cnt, ctx->private_ctx);
 }
 
-static int g_rpc_tree_cb(const char *xpath, const sr_node_t *input, const size_t input_cnt,\
+static int g_rpc_tree_cb(sr_session_ctx_t *session, const char *xpath, const sr_node_t *input, const size_t input_cnt,\
                          sr_node_t **output, size_t *output_cnt, void *private_ctx)
 {
     Wrap_cb *ctx = (Wrap_cb *) private_ctx;
-    return ctx->rpc_tree_cb(xpath, input, input_cnt, output, output_cnt, ctx->private_ctx);
+    return ctx->rpc_tree_cb(session, xpath, input, input_cnt, output, output_cnt, ctx->private_ctx);
 }
 
-static int g_action_tree_cb(const char *xpath, const sr_node_t *input, const size_t input_cnt,\
+static int g_action_tree_cb(sr_session_ctx_t *session, const char *xpath, const sr_node_t *input, const size_t input_cnt,\
                          sr_node_t **output, size_t *output_cnt, void *private_ctx)
 {
     Wrap_cb *ctx = (Wrap_cb *) private_ctx;
-    return ctx->action_tree_cb(xpath, input, input_cnt, output, output_cnt, ctx->private_ctx);
+    return ctx->action_tree_cb(session, xpath, input, input_cnt, output, output_cnt, ctx->private_ctx);
 }
 
 static int g_dp_get_items_cb(const char *xpath, sr_val_t **values, size_t *values_cnt, uint64_t request_id, const char *original_xpath, void *private_ctx)

--- a/tests/cl_test.c
+++ b/tests/cl_test.c
@@ -2415,7 +2415,7 @@ cl_copy_config_test2(void **state)
 }
 
 static int
-test_rpc_cb(const char *xpath, const sr_val_t *input, const size_t input_cnt,
+test_rpc_cb(sr_session_ctx_t *session, const char *xpath, const sr_val_t *input, const size_t input_cnt,
         sr_val_t **output, size_t *output_cnt, void *private_ctx)
 {
     int *callback_called = (int*)private_ctx;
@@ -2566,7 +2566,7 @@ cl_rpc_test(void **state)
 }
 
 static int
-test_rpc_tree_cb(const char *xpath, const sr_node_t *input, const size_t input_cnt,
+test_rpc_tree_cb(sr_session_ctx_t *session, const char *xpath, const sr_node_t *input, const size_t input_cnt,
         sr_node_t **output, size_t *output_cnt, void *private_ctx)
 {
     const sr_node_t *sr_in_node = NULL;
@@ -2993,7 +2993,7 @@ cl_rpc_combo_test(void **state)
 }
 
 static int
-test_failing_rpc_cb(const char *xpath, const sr_val_t *input, const size_t input_cnt,
+test_failing_rpc_cb(sr_session_ctx_t *session, const char *xpath, const sr_val_t *input, const size_t input_cnt,
         sr_val_t **output, size_t *output_cnt, void *private_ctx)
 {
     int *callback_called = (int*)private_ctx;
@@ -3045,7 +3045,7 @@ cl_failed_rpc_test(void **state)
 }
 
 static int
-test_invalid_rpc_cb(const char *xpath, const sr_val_t *input, const size_t input_cnt,
+test_invalid_rpc_cb(sr_session_ctx_t *session, const char *xpath, const sr_val_t *input, const size_t input_cnt,
         sr_val_t **output, size_t *output_cnt, void *private_ctx)
 {
     int *callback_called = (int*)private_ctx;
@@ -3122,7 +3122,7 @@ cl_invalid_rpc_test(void **state)
 }
 
 static int
-test_action_cb1(const char *xpath, const sr_val_t *input, const size_t input_cnt,
+test_action_cb1(sr_session_ctx_t *session, const char *xpath, const sr_val_t *input, const size_t input_cnt,
         sr_val_t **output, size_t *output_cnt, void *private_ctx)
 {
     int *callback_called = (int*)private_ctx;
@@ -3155,7 +3155,7 @@ test_action_cb1(const char *xpath, const sr_val_t *input, const size_t input_cnt
 }
 
 static int
-test_action_cb2(const char *xpath, const sr_val_t *input, const size_t input_cnt,
+test_action_cb2(sr_session_ctx_t *session, const char *xpath, const sr_val_t *input, const size_t input_cnt,
         sr_val_t **output, size_t *output_cnt, void *private_ctx)
 {
     int *callback_called = (int*)private_ctx;
@@ -3183,7 +3183,7 @@ test_action_cb2(const char *xpath, const sr_val_t *input, const size_t input_cnt
 }
 
 static int
-test_action_tree_cb1(const char *xpath, const sr_node_t *input, const size_t input_cnt,
+test_action_tree_cb1(sr_session_ctx_t *session, const char *xpath, const sr_node_t *input, const size_t input_cnt,
         sr_node_t **output, size_t *output_cnt, void *private_ctx)
 {
     const sr_node_t *sr_in_node = NULL;
@@ -3228,7 +3228,7 @@ test_action_tree_cb1(const char *xpath, const sr_node_t *input, const size_t inp
 }
 
 static int
-test_action_tree_cb2(const char *xpath, const sr_node_t *input, const size_t input_cnt,
+test_action_tree_cb2(sr_session_ctx_t *session, const char *xpath, const sr_node_t *input, const size_t input_cnt,
         sr_node_t **output, size_t *output_cnt, void *private_ctx)
 {
     int *callback_called = (int*)private_ctx;

--- a/tests/cl_test2.c
+++ b/tests/cl_test2.c
@@ -86,7 +86,7 @@ empty_module_change_cb(sr_session_ctx_t *session, const char *module_name, sr_no
 }
 
 static int
-test_action_cb1(const char *xpath, const sr_val_t *input, const size_t input_cnt,
+test_action_cb1(sr_session_ctx_t *session, const char *xpath, const sr_val_t *input, const size_t input_cnt,
         sr_val_t **output, size_t *output_cnt, void *private_ctx)
 {
     int *callback_called = (int*)private_ctx;
@@ -177,7 +177,7 @@ test_module_change_cb(sr_session_ctx_t *session, const char *module_name, sr_not
 }
 
 static int
-test_rpc_cb(const char *xpath, const sr_val_t *input, const size_t input_cnt,
+test_rpc_cb(sr_session_ctx_t *session, const char *xpath, const sr_val_t *input, const size_t input_cnt,
         sr_val_t **output, size_t *output_cnt, void *private_ctx)
 {
     int *callback_called = (int*)private_ctx;

--- a/tests/measure_performance.c
+++ b/tests/measure_performance.c
@@ -755,7 +755,7 @@ perf_commit_test(void **state, int op_num, int *items) {
 }
 
 static int
-test_rpc_cb(const char *xpath, const sr_val_t *input, const size_t input_cnt,
+test_rpc_cb(sr_session_ctx_t *session, const char *xpath, const sr_val_t *input, const size_t input_cnt,
         sr_val_t **output, size_t *output_cnt, void *private_ctx)
 {
     sr_val_t *v = NULL;

--- a/tests/nacm_cl_test.c
+++ b/tests/nacm_cl_test.c
@@ -1069,7 +1069,7 @@ sysrepo_teardown(void **state)
 }
 
 static int
-dummy_rpc_cb(const char *xpath, const sr_val_t *input, const size_t input_cnt,
+dummy_rpc_cb(sr_session_ctx_t *session, const char *xpath, const sr_val_t *input, const size_t input_cnt,
         sr_val_t **output, size_t *output_cnt, void *private_ctx)
 {
     inc_cb_call_count();


### PR DESCRIPTION
### Description
Extended _rpc_cb_ with parameter _netconf_id_. This value is set in Netopeer2-server. In the case of unknown netconf id, this parameter should be 0.

### Test case
Manual tests.

### Closure
Netopeer2 #363