### PR TITLE
Use LINUX_OFD_LOCK file locks when available.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -140,6 +140,7 @@ set(CMAKE_REQUIRED_LIBRARIES pthread)
 include(CheckFunctionExists)
 include(CheckIncludeFiles)
 include(CheckStructHasMember)
+include(CheckSymbolExists)
 CHECK_FUNCTION_EXISTS(pthread_rwlockattr_setkind_np HAVE_PTHREAD_RWLOCKATTR_SETKIND_NP)
 CHECK_FUNCTION_EXISTS(getpeereid HAVE_GETPEEREID)
 CHECK_FUNCTION_EXISTS(getpeerucred HAVE_GETPEERUCRED)
@@ -152,6 +153,7 @@ if(HAVE_MKSTEMPS)
     set(CMAKE_C_FLAGS         "${CMAKE_C_FLAGS} -DHAVE_MKSTEMPS")
 endif(HAVE_MKSTEMPS)
 CHECK_STRUCT_HAS_MEMBER("struct stat" st_mtim "sys/stat.h" HAVE_STAT_ST_MTIM)
+CHECK_SYMBOL_EXISTS("F_OFD_SETLKW" "fcntl.h" HAVE_LINUX_OFD_LOCK)
 
 # user options
 set(ENABLE_NACM 0 CACHE BOOL

--- a/src/common/sr_constants.h.in
+++ b/src/common/sr_constants.h.in
@@ -38,6 +38,7 @@
 #cmakedefine HAVE_STAT_ST_MTIM
 #cmakedefine HAVE_TIMED_LOCK
 #cmakedefine HAVE_FSETXATTR
+#cmakedefine HAVE_LINUX_OFD_LOCK
 
 /** Use libavl (if defined) or libredblack (if not defined) for binary tree manipulations. */
 #cmakedefine USE_AVL_LIB

--- a/src/data_manager.c
+++ b/src/data_manager.c
@@ -5800,13 +5800,22 @@ dm_copy_config(dm_ctx_t *dm_ctx, dm_session_t *session, const sr_list_t *module_
             if (NULL != session) {
                 ac_set_user_identity(dm_ctx->ac_ctx, session->user_credentials);
             }
-            fds[opened_files] = open(file_name, O_RDWR | O_TRUNC);
+            fds[opened_files] = open(file_name, O_RDWR);
             if (NULL != session) {
                 ac_unset_user_identity(dm_ctx->ac_ctx, session->user_credentials);
             }
             if (-1 == fds[opened_files]) {
                 SR_LOG_ERR("File %s can not be opened", file_name);
                 free(file_name);
+                goto cleanup;
+            }
+            /* lock, write, blocking */
+            sr_lock_fd(fds[opened_files], true, true);
+            if (ftruncate(fds[opened_files], 0) != 0)
+            {
+                SR_LOG_ERR("File %s can not be truncated: %s", file_name, sr_strerror_safe(errno));
+                free(file_name);
+                opened_files++;
                 goto cleanup;
             }
             opened_files++;


### PR DESCRIPTION
fix issue #1396.

F_OFD_SETLK works as F_SETLK, only it is associated with file descriptor
rather then the process id, so concurrent access from two different threads
can be prevented (see fcntl man pages).

Pull requests are mostly made to solve problems, add features and make other necessary adjustments.
Every pull request should be preceded by an issue which it is supposed to solve.
Issue is needed before pull request so community could discuss what actually should be done about it.
Developers have to know if applying the request would make (breaking) changes to API/ABI (versioning purposes), what kind of test it needs (QA), etc.
On making pull request, delete this paragraph (after reading it) and fill in following.


### Closure
#1396
