### PR TITLE
Cpp reallocation2

### DIFF
--- a/swig/cpp/src/Internal.cpp
+++ b/swig/cpp/src/Internal.cpp
@@ -70,6 +70,8 @@ Deleter::Deleter(sr_session_ctx_t *sess) {
 }
 Deleter::~Deleter() {
     switch(_t) {
+    case Free_Type::INVALID:
+    break;
     case Free_Type::VAL:
         if (v._val) sr_free_val(v._val);
     v._val = nullptr;
@@ -108,6 +110,10 @@ Deleter::~Deleter() {
     v._sess = nullptr;
     break;
     }
+}
+// Stop deletion from occuring on destruction, used by reallocate
+void Deleter::invalidate(void) {
+    _t = Free_Type::INVALID;
 }
 
 }

--- a/swig/cpp/src/Internal.hpp
+++ b/swig/cpp/src/Internal.hpp
@@ -33,6 +33,7 @@ extern "C" {
 namespace sysrepo {
 
 enum class Free_Type {
+    INVALID,
     VAL,
     VALS,
     VALS_POINTER,
@@ -68,6 +69,7 @@ public:
     Deleter(sr_node_t **trees, size_t *cnt);
     Deleter(sr_schema_t *sch, size_t cnt);
     Deleter(sr_session_ctx_t *sess);
+    void invalidate(void);
     ~Deleter();
 
 private:

--- a/swig/cpp/src/Struct.cpp
+++ b/swig/cpp/src/Struct.cpp
@@ -572,6 +572,10 @@ sr_val_t* Vals::reallocate(size_t n) {
     if (ret != SR_ERR_OK)
         throw_exception(ret);
     _cnt = n;
+    if (_deleter) {
+        _deleter->invalidate();
+        _deleter = S_Deleter(new Deleter(_vals, _cnt));
+    }
     return _vals;
 }
 

--- a/swig/cpp/src/Struct.cpp
+++ b/swig/cpp/src/Struct.cpp
@@ -587,22 +587,24 @@ S_Vals Vals_Holder::vals(void) {
 S_Vals Vals_Holder::allocate(size_t n) {
     if (_allocate == false)
         throw_exception(SR_ERR_DATA_EXISTS);
-    _allocate = false;
 
     if (n == 0)
         return nullptr;
 
-    *p_cnt = n;
     int ret = sr_new_values(n, p_vals);
     if (ret != SR_ERR_OK)
         throw_exception(ret);
+
+    *p_cnt = n;
+    _allocate = false;
 
     p_Vals = S_Vals(new Vals(p_vals, p_cnt, nullptr));
     return p_Vals;
 }
 S_Vals Vals_Holder::reallocate(size_t n) {
-    if (_allocate == true)
-        throw_exception(SR_ERR_DATA_MISSING);
+    if (_allocate == true) {
+        return allocate(n);
+    }
     *p_vals = p_Vals->reallocate(n);
     *p_cnt = n;
     return p_Vals;


### PR DESCRIPTION

### Description
Improvements for cpp allocation/reallocation

### Test case
1. Calling Vals_Holder::reallocate before Vals_Holder::allocate causes an exception to be thrown.

2. Calling Vals_Holder::allocate(0) followed by Vals_Holder::allocate(n) where n>0 causes an exception to  be thrown.

This change performs an allocation instead of throwing an exception for both of these cases.

