### PR TITLE
Improvements/Cleanup of C++ Wrapper classes

### DIFF
--- a/swig/cpp/examples/cpp_rpc_example.cpp
+++ b/swig/cpp/examples/cpp_rpc_example.cpp
@@ -192,11 +192,11 @@ class My_Callback:public sysrepo::Callback {
             print_tree(in_trees->tree(n));
 
         out_trees->tree(0)->set_name("status");
-        out_trees->tree(0)->set("The image acmefw-2.3 is being installed.", SR_STRING_T);
+        out_trees->tree(0)->set("The image acmefw-2.3 is being installed.");
         out_trees->tree(1)->set_name("version");
-        out_trees->tree(1)->set("2.3", SR_STRING_T);
+        out_trees->tree(1)->set("2.3");
         out_trees->tree(2)->set_name("location");
-        out_trees->tree(2)->set("/root/", SR_STRING_T);
+        out_trees->tree(2)->set("/root/");
 
     return SR_ERR_OK;
     }
@@ -245,7 +245,7 @@ main(int argc, char **argv)
         sysrepo::S_Trees in_trees(new sysrepo::Trees(1));
 
         in_trees->tree(0)->set_name("image-name");
-        in_trees->tree(0)->set("acmefw-2.3", SR_STRING_T);
+        in_trees->tree(0)->set("acmefw-2.3");
 
         cout << "\n ========== START RPC TREE CALL ==========\n" << endl;
         auto out_trees = sess->rpc_send("/test-module:activate-software-image", in_trees);

--- a/swig/cpp/examples/cpp_rpc_example.cpp
+++ b/swig/cpp/examples/cpp_rpc_example.cpp
@@ -171,14 +171,11 @@ class My_Callback:public sysrepo::Callback {
             print_value(in_vals->val(n));
 
         out_vals->val(0)->set("/test-module:activate-software-image/status",\
-                              "The image acmefw-2.3 is being installed.",\
-                              SR_STRING_T);
+                              "The image acmefw-2.3 is being installed.");
         out_vals->val(1)->set("/test-module:activate-software-image/version",\
-                            "2.3",\
-                            SR_STRING_T);
+                            "2.3");
         out_vals->val(2)->set("/test-module:activate-software-image/location",\
-                            "/root/",\
-                            SR_STRING_T);
+                            "/root/");
 
     return SR_ERR_OK;
     }
@@ -226,11 +223,9 @@ main(int argc, char **argv)
         sysrepo::S_Vals in_vals(new sysrepo::Vals(2));
 
         in_vals->val(0)->set("/test-module:activate-software-image/image-name",\
-                           "acmefw-2.3",\
-               SR_STRING_T);
+                           "acmefw-2.3");
         in_vals->val(1)->set("/test-module:activate-software-image/location",\
-                           "/root/",\
-                           SR_STRING_T);
+                           "/root/");
 
         cout << "\n ========== START RPC CALL ==========\n" << endl;
         auto out_vals = sess->rpc_send("/test-module:activate-software-image", in_vals);

--- a/swig/cpp/examples/cpp_set_item_example.cpp
+++ b/swig/cpp/examples/cpp_set_item_example.cpp
@@ -46,7 +46,7 @@ main(int argc, char **argv)
         (list entry will be automatically created if it does not exist) */
         const char *xpath_num = "/ietf-interfaces:interfaces/interface[name='gigaeth0']/ietf-ip:ipv6/address[ip='fe80::ab8']/prefix-length";
         uint8_t num = 64;
-        sysrepo::S_Val value_num(new sysrepo::Val(num, SR_UINT8_T));
+        sysrepo::S_Val value_num(new sysrepo::Val(num));
         sess->set_item(xpath_num, value_num);
 
         sess->commit();

--- a/swig/cpp/examples/cpp_turing_rpc_example.cpp
+++ b/swig/cpp/examples/cpp_turing_rpc_example.cpp
@@ -56,9 +56,9 @@ class My_Callback:public sysrepo::Callback {
             auto output = holder->allocate(2);
 
             /* set 'output/step-count' leaf */
-            output->val(0)->set("/turing-machine:run-until/step-count", (uint64_t) 256, SR_UINT64_T);
+            output->val(0)->set("/turing-machine:run-until/step-count", (uint64_t) 256);
             /* set 'output/halted' leaf */
-            output->val(1)->set("/turing-machine:run-until/halted", false, SR_BOOL_T);
+            output->val(1)->set("/turing-machine:run-until/halted", false);
 
             std::cout << ">>> RPC Output:" << std::endl << std::endl;
             for (size_t i = 0; i < output->val_cnt(); ++i) {
@@ -130,8 +130,8 @@ rpc_caller(sysrepo::S_Session sess)
         sysrepo::S_Vals input(new sysrepo::Vals(7));
 
         /* set 'input/state' leaf */
-        input->val(0)->set("/turing-machine:run-until/state", (uint16_t) 10, SR_UINT16_T);
-        input->val(1)->set("/turing-machine:run-until/head-position", (int64_t) 123, SR_INT64_T);
+        input->val(0)->set("/turing-machine:run-until/state", (uint16_t) 10);
+        input->val(1)->set("/turing-machine:run-until/head-position", (int64_t) 123);
         /* set 'input/tape' list entries */
         for (int i = 0; i < 5; ++i) {
             // WTF
@@ -139,7 +139,7 @@ rpc_caller(sysrepo::S_Session sess)
             char xpath_str[100] = {0};
             sprintf(xpath_str, "/turing-machine:run-until/tape/cell[coord='%d']/symbol", i);
             sprintf(value, "%c", 'A'+i);
-            input->val(i+2)->set(xpath_str, value, SR_STRING_T);
+            input->val(i+2)->set(xpath_str, value);
         }
 
         std::cout << std::endl << std::endl << " ========== EXECUTING RPC ==========" << std::endl << std::endl;

--- a/swig/cpp/examples/cpp_turing_rpc_example.cpp
+++ b/swig/cpp/examples/cpp_turing_rpc_example.cpp
@@ -56,7 +56,7 @@ class My_Callback:public sysrepo::Callback {
             auto output = holder->allocate(2);
 
             /* set 'output/step-count' leaf */
-            output->val(0)->set("/turing-machine:run-until/step-count", (uint64_t) 256);
+            output->val(0)->set("/turing-machine:run-until/step-count", uint64_t{256});
             /* set 'output/halted' leaf */
             output->val(1)->set("/turing-machine:run-until/halted", false);
 
@@ -130,8 +130,8 @@ rpc_caller(sysrepo::S_Session sess)
         sysrepo::S_Vals input(new sysrepo::Vals(7));
 
         /* set 'input/state' leaf */
-        input->val(0)->set("/turing-machine:run-until/state", (uint16_t) 10);
-        input->val(1)->set("/turing-machine:run-until/head-position", (int64_t) 123);
+        input->val(0)->set("/turing-machine:run-until/state", uint16_t{10});
+        input->val(1)->set("/turing-machine:run-until/head-position", int64_t{123});
         /* set 'input/tape' list entries */
         for (int i = 0; i < 5; ++i) {
             // WTF

--- a/swig/cpp/src/Struct.cpp
+++ b/swig/cpp/src/Struct.cpp
@@ -68,7 +68,7 @@ char *Data::get_instanceid() const {
 }
 int8_t Data::get_int8() const {
     if (_t != SR_INT8_T) throw_exception(SR_ERR_DATA_MISSING);
-    return _d.int8_val;
+    return _d.int32_val;
 }
 int16_t Data::get_int16() const {
     if (_t != SR_INT16_T) throw_exception(SR_ERR_DATA_MISSING);

--- a/swig/cpp/src/Struct.cpp
+++ b/swig/cpp/src/Struct.cpp
@@ -88,7 +88,7 @@ char *Data::get_string() const {
 }
 uint8_t Data::get_uint8() const {
     if (_t != SR_UINT8_T) throw_exception(SR_ERR_DATA_MISSING);
-    return _d.uint32_val;
+    return _d.uint8_val;
 }
 uint16_t Data::get_uint16() const {
     if (_t != SR_UINT16_T) throw_exception(SR_ERR_DATA_MISSING);
@@ -105,8 +105,7 @@ uint64_t Data::get_uint64() const {
 
 // Val
 Val::Val(sr_val_t *val, S_Deleter deleter) {
-    if (val == nullptr)
-        throw_exception(SR_ERR_INVAL_ARG);
+    if (val == nullptr) throw_exception(SR_ERR_INVAL_ARG);
     _val = val;
     _deleter = deleter;
 }
@@ -120,16 +119,14 @@ Val::Val(const char *value, sr_type_t type) {
     sr_val_t *val = nullptr;
     val = (sr_val_t*) calloc(1, sizeof(sr_val_t));
 
-    if (val == nullptr)
-        throw_exception(SR_ERR_NOMEM);
+    if (val == nullptr) throw_exception(SR_ERR_NOMEM);
 
     val->type = type;
 
     if (type == SR_BINARY_T || type == SR_BITS_T || type == SR_ENUM_T || type == SR_IDENTITYREF_T || \
         type == SR_INSTANCEID_T || type == SR_STRING_T) {
         ret = sr_val_set_str_data(val, type, value);
-        if (ret != SR_ERR_OK)
-            throw_exception(ret);
+        if (ret != SR_ERR_OK) throw_exception(ret);
     } else if (value != nullptr && ( type != SR_LIST_T && type != SR_CONTAINER_T && type != SR_CONTAINER_PRESENCE_T &&\
         type != SR_UNKNOWN_T && type != SR_LEAF_EMPTY_T)) {
         free(val);
@@ -140,87 +137,56 @@ Val::Val(const char *value, sr_type_t type) {
     _deleter = S_Deleter(new Deleter(val));
 }
 Val::Val(bool bool_val, sr_type_t type) {
+    if (type != SR_BOOL_T) throw_exception(SR_ERR_INVAL_ARG);
     sr_val_t *val = nullptr;
     val = (sr_val_t*) calloc(1, sizeof(sr_val_t));
-    if (val == nullptr)
-        throw_exception(SR_ERR_NOMEM);
-    if (type == SR_BOOL_T) {
-	val->data.bool_val = bool_val;
-    } else {
-        free(val);
-        throw_exception(SR_ERR_INVAL_ARG);
-    }
-
-    val->type = type;
+    if (val == nullptr) throw_exception(SR_ERR_NOMEM);
+    val->data.bool_val = bool_val;
+    val->type = SR_BOOL_T;
     _val = val;
     _deleter = S_Deleter(new Deleter(val));
 }
-Val::Val(double decimal64_val) {
+Val::Val(double decimal64_val, sr_type_t type) {
+    if (type != SR_DECIMAL64_T) throw_exception(SR_ERR_INVAL_ARG);
     sr_val_t *val = nullptr;
     val = (sr_val_t*) calloc(1, sizeof(sr_val_t));
-    if (val == nullptr) {
-        throw_exception(SR_ERR_NOMEM);
-    } else {
-	val->data.decimal64_val = decimal64_val;
-    }
-
+    if (val == nullptr) throw_exception(SR_ERR_NOMEM);
+    val->data.decimal64_val = decimal64_val;
     val->type = SR_DECIMAL64_T;
     _val = val;
     _deleter = S_Deleter(new Deleter(val));
 }
-Val::Val(int8_t int8_val, sr_type_t type) {
+Val::Val(int8_t int8_val) {
     sr_val_t *val = nullptr;
     val = (sr_val_t*) calloc(1, sizeof(sr_val_t));
-    if (val == nullptr)
-        throw_exception(SR_ERR_NOMEM);
-    if (type == SR_INT8_T) {
-	val->data.int8_val = int8_val;
-    } else {
-        free(val);
-        throw_exception(SR_ERR_INVAL_ARG);
-    }
-
-    val->type = type;
+    if (val == nullptr) throw_exception(SR_ERR_NOMEM);
+    val->data.int8_val = int8_val;
+    val->type = SR_INT8_T;
     _val = val;
     _deleter = S_Deleter(new Deleter(val));
 }
-Val::Val(int16_t int16_val, sr_type_t type) {
+Val::Val(int16_t int16_val) {
     sr_val_t *val = nullptr;
     val = (sr_val_t*) calloc(1, sizeof(sr_val_t));
-    if (val == nullptr)
-        throw_exception(SR_ERR_NOMEM);
-    if (type == SR_INT16_T) {
-	val->data.int16_val = int16_val;
-    } else {
-        free(val);
-        throw_exception(SR_ERR_INVAL_ARG);
-    }
-
-    val->type = type;
+    if (val == nullptr) throw_exception(SR_ERR_NOMEM);
+    val->data.int16_val = int16_val;
+    val->type = SR_INT16_T;
     _val = val;
     _deleter = S_Deleter(new Deleter(val));
 }
-Val::Val(int32_t int32_val, sr_type_t type) {
+Val::Val(int32_t int32_val) {
     sr_val_t *val = nullptr;
     val = (sr_val_t*) calloc(1, sizeof(sr_val_t));
-    if (val == nullptr)
-        throw_exception(SR_ERR_NOMEM);
-    if (type == SR_INT32_T) {
-	val->data.int32_val = int32_val;
-    } else {
-        free(val);
-        throw_exception(SR_ERR_INVAL_ARG);
-    }
-
-    val->type = type;
+    if (val == nullptr) throw_exception(SR_ERR_NOMEM);
+    val->data.int32_val = int32_val;
+    val->type = SR_INT32_T;
     _val = val;
     _deleter = S_Deleter(new Deleter(val));
 }
 Val::Val(int64_t int64_val, sr_type_t type) {
     sr_val_t *val = nullptr;
     val = (sr_val_t*) calloc(1, sizeof(sr_val_t));
-    if (val == nullptr)
-        throw_exception(SR_ERR_NOMEM);
+    if (val == nullptr) throw_exception(SR_ERR_NOMEM);
     if (type == SR_UINT64_T) {
         val->data.uint64_val = (uint64_t) int64_val;
     } else if (type == SR_UINT32_T) {
@@ -237,8 +203,10 @@ Val::Val(int64_t int64_val, sr_type_t type) {
         val->data.int16_val = (int16_t) int64_val;
     } else if (type == SR_INT8_T) {
         val->data.int8_val = (int8_t) int64_val;
+    } else if (type == SR_BOOL_T) {
+        val->data.bool_val = (bool) int64_val;
     } else {
-	    printf("\nERROR \n\n\n\n");
+        printf("\nERROR \n\n\n\n");
         free(val);
         throw_exception(SR_ERR_INVAL_ARG);
     }
@@ -247,67 +215,40 @@ Val::Val(int64_t int64_val, sr_type_t type) {
     _val = val;
     _deleter = S_Deleter(new Deleter(val));
 }
-Val::Val(uint8_t uint8_val, sr_type_t type) {
+Val::Val(uint8_t uint8_val) {
     sr_val_t *val = nullptr;
     val = (sr_val_t*) calloc(1, sizeof(sr_val_t));
-    if (val == nullptr)
-        throw_exception(SR_ERR_NOMEM);
-    if (type == SR_UINT8_T) {
-	val->data.uint8_val = uint8_val;
-    } else {
-        free(val);
-        throw_exception(SR_ERR_INVAL_ARG);
-    }
-
-    val->type = type;
+    if (val == nullptr) throw_exception(SR_ERR_NOMEM);
+    val->data.uint8_val = uint8_val;
+    val->type = SR_UINT8_T;
     _val = val;
     _deleter = S_Deleter(new Deleter(val));
 }
-Val::Val(uint16_t uint16_val, sr_type_t type) {
+Val::Val(uint16_t uint16_val) {
     sr_val_t *val = nullptr;
     val = (sr_val_t*) calloc(1, sizeof(sr_val_t));
-    if (val == nullptr)
-        throw_exception(SR_ERR_NOMEM);
-    if (type == SR_UINT16_T) {
-	val->data.uint16_val = uint16_val;
-    } else {
-        free(val);
-        throw_exception(SR_ERR_INVAL_ARG);
-    }
-
-    val->type = type;
+    if (val == nullptr) throw_exception(SR_ERR_NOMEM);
+    val->data.uint16_val = uint16_val;
+    val->type = SR_UINT16_T;
     _val = val;
     _deleter = S_Deleter(new Deleter(val));
 }
-Val::Val(uint32_t uint32_val, sr_type_t type) {
+Val::Val(uint32_t uint32_val) {
     sr_val_t *val = nullptr;
     val = (sr_val_t*) calloc(1, sizeof(sr_val_t));
-    if (val == nullptr)
-        throw_exception(SR_ERR_NOMEM);
-    if (type == SR_UINT32_T) {
-	val->data.uint32_val = uint32_val;
-    } else {
-        free(val);
-        throw_exception(SR_ERR_INVAL_ARG);
-    }
-
-    val->type = type;
+    if (val == nullptr) throw_exception(SR_ERR_NOMEM);
+    val->data.uint32_val = uint32_val;
+    val->type = SR_UINT32_T;
     _val = val;
     _deleter = S_Deleter(new Deleter(val));
 }
 Val::Val(uint64_t uint64_val, sr_type_t type) {
+    if (type != SR_UINT64_T) throw_exception(SR_ERR_INVAL_ARG);
     sr_val_t *val = nullptr;
     val = (sr_val_t*) calloc(1, sizeof(sr_val_t));
-    if (val == nullptr)
-        throw_exception(SR_ERR_NOMEM);
-    if (type == SR_UINT64_T) {
-	val->data.uint64_val = uint64_val;
-    } else {
-        free(val);
-        throw_exception(SR_ERR_INVAL_ARG);
-    }
-
-    val->type = type;
+    if (val == nullptr) throw_exception(SR_ERR_NOMEM);
+    val->data.uint64_val = uint64_val;
+    val->type = SR_UINT64_T;
     _val = val;
     _deleter = S_Deleter(new Deleter(val));
 }
@@ -331,20 +272,17 @@ void Val::set(const char *xpath, const char *value, sr_type_t type) {
     }
 }
 void Val::set(const char *xpath, bool bool_val, sr_type_t type) {
+    if (type != SR_BOOL_T) throw_exception(SR_ERR_INVAL_ARG);
     if (_val == nullptr) throw_exception(SR_ERR_OPERATION_FAILED);
 
     int ret = sr_val_set_xpath(_val, xpath);
     if (ret != SR_ERR_OK) throw_exception(ret);
 
-    if (type == SR_BOOL_T) {
-	    _val->data.bool_val = bool_val;
-    } else {
-        throw_exception(SR_ERR_INVAL_ARG);
-    }
-
-    _val->type = type;
+    _val->data.bool_val = bool_val;
+    _val->type = SR_BOOL_T;
 }
-void Val::set(const char *xpath, double decimal64_val) {
+void Val::set(const char *xpath, double decimal64_val, sr_type_t type) {
+    if (type != SR_DECIMAL64_T) throw_exception(SR_ERR_INVAL_ARG);
     if (_val == nullptr) throw_exception(SR_ERR_OPERATION_FAILED);
 
     int ret = sr_val_set_xpath(_val, xpath);
@@ -354,47 +292,32 @@ void Val::set(const char *xpath, double decimal64_val) {
 
     _val->type = SR_DECIMAL64_T;
 }
-void Val::set(const char *xpath, int8_t int8_val, sr_type_t type) {
+void Val::set(const char *xpath, int8_t int8_val) {
     if (_val == nullptr) throw_exception(SR_ERR_OPERATION_FAILED);
 
     int ret = sr_val_set_xpath(_val, xpath);
     if (ret != SR_ERR_OK) throw_exception(ret);
 
-    if (type == SR_INT8_T) {
-	    _val->data.int8_val = int8_val;
-    } else {
-        throw_exception(SR_ERR_INVAL_ARG);
-    }
-
-    _val->type = type;
+    _val->data.int8_val = int8_val;
+    _val->type = SR_INT8_T;
 }
-void Val::set(const char *xpath, int16_t int16_val, sr_type_t type) {
+void Val::set(const char *xpath, int16_t int16_val) {
     if (_val == nullptr) throw_exception(SR_ERR_OPERATION_FAILED);
 
     int ret = sr_val_set_xpath(_val, xpath);
     if (ret != SR_ERR_OK) throw_exception(ret);
 
-    if (type == SR_INT16_T) {
-	    _val->data.int16_val = int16_val;
-    } else {
-        throw_exception(SR_ERR_INVAL_ARG);
-    }
-
-    _val->type = type;
+    _val->data.int16_val = int16_val;
+    _val->type = SR_INT16_T;
 }
-void Val::set(const char *xpath, int32_t int32_val, sr_type_t type) {
+void Val::set(const char *xpath, int32_t int32_val) {
     if (_val == nullptr) throw_exception(SR_ERR_OPERATION_FAILED);
 
     int ret = sr_val_set_xpath(_val, xpath);
     if (ret != SR_ERR_OK) throw_exception(ret);
 
-    if (type == SR_INT32_T) {
-	    _val->data.int32_val = int32_val;
-    } else {
-        throw_exception(SR_ERR_INVAL_ARG);
-    }
-
-    _val->type = type;
+    _val->data.int32_val = int32_val;
+    _val->type = SR_INT32_T;
 }
 
 void Val::set(const char *xpath, int64_t int64_val, sr_type_t type) {
@@ -419,71 +342,71 @@ void Val::set(const char *xpath, int64_t int64_val, sr_type_t type) {
         _val->data.int16_val = (int16_t) int64_val;
     } else if (type == SR_INT8_T) {
         _val->data.int8_val = (int8_t) int64_val;
+    } else if (type == SR_BOOL_T) {
+        _val->data.bool_val = (bool) int64_val;
     } else {
         throw_exception(SR_ERR_INVAL_ARG);
     }
 
     _val->type = type;
 }
-void Val::set(const char *xpath, uint8_t uint8_val, sr_type_t type) {
+void Val::set(const char *xpath, uint8_t uint8_val) {
     if (_val == nullptr) throw_exception(SR_ERR_OPERATION_FAILED);
 
     int ret = sr_val_set_xpath(_val, xpath);
     if (ret != SR_ERR_OK) throw_exception(ret);
 
-    if (type == SR_UINT8_T) {
-	    _val->data.uint8_val = uint8_val;
-    } else {
-        throw_exception(SR_ERR_INVAL_ARG);
-    }
-
-    _val->type = type;
+    _val->data.uint8_val = uint8_val;
+    _val->type = SR_UINT8_T;
 }
-void Val::set(const char *xpath, uint16_t uint16_val, sr_type_t type) {
+void Val::set(const char *xpath, uint16_t uint16_val) {
     if (_val == nullptr) throw_exception(SR_ERR_OPERATION_FAILED);
 
     int ret = sr_val_set_xpath(_val, xpath);
     if (ret != SR_ERR_OK) throw_exception(ret);
 
-    if (type == SR_UINT16_T) {
-	    _val->data.uint16_val = uint16_val;
-    } else {
-        throw_exception(SR_ERR_INVAL_ARG);
-    }
-
-    _val->type = type;
+    _val->data.uint16_val = uint16_val;
+    _val->type = SR_UINT16_T;
 }
-void Val::set(const char *xpath, uint32_t uint32_val, sr_type_t type) {
+void Val::set(const char *xpath, uint32_t uint32_val) {
     if (_val == nullptr) throw_exception(SR_ERR_OPERATION_FAILED);
 
     int ret = sr_val_set_xpath(_val, xpath);
     if (ret != SR_ERR_OK) throw_exception(ret);
 
-    if (type == SR_UINT32_T) {
-	    _val->data.uint32_val = uint32_val;
-    } else {
-        throw_exception(SR_ERR_INVAL_ARG);
-    }
-
-    _val->type = type;
+    _val->data.uint32_val = uint32_val;
+    _val->type = SR_UINT32_T;
 }
 void Val::set(const char *xpath, uint64_t uint64_val, sr_type_t type) {
+    if (type != SR_UINT64_T) throw_exception(SR_ERR_INVAL_ARG);
     if (_val == nullptr) throw_exception(SR_ERR_OPERATION_FAILED);
 
     int ret = sr_val_set_xpath(_val, xpath);
     if (ret != SR_ERR_OK) throw_exception(ret);
 
-    if (type == SR_UINT64_T) {
-	    _val->data.uint64_val = uint64_val;
-    } else {
-        throw_exception(SR_ERR_INVAL_ARG);
-    }
-
-    _val->type = type;
+    _val->data.uint64_val = uint64_val;
+    _val->type = SR_UINT64_T;
 }
-void Val::xpath_set(char *xpath) {
+char *Val::xpath() {
+    return (_val ? _val->xpath : nullptr);
+}
+void Val::xpath_set(const char *xpath) {
     int ret = sr_val_set_xpath(_val, xpath);
     if (ret != SR_ERR_OK) throw_exception(ret);
+}
+sr_type_t Val::type() {
+    return (_val ? _val->type : SR_UNKNOWN_T);
+}
+bool Val::dflt() {
+    return (_val ? _val->dflt : false);
+}
+void Val::dflt_set(bool data) {
+    if (_val == nullptr) throw_exception(SR_ERR_OPERATION_FAILED);
+    _val->dflt = data;
+}
+S_Data Val::data() {
+    S_Data data(new Data(_val->data, _val->type, _deleter));
+    return data;
 }
 std::string Val::to_string() {
     char *mem = nullptr;
@@ -516,8 +439,7 @@ std::string Val::val_to_string() {
 S_Val Val::dup() {
     sr_val_t *new_val = nullptr;
     int ret = sr_dup_val(_val, &new_val);
-    if (ret != SR_ERR_OK)
-        throw_exception(ret);
+    if (ret != SR_ERR_OK) throw_exception(ret);
 
     S_Deleter deleter(new Deleter(new_val));
     S_Val val(new Val(new_val, deleter));
@@ -539,8 +461,7 @@ Vals::Vals(sr_val_t **vals, size_t *cnt, S_Deleter deleter) {
 Vals::Vals(size_t cnt): Vals() {
     if (cnt) {
         int ret = sr_new_values(cnt, &_vals);
-        if (ret != SR_ERR_OK)
-            throw_exception(ret);
+        if (ret != SR_ERR_OK) throw_exception(ret);
 
         _cnt = cnt;
         _deleter = S_Deleter(new Deleter(_vals, _cnt));
@@ -549,10 +470,8 @@ Vals::Vals(size_t cnt): Vals() {
 Vals::Vals(): _cnt(0), _vals(nullptr) {}
 Vals::~Vals() {}
 S_Val Vals::val(size_t n) {
-    if (n >= _cnt)
-        throw std::out_of_range("Vals::val: index out of range");
-    if (!_vals)
-        throw std::logic_error("Vals::val: called on null Vals");
+    if (n >= _cnt) throw std::out_of_range("Vals::val: index out of range");
+    if (!_vals) throw std::logic_error("Vals::val: called on null Vals");
 
     S_Val val(new Val(&_vals[n], _deleter));
     return val;
@@ -560,8 +479,7 @@ S_Val Vals::val(size_t n) {
 S_Vals Vals::dup() {
     sr_val_t *new_val = nullptr;
     int ret = sr_dup_values(_vals, _cnt, &new_val);
-    if (ret != SR_ERR_OK)
-        throw_exception(ret);
+    if (ret != SR_ERR_OK) throw_exception(ret);
 
     S_Deleter deleter(new Deleter(new_val, _cnt));
     S_Vals vals(new Vals(new_val, _cnt, deleter));
@@ -575,8 +493,7 @@ Vals_Holder::Vals_Holder(sr_val_t **vals, size_t *cnt) {
     _allocate = true;
 }
 S_Vals Vals_Holder::allocate(size_t n) {
-    if (_allocate == false)
-        throw_exception(SR_ERR_DATA_EXISTS);
+    if (_allocate == false) throw_exception(SR_ERR_DATA_EXISTS);
     _allocate = false;
 
     if (n == 0)
@@ -608,8 +525,7 @@ Error::~Error() {}
 Errors::Errors() {_info = nullptr; _cnt = 0;}
 Errors::~Errors() {}
 S_Error Errors::error(size_t n) {
-    if (n >= _cnt)
-        throw std::out_of_range("Errors:error: index out of range");
+    if (n >= _cnt) throw std::out_of_range("Errors:error: index out of range");
 
     S_Error error(new Error(&_info[n]));
     return error;
@@ -638,15 +554,13 @@ S_Schema_Revision Yang_Schema::revision() {
     return rev;
 }
 S_Schema_Submodule Yang_Schema::submodule(size_t n) {
-    if (n >= _sch->submodule_count)
-        throw std::out_of_range("Schema_Submodule::submodule: index out of range");
+    if (n >= _sch->submodule_count) throw std::out_of_range("Schema_Submodule::submodule: index out of range");
 
     S_Schema_Submodule sub(new Schema_Submodule(_sch->submodules[n], _deleter));
     return sub;
 }
 char *Yang_Schema::enabled_features(size_t n) {
-    if (n >= _sch->enabled_feature_cnt)
-        throw std::out_of_range("Yang_Schema::enabled_features: index out of range");
+    if (n >= _sch->enabled_feature_cnt) throw std::out_of_range("Yang_Schema::enabled_features: index out of range");
 
    return _sch->enabled_features[n];
 }
@@ -659,8 +573,7 @@ Yang_Schemas::Yang_Schemas() {
 }
 Yang_Schemas::~Yang_Schemas() {}
 S_Yang_Schema Yang_Schemas::schema(size_t n) {
-    if (n >= _cnt)
-        throw std::out_of_range("Yang_Schema::schema: index out of range");
+    if (n >= _cnt) throw std::out_of_range("Yang_Schema::schema: index out of range");
 
     S_Yang_Schema rev(new Yang_Schema((sr_schema_t *) &_sch[n], _deleter));
     return rev;
@@ -674,8 +587,7 @@ Fd_Change::~Fd_Change() {}
 Fd_Changes::Fd_Changes(sr_fd_change_t *ch, size_t cnt) {_ch = ch; _cnt = cnt;}
 Fd_Changes::~Fd_Changes() {}
 S_Fd_Change Fd_Changes::fd_change(size_t n) {
-    if (n >= _cnt)
-        throw std::out_of_range("Fd_Changes::fd_change: index out of range");
+    if (n >= _cnt) throw std::out_of_range("Fd_Changes::fd_change: index out of range");
 
     S_Fd_Change change(new Fd_Change(&_ch[n]));
     return change;

--- a/swig/cpp/src/Struct.cpp
+++ b/swig/cpp/src/Struct.cpp
@@ -39,73 +39,107 @@ namespace sysrepo {
 Data::Data(sr_data_t data, sr_type_t type, S_Deleter deleter) {_d = data; _t = type; _deleter = deleter;}
 Data::~Data() {}
 char *Data::get_binary() const {
-    if (_t != SR_BINARY_T) throw_exception(SR_ERR_DATA_MISSING);
+    if (_t != SR_BINARY_T) {
+        throw_exception(SR_ERR_DATA_MISSING);
+    }
     return _d.binary_val;
 }
 char *Data::get_bits() const {
-    if (_t != SR_BITS_T) throw_exception(SR_ERR_DATA_MISSING);
+    if (_t != SR_BITS_T) {
+        throw_exception(SR_ERR_DATA_MISSING);
+    }
     return _d.bits_val;
 }
 bool Data::get_bool() const {
-    if (_t != SR_BOOL_T) throw_exception(SR_ERR_DATA_MISSING);
+    if (_t != SR_BOOL_T) {
+        throw_exception(SR_ERR_DATA_MISSING);
+    }
     return _d.bool_val;
 }
 double Data::get_decimal64() const {
-    if (_t != SR_DECIMAL64_T) throw_exception(SR_ERR_DATA_MISSING);
+    if (_t != SR_DECIMAL64_T) {
+        throw_exception(SR_ERR_DATA_MISSING);
+    }
     return _d.decimal64_val;
 }
 char *Data::get_enum() const {
-    if (_t != SR_ENUM_T) throw_exception(SR_ERR_DATA_MISSING);
+    if (_t != SR_ENUM_T) {
+        throw_exception(SR_ERR_DATA_MISSING);
+    }
     return _d.enum_val;
 }
 char *Data::get_identityref() const {
-    if (_t != SR_IDENTITYREF_T) throw_exception(SR_ERR_DATA_MISSING);
+    if (_t != SR_IDENTITYREF_T) {
+        throw_exception(SR_ERR_DATA_MISSING);
+    }
     return _d.identityref_val;
 }
 char *Data::get_instanceid() const {
-    if (_t != SR_INSTANCEID_T) throw_exception(SR_ERR_DATA_MISSING);
+    if (_t != SR_INSTANCEID_T) {
+        throw_exception(SR_ERR_DATA_MISSING);
+    }
     return _d.instanceid_val;
 }
 int8_t Data::get_int8() const {
-    if (_t != SR_INT8_T) throw_exception(SR_ERR_DATA_MISSING);
+    if (_t != SR_INT8_T) {
+        throw_exception(SR_ERR_DATA_MISSING);
+    }
     return _d.int32_val;
 }
 int16_t Data::get_int16() const {
-    if (_t != SR_INT16_T) throw_exception(SR_ERR_DATA_MISSING);
+    if (_t != SR_INT16_T) {
+        throw_exception(SR_ERR_DATA_MISSING);
+    }
     return _d.uint32_val;
 }
 int32_t Data::get_int32() const {
-    if (_t != SR_INT32_T) throw_exception(SR_ERR_DATA_MISSING);
+    if (_t != SR_INT32_T) {
+        throw_exception(SR_ERR_DATA_MISSING);
+    }
     return _d.int32_val;
 }
 int64_t Data::get_int64() const {
-    if (_t != SR_INT64_T) throw_exception(SR_ERR_DATA_MISSING);
+    if (_t != SR_INT64_T) {
+        throw_exception(SR_ERR_DATA_MISSING);
+    }
     return _d.int64_val;
 }
 char *Data::get_string() const {
-    if (_t != SR_STRING_T) throw_exception(SR_ERR_DATA_MISSING);
+    if (_t != SR_STRING_T) {
+        throw_exception(SR_ERR_DATA_MISSING);
+    }
     return _d.string_val;
 }
 uint8_t Data::get_uint8() const {
-    if (_t != SR_UINT8_T) throw_exception(SR_ERR_DATA_MISSING);
+    if (_t != SR_UINT8_T) {
+        throw_exception(SR_ERR_DATA_MISSING);
+    }
     return _d.uint8_val;
 }
 uint16_t Data::get_uint16() const {
-    if (_t != SR_UINT16_T) throw_exception(SR_ERR_DATA_MISSING);
+    if (_t != SR_UINT16_T) {
+        throw_exception(SR_ERR_DATA_MISSING);
+    }
     return _d.uint16_val;
 }
 uint32_t Data::get_uint32() const {
-    if (_t != SR_UINT32_T) throw_exception(SR_ERR_DATA_MISSING);
+    if (_t != SR_UINT32_T) {
+        throw_exception(SR_ERR_DATA_MISSING);
+    }
     return _d.uint32_val;
 }
 uint64_t Data::get_uint64() const {
-    if (_t != SR_UINT64_T) throw_exception(SR_ERR_DATA_MISSING);
+    if (_t != SR_UINT64_T) {
+        throw_exception(SR_ERR_DATA_MISSING);
+    }
     return _d.uint64_val;
 }
 
 // Val
 Val::Val(sr_val_t *val, S_Deleter deleter) {
-    if (val == nullptr) throw_exception(SR_ERR_INVAL_ARG);
+    if (val == nullptr) {
+        throw_exception(SR_ERR_INVAL_ARG);
+    }
     _val = val;
     _deleter = deleter;
 }
@@ -119,14 +153,18 @@ Val::Val(const char *value, sr_type_t type) {
     sr_val_t *val = nullptr;
     val = (sr_val_t*) calloc(1, sizeof(sr_val_t));
 
-    if (val == nullptr) throw_exception(SR_ERR_NOMEM);
+    if (val == nullptr) {
+        throw_exception(SR_ERR_NOMEM);
+    }
 
     val->type = type;
 
     if (type == SR_BINARY_T || type == SR_BITS_T || type == SR_ENUM_T || type == SR_IDENTITYREF_T || \
         type == SR_INSTANCEID_T || type == SR_STRING_T) {
         ret = sr_val_set_str_data(val, type, value);
-        if (ret != SR_ERR_OK) throw_exception(ret);
+        if (ret != SR_ERR_OK) {
+            throw_exception(ret);
+        }
     } else if (value != nullptr && ( type != SR_LIST_T && type != SR_CONTAINER_T && type != SR_CONTAINER_PRESENCE_T &&\
         type != SR_UNKNOWN_T && type != SR_LEAF_EMPTY_T)) {
         free(val);
@@ -137,20 +175,28 @@ Val::Val(const char *value, sr_type_t type) {
     _deleter = S_Deleter(new Deleter(val));
 }
 Val::Val(bool bool_val, sr_type_t type) {
-    if (type != SR_BOOL_T) throw_exception(SR_ERR_INVAL_ARG);
+    if (type != SR_BOOL_T) {
+        throw_exception(SR_ERR_INVAL_ARG);
+    }
     sr_val_t *val = nullptr;
     val = (sr_val_t*) calloc(1, sizeof(sr_val_t));
-    if (val == nullptr) throw_exception(SR_ERR_NOMEM);
+    if (val == nullptr) {
+        throw_exception(SR_ERR_NOMEM);
+    }
     val->data.bool_val = bool_val;
     val->type = SR_BOOL_T;
     _val = val;
     _deleter = S_Deleter(new Deleter(val));
 }
 Val::Val(double decimal64_val, sr_type_t type) {
-    if (type != SR_DECIMAL64_T) throw_exception(SR_ERR_INVAL_ARG);
+    if (type != SR_DECIMAL64_T) {
+        throw_exception(SR_ERR_INVAL_ARG);
+    }
     sr_val_t *val = nullptr;
     val = (sr_val_t*) calloc(1, sizeof(sr_val_t));
-    if (val == nullptr) throw_exception(SR_ERR_NOMEM);
+    if (val == nullptr) {
+        throw_exception(SR_ERR_NOMEM);
+    }
     val->data.decimal64_val = decimal64_val;
     val->type = SR_DECIMAL64_T;
     _val = val;
@@ -159,7 +205,9 @@ Val::Val(double decimal64_val, sr_type_t type) {
 Val::Val(int8_t int8_val) {
     sr_val_t *val = nullptr;
     val = (sr_val_t*) calloc(1, sizeof(sr_val_t));
-    if (val == nullptr) throw_exception(SR_ERR_NOMEM);
+    if (val == nullptr) {
+        throw_exception(SR_ERR_NOMEM);
+    }
     val->data.int8_val = int8_val;
     val->type = SR_INT8_T;
     _val = val;
@@ -168,7 +216,9 @@ Val::Val(int8_t int8_val) {
 Val::Val(int16_t int16_val) {
     sr_val_t *val = nullptr;
     val = (sr_val_t*) calloc(1, sizeof(sr_val_t));
-    if (val == nullptr) throw_exception(SR_ERR_NOMEM);
+    if (val == nullptr) {
+        throw_exception(SR_ERR_NOMEM);
+    }
     val->data.int16_val = int16_val;
     val->type = SR_INT16_T;
     _val = val;
@@ -177,7 +227,9 @@ Val::Val(int16_t int16_val) {
 Val::Val(int32_t int32_val) {
     sr_val_t *val = nullptr;
     val = (sr_val_t*) calloc(1, sizeof(sr_val_t));
-    if (val == nullptr) throw_exception(SR_ERR_NOMEM);
+    if (val == nullptr) {
+        throw_exception(SR_ERR_NOMEM);
+    }
     val->data.int32_val = int32_val;
     val->type = SR_INT32_T;
     _val = val;
@@ -186,7 +238,9 @@ Val::Val(int32_t int32_val) {
 Val::Val(int64_t int64_val, sr_type_t type) {
     sr_val_t *val = nullptr;
     val = (sr_val_t*) calloc(1, sizeof(sr_val_t));
-    if (val == nullptr) throw_exception(SR_ERR_NOMEM);
+    if (val == nullptr) {
+        throw_exception(SR_ERR_NOMEM);
+    }
     if (type == SR_UINT64_T) {
         val->data.uint64_val = (uint64_t) int64_val;
     } else if (type == SR_UINT32_T) {
@@ -218,7 +272,9 @@ Val::Val(int64_t int64_val, sr_type_t type) {
 Val::Val(uint8_t uint8_val) {
     sr_val_t *val = nullptr;
     val = (sr_val_t*) calloc(1, sizeof(sr_val_t));
-    if (val == nullptr) throw_exception(SR_ERR_NOMEM);
+    if (val == nullptr) {
+        throw_exception(SR_ERR_NOMEM);
+    }
     val->data.uint8_val = uint8_val;
     val->type = SR_UINT8_T;
     _val = val;
@@ -227,7 +283,9 @@ Val::Val(uint8_t uint8_val) {
 Val::Val(uint16_t uint16_val) {
     sr_val_t *val = nullptr;
     val = (sr_val_t*) calloc(1, sizeof(sr_val_t));
-    if (val == nullptr) throw_exception(SR_ERR_NOMEM);
+    if (val == nullptr) {
+        throw_exception(SR_ERR_NOMEM);
+    }
     val->data.uint16_val = uint16_val;
     val->type = SR_UINT16_T;
     _val = val;
@@ -236,17 +294,23 @@ Val::Val(uint16_t uint16_val) {
 Val::Val(uint32_t uint32_val) {
     sr_val_t *val = nullptr;
     val = (sr_val_t*) calloc(1, sizeof(sr_val_t));
-    if (val == nullptr) throw_exception(SR_ERR_NOMEM);
+    if (val == nullptr) {
+        throw_exception(SR_ERR_NOMEM);
+    }
     val->data.uint32_val = uint32_val;
     val->type = SR_UINT32_T;
     _val = val;
     _deleter = S_Deleter(new Deleter(val));
 }
 Val::Val(uint64_t uint64_val, sr_type_t type) {
-    if (type != SR_UINT64_T) throw_exception(SR_ERR_INVAL_ARG);
+    if (type != SR_UINT64_T) {
+        throw_exception(SR_ERR_INVAL_ARG);
+    }
     sr_val_t *val = nullptr;
     val = (sr_val_t*) calloc(1, sizeof(sr_val_t));
-    if (val == nullptr) throw_exception(SR_ERR_NOMEM);
+    if (val == nullptr) {
+        throw_exception(SR_ERR_NOMEM);
+    }
     val->data.uint64_val = uint64_val;
     val->type = SR_UINT64_T;
     _val = val;
@@ -254,77 +318,110 @@ Val::Val(uint64_t uint64_val, sr_type_t type) {
 }
 void Val::set(const char *xpath, const char *value, sr_type_t type) {
     int ret = SR_ERR_OK;
-    if (_val == nullptr) throw_exception(SR_ERR_OPERATION_FAILED);
+    if (_val == nullptr) {
+        throw_exception(SR_ERR_OPERATION_FAILED);
+    }
 
     ret = sr_val_set_xpath(_val, xpath);
-    if (ret != SR_ERR_OK) throw_exception(ret);
+    if (ret != SR_ERR_OK) {
+        throw_exception(ret);
+    }
 
     _val->type = type;
 
     if (type == SR_BINARY_T || type == SR_BITS_T || type == SR_ENUM_T || type == SR_IDENTITYREF_T || \
         type == SR_INSTANCEID_T || type == SR_STRING_T) {
         ret = sr_val_set_str_data(_val, type, value);
-        if (ret != SR_ERR_OK)
+        if (ret != SR_ERR_OK) {
             throw_exception(ret);
+        }
     } else if (value != nullptr && ( type != SR_LIST_T && type != SR_CONTAINER_T && type != SR_CONTAINER_PRESENCE_T &&\
         type != SR_UNKNOWN_T && type != SR_LEAF_EMPTY_T)) {
         throw_exception(SR_ERR_INVAL_ARG);
     }
 }
 void Val::set(const char *xpath, bool bool_val, sr_type_t type) {
-    if (type != SR_BOOL_T) throw_exception(SR_ERR_INVAL_ARG);
-    if (_val == nullptr) throw_exception(SR_ERR_OPERATION_FAILED);
+    if (type != SR_BOOL_T) {
+        throw_exception(SR_ERR_INVAL_ARG);
+    }
+    if (_val == nullptr) {
+        throw_exception(SR_ERR_OPERATION_FAILED);
+    }
 
     int ret = sr_val_set_xpath(_val, xpath);
-    if (ret != SR_ERR_OK) throw_exception(ret);
+    if (ret != SR_ERR_OK) {
+        throw_exception(ret);
+    }
 
     _val->data.bool_val = bool_val;
     _val->type = SR_BOOL_T;
 }
 void Val::set(const char *xpath, double decimal64_val, sr_type_t type) {
-    if (type != SR_DECIMAL64_T) throw_exception(SR_ERR_INVAL_ARG);
-    if (_val == nullptr) throw_exception(SR_ERR_OPERATION_FAILED);
+    if (type != SR_DECIMAL64_T) {
+        throw_exception(SR_ERR_INVAL_ARG);
+    }
+    if (_val == nullptr) {
+        throw_exception(SR_ERR_OPERATION_FAILED);
+    }
 
     int ret = sr_val_set_xpath(_val, xpath);
-    if (ret != SR_ERR_OK) throw_exception(ret);
+    if (ret != SR_ERR_OK) {
+        throw_exception(ret);
+    }
 
     _val->data.decimal64_val = decimal64_val;
 
     _val->type = SR_DECIMAL64_T;
 }
 void Val::set(const char *xpath, int8_t int8_val) {
-    if (_val == nullptr) throw_exception(SR_ERR_OPERATION_FAILED);
+    if (_val == nullptr) {
+        throw_exception(SR_ERR_OPERATION_FAILED);
+    }
 
     int ret = sr_val_set_xpath(_val, xpath);
-    if (ret != SR_ERR_OK) throw_exception(ret);
+    if (ret != SR_ERR_OK) {
+        throw_exception(ret);
+    }
 
     _val->data.int8_val = int8_val;
     _val->type = SR_INT8_T;
 }
 void Val::set(const char *xpath, int16_t int16_val) {
-    if (_val == nullptr) throw_exception(SR_ERR_OPERATION_FAILED);
+    if (_val == nullptr) {
+        throw_exception(SR_ERR_OPERATION_FAILED);
+    }
 
     int ret = sr_val_set_xpath(_val, xpath);
-    if (ret != SR_ERR_OK) throw_exception(ret);
+    if (ret != SR_ERR_OK) {
+        throw_exception(ret);
+    }
 
     _val->data.int16_val = int16_val;
     _val->type = SR_INT16_T;
 }
 void Val::set(const char *xpath, int32_t int32_val) {
-    if (_val == nullptr) throw_exception(SR_ERR_OPERATION_FAILED);
+    if (_val == nullptr) {
+        throw_exception(SR_ERR_OPERATION_FAILED);
+    }
 
     int ret = sr_val_set_xpath(_val, xpath);
-    if (ret != SR_ERR_OK) throw_exception(ret);
+    if (ret != SR_ERR_OK) {
+        throw_exception(ret);
+    }
 
     _val->data.int32_val = int32_val;
     _val->type = SR_INT32_T;
 }
 
 void Val::set(const char *xpath, int64_t int64_val, sr_type_t type) {
-    if (_val == nullptr) throw_exception(SR_ERR_OPERATION_FAILED);
+    if (_val == nullptr) {
+        throw_exception(SR_ERR_OPERATION_FAILED);
+    }
 
     int ret = sr_val_set_xpath(_val, xpath);
-    if (ret != SR_ERR_OK) throw_exception(ret);
+    if (ret != SR_ERR_OK) {
+        throw_exception(ret);
+    }
 
     if (type == SR_UINT64_T) {
         _val->data.uint64_val = (uint64_t) int64_val;
@@ -351,38 +448,56 @@ void Val::set(const char *xpath, int64_t int64_val, sr_type_t type) {
     _val->type = type;
 }
 void Val::set(const char *xpath, uint8_t uint8_val) {
-    if (_val == nullptr) throw_exception(SR_ERR_OPERATION_FAILED);
+    if (_val == nullptr) {
+        throw_exception(SR_ERR_OPERATION_FAILED);
+    }
 
     int ret = sr_val_set_xpath(_val, xpath);
-    if (ret != SR_ERR_OK) throw_exception(ret);
+    if (ret != SR_ERR_OK) {
+        throw_exception(ret);
+    }
 
     _val->data.uint8_val = uint8_val;
     _val->type = SR_UINT8_T;
 }
 void Val::set(const char *xpath, uint16_t uint16_val) {
-    if (_val == nullptr) throw_exception(SR_ERR_OPERATION_FAILED);
+    if (_val == nullptr) {
+        throw_exception(SR_ERR_OPERATION_FAILED);
+    }
 
     int ret = sr_val_set_xpath(_val, xpath);
-    if (ret != SR_ERR_OK) throw_exception(ret);
+    if (ret != SR_ERR_OK) {
+        throw_exception(ret);
+    }
 
     _val->data.uint16_val = uint16_val;
     _val->type = SR_UINT16_T;
 }
 void Val::set(const char *xpath, uint32_t uint32_val) {
-    if (_val == nullptr) throw_exception(SR_ERR_OPERATION_FAILED);
+    if (_val == nullptr) {
+        throw_exception(SR_ERR_OPERATION_FAILED);
+    }
 
     int ret = sr_val_set_xpath(_val, xpath);
-    if (ret != SR_ERR_OK) throw_exception(ret);
+    if (ret != SR_ERR_OK) {
+        throw_exception(ret);
+    }
 
     _val->data.uint32_val = uint32_val;
     _val->type = SR_UINT32_T;
 }
 void Val::set(const char *xpath, uint64_t uint64_val, sr_type_t type) {
-    if (type != SR_UINT64_T) throw_exception(SR_ERR_INVAL_ARG);
-    if (_val == nullptr) throw_exception(SR_ERR_OPERATION_FAILED);
+    if (type != SR_UINT64_T) {
+        throw_exception(SR_ERR_INVAL_ARG);
+    }
+    if (_val == nullptr) {
+        throw_exception(SR_ERR_OPERATION_FAILED);
+    }
 
     int ret = sr_val_set_xpath(_val, xpath);
-    if (ret != SR_ERR_OK) throw_exception(ret);
+    if (ret != SR_ERR_OK) {
+        throw_exception(ret);
+    }
 
     _val->data.uint64_val = uint64_val;
     _val->type = SR_UINT64_T;
@@ -392,7 +507,9 @@ char *Val::xpath() {
 }
 void Val::xpath_set(const char *xpath) {
     int ret = sr_val_set_xpath(_val, xpath);
-    if (ret != SR_ERR_OK) throw_exception(ret);
+    if (ret != SR_ERR_OK) {
+        throw_exception(ret);
+    }
 }
 sr_type_t Val::type() {
     return (_val ? _val->type : SR_UNKNOWN_T);
@@ -401,7 +518,9 @@ bool Val::dflt() {
     return (_val ? _val->dflt : false);
 }
 void Val::dflt_set(bool data) {
-    if (_val == nullptr) throw_exception(SR_ERR_OPERATION_FAILED);
+    if (_val == nullptr) {
+        throw_exception(SR_ERR_OPERATION_FAILED);
+    }
     _val->dflt = data;
 }
 S_Data Val::data() {
@@ -439,7 +558,9 @@ std::string Val::val_to_string() {
 S_Val Val::dup() {
     sr_val_t *new_val = nullptr;
     int ret = sr_dup_val(_val, &new_val);
-    if (ret != SR_ERR_OK) throw_exception(ret);
+    if (ret != SR_ERR_OK) {
+        throw_exception(ret);
+    }
 
     S_Deleter deleter(new Deleter(new_val));
     S_Val val(new Val(new_val, deleter));
@@ -461,7 +582,9 @@ Vals::Vals(sr_val_t **vals, size_t *cnt, S_Deleter deleter) {
 Vals::Vals(size_t cnt): Vals() {
     if (cnt) {
         int ret = sr_new_values(cnt, &_vals);
-        if (ret != SR_ERR_OK) throw_exception(ret);
+        if (ret != SR_ERR_OK) {
+            throw_exception(ret);
+        }
 
         _cnt = cnt;
         _deleter = S_Deleter(new Deleter(_vals, _cnt));
@@ -479,7 +602,9 @@ S_Val Vals::val(size_t n) {
 S_Vals Vals::dup() {
     sr_val_t *new_val = nullptr;
     int ret = sr_dup_values(_vals, _cnt, &new_val);
-    if (ret != SR_ERR_OK) throw_exception(ret);
+    if (ret != SR_ERR_OK) {
+        throw_exception(ret);
+    }
 
     S_Deleter deleter(new Deleter(new_val, _cnt));
     S_Vals vals(new Vals(new_val, _cnt, deleter));
@@ -493,7 +618,9 @@ Vals_Holder::Vals_Holder(sr_val_t **vals, size_t *cnt) {
     _allocate = true;
 }
 S_Vals Vals_Holder::allocate(size_t n) {
-    if (_allocate == false) throw_exception(SR_ERR_DATA_EXISTS);
+    if (_allocate == false) {
+        throw_exception(SR_ERR_DATA_EXISTS);
+    }
     _allocate = false;
 
     if (n == 0)
@@ -501,8 +628,9 @@ S_Vals Vals_Holder::allocate(size_t n) {
 
     *p_cnt = n;
     int ret = sr_new_values(n, p_vals);
-    if (ret != SR_ERR_OK)
+    if (ret != SR_ERR_OK) {
         throw_exception(ret);
+    }
     S_Vals vals(new Vals(p_vals, p_cnt, nullptr));
     return vals;
 }

--- a/swig/cpp/src/Struct.hpp
+++ b/swig/cpp/src/Struct.hpp
@@ -103,26 +103,26 @@ public:
      * SR_IDENTITYREF_T and SR_INSTANCEID_T.*/
     Val(const char *val, sr_type_t type = SR_STRING_T);
     /** Constructor for bool value.*/
-    Val(bool bool_val, sr_type_t type = SR_BOOL_T);
+    explicit Val(bool bool_val, sr_type_t type = SR_BOOL_T);
     /** Constructor for decimal64 value.*/
-    Val(double decimal64_val);
+    explicit Val(double decimal64_val, sr_type_t type = SR_DECIMAL64_T);
     /** Constructor for int8 value, C++ only.*/
-    Val(int8_t int8_val, sr_type_t type);
+    explicit Val(int8_t int8_val);
     /** Constructor for int16 value, C++ only.*/
-    Val(int16_t int16_val, sr_type_t type);
+    explicit Val(int16_t int16_val);
     /** Constructor for int32 value, C++ only.*/
-    Val(int32_t int32_val, sr_type_t type);
-    /** Constructor for int64 value, type can be SR_INT8_T, SR_INT16_T, SR_INT32_T,
-     * SR_INT64_T, SR_UINT8_T, SR_UINT16_T and SR_UINT32_T,*/
-    Val(int64_t int64_val, sr_type_t type);
+    explicit Val(int32_t int32_val);
+    /** Constructor for int64 value, type can be SR_BOOL_T, SR_INT8_T, SR_INT16_T, SR_INT32_T,
+     * SR_INT64_T, SR_UINT8_T, SR_UINT16_T, SR_UINT32_T, and SR_UINT64_T*/
+    Val(int64_t int64_val, sr_type_t type = SR_INT64_T);
     /** Constructor for uint8 value, C++ only.*/
-    Val(uint8_t uint8_val, sr_type_t type);
+    explicit Val(uint8_t uint8_val);
     /** Constructor for uint16 value, C++ only.*/
-    Val(uint16_t uint16_val, sr_type_t type);
+    explicit Val(uint16_t uint16_val);
     /** Constructor for uint32 value, C++ only.*/
-    Val(uint32_t uint32_val, sr_type_t type);
+    explicit Val(uint32_t uint32_val);
     /** Constructor for uint64 value, C++ only.*/
-    Val(uint64_t uint64_val, sr_type_t type);
+    explicit Val(uint64_t uint64_val, sr_type_t type = SR_UINT64_T);
    ~Val();
     /** Setter for string value, type can be SR_STRING_T, SR_BINARY_T, SR_BITS_T, SR_ENUM_T,
      * SR_IDENTITYREF_T and SR_INSTANCEID_T.*/
@@ -130,36 +130,36 @@ public:
     /** Setter for bool value.*/
     void set(const char *xpath, bool bool_val, sr_type_t type = SR_BOOL_T);
     /** Setter for decimal64 value.*/
-    void set(const char *xpath, double decimal64_val);
+    void set(const char *xpath, double decimal64_val, sr_type_t type = SR_DECIMAL64_T);
     /** Setter for int8 value, C++ only.*/
-    void set(const char *xpath, int8_t int8_val, sr_type_t type);
+    void set(const char *xpath, int8_t int8_val);
     /** Setter for int16 value, C++ only.*/
-    void set(const char *xpath, int16_t int16_val, sr_type_t type);
+    void set(const char *xpath, int16_t int16_val);
     /** Setter for int32 value, C++ only.*/
-    void set(const char *xpath, int32_t int32_val, sr_type_t type);
-    /** Setter for int64 value, type can be SR_INT8_T, SR_INT16_T, SR_INT32_T,
-     * SR_INT64_T, SR_UINT8_T, SR_UINT16_T and SR_UINT32_T,*/
-    void set(const char *xpath, int64_t int64_val, sr_type_t type);
+    void set(const char *xpath, int32_t int32_val);
+    /** Setter for int64 value, type can be SR_BOOL_T, SR_INT8_T, SR_INT16_T, SR_INT32_T,
+     * SR_INT64_T, SR_UINT8_T, SR_UINT16_T, SR_UINT32_T, and SR_UINT64_T*/
+    void set(const char *xpath, int64_t int64_val, sr_type_t type = SR_INT64_T);
     /** Setter for uint8 value, C++ only.*/
-    void set(const char *xpath, uint8_t uint8_val, sr_type_t type);
+    void set(const char *xpath, uint8_t uint8_val);
     /** Setter for uint16 value, C++ only.*/
-    void set(const char *xpath, uint16_t uint16_val, sr_type_t type);
+    void set(const char *xpath, uint16_t uint16_val);
     /** Setter for uint32 value, C++ only.*/
-    void set(const char *xpath, uint32_t uint32_val, sr_type_t type);
+    void set(const char *xpath, uint32_t uint32_val);
     /** Setter for uint64 value, C++ only.*/
-    void set(const char *xpath, uint64_t uint64_val, sr_type_t type);
+    void set(const char *xpath, uint64_t uint64_val, sr_type_t type = SR_UINT64_T);
     /** Getter for xpath.*/
-    char *xpath() {return _val->xpath;};
+    char *xpath();
     /** Setter for xpath.*/
-    void xpath_set(char *xpath);
+    void xpath_set(const char *xpath);
     /** Getter for type.*/
-    sr_type_t type() {return _val->type;};
+    sr_type_t type();
     /** Getter for dflt.*/
-    bool dflt() {return _val->dflt;};
+    bool dflt();
     /** Setter for dflt.*/
-    void dflt_set(bool data) {_val->dflt = data;};
+    void dflt_set(bool data);
     /** Getter for data.*/
-    S_Data data() {S_Data data(new Data(_val->data, _val->type, _deleter)); return data;};
+    S_Data data();
     /** Wrapper for [sr_print_val_mem](@ref sr_print_val_mem) */
     std::string to_string();
     /** Wrapper for [sr_val_to_string](@ref sr_val_to_string) */

--- a/swig/cpp/src/Tree.cpp
+++ b/swig/cpp/src/Tree.cpp
@@ -190,43 +190,32 @@ void Tree::set(const char *value, sr_type_t type) {
 }
 void Tree::set(bool bool_val, sr_type_t type) {
     if (type == SR_BOOL_T) {
-	    _node->data.bool_val = bool_val;
+        _node->data.bool_val = bool_val;
     } else {
         throw_exception(SR_ERR_INVAL_ARG);
     }
 
     _node->type = type;
 }
-void Tree::set(double decimal64_val) {
-    _node->data.decimal64_val = decimal64_val;
+void Tree::set(double decimal64_val, sr_type_t type) {
+    if (type == SR_DECIMAL64_T) {
+        _node->data.decimal64_val = decimal64_val;
+    } else {
+        throw_exception(SR_ERR_INVAL_ARG);
+    }
     _node->type = SR_DECIMAL64_T;
 }
-void Tree::set(int8_t int8_val, sr_type_t type) {
-    if (type == SR_INT8_T) {
-	    _node->data.int8_val = int8_val;
-    } else {
-        throw_exception(SR_ERR_INVAL_ARG);
-    }
-
-    _node->type = type;
+void Tree::set(int8_t int8_val) {
+    _node->data.int8_val = int8_val;
+    _node->type = SR_INT8_T;
 }
-void Tree::set(int16_t int16_val, sr_type_t type) {
-    if (type == SR_INT16_T) {
-	    _node->data.int16_val = int16_val;
-    } else {
-        throw_exception(SR_ERR_INVAL_ARG);
-    }
-
-    _node->type = type;
+void Tree::set(int16_t int16_val) {
+    _node->data.int16_val = int16_val;
+    _node->type = SR_INT16_T;
 }
-void Tree::set(int32_t int32_val, sr_type_t type) {
-    if (type == SR_INT32_T) {
-	    _node->data.int32_val = int32_val;
-    } else {
-        throw_exception(SR_ERR_INVAL_ARG);
-    }
-
-    _node->type = type;
+void Tree::set(int32_t int32_val) {
+    _node->data.int32_val = int32_val;
+    _node->type = SR_INT32_T;
 }
 void Tree::set(int64_t int64_val, sr_type_t type) {
     if (type == SR_UINT64_T) {
@@ -245,47 +234,34 @@ void Tree::set(int64_t int64_val, sr_type_t type) {
         _node->data.int16_val = (int16_t) int64_val;
     } else if (type == SR_INT8_T) {
         _node->data.int8_val = (int8_t) int64_val;
+    } else if (type == SR_BOOL_T) {
+        _node->data.bool_val = (bool) int64_val;
     } else {
         throw_exception(SR_ERR_INVAL_ARG);
     }
 
     _node->type = type;
 }
-void Tree::set(uint8_t uint8_val, sr_type_t type) {
-    if (type == SR_UINT8_T) {
-	    _node->data.uint8_val = uint8_val;
-    } else {
-        throw_exception(SR_ERR_INVAL_ARG);
-    }
-
-    _node->type = type;
+void Tree::set(uint8_t uint8_val) {
+    _node->data.uint8_val = uint8_val;
+    _node->type = SR_UINT8_T;
 }
-void Tree::set(uint16_t uint16_val, sr_type_t type) {
-    if (type == SR_UINT16_T) {
-	    _node->data.uint16_val = uint16_val;
-    } else {
-        throw_exception(SR_ERR_INVAL_ARG);
-    }
-
-    _node->type = type;
+void Tree::set(uint16_t uint16_val) {
+    _node->data.uint16_val = uint16_val;
+    _node->type = SR_UINT16_T;
 }
-void Tree::set(uint32_t uint32_val, sr_type_t type) {
-    if (type == SR_UINT32_T) {
-	    _node->data.uint32_val = uint32_val;
-    } else {
-        throw_exception(SR_ERR_INVAL_ARG);
-    }
-
-    _node->type = type;
+void Tree::set(uint32_t uint32_val) {
+    _node->data.uint32_val = uint32_val;
+    _node->type = SR_UINT32_T;
 }
 void Tree::set(uint64_t uint64_val, sr_type_t type) {
     if (type == SR_UINT64_T) {
-	    _node->data.uint64_val = uint64_val;
+        _node->data.uint64_val = uint64_val;
     } else {
         throw_exception(SR_ERR_INVAL_ARG);
     }
 
-    _node->type = type;
+    _node->type = SR_UINT64_T;
 }
 
 Trees::Trees(size_t cnt): Trees() {

--- a/swig/cpp/src/Tree.cpp
+++ b/swig/cpp/src/Tree.cpp
@@ -40,8 +40,9 @@ Tree::Tree() {
 Tree::Tree(const char *root_name, const char *root_module_name) {
     sr_node_t *node;
     int ret = sr_new_tree(root_name, root_module_name, &node);
-    if (ret != SR_ERR_OK)
+    if (ret != SR_ERR_OK) {
         throw_exception(ret);
+    }
 
     _deleter = S_Deleter(new Deleter(node));
     _node = node;
@@ -57,7 +58,9 @@ S_Tree Tree::dup() {
 
     sr_node_t *tree_dup = nullptr;
     int ret = sr_dup_tree(_node, &tree_dup);
-    if (ret != SR_ERR_OK) throw_exception(ret);
+    if (ret != SR_ERR_OK) {
+        throw_exception(ret);
+    }
 
     S_Deleter deleter(new Deleter(tree_dup));
     S_Tree dup(new Tree(tree_dup, deleter));
@@ -135,7 +138,9 @@ std::string Tree::to_string(int depth_limit) {
 std::string Tree::value_to_string() {
     char *mem = nullptr;
 
-    if (_node == nullptr) throw_exception(SR_ERR_DATA_MISSING);
+    if (_node == nullptr) {
+        throw_exception(SR_ERR_DATA_MISSING);
+    }
 
     sr_val_t *val = (sr_val_t *) _node;
 
@@ -154,24 +159,40 @@ std::string Tree::value_to_string() {
     throw_exception(ret);
 }
 void Tree::set_name(const char *name) {
-    if (_node == nullptr) throw_exception(SR_ERR_DATA_MISSING);
+    if (_node == nullptr) {
+        throw_exception(SR_ERR_DATA_MISSING);
+    }
     int ret = sr_node_set_name(_node, name);
-    if (ret != SR_ERR_OK) throw_exception(ret);
+    if (ret != SR_ERR_OK) {
+        throw_exception(ret);
+    }
 }
 void Tree::set_module(const char *module_name) {
-    if (_node == nullptr) throw_exception(SR_ERR_DATA_MISSING);
+    if (_node == nullptr) {
+        throw_exception(SR_ERR_DATA_MISSING);
+    }
     int ret = sr_node_set_module(_node, module_name);
-    if (ret != SR_ERR_OK) throw_exception(ret);
+    if (ret != SR_ERR_OK) {
+        throw_exception(ret);
+    }
 }
 void Tree::set_str_data(sr_type_t type, const char *string_val) {
-    if (_node == nullptr) throw_exception(SR_ERR_DATA_MISSING);
+    if (_node == nullptr) {
+        throw_exception(SR_ERR_DATA_MISSING);
+    }
     int ret = sr_node_set_str_data(_node, type, string_val);
-    if (ret != SR_ERR_OK) throw_exception(ret);
+    if (ret != SR_ERR_OK) {
+        throw_exception(ret);
+    }
 }
 void Tree::add_child(const char *child_name, const char *child_module_name, S_Tree child) {
-    if (_node == nullptr) throw_exception(SR_ERR_DATA_MISSING);
+    if (_node == nullptr) {
+        throw_exception(SR_ERR_DATA_MISSING);
+    }
     int ret = sr_node_add_child(_node, child_name, child_module_name, &child->_node);
-    if (ret != SR_ERR_OK) throw_exception(ret);
+    if (ret != SR_ERR_OK) {
+        throw_exception(ret);
+    }
 }
 void Tree::set(const char *value, sr_type_t type) {
     int ret = SR_ERR_OK;
@@ -181,8 +202,9 @@ void Tree::set(const char *value, sr_type_t type) {
     if (type == SR_BINARY_T || type == SR_BITS_T || type == SR_ENUM_T || type == SR_IDENTITYREF_T || \
         type == SR_INSTANCEID_T || type == SR_STRING_T) {
         ret = sr_node_set_str_data(_node, type, value);
-        if (ret != SR_ERR_OK)
+        if (ret != SR_ERR_OK) {
             throw_exception(ret);
+        }
     } else if (value != nullptr && ( type != SR_LIST_T && type != SR_CONTAINER_T && type != SR_CONTAINER_PRESENCE_T &&\
         type != SR_UNKNOWN_T && type != SR_LEAF_EMPTY_T)) {
         throw_exception(SR_ERR_INVAL_ARG);
@@ -267,8 +289,9 @@ void Tree::set(uint64_t uint64_val, sr_type_t type) {
 Trees::Trees(size_t cnt): Trees() {
     if (cnt) {
         int ret = sr_new_trees(cnt, &_trees);
-        if (ret != SR_ERR_OK)
+        if (ret != SR_ERR_OK) {
             throw_exception(ret);
+        }
 
         _cnt = cnt;
         _deleter = S_Deleter(new Deleter(_trees, _cnt));
@@ -307,7 +330,9 @@ S_Trees Trees::dup() {
 
     sr_node_t *tree_dup = nullptr;
     int ret = sr_dup_trees(_trees, _cnt, &tree_dup);
-    if (ret != SR_ERR_OK) throw_exception(ret);
+    if (ret != SR_ERR_OK) {
+        throw_exception(ret);
+    }
 
     S_Trees dup(new Trees(tree_dup, _cnt));
     return dup;
@@ -320,8 +345,9 @@ Trees_Holder::Trees_Holder(sr_node_t **trees, size_t *cnt) {
     _allocate = true;
 }
 S_Trees Trees_Holder::allocate(size_t n) {
-    if (_allocate == false)
+    if (_allocate == false) {
         throw_exception(SR_ERR_DATA_EXISTS);
+    }
     _allocate = false;
 
     if (n == 0)
@@ -329,8 +355,9 @@ S_Trees Trees_Holder::allocate(size_t n) {
 
     *p_cnt = n;
     int ret = sr_new_trees(n, p_trees);
-    if (ret != SR_ERR_OK)
+    if (ret != SR_ERR_OK) {
         throw_exception(ret);
+    }
     S_Trees trees(new Trees(p_trees, p_cnt, nullptr));
     return trees;
 }

--- a/swig/cpp/src/Tree.hpp
+++ b/swig/cpp/src/Tree.hpp
@@ -92,24 +92,24 @@ public:
     /** Setter for bool value.*/
     void set(bool bool_val, sr_type_t type = SR_BOOL_T);
     /** Setter for decimal64 value.*/
-    void set(double decimal64_val);
+    void set(double decimal64_val, sr_type_t type = SR_DECIMAL64_T);
     /** Setter for int8 value, C++ only.*/
-    void set(int8_t int8_val, sr_type_t type);
+    void set(int8_t int8_val);
     /** Setter for int16 value, C++ only.*/
-    void set(int16_t int16_val, sr_type_t type);
+    void set(int16_t int16_val);
     /** Setter for int32 value, C++ only.*/
-    void set(int32_t int32_val, sr_type_t type);
-    /** Setter for int64 value, type can be SR_INT8_T, SR_INT16_T, SR_INT32_T,
-     * SR_INT64_T, SR_UINT8_T, SR_UINT16_T and SR_UINT32_T,*/
-    void set(int64_t int64_val, sr_type_t type);
+    void set(int32_t int32_val);
+    /** Setter for int64 value, type can be SR_BOOL_T, SR_INT8_T, SR_INT16_T, SR_INT32_T,
+     * SR_INT64_T, SR_UINT8_T, SR_UINT16_T, SR_UINT32_T, and SR_UINT64_T */
+    void set(int64_t int64_val, sr_type_t type = SR_INT64_T);
     /** Setter for uint8 value, C++ only.*/
-    void set(uint8_t uint8_val, sr_type_t type);
+    void set(uint8_t uint8_val);
     /** Setter for uint16 value, C++ only.*/
-    void set(uint16_t uint16_val, sr_type_t type);
+    void set(uint16_t uint16_val);
     /** Setter for uint32 value, C++ only.*/
-    void set(uint32_t uint32_val, sr_type_t type);
+    void set(uint32_t uint32_val);
     /** Setter for uint64 value, C++ only.*/
-    void set(uint64_t uint64_val, sr_type_t type);
+    void set(uint64_t uint64_val, sr_type_t type = SR_UINT64_T);
     ~Tree();
 
     friend class Session;

--- a/swig/cpp/src/Xpath.cpp
+++ b/swig/cpp/src/Xpath.cpp
@@ -32,8 +32,9 @@ Xpath_Ctx::Xpath_Ctx() {
     sr_xpath_ctx_t *state = nullptr;
     state = (sr_xpath_ctx_t *) calloc(1, sizeof(*state));
 
-    if (state == nullptr)
+    if (state == nullptr) {
         throw_exception(SR_ERR_NOMEM);
+    }
 
     _state = state;
 }

--- a/swig/cpp/tests/changes.cpp
+++ b/swig/cpp/tests/changes.cpp
@@ -39,9 +39,9 @@ void init_test(sysrepo::S_Session sess)
 
     subs->module_change_subscribe(module_name.c_str(), cb, NULL, 0, SR_SUBSCR_DEFAULT | SR_SUBSCR_APPLY_ONLY);
 
-    for (int i = LOW_BOUND; i < HIGH_BOUND; i++) {
+    for (int32_t i = LOW_BOUND; i < HIGH_BOUND; i++) {
         const auto xpath = get_xpath(get_test_name(i), "number");
-        sysrepo::S_Val vset(new sysrepo::Val((int32_t)i, SR_INT32_T));
+        sysrepo::S_Val vset(new sysrepo::Val(i));
         sess->set_item(xpath.c_str(), vset);
     }
 
@@ -122,7 +122,7 @@ test_module_change_modify(sysrepo::S_Session sess)
     subs->module_change_subscribe(module_name.c_str(), cb, NULL, 0, SR_SUBSCR_DEFAULT | SR_SUBSCR_APPLY_ONLY);
 
     const auto xpath = get_xpath(get_test_name(LOW_BOUND), "number");
-    sysrepo::S_Val vset(new sysrepo::Val((int32_t)42, SR_INT32_T));
+    sysrepo::S_Val vset(new sysrepo::Val(42));
     sess->set_item(xpath.c_str(), vset);
     sess->commit();
     subs->unsubscribe();
@@ -162,7 +162,7 @@ test_module_change_create(sysrepo::S_Session sess)
     subs->module_change_subscribe(module_name.c_str(), cb, NULL, 0, SR_SUBSCR_DEFAULT | SR_SUBSCR_APPLY_ONLY);
 
     const auto xpath = get_xpath(get_test_name(HIGH_BOUND), "number");
-    sysrepo::S_Val vset(new sysrepo::Val((int32_t)42, SR_INT32_T));
+    sysrepo::S_Val vset(new sysrepo::Val(42));
     sess->set_item(xpath.c_str(), vset);
     sess->commit();
 

--- a/swig/cpp/tests/operations.cpp
+++ b/swig/cpp/tests/operations.cpp
@@ -23,9 +23,9 @@ std::string get_xpath(const std::string &test_name, const std::string &node_name
 }
 
 void init_test(sysrepo::S_Session sess) {
-    for (int i = LOW_BOUND; i < HIGH_BOUND; i++) {
+    for (int32_t i = LOW_BOUND; i < HIGH_BOUND; i++) {
         const auto xpath = get_xpath(get_test_name(i), "number");
-        sysrepo::S_Val vset(new sysrepo::Val((int32_t)i, SR_INT32_T));
+        sysrepo::S_Val vset(new sysrepo::Val(i));
         sess->set_item(xpath.c_str(), vset);
     }
 
@@ -72,7 +72,7 @@ void test_set_item(sysrepo::S_Session sess)
 {
     for (int32_t i = LOW_BOUND; i < HIGH_BOUND; i++) {
         const auto xpath = get_xpath(get_test_name(i), "number");
-        sysrepo::S_Val vset(new sysrepo::Val((int32_t)i, SR_INT32_T));
+        sysrepo::S_Val vset(new sysrepo::Val(i));
         sess->set_item(xpath.c_str(), vset);
     }
 

--- a/swig/swig_base/cpp_classes.i
+++ b/swig/swig_base/cpp_classes.i
@@ -63,6 +63,7 @@
 #ifndef SWIGLUA
 %shared_ptr(sysrepo::Data);
 #endif
+%ignore Data::Data(sr_data_t, sr_type_t, S_Deleter);
 %ignore Data::Data(sr_data_t, sr_type_t);
 %ignore Data::Data(sr_data_t);
 

--- a/swig/swig_base/lua_base.i
+++ b/swig/swig_base/lua_base.i
@@ -28,6 +28,14 @@
 %ignore Val::set(char const *,uint32_t,sr_type_t);
 %ignore Val::set(char const *,uint64_t,sr_type_t);
 
+%ignore Val::set(char const *,int8_t);
+%ignore Val::set(char const *,int16_t);
+%ignore Val::set(char const *,int32_t);
+%ignore Val::set(char const *,uint8_t);
+%ignore Val::set(char const *,uint16_t);
+%ignore Val::set(char const *,uint32_t);
+%ignore Val::set(char const *,uint64_t);
+
 %ignore Tree::Tree(int8_t,sr_type_t);
 %ignore Tree::Tree(int16_t,sr_type_t);
 %ignore Tree::Tree(int32_t,sr_type_t);
@@ -35,6 +43,14 @@
 %ignore Tree::Tree(uint16_t,sr_type_t);
 %ignore Tree::Tree(uint32_t,sr_type_t);
 %ignore Tree::Tree(uint64_t,sr_type_t);
+
+%ignore Tree::Tree(int8_t);
+%ignore Tree::Tree(int16_t);
+%ignore Tree::Tree(int32_t);
+%ignore Tree::Tree(uint8_t);
+%ignore Tree::Tree(uint16_t);
+%ignore Tree::Tree(uint32_t);
+%ignore Tree::Tree(uint64_t);
 
 %ignore Tree::set(char const *,int8_t,sr_type_t);
 %ignore Tree::set(char const *,int16_t,sr_type_t);
@@ -44,6 +60,14 @@
 %ignore Tree::set(char const *,uint32_t,sr_type_t);
 %ignore Tree::set(char const *,uint64_t,sr_type_t);
 
+%ignore Tree::set(char const *,int8_t);
+%ignore Tree::set(char const *,int16_t);
+%ignore Tree::set(char const *,int32_t);
+%ignore Tree::set(char const *,uint8_t);
+%ignore Tree::set(char const *,uint16_t);
+%ignore Tree::set(char const *,uint32_t);
+%ignore Tree::set(char const *,uint64_t);
+
 %ignore Tree::set(int8_t,sr_type_t);
 %ignore Tree::set(int16_t,sr_type_t);
 %ignore Tree::set(int32_t,sr_type_t);
@@ -51,6 +75,14 @@
 %ignore Tree::set(uint16_t,sr_type_t);
 %ignore Tree::set(uint32_t,sr_type_t);
 %ignore Tree::set(uint64_t,sr_type_t);
+
+%ignore Tree::set(int8_t);
+%ignore Tree::set(int16_t);
+%ignore Tree::set(int32_t);
+%ignore Tree::set(uint8_t);
+%ignore Tree::set(uint16_t);
+%ignore Tree::set(uint32_t);
+%ignore Tree::set(uint64_t);
 
 %include "../swig_base/base.i"
 %include "../swig_base/libsysrepoEnums.i"

--- a/swig/swig_base/python_base.i
+++ b/swig/swig_base/python_base.i
@@ -26,6 +26,14 @@
 %ignore sysrepo::Val::set(char const *,uint32_t,sr_type_t);
 %ignore sysrepo::Val::set(char const *,uint64_t,sr_type_t);
 
+%ignore sysrepo::Val::set(char const *,int8_t);
+%ignore sysrepo::Val::set(char const *,int16_t);
+%ignore sysrepo::Val::set(char const *,int32_t);
+%ignore sysrepo::Val::set(char const *,uint8_t);
+%ignore sysrepo::Val::set(char const *,uint16_t);
+%ignore sysrepo::Val::set(char const *,uint32_t);
+%ignore sysrepo::Val::set(char const *,uint64_t);
+
 %ignore sysrepo::Tree::Tree(int8_t,sr_type_t);
 %ignore sysrepo::Tree::Tree(int16_t,sr_type_t);
 %ignore sysrepo::Tree::Tree(int32_t,sr_type_t);
@@ -33,6 +41,14 @@
 %ignore sysrepo::Tree::Tree(uint16_t,sr_type_t);
 %ignore sysrepo::Tree::Tree(uint32_t,sr_type_t);
 %ignore sysrepo::Tree::Tree(uint64_t,sr_type_t);
+
+%ignore sysrepo::Tree::Tree(int8_t);
+%ignore sysrepo::Tree::Tree(int16_t);
+%ignore sysrepo::Tree::Tree(int32_t);
+%ignore sysrepo::Tree::Tree(uint8_t);
+%ignore sysrepo::Tree::Tree(uint16_t);
+%ignore sysrepo::Tree::Tree(uint32_t);
+%ignore sysrepo::Tree::Tree(uint64_t);
 
 %ignore sysrepo::Tree::set(char const *,int8_t,sr_type_t);
 %ignore sysrepo::Tree::set(char const *,int16_t,sr_type_t);
@@ -42,6 +58,14 @@
 %ignore sysrepo::Tree::set(char const *,uint32_t,sr_type_t);
 %ignore sysrepo::Tree::set(char const *,uint64_t,sr_type_t);
 
+%ignore sysrepo::Tree::set(char const *,int8_t);
+%ignore sysrepo::Tree::set(char const *,int16_t);
+%ignore sysrepo::Tree::set(char const *,int32_t);
+%ignore sysrepo::Tree::set(char const *,uint8_t);
+%ignore sysrepo::Tree::set(char const *,uint16_t);
+%ignore sysrepo::Tree::set(char const *,uint32_t);
+%ignore sysrepo::Tree::set(char const *,uint64_t);
+
 %ignore sysrepo::Tree::set(int8_t,sr_type_t);
 %ignore sysrepo::Tree::set(int16_t,sr_type_t);
 %ignore sysrepo::Tree::set(int32_t,sr_type_t);
@@ -49,6 +73,14 @@
 %ignore sysrepo::Tree::set(uint16_t,sr_type_t);
 %ignore sysrepo::Tree::set(uint32_t,sr_type_t);
 %ignore sysrepo::Tree::set(uint64_t,sr_type_t);
+
+%ignore sysrepo::Tree::set(int8_t);
+%ignore sysrepo::Tree::set(int16_t);
+%ignore sysrepo::Tree::set(int32_t);
+%ignore sysrepo::Tree::set(uint8_t);
+%ignore sysrepo::Tree::set(uint16_t);
+%ignore sysrepo::Tree::set(uint32_t);
+%ignore sysrepo::Tree::set(uint64_t);
 
 %include "../swig_base/base.i"
 %include "../swig_base/libsysrepoEnums.i"


### PR DESCRIPTION
### Description
The current C++ wrappers are ambiguous for certain data types and can't be used without explicit casting. The modifications remove the ambiguity and allow using the C++ wrappers based only on type of parameter passed to the functions.

### Test case
I have updated existing test cases to remove explicit casts and type fields when they are no longer necessary. 

I was not able to perform a make test for LUA bindings (did not work on my machine for some reason)

All other tests passed.

### Closure
There is not an open ticket for this change