### PR TITLE
Fixed the issue of getting NULL values content when invoking sr_get_i…

### DIFF
--- a/src/clientlib/client_library.c
+++ b/src/clientlib/client_library.c
@@ -967,6 +967,7 @@ sr_get_items(sr_session_ctx_t *session, const char *xpath, sr_val_t **values, si
 {
     Sr__Msg *msg_req = NULL, *msg_resp = NULL;
     sr_mem_ctx_t *sr_mem = NULL;
+    sr_val_t *p_values = NULL;
     int rc = SR_ERR_OK;
 
     CHECK_NULL_ARG5(session, session->conn_ctx, xpath, values, value_cnt);
@@ -993,8 +994,9 @@ sr_get_items(sr_session_ctx_t *session, const char *xpath, sr_val_t **values, si
 
     /* copy the content of gpb values to sr_val_t */
     rc = sr_values_gpb_to_sr((sr_mem_ctx_t *)msg_resp->_sysrepo_mem_ctx, msg_resp->response->get_items_resp->values,
-                             msg_resp->response->get_items_resp->n_values, values, value_cnt);
+                             msg_resp->response->get_items_resp->n_values, &p_values, value_cnt);
     CHECK_RC_MSG_GOTO(rc, cleanup, "Error by copying the values from GPB.");
+    *values = p_values;
 
 cleanup:
     if (NULL != msg_req) {


### PR DESCRIPTION
### Description
To fix the issue of getting NULL values content when invoking sr_get_items.

### Test case
The value of "*values" in "sr_get_items" is an address, and it is not assigned at all in old code.
So the copied content of gpb values can not be got after invoking sr_get_items.
Referred Test Cases:
cl_test, cl_test2, cl_state_data_test
Test Result:
      Start 35: cl_test
35/62 Test #35: cl_test .............................   Passed    2.01 sec
      Start 36: cl_test_valgrind
36/62 Test #36: cl_test_valgrind ....................   Passed   44.90 sec
      Start 37: cl_test2
37/62 Test #37: cl_test2 ............................   Passed    2.58 sec
      Start 38: cl_test2_valgrind
38/62 Test #38: cl_test2_valgrind ...................   Passed   37.62 sec
      Start 41: cl_state_data_test
41/62 Test #41: cl_state_data_test ..................   Passed    1.14 sec
      Start 42: cl_state_data_test_valgrind
42/62 Test #42: cl_state_data_test_valgrind .........   Passed   24.86 sec

100% tests passed, 0 tests failed out of 62

### Closure
#1419 

