### PR TITLE
Updated information about passive subscriptions and enabled event

### DIFF
--- a/inc/sysrepo.h
+++ b/inc/sysrepo.h
@@ -1169,7 +1169,8 @@ typedef enum sr_subscr_flag_e {
     SR_SUBSCR_APPLY_ONLY = 4,
 
     /**
-     * @brief The subscriber wants ::SR_EV_ENABLED notifications to be sent to them.
+     * @brief The subscriber wants ::SR_EV_ENABLED notifications to be sent to them. Does not work for passive
+     * (::SR_SUBSCR_PASSIVE) subscriptions.
      */
     SR_SUBSCR_EV_ENABLED = 8,
 


### PR DESCRIPTION
### Description
Enabled event is delivered to subscriptions only at the moment of subscribing, which means that passive subscriptions will never get this event.

### Closure
Refs #1431
