### PR TITLE
Fix heap-use-after-free when reallocating Vals

### DIFF
--- a/swig/cpp/src/Internal.cpp
+++ b/swig/cpp/src/Internal.cpp
@@ -19,6 +19,7 @@
  * limitations under the License.
  */
 
+#include <cassert>
 #include <iostream>
 
 #include "Sysrepo.hpp"
@@ -108,6 +109,14 @@ Deleter::~Deleter() {
     v._sess = nullptr;
     break;
     }
+}
+
+/** @short Notify the deleter that the underlying storage was reallocated */
+void Deleter::update_vals_with_count(sr_val_t *val, size_t cnt)
+{
+    assert(_t == Free_Type::VALS);
+    v._val = val;
+    c._cnt = cnt;
 }
 
 }

--- a/swig/cpp/src/Internal.hpp
+++ b/swig/cpp/src/Internal.hpp
@@ -70,6 +70,8 @@ public:
     Deleter(sr_session_ctx_t *sess);
     ~Deleter();
 
+    void update_vals_with_count(sr_val_t *val, size_t cnt);
+
 private:
     count_t c;
     value_t v;

--- a/swig/cpp/src/Struct.cpp
+++ b/swig/cpp/src/Struct.cpp
@@ -436,6 +436,7 @@ sr_val_t* Vals::reallocate(size_t n) {
     if (ret != SR_ERR_OK)
         throw_exception(ret);
     _cnt = n;
+    _deleter->update_vals_with_count(_vals, _cnt);
     return _vals;
 }
 


### PR DESCRIPTION
Commit 51c90eb2edd6f40d87bb8bb8fbb09e1a41acdbdf added support for reallocating the storage within the `Vals` class, but the `Deleter` was not getting updated. Here's how it ended up when built with ASAN:
```
  1/1 Test #31: cpp_operations ...................***Failed   22.77 sec
  =================================================================
  ==28545==ERROR: AddressSanitizer: heap-use-after-free on address 0x60e000002ce0 at pc 0x7f78eda5b713 bp 0x7ffea869df90 sp 0x7ffea869df80
  READ of size 8 at 0x60e000002ce0 thread T0
      #0 0x7f78eda5b712 in sr_free_values sysrepo/src/common/sr_common.c:87
      #1 0x7f78ee90a3b9 in sysrepo::Deleter::~Deleter() sysrepo/swig/cpp/src/Internal.cpp:78
      #2 0x7f78ee8f0e42 in std::_Sp_counted_ptr<sysrepo::Deleter*, (__gnu_cxx::_Lock_policy)2>::_M_dispose() /usr/lib/gcc/x86_64-pc-linux-gnu/8.1.0/include/g++-v8/bits/shared_ptr_base.h:383
      #3 0x5614a5fb7805 in std::_Sp_counted_base<(__gnu_cxx::_Lock_policy)2>::_M_release() /usr/lib/gcc/x86_64-pc-linux-gnu/8.1.0/include/g++-v8/bits/shared_ptr_base.h:161
      #4 0x5614a5fb6b4c in std::__shared_count<(__gnu_cxx::_Lock_policy)2>::~__shared_count() /usr/lib/gcc/x86_64-pc-linux-gnu/8.1.0/include/g++-v8/bits/shared_ptr_base.h:712
      #5 0x5614a5fb470c in std::__shared_ptr<sysrepo::Deleter, (__gnu_cxx::_Lock_policy)2>::~__shared_ptr() /usr/lib/gcc/x86_64-pc-linux-gnu/8.1.0/include/g++-v8/bits/shared_ptr_base.h:1151
      #6 0x5614a5fb48a1 in std::shared_ptr<sysrepo::Deleter>::~shared_ptr() /usr/lib/gcc/x86_64-pc-linux-gnu/8.1.0/include/g++-v8/bits/shared_ptr.h:103
      #7 0x7f78ee8f9158 in sysrepo::Vals::~Vals() sysrepo/swig/cpp/src/Struct.cpp:414
      #8 0x5614a5fbde52 in std::_Sp_counted_ptr<sysrepo::Vals*, (__gnu_cxx::_Lock_policy)2>::_M_dispose() /usr/lib/gcc/x86_64-pc-linux-gnu/8.1.0/include/g++-v8/bits/shared_ptr_base.h:383
      #9 0x5614a5fb7805 in std::_Sp_counted_base<(__gnu_cxx::_Lock_policy)2>::_M_release() /usr/lib/gcc/x86_64-pc-linux-gnu/8.1.0/include/g++-v8/bits/shared_ptr_base.h:161
      #10 0x5614a5fb6b4c in std::__shared_count<(__gnu_cxx::_Lock_policy)2>::~__shared_count() /usr/lib/gcc/x86_64-pc-linux-gnu/8.1.0/include/g++-v8/bits/shared_ptr_base.h:712
      #11 0x5614a5fb542c in std::__shared_ptr<sysrepo::Vals, (__gnu_cxx::_Lock_policy)2>::~__shared_ptr() /usr/lib/gcc/x86_64-pc-linux-gnu/8.1.0/include/g++-v8/bits/shared_ptr_base.h:1151
      #12 0x5614a5fb54b9 in std::shared_ptr<sysrepo::Vals>::~shared_ptr() /usr/lib/gcc/x86_64-pc-linux-gnu/8.1.0/include/g++-v8/bits/shared_ptr.h:103
      #13 0x5614a5fb2f5f in test_vals() sysrepo/swig/cpp/tests/operations.cpp:90
      #14 0x5614a5fb3b4b in main sysrepo/swig/cpp/tests/operations.cpp:116
      #15 0x7f78e99b6c4d in __libc_start_main ../csu/libc-start.c:295
      #16 0x5614a5faf3b9 in _start (_build/sysrepo/GCC_8_1_NETCONF-Debug/swig/cpp/tests/cpp_operations+0x203b9)

  0x60e000002ce0 is located 0 bytes inside of 160-byte region [0x60e000002ce0,0x60e000002d80)
  freed by thread T0 here:
      #0 0x7f78eecd65d0 in __interceptor_realloc /var/tmp/portage/sys-devel/gcc-8.1.0-r1/work/gcc-8.1.0/libsanitizer/asan/asan_malloc_linux.cc:105
      #1 0x7f78edaee988 in sr_realloc sysrepo/src/common/sr_mem_mgmt.c:294
      #2 0x7f78edafd99f in sr_realloc_values sysrepo/src/utils/values.c:192
      #3 0x7f78ee8f9be1 in sysrepo::Vals::reallocate(unsigned long) sysrepo/swig/cpp/src/Struct.cpp:435
      #4 0x5614a5fb2f41 in test_vals() sysrepo/swig/cpp/tests/operations.cpp:98
      #5 0x5614a5fb3b4b in main sysrepo/swig/cpp/tests/operations.cpp:116
      #6 0x7f78e99b6c4d in __libc_start_main ../csu/libc-start.c:295

  previously allocated by thread T0 here:
      #0 0x7f78eecd63a8 in __interceptor_calloc /var/tmp/portage/sys-devel/gcc-8.1.0-r1/work/gcc-8.1.0/libsanitizer/asan/asan_malloc_linux.cc:95
      #1 0x7f78edaefbf2 in sr_calloc sysrepo/src/common/sr_mem_mgmt.c:373
      #2 0x7f78edafd044 in sr_new_values_ctx sysrepo/src/utils/values.c:141
      #3 0x7f78edafd334 in sr_new_values sysrepo/src/utils/values.c:166
      #4 0x7f78ee8f8c41 in sysrepo::Vals::Vals(unsigned long) sysrepo/swig/cpp/src/Struct.cpp:405
      #5 0x5614a5fb24aa in test_vals() sysrepo/swig/cpp/tests/operations.cpp:90
      #6 0x5614a5fb3b4b in main sysrepo/swig/cpp/tests/operations.cpp:116
      #7 0x7f78e99b6c4d in __libc_start_main ../csu/libc-start.c:295

  SUMMARY: AddressSanitizer: heap-use-after-free sysrepo/src/common/sr_common.c:87 in sr_free_values
```
Fix this by adding a helper method to the `Deleter` which is used for updating its idea of the backing storage.

Cc: @kpbarrett