### PR TITLE
C++ Wrapper improvements

### DIFF
--- a/swig/cpp/examples/cpp_rpc_example.cpp
+++ b/swig/cpp/examples/cpp_rpc_example.cpp
@@ -192,11 +192,11 @@ class My_Callback:public sysrepo::Callback {
             print_tree(in_trees->tree(n));
 
         out_trees->tree(0)->set_name("status");
-        out_trees->tree(0)->set("The image acmefw-2.3 is being installed.", SR_STRING_T);
+        out_trees->tree(0)->set("The image acmefw-2.3 is being installed.");
         out_trees->tree(1)->set_name("version");
-        out_trees->tree(1)->set("2.3", SR_STRING_T);
+        out_trees->tree(1)->set("2.3");
         out_trees->tree(2)->set_name("location");
-        out_trees->tree(2)->set("/root/", SR_STRING_T);
+        out_trees->tree(2)->set("/root/");
 
     return SR_ERR_OK;
     }
@@ -245,7 +245,7 @@ main(int argc, char **argv)
         sysrepo::S_Trees in_trees(new sysrepo::Trees(1));
 
         in_trees->tree(0)->set_name("image-name");
-        in_trees->tree(0)->set("acmefw-2.3", SR_STRING_T);
+        in_trees->tree(0)->set("acmefw-2.3");
 
         cout << "\n ========== START RPC TREE CALL ==========\n" << endl;
         auto out_trees = sess->rpc_send("/test-module:activate-software-image", in_trees);

--- a/swig/cpp/examples/cpp_set_item_example.cpp
+++ b/swig/cpp/examples/cpp_set_item_example.cpp
@@ -46,7 +46,7 @@ main(int argc, char **argv)
         (list entry will be automatically created if it does not exist) */
         const char *xpath_num = "/ietf-interfaces:interfaces/interface[name='gigaeth0']/ietf-ip:ipv6/address[ip='fe80::ab8']/prefix-length";
         uint8_t num = 64;
-        sysrepo::S_Val value_num(new sysrepo::Val(num, SR_UINT8_T));
+        sysrepo::S_Val value_num(new sysrepo::Val(num));
         sess->set_item(xpath_num, value_num);
 
         sess->commit();

--- a/swig/cpp/examples/cpp_turing_rpc_example.cpp
+++ b/swig/cpp/examples/cpp_turing_rpc_example.cpp
@@ -56,7 +56,7 @@ class My_Callback:public sysrepo::Callback {
             auto output = holder->allocate(1);
 
             /* set 'output/step-count' leaf */
-            output->val(0)->set("/turing-machine:run-until/step-count", (uint64_t) 256, SR_UINT64_T);
+            output->val(0)->set("/turing-machine:run-until/step-count", uint64_t{256});
 
             std::cout << ">>> RPC Output:" << std::endl << std::endl;
             for (size_t i = 0; i < output->val_cnt(); ++i) {
@@ -67,7 +67,7 @@ class My_Callback:public sysrepo::Callback {
             holder->reallocate(2);
 
             /* set 'output/halted' leaf */
-            output->val(1)->set("/turing-machine:run-until/halted", false, SR_BOOL_T);
+            output->val(1)->set("/turing-machine:run-until/halted", false);
 
             std::cout << ">>> RPC Output:" << std::endl << std::endl;
             for (size_t i = 0; i < output->val_cnt(); ++i) {
@@ -139,8 +139,8 @@ rpc_caller(sysrepo::S_Session sess)
         sysrepo::S_Vals input(new sysrepo::Vals(7));
 
         /* set 'input/state' leaf */
-        input->val(0)->set("/turing-machine:run-until/state", (uint16_t) 10, SR_UINT16_T);
-        input->val(1)->set("/turing-machine:run-until/head-position", (int64_t) 123, SR_INT64_T);
+        input->val(0)->set("/turing-machine:run-until/state", uint16_t{10});
+        input->val(1)->set("/turing-machine:run-until/head-position", int64_t{123});
         /* set 'input/tape' list entries */
         for (int i = 0; i < 5; ++i) {
             // WTF
@@ -148,7 +148,7 @@ rpc_caller(sysrepo::S_Session sess)
             char xpath_str[100] = {0};
             sprintf(xpath_str, "/turing-machine:run-until/tape/cell[coord='%d']/symbol", i);
             sprintf(value, "%c", 'A'+i);
-            input->val(i+2)->set(xpath_str, value, SR_STRING_T);
+            input->val(i+2)->set(xpath_str, value);
         }
 
         std::cout << std::endl << std::endl << " ========== EXECUTING RPC ==========" << std::endl << std::endl;

--- a/swig/cpp/src/Struct.cpp
+++ b/swig/cpp/src/Struct.cpp
@@ -140,87 +140,61 @@ Val::Val(const char *value, sr_type_t type) {
     _deleter = S_Deleter(new Deleter(val));
 }
 Val::Val(bool bool_val, sr_type_t type) {
+    if (type != SR_BOOL_T) 
+        throw_exception(SR_ERR_INVAL_ARG);
     sr_val_t *val = nullptr;
     val = (sr_val_t*) calloc(1, sizeof(sr_val_t));
-    if (val == nullptr)
+    if (val == nullptr) 
         throw_exception(SR_ERR_NOMEM);
-    if (type == SR_BOOL_T) {
-	val->data.bool_val = bool_val;
-    } else {
-        free(val);
-        throw_exception(SR_ERR_INVAL_ARG);
-    }
-
-    val->type = type;
+    val->data.bool_val = bool_val;
+    val->type = SR_BOOL_T;
     _val = val;
     _deleter = S_Deleter(new Deleter(val));
 }
 Val::Val(double decimal64_val) {
     sr_val_t *val = nullptr;
     val = (sr_val_t*) calloc(1, sizeof(sr_val_t));
-    if (val == nullptr) {
+    if (val == nullptr)
         throw_exception(SR_ERR_NOMEM);
-    } else {
-	val->data.decimal64_val = decimal64_val;
-    }
-
+    val->data.decimal64_val = decimal64_val;
     val->type = SR_DECIMAL64_T;
     _val = val;
     _deleter = S_Deleter(new Deleter(val));
 }
-Val::Val(int8_t int8_val, sr_type_t type) {
+Val::Val(int8_t int8_val) {
     sr_val_t *val = nullptr;
     val = (sr_val_t*) calloc(1, sizeof(sr_val_t));
     if (val == nullptr)
         throw_exception(SR_ERR_NOMEM);
-    if (type == SR_INT8_T) {
-	val->data.int8_val = int8_val;
-    } else {
-        free(val);
-        throw_exception(SR_ERR_INVAL_ARG);
-    }
-
-    val->type = type;
+    val->data.int8_val = int8_val;
+    val->type = SR_INT8_T;
     _val = val;
     _deleter = S_Deleter(new Deleter(val));
 }
-Val::Val(int16_t int16_val, sr_type_t type) {
+Val::Val(int16_t int16_val) {
     sr_val_t *val = nullptr;
     val = (sr_val_t*) calloc(1, sizeof(sr_val_t));
     if (val == nullptr)
         throw_exception(SR_ERR_NOMEM);
-    if (type == SR_INT16_T) {
-	val->data.int16_val = int16_val;
-    } else {
-        free(val);
-        throw_exception(SR_ERR_INVAL_ARG);
-    }
-
-    val->type = type;
+    val->data.int16_val = int16_val;
+    val->type = SR_INT16_T;
     _val = val;
     _deleter = S_Deleter(new Deleter(val));
 }
-Val::Val(int32_t int32_val, sr_type_t type) {
+Val::Val(int32_t int32_val) {
     sr_val_t *val = nullptr;
     val = (sr_val_t*) calloc(1, sizeof(sr_val_t));
     if (val == nullptr)
         throw_exception(SR_ERR_NOMEM);
-    if (type == SR_INT32_T) {
-	val->data.int32_val = int32_val;
-    } else {
-        free(val);
-        throw_exception(SR_ERR_INVAL_ARG);
-    }
-
-    val->type = type;
+    val->data.int32_val = int32_val;
+    val->type = SR_INT32_T;
     _val = val;
     _deleter = S_Deleter(new Deleter(val));
 }
 Val::Val(int64_t int64_val, sr_type_t type) {
     sr_val_t *val = nullptr;
     val = (sr_val_t*) calloc(1, sizeof(sr_val_t));
-    if (val == nullptr)
-        throw_exception(SR_ERR_NOMEM);
+    if (val == nullptr) throw_exception(SR_ERR_NOMEM);
     if (type == SR_UINT64_T) {
         val->data.uint64_val = (uint64_t) int64_val;
     } else if (type == SR_UINT32_T) {
@@ -237,8 +211,10 @@ Val::Val(int64_t int64_val, sr_type_t type) {
         val->data.int16_val = (int16_t) int64_val;
     } else if (type == SR_INT8_T) {
         val->data.int8_val = (int8_t) int64_val;
+    } else if (type == SR_BOOL_T) {
+        val->data.bool_val = (bool) int64_val;
     } else {
-	    printf("\nERROR \n\n\n\n");
+        printf("\nERROR \n\n\n\n");
         free(val);
         throw_exception(SR_ERR_INVAL_ARG);
     }
@@ -247,73 +223,50 @@ Val::Val(int64_t int64_val, sr_type_t type) {
     _val = val;
     _deleter = S_Deleter(new Deleter(val));
 }
-Val::Val(uint8_t uint8_val, sr_type_t type) {
+Val::Val(uint8_t uint8_val) {
     sr_val_t *val = nullptr;
     val = (sr_val_t*) calloc(1, sizeof(sr_val_t));
     if (val == nullptr)
         throw_exception(SR_ERR_NOMEM);
-    if (type == SR_UINT8_T) {
-	val->data.uint8_val = uint8_val;
-    } else {
-        free(val);
-        throw_exception(SR_ERR_INVAL_ARG);
-    }
-
-    val->type = type;
+    val->data.uint8_val = uint8_val;
+    val->type = SR_UINT8_T;
     _val = val;
     _deleter = S_Deleter(new Deleter(val));
 }
-Val::Val(uint16_t uint16_val, sr_type_t type) {
+Val::Val(uint16_t uint16_val) {
     sr_val_t *val = nullptr;
     val = (sr_val_t*) calloc(1, sizeof(sr_val_t));
     if (val == nullptr)
         throw_exception(SR_ERR_NOMEM);
-    if (type == SR_UINT16_T) {
-	val->data.uint16_val = uint16_val;
-    } else {
-        free(val);
-        throw_exception(SR_ERR_INVAL_ARG);
-    }
-
-    val->type = type;
+    val->data.uint16_val = uint16_val;
+    val->type = SR_UINT16_T;
     _val = val;
     _deleter = S_Deleter(new Deleter(val));
 }
-Val::Val(uint32_t uint32_val, sr_type_t type) {
+Val::Val(uint32_t uint32_val) {
     sr_val_t *val = nullptr;
     val = (sr_val_t*) calloc(1, sizeof(sr_val_t));
     if (val == nullptr)
         throw_exception(SR_ERR_NOMEM);
-    if (type == SR_UINT32_T) {
-	val->data.uint32_val = uint32_val;
-    } else {
-        free(val);
-        throw_exception(SR_ERR_INVAL_ARG);
-    }
-
-    val->type = type;
+    val->data.uint32_val = uint32_val;
+    val->type = SR_UINT32_T;
     _val = val;
     _deleter = S_Deleter(new Deleter(val));
 }
-Val::Val(uint64_t uint64_val, sr_type_t type) {
+Val::Val(uint64_t uint64_val) {
     sr_val_t *val = nullptr;
     val = (sr_val_t*) calloc(1, sizeof(sr_val_t));
     if (val == nullptr)
         throw_exception(SR_ERR_NOMEM);
-    if (type == SR_UINT64_T) {
-	val->data.uint64_val = uint64_val;
-    } else {
-        free(val);
-        throw_exception(SR_ERR_INVAL_ARG);
-    }
-
-    val->type = type;
+    val->data.uint64_val = uint64_val;
+    val->type = SR_UINT64_T;
     _val = val;
     _deleter = S_Deleter(new Deleter(val));
 }
 void Val::set(const char *xpath, const char *value, sr_type_t type) {
     int ret = SR_ERR_OK;
-    if (_val == nullptr) throw_exception(SR_ERR_OPERATION_FAILED);
+    if (_val == nullptr)
+        throw_exception(SR_ERR_OPERATION_FAILED);
 
     ret = sr_val_set_xpath(_val, xpath);
     if (ret != SR_ERR_OK) throw_exception(ret);
@@ -331,18 +284,16 @@ void Val::set(const char *xpath, const char *value, sr_type_t type) {
     }
 }
 void Val::set(const char *xpath, bool bool_val, sr_type_t type) {
-    if (_val == nullptr) throw_exception(SR_ERR_OPERATION_FAILED);
+    if (type != SR_BOOL_T) throw_exception(SR_ERR_INVAL_ARG);
+
+    if (_val == nullptr)
+        throw_exception(SR_ERR_OPERATION_FAILED);
 
     int ret = sr_val_set_xpath(_val, xpath);
     if (ret != SR_ERR_OK) throw_exception(ret);
 
-    if (type == SR_BOOL_T) {
-	    _val->data.bool_val = bool_val;
-    } else {
-        throw_exception(SR_ERR_INVAL_ARG);
-    }
-
-    _val->type = type;
+    _val->data.bool_val = bool_val;
+    _val->type = SR_BOOL_T;
 }
 void Val::set(const char *xpath, double decimal64_val) {
     if (_val == nullptr) throw_exception(SR_ERR_OPERATION_FAILED);
@@ -354,47 +305,32 @@ void Val::set(const char *xpath, double decimal64_val) {
 
     _val->type = SR_DECIMAL64_T;
 }
-void Val::set(const char *xpath, int8_t int8_val, sr_type_t type) {
+void Val::set(const char *xpath, int8_t int8_val) {
     if (_val == nullptr) throw_exception(SR_ERR_OPERATION_FAILED);
 
     int ret = sr_val_set_xpath(_val, xpath);
     if (ret != SR_ERR_OK) throw_exception(ret);
 
-    if (type == SR_INT8_T) {
-	    _val->data.int8_val = int8_val;
-    } else {
-        throw_exception(SR_ERR_INVAL_ARG);
-    }
-
-    _val->type = type;
+    _val->data.int8_val = int8_val;
+    _val->type = SR_INT8_T;
 }
-void Val::set(const char *xpath, int16_t int16_val, sr_type_t type) {
+void Val::set(const char *xpath, int16_t int16_val) {
     if (_val == nullptr) throw_exception(SR_ERR_OPERATION_FAILED);
 
     int ret = sr_val_set_xpath(_val, xpath);
     if (ret != SR_ERR_OK) throw_exception(ret);
 
-    if (type == SR_INT16_T) {
-	    _val->data.int16_val = int16_val;
-    } else {
-        throw_exception(SR_ERR_INVAL_ARG);
-    }
-
-    _val->type = type;
+    _val->data.int16_val = int16_val;
+    _val->type = SR_INT16_T;
 }
-void Val::set(const char *xpath, int32_t int32_val, sr_type_t type) {
+void Val::set(const char *xpath, int32_t int32_val) {
     if (_val == nullptr) throw_exception(SR_ERR_OPERATION_FAILED);
 
     int ret = sr_val_set_xpath(_val, xpath);
     if (ret != SR_ERR_OK) throw_exception(ret);
 
-    if (type == SR_INT32_T) {
-	    _val->data.int32_val = int32_val;
-    } else {
-        throw_exception(SR_ERR_INVAL_ARG);
-    }
-
-    _val->type = type;
+    _val->data.int32_val = int32_val;
+    _val->type = SR_INT32_T;
 }
 
 void Val::set(const char *xpath, int64_t int64_val, sr_type_t type) {
@@ -425,63 +361,43 @@ void Val::set(const char *xpath, int64_t int64_val, sr_type_t type) {
 
     _val->type = type;
 }
-void Val::set(const char *xpath, uint8_t uint8_val, sr_type_t type) {
+void Val::set(const char *xpath, uint8_t uint8_val) {
     if (_val == nullptr) throw_exception(SR_ERR_OPERATION_FAILED);
 
     int ret = sr_val_set_xpath(_val, xpath);
     if (ret != SR_ERR_OK) throw_exception(ret);
 
-    if (type == SR_UINT8_T) {
-	    _val->data.uint8_val = uint8_val;
-    } else {
-        throw_exception(SR_ERR_INVAL_ARG);
-    }
-
-    _val->type = type;
+    _val->data.uint8_val = uint8_val;
+    _val->type = SR_UINT8_T;
 }
-void Val::set(const char *xpath, uint16_t uint16_val, sr_type_t type) {
+void Val::set(const char *xpath, uint16_t uint16_val) {
     if (_val == nullptr) throw_exception(SR_ERR_OPERATION_FAILED);
 
     int ret = sr_val_set_xpath(_val, xpath);
     if (ret != SR_ERR_OK) throw_exception(ret);
 
-    if (type == SR_UINT16_T) {
-	    _val->data.uint16_val = uint16_val;
-    } else {
-        throw_exception(SR_ERR_INVAL_ARG);
-    }
-
-    _val->type = type;
+    _val->data.uint16_val = uint16_val;
+    _val->type = SR_UINT16_T;
 }
-void Val::set(const char *xpath, uint32_t uint32_val, sr_type_t type) {
+void Val::set(const char *xpath, uint32_t uint32_val) {
     if (_val == nullptr) throw_exception(SR_ERR_OPERATION_FAILED);
 
     int ret = sr_val_set_xpath(_val, xpath);
     if (ret != SR_ERR_OK) throw_exception(ret);
 
-    if (type == SR_UINT32_T) {
-	    _val->data.uint32_val = uint32_val;
-    } else {
-        throw_exception(SR_ERR_INVAL_ARG);
-    }
-
-    _val->type = type;
+    _val->data.uint32_val = uint32_val;
+    _val->type = SR_UINT32_T;
 }
-void Val::set(const char *xpath, uint64_t uint64_val, sr_type_t type) {
+void Val::set(const char *xpath, uint64_t uint64_val) {
     if (_val == nullptr) throw_exception(SR_ERR_OPERATION_FAILED);
 
     int ret = sr_val_set_xpath(_val, xpath);
     if (ret != SR_ERR_OK) throw_exception(ret);
 
-    if (type == SR_UINT64_T) {
-	    _val->data.uint64_val = uint64_val;
-    } else {
-        throw_exception(SR_ERR_INVAL_ARG);
-    }
-
-    _val->type = type;
+    _val->data.uint64_val = uint64_val;
+    _val->type = SR_UINT64_T;
 }
-void Val::xpath_set(char *xpath) {
+void Val::xpath_set(const char *xpath) {
     int ret = sr_val_set_xpath(_val, xpath);
     if (ret != SR_ERR_OK) throw_exception(ret);
 }
@@ -601,8 +517,7 @@ S_Vals Vals_Holder::allocate(size_t n) {
     return p_Vals;
 }
 S_Vals Vals_Holder::reallocate(size_t n) {
-    if (_allocate == true)
-        throw_exception(SR_ERR_DATA_MISSING);
+    if (_allocate) return allocate(n);
     *p_vals = p_Vals->reallocate(n);
     *p_cnt = n;
     return p_Vals;

--- a/swig/cpp/src/Struct.hpp
+++ b/swig/cpp/src/Struct.hpp
@@ -103,26 +103,26 @@ public:
      * SR_IDENTITYREF_T and SR_INSTANCEID_T.*/
     Val(const char *val, sr_type_t type = SR_STRING_T);
     /** Constructor for bool value.*/
-    Val(bool bool_val, sr_type_t type = SR_BOOL_T);
+    explicit Val(bool bool_val, sr_type_t type = SR_BOOL_T);
     /** Constructor for decimal64 value.*/
-    Val(double decimal64_val);
+    explicit Val(double decimal64_val);
     /** Constructor for int8 value, C++ only.*/
-    Val(int8_t int8_val, sr_type_t type);
+    explicit Val(int8_t int8_val);
     /** Constructor for int16 value, C++ only.*/
-    Val(int16_t int16_val, sr_type_t type);
+    explicit Val(int16_t int16_val);
     /** Constructor for int32 value, C++ only.*/
-    Val(int32_t int32_val, sr_type_t type);
+    explicit Val(int32_t int32_val);
     /** Constructor for int64 value, type can be SR_INT8_T, SR_INT16_T, SR_INT32_T,
-     * SR_INT64_T, SR_UINT8_T, SR_UINT16_T and SR_UINT32_T,*/
-    Val(int64_t int64_val, sr_type_t type);
+     * SR_INT64_T, SR_UINT8_T, SR_UINT16_T, SR_UINT32_T, and SR_UINT64_T*/
+    Val(int64_t int64_val, sr_type_t type = SR_INT64_T);
     /** Constructor for uint8 value, C++ only.*/
-    Val(uint8_t uint8_val, sr_type_t type);
+    explicit Val(uint8_t uint8_val);
     /** Constructor for uint16 value, C++ only.*/
-    Val(uint16_t uint16_val, sr_type_t type);
+    explicit Val(uint16_t uint16_val);
     /** Constructor for uint32 value, C++ only.*/
-    Val(uint32_t uint32_val, sr_type_t type);
+    explicit Val(uint32_t uint32_val);
     /** Constructor for uint64 value, C++ only.*/
-    Val(uint64_t uint64_val, sr_type_t type);
+    explicit Val(uint64_t uint64_val);
    ~Val();
     /** Setter for string value, type can be SR_STRING_T, SR_BINARY_T, SR_BITS_T, SR_ENUM_T,
      * SR_IDENTITYREF_T and SR_INSTANCEID_T.*/
@@ -132,26 +132,26 @@ public:
     /** Setter for decimal64 value.*/
     void set(const char *xpath, double decimal64_val);
     /** Setter for int8 value, C++ only.*/
-    void set(const char *xpath, int8_t int8_val, sr_type_t type);
+    void set(const char *xpath, int8_t int8_val);
     /** Setter for int16 value, C++ only.*/
-    void set(const char *xpath, int16_t int16_val, sr_type_t type);
+    void set(const char *xpath, int16_t int16_val);
     /** Setter for int32 value, C++ only.*/
-    void set(const char *xpath, int32_t int32_val, sr_type_t type);
+    void set(const char *xpath, int32_t int32_val);
     /** Setter for int64 value, type can be SR_INT8_T, SR_INT16_T, SR_INT32_T,
-     * SR_INT64_T, SR_UINT8_T, SR_UINT16_T and SR_UINT32_T,*/
-    void set(const char *xpath, int64_t int64_val, sr_type_t type);
+     * SR_INT64_T, SR_UINT8_T, SR_UINT16_T, SR_UINT32_T, and SR_UINT64_T*/
+    void set(const char *xpath, int64_t int64_val, sr_type_t type = SR_INT64_T);
     /** Setter for uint8 value, C++ only.*/
-    void set(const char *xpath, uint8_t uint8_val, sr_type_t type);
+    void set(const char *xpath, uint8_t uint8_val);
     /** Setter for uint16 value, C++ only.*/
-    void set(const char *xpath, uint16_t uint16_val, sr_type_t type);
+    void set(const char *xpath, uint16_t uint16_val);
     /** Setter for uint32 value, C++ only.*/
-    void set(const char *xpath, uint32_t uint32_val, sr_type_t type);
+    void set(const char *xpath, uint32_t uint32_val);
     /** Setter for uint64 value, C++ only.*/
-    void set(const char *xpath, uint64_t uint64_val, sr_type_t type);
+    void set(const char *xpath, uint64_t uint64_val);
     /** Getter for xpath.*/
     char *xpath() {return _val->xpath;};
     /** Setter for xpath.*/
-    void xpath_set(char *xpath);
+    void xpath_set(const char *xpath);
     /** Getter for type.*/
     sr_type_t type() {return _val->type;};
     /** Getter for dflt.*/

--- a/swig/cpp/src/Tree.cpp
+++ b/swig/cpp/src/Tree.cpp
@@ -190,7 +190,7 @@ void Tree::set(const char *value, sr_type_t type) {
 }
 void Tree::set(bool bool_val, sr_type_t type) {
     if (type == SR_BOOL_T) {
-	    _node->data.bool_val = bool_val;
+        _node->data.bool_val = bool_val;
     } else {
         throw_exception(SR_ERR_INVAL_ARG);
     }
@@ -201,32 +201,17 @@ void Tree::set(double decimal64_val) {
     _node->data.decimal64_val = decimal64_val;
     _node->type = SR_DECIMAL64_T;
 }
-void Tree::set(int8_t int8_val, sr_type_t type) {
-    if (type == SR_INT8_T) {
-	    _node->data.int8_val = int8_val;
-    } else {
-        throw_exception(SR_ERR_INVAL_ARG);
-    }
-
-    _node->type = type;
+void Tree::set(int8_t int8_val) {
+    _node->data.int8_val = int8_val;
+    _node->type = SR_INT8_T;
 }
-void Tree::set(int16_t int16_val, sr_type_t type) {
-    if (type == SR_INT16_T) {
-	    _node->data.int16_val = int16_val;
-    } else {
-        throw_exception(SR_ERR_INVAL_ARG);
-    }
-
-    _node->type = type;
+void Tree::set(int16_t int16_val) {
+    _node->data.int16_val = int16_val;
+    _node->type = SR_INT16_T;
 }
-void Tree::set(int32_t int32_val, sr_type_t type) {
-    if (type == SR_INT32_T) {
-	    _node->data.int32_val = int32_val;
-    } else {
-        throw_exception(SR_ERR_INVAL_ARG);
-    }
-
-    _node->type = type;
+void Tree::set(int32_t int32_val) {
+    _node->data.int32_val = int32_val;
+    _node->type = SR_INT32_T;
 }
 void Tree::set(int64_t int64_val, sr_type_t type) {
     if (type == SR_UINT64_T) {
@@ -251,41 +236,21 @@ void Tree::set(int64_t int64_val, sr_type_t type) {
 
     _node->type = type;
 }
-void Tree::set(uint8_t uint8_val, sr_type_t type) {
-    if (type == SR_UINT8_T) {
-	    _node->data.uint8_val = uint8_val;
-    } else {
-        throw_exception(SR_ERR_INVAL_ARG);
-    }
-
-    _node->type = type;
+void Tree::set(uint8_t uint8_val) {
+    _node->data.uint8_val = uint8_val;
+    _node->type = SR_UINT8_T;
 }
-void Tree::set(uint16_t uint16_val, sr_type_t type) {
-    if (type == SR_UINT16_T) {
-	    _node->data.uint16_val = uint16_val;
-    } else {
-        throw_exception(SR_ERR_INVAL_ARG);
-    }
-
-    _node->type = type;
+void Tree::set(uint16_t uint16_val) {
+    _node->data.uint16_val = uint16_val;
+    _node->type = SR_UINT16_T;
 }
-void Tree::set(uint32_t uint32_val, sr_type_t type) {
-    if (type == SR_UINT32_T) {
-	    _node->data.uint32_val = uint32_val;
-    } else {
-        throw_exception(SR_ERR_INVAL_ARG);
-    }
-
-    _node->type = type;
+void Tree::set(uint32_t uint32_val) {
+    _node->data.uint32_val = uint32_val;
+    _node->type = SR_UINT32_T;
 }
-void Tree::set(uint64_t uint64_val, sr_type_t type) {
-    if (type == SR_UINT64_T) {
-	    _node->data.uint64_val = uint64_val;
-    } else {
-        throw_exception(SR_ERR_INVAL_ARG);
-    }
-
-    _node->type = type;
+void Tree::set(uint64_t uint64_val) {
+    _node->data.uint64_val = uint64_val;
+    _node->type = SR_UINT64_T;
 }
 
 Trees::Trees(size_t cnt): Trees() {

--- a/swig/cpp/src/Tree.hpp
+++ b/swig/cpp/src/Tree.hpp
@@ -94,22 +94,22 @@ public:
     /** Setter for decimal64 value.*/
     void set(double decimal64_val);
     /** Setter for int8 value, C++ only.*/
-    void set(int8_t int8_val, sr_type_t type);
+    void set(int8_t int8_val);
     /** Setter for int16 value, C++ only.*/
-    void set(int16_t int16_val, sr_type_t type);
+    void set(int16_t int16_val);
     /** Setter for int32 value, C++ only.*/
-    void set(int32_t int32_val, sr_type_t type);
+    void set(int32_t int32_val);
     /** Setter for int64 value, type can be SR_INT8_T, SR_INT16_T, SR_INT32_T,
-     * SR_INT64_T, SR_UINT8_T, SR_UINT16_T and SR_UINT32_T,*/
-    void set(int64_t int64_val, sr_type_t type);
+     * SR_INT64_T, SR_UINT8_T, SR_UINT16_T, SR_UINT32_T, and SR_UINT64_T */
+    void set(int64_t int64_val, sr_type_t type = SR_INT64_T);
     /** Setter for uint8 value, C++ only.*/
-    void set(uint8_t uint8_val, sr_type_t type);
+    void set(uint8_t uint8_val);
     /** Setter for uint16 value, C++ only.*/
-    void set(uint16_t uint16_val, sr_type_t type);
+    void set(uint16_t uint16_val);
     /** Setter for uint32 value, C++ only.*/
-    void set(uint32_t uint32_val, sr_type_t type);
+    void set(uint32_t uint32_val);
     /** Setter for uint64 value, C++ only.*/
-    void set(uint64_t uint64_val, sr_type_t type);
+    void set(uint64_t uint64_val);
     ~Tree();
 
     friend class Session;

--- a/swig/cpp/tests/changes.cpp
+++ b/swig/cpp/tests/changes.cpp
@@ -39,9 +39,9 @@ void init_test(sysrepo::S_Session sess)
 
     subs->module_change_subscribe(module_name.c_str(), cb, NULL, 0, SR_SUBSCR_DEFAULT | SR_SUBSCR_APPLY_ONLY);
 
-    for (int i = LOW_BOUND; i < HIGH_BOUND; i++) {
+    for (int32_t i = LOW_BOUND; i < HIGH_BOUND; i++) {
         const auto xpath = get_xpath(get_test_name(i), "number");
-        sysrepo::S_Val vset(new sysrepo::Val((int32_t)i, SR_INT32_T));
+        sysrepo::S_Val vset(new sysrepo::Val(i));
         sess->set_item(xpath.c_str(), vset);
     }
 
@@ -122,7 +122,7 @@ test_module_change_modify(sysrepo::S_Session sess)
     subs->module_change_subscribe(module_name.c_str(), cb, NULL, 0, SR_SUBSCR_DEFAULT | SR_SUBSCR_APPLY_ONLY);
 
     const auto xpath = get_xpath(get_test_name(LOW_BOUND), "number");
-    sysrepo::S_Val vset(new sysrepo::Val((int32_t)42, SR_INT32_T));
+    sysrepo::S_Val vset(new sysrepo::Val(int32_t{42}));
     sess->set_item(xpath.c_str(), vset);
     sess->commit();
     subs->unsubscribe();
@@ -162,7 +162,7 @@ test_module_change_create(sysrepo::S_Session sess)
     subs->module_change_subscribe(module_name.c_str(), cb, NULL, 0, SR_SUBSCR_DEFAULT | SR_SUBSCR_APPLY_ONLY);
 
     const auto xpath = get_xpath(get_test_name(HIGH_BOUND), "number");
-    sysrepo::S_Val vset(new sysrepo::Val((int32_t)42, SR_INT32_T));
+    sysrepo::S_Val vset(new sysrepo::Val(int32_t{42}));
     sess->set_item(xpath.c_str(), vset);
     sess->commit();
 

--- a/swig/cpp/tests/operations.cpp
+++ b/swig/cpp/tests/operations.cpp
@@ -23,9 +23,9 @@ std::string get_xpath(const std::string &test_name, const std::string &node_name
 }
 
 void init_test(sysrepo::S_Session sess) {
-    for (int i = LOW_BOUND; i < HIGH_BOUND; i++) {
+    for (int32_t i = LOW_BOUND; i < HIGH_BOUND; i++) {
         const auto xpath = get_xpath(get_test_name(i), "number");
-        sysrepo::S_Val vset(new sysrepo::Val((int32_t)i, SR_INT32_T));
+        sysrepo::S_Val vset(new sysrepo::Val((i)));
         sess->set_item(xpath.c_str(), vset);
     }
 
@@ -72,7 +72,7 @@ void test_set_item(sysrepo::S_Session sess)
 {
     for (int32_t i = LOW_BOUND; i < HIGH_BOUND; i++) {
         const auto xpath = get_xpath(get_test_name(i), "number");
-        sysrepo::S_Val vset(new sysrepo::Val((int32_t)i, SR_INT32_T));
+        sysrepo::S_Val vset(new sysrepo::Val(i));
         sess->set_item(xpath.c_str(), vset);
     }
 

--- a/swig/swig_base/lua_base.i
+++ b/swig/swig_base/lua_base.i
@@ -2,14 +2,6 @@
 
 %ignore sysrepo::Callback;
 
-%ignore sysrepo::Val::Val(int8_t,sr_type_t);
-%ignore sysrepo::Val::Val(int16_t,sr_type_t);
-%ignore sysrepo::Val::Val(int32_t,sr_type_t);
-%ignore sysrepo::Val::Val(uint8_t,sr_type_t);
-%ignore sysrepo::Val::Val(uint16_t,sr_type_t);
-%ignore sysrepo::Val::Val(uint32_t,sr_type_t);
-%ignore sysrepo::Val::Val(uint64_t,sr_type_t);
-
 %ignore sysrepo::Val::Val(int8_t);
 %ignore sysrepo::Val::Val(int16_t);
 %ignore sysrepo::Val::Val(int32_t);
@@ -18,29 +10,29 @@
 %ignore sysrepo::Val::Val(uint32_t);
 %ignore sysrepo::Val::Val(uint64_t);
 
-%ignore sysrepo::Val::set(char const *,int8_t,sr_type_t);
-%ignore sysrepo::Val::set(char const *,int16_t,sr_type_t);
-%ignore sysrepo::Val::set(char const *,int32_t,sr_type_t);
-%ignore sysrepo::Val::set(char const *,uint8_t,sr_type_t);
-%ignore sysrepo::Val::set(char const *,uint16_t,sr_type_t);
-%ignore sysrepo::Val::set(char const *,uint32_t,sr_type_t);
-%ignore sysrepo::Val::set(char const *,uint64_t,sr_type_t);
+%ignore sysrepo::Val::set(char const *,int8_t);
+%ignore sysrepo::Val::set(char const *,int16_t);
+%ignore sysrepo::Val::set(char const *,int32_t);
+%ignore sysrepo::Val::set(char const *,uint8_t);
+%ignore sysrepo::Val::set(char const *,uint16_t);
+%ignore sysrepo::Val::set(char const *,uint32_t);
+%ignore sysrepo::Val::set(char const *,uint64_t);
 
-%ignore sysrepo::Tree::Tree(int8_t,sr_type_t);
-%ignore sysrepo::Tree::Tree(int16_t,sr_type_t);
-%ignore sysrepo::Tree::Tree(int32_t,sr_type_t);
-%ignore sysrepo::Tree::Tree(uint8_t,sr_type_t);
-%ignore sysrepo::Tree::Tree(uint16_t,sr_type_t);
-%ignore sysrepo::Tree::Tree(uint32_t,sr_type_t);
-%ignore sysrepo::Tree::Tree(uint64_t,sr_type_t);
+%ignore sysrepo::Tree::Tree(int8_t);
+%ignore sysrepo::Tree::Tree(int16_t);
+%ignore sysrepo::Tree::Tree(int32_t);
+%ignore sysrepo::Tree::Tree(uint8_t);
+%ignore sysrepo::Tree::Tree(uint16_t);
+%ignore sysrepo::Tree::Tree(uint32_t);
+%ignore sysrepo::Tree::Tree(uint64_t);
 
-%ignore sysrepo::Tree::set(char const *,int8_t,sr_type_t);
-%ignore sysrepo::Tree::set(char const *,int16_t,sr_type_t);
-%ignore sysrepo::Tree::set(char const *,int32_t,sr_type_t);
-%ignore sysrepo::Tree::set(char const *,uint8_t,sr_type_t);
-%ignore sysrepo::Tree::set(char const *,uint16_t,sr_type_t);
-%ignore sysrepo::Tree::set(char const *,uint32_t,sr_type_t);
-%ignore sysrepo::Tree::set(char const *,uint64_t,sr_type_t);
+%ignore sysrepo::Tree::set(char const *,int8_t);
+%ignore sysrepo::Tree::set(char const *,int16_t);
+%ignore sysrepo::Tree::set(char const *,int32_t);
+%ignore sysrepo::Tree::set(char const *,uint8_t);
+%ignore sysrepo::Tree::set(char const *,uint16_t);
+%ignore sysrepo::Tree::set(char const *,uint32_t);
+%ignore sysrepo::Tree::set(char const *,uint64_t);
 
 %ignore sysrepo::Tree::set(int8_t,sr_type_t);
 %ignore sysrepo::Tree::set(int16_t,sr_type_t);

--- a/swig/swig_base/python_base.i
+++ b/swig/swig_base/python_base.i
@@ -2,14 +2,6 @@
 
 %ignore Callback;
 
-%ignore sysrepo::Val::Val(int8_t,sr_type_t);
-%ignore sysrepo::Val::Val(int16_t,sr_type_t);
-%ignore sysrepo::Val::Val(int32_t,sr_type_t);
-%ignore sysrepo::Val::Val(uint8_t,sr_type_t);
-%ignore sysrepo::Val::Val(uint16_t,sr_type_t);
-%ignore sysrepo::Val::Val(uint32_t,sr_type_t);
-%ignore sysrepo::Val::Val(uint64_t,sr_type_t);
-
 %ignore sysrepo::Val::Val(int8_t);
 %ignore sysrepo::Val::Val(int16_t);
 %ignore sysrepo::Val::Val(int32_t);
@@ -18,37 +10,37 @@
 %ignore sysrepo::Val::Val(uint32_t);
 %ignore sysrepo::Val::Val(uint64_t);
 
-%ignore sysrepo::Val::set(char const *,int8_t,sr_type_t);
-%ignore sysrepo::Val::set(char const *,int16_t,sr_type_t);
-%ignore sysrepo::Val::set(char const *,int32_t,sr_type_t);
-%ignore sysrepo::Val::set(char const *,uint8_t,sr_type_t);
-%ignore sysrepo::Val::set(char const *,uint16_t,sr_type_t);
-%ignore sysrepo::Val::set(char const *,uint32_t,sr_type_t);
-%ignore sysrepo::Val::set(char const *,uint64_t,sr_type_t);
+%ignore sysrepo::Val::set(char const *,int8_t);
+%ignore sysrepo::Val::set(char const *,int16_t);
+%ignore sysrepo::Val::set(char const *,int32_t);
+%ignore sysrepo::Val::set(char const *,uint8_t);
+%ignore sysrepo::Val::set(char const *,uint16_t);
+%ignore sysrepo::Val::set(char const *,uint32_t);
+%ignore sysrepo::Val::set(char const *,uint64_t);
 
-%ignore sysrepo::Tree::Tree(int8_t,sr_type_t);
-%ignore sysrepo::Tree::Tree(int16_t,sr_type_t);
-%ignore sysrepo::Tree::Tree(int32_t,sr_type_t);
-%ignore sysrepo::Tree::Tree(uint8_t,sr_type_t);
-%ignore sysrepo::Tree::Tree(uint16_t,sr_type_t);
-%ignore sysrepo::Tree::Tree(uint32_t,sr_type_t);
-%ignore sysrepo::Tree::Tree(uint64_t,sr_type_t);
+%ignore sysrepo::Tree::Tree(int8_t);
+%ignore sysrepo::Tree::Tree(int16_t);
+%ignore sysrepo::Tree::Tree(int32_t);
+%ignore sysrepo::Tree::Tree(uint8_t);
+%ignore sysrepo::Tree::Tree(uint16_t);
+%ignore sysrepo::Tree::Tree(uint32_t);
+%ignore sysrepo::Tree::Tree(uint64_t);
 
-%ignore sysrepo::Tree::set(char const *,int8_t,sr_type_t);
-%ignore sysrepo::Tree::set(char const *,int16_t,sr_type_t);
-%ignore sysrepo::Tree::set(char const *,int32_t,sr_type_t);
-%ignore sysrepo::Tree::set(char const *,uint8_t,sr_type_t);
-%ignore sysrepo::Tree::set(char const *,uint16_t,sr_type_t);
-%ignore sysrepo::Tree::set(char const *,uint32_t,sr_type_t);
-%ignore sysrepo::Tree::set(char const *,uint64_t,sr_type_t);
+%ignore sysrepo::Tree::set(char const *,int8_t);
+%ignore sysrepo::Tree::set(char const *,int16_t);
+%ignore sysrepo::Tree::set(char const *,int32_t);
+%ignore sysrepo::Tree::set(char const *,uint8_t);
+%ignore sysrepo::Tree::set(char const *,uint16_t);
+%ignore sysrepo::Tree::set(char const *,uint32_t);
+%ignore sysrepo::Tree::set(char const *,uint64_t);
 
-%ignore sysrepo::Tree::set(int8_t,sr_type_t);
-%ignore sysrepo::Tree::set(int16_t,sr_type_t);
-%ignore sysrepo::Tree::set(int32_t,sr_type_t);
-%ignore sysrepo::Tree::set(uint8_t,sr_type_t);
-%ignore sysrepo::Tree::set(uint16_t,sr_type_t);
-%ignore sysrepo::Tree::set(uint32_t,sr_type_t);
-%ignore sysrepo::Tree::set(uint64_t,sr_type_t);
+%ignore sysrepo::Tree::set(int8_t);
+%ignore sysrepo::Tree::set(int16_t);
+%ignore sysrepo::Tree::set(int32_t);
+%ignore sysrepo::Tree::set(uint8_t);
+%ignore sysrepo::Tree::set(uint16_t);
+%ignore sysrepo::Tree::set(uint32_t);
+%ignore sysrepo::Tree::set(uint64_t);
 
 %include "../swig_base/base.i"
 %include "../swig_base/libsysrepoEnums.i"


### PR DESCRIPTION
### Description
The current C++ wrappers are ambiguous for certain data types and can't be used without explicit casting. The modifications remove the ambiguity and allow using the C++ wrappers based only on type of parameter passed to the functions. It also removes any type args that are no longer needed.

### Test case
I have updated existing test cases to remove explicit casts and type fields when they are no longer necessary.
