### PR TITLE
Handle operations with augments

### DIFF
--- a/src/data_manager.c
+++ b/src/data_manager.c
@@ -6474,7 +6474,7 @@ dm_validate_procedure_content(rp_ctx_t *rp_ctx, rp_session_t *session, dm_data_i
                 node = node->next;
                 backtracking = false;
             } else {
-                node = node->parent;
+                node = lys_parent(node);
             }
         }
     }


### PR DESCRIPTION
### Description
In case there are augments in a schema tree, `lys_parent()` must be used instead of the pointer `node->parent` directly.

### Closure
Fixes #1399