### PR TITLE
Use LINUX_OFD_LOCK file locks when available.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -154,6 +154,7 @@ set(CMAKE_REQUIRED_LIBRARIES pthread)
 include(CheckFunctionExists)
 include(CheckIncludeFiles)
 include(CheckStructHasMember)
+include(CheckSymbolExists)
 check_include_file(stdatomic.h HAVE_STDATOMIC)
 CHECK_FUNCTION_EXISTS(pthread_rwlockattr_setkind_np HAVE_PTHREAD_RWLOCKATTR_SETKIND_NP)
 CHECK_FUNCTION_EXISTS(getpeereid HAVE_GETPEEREID)
@@ -167,6 +168,7 @@ if(HAVE_MKSTEMPS)
     set(CMAKE_C_FLAGS         "${CMAKE_C_FLAGS} -DHAVE_MKSTEMPS")
 endif(HAVE_MKSTEMPS)
 CHECK_STRUCT_HAS_MEMBER("struct stat" st_mtim "sys/stat.h" HAVE_STAT_ST_MTIM)
+CHECK_SYMBOL_EXISTS("F_OFD_SETLKW" "fcntl.h" HAVE_LINUX_OFD_LOCK)
 
 # user options
 set(ENABLE_NACM 0 CACHE BOOL

--- a/src/common/sr_constants.h.in
+++ b/src/common/sr_constants.h.in
@@ -38,6 +38,7 @@
 #cmakedefine HAVE_STAT_ST_MTIM
 #cmakedefine HAVE_TIMED_LOCK
 #cmakedefine HAVE_FSETXATTR
+#cmakedefine HAVE_LINUX_OFD_LOCK
 #cmakedefine HAVE_STDATOMIC
 #ifdef HAVE_STDATOMIC
 # include <stdatomic.h>

--- a/src/common/sr_utils.c
+++ b/src/common/sr_utils.c
@@ -20,6 +20,10 @@
  * limitations under the License.
  */
 
+#include "sr_constants.h"
+#ifdef HAVE_LINUX_OFD_LOCK
+#define _GNU_SOURCE
+#endif
 #include <sys/types.h>
 #include <sys/socket.h>
 #include <unistd.h>
@@ -441,10 +445,18 @@ sr_lock_fd_internal(int fd, bool lock, bool write, bool wait)
     fl.l_whence = SEEK_SET; /* from the beginning */
     fl.l_start = 0;         /* with offset 0*/
     fl.l_len = 0;           /* to EOF */
+#ifdef HAVE_LINUX_OFD_LOCK
+    fl.l_pid = 0;
+#else
     fl.l_pid = getpid();
+#endif
 
     /* set the lock, waiting if requested and necessary */
+#ifdef HAVE_LINUX_OFD_LOCK
+    ret = fcntl(fd, wait ? F_OFD_SETLKW : F_OFD_SETLK, &fl);
+#else
     ret = fcntl(fd, wait ? F_SETLKW : F_SETLK, &fl);
+#endif
 
     if (-1 == ret) {
         SR_LOG_WRN("Unable to acquire the lock on fd %d: %s", fd, sr_strerror_safe(errno));

--- a/src/data_manager.c
+++ b/src/data_manager.c
@@ -5814,8 +5814,7 @@ dm_copy_config(dm_ctx_t *dm_ctx, dm_session_t *session, const sr_list_t *module_
             }
             /* lock, write, blocking */
             sr_lock_fd(fds[opened_files], true, true);
-            if (ftruncate(fds[opened_files], 0) != 0)
-            {
+            if (ftruncate(fds[opened_files], 0) != 0) {
                 SR_LOG_ERR("File %s can not be truncated: %s", file_name, sr_strerror_safe(errno));
                 free(file_name);
                 opened_files++;

--- a/src/data_manager.c
+++ b/src/data_manager.c
@@ -5803,13 +5803,22 @@ dm_copy_config(dm_ctx_t *dm_ctx, dm_session_t *session, const sr_list_t *module_
             if (NULL != session) {
                 ac_set_user_identity(dm_ctx->ac_ctx, session->user_credentials);
             }
-            fds[opened_files] = open(file_name, O_RDWR | O_TRUNC);
+            fds[opened_files] = open(file_name, O_RDWR);
             if (NULL != session) {
                 ac_unset_user_identity(dm_ctx->ac_ctx, session->user_credentials);
             }
             if (-1 == fds[opened_files]) {
                 SR_LOG_ERR("File %s can not be opened", file_name);
                 free(file_name);
+                goto cleanup;
+            }
+            /* lock, write, blocking */
+            sr_lock_fd(fds[opened_files], true, true);
+            if (ftruncate(fds[opened_files], 0) != 0)
+            {
+                SR_LOG_ERR("File %s can not be truncated: %s", file_name, sr_strerror_safe(errno));
+                free(file_name);
+                opened_files++;
                 goto cleanup;
             }
             opened_files++;


### PR DESCRIPTION
### Description
F_OFD_SETLK works as F_SETLK, only it is associated with file descriptor
rather then the process id, so concurrent access from two different threads
can be prevented.

### Closure
fix issue #1396.

