### PR TITLE
Use atomic for message ref counter

### DIFF
--- a/src/clientlib/cl_common.c
+++ b/src/clientlib/cl_common.c
@@ -267,7 +267,7 @@ cl_message_recv(sr_conn_ctx_t *conn_ctx, Sr__Msg **msg, sr_mem_ctx_t *sr_mem_res
     /* associate message with context */
     if (NULL != sr_mem) {
         (*msg)->_sysrepo_mem_ctx = (uint64_t)sr_mem;
-        ++sr_mem->obj_count;
+        ATOMIC_INC(&sr_mem->obj_count);
     }
 
     return SR_ERR_OK;

--- a/src/clientlib/cl_subscription_manager.c
+++ b/src/clientlib/cl_subscription_manager.c
@@ -1076,7 +1076,7 @@ cl_sm_conn_msg_process(cl_sm_ctx_t *sm_ctx, cl_sm_conn_ctx_t *conn, uint8_t *msg
     /* associate message with context */
     if (NULL != sr_mem) {
         msg->_sysrepo_mem_ctx = (uint64_t)sr_mem;
-        ++sr_mem->obj_count;
+        ATOMIC_INC(&sr_mem->obj_count);
     }
 
     /* check the message */

--- a/src/common/sr_common.c
+++ b/src/common/sr_common.c
@@ -70,7 +70,7 @@ sr_free_val(sr_val_t *value)
 {
     if (NULL != value) {
         if (NULL != value->_sr_mem) {
-            if (0 == --value->_sr_mem->obj_count) {
+            if (ATOMIC_DEC(&value->_sr_mem->obj_count) == 1) {
                 sr_mem_free(value->_sr_mem);
             }
         } else {
@@ -85,7 +85,7 @@ sr_free_values(sr_val_t *values, size_t count)
 {
     if (NULL != values) {
         if (values[0]._sr_mem) {
-            if (0 == --values[0]._sr_mem->obj_count) {
+            if (ATOMIC_DEC(&values[0]._sr_mem->obj_count) == 1) {
                 sr_mem_free(values[0]._sr_mem);
             }
         } else {
@@ -102,7 +102,7 @@ sr_free_schemas(sr_schema_t *schemas, size_t count)
 {
     if (NULL != schemas) {
         if (schemas[0]._sr_mem) {
-            if (0 == --schemas[0]._sr_mem->obj_count) {
+            if (ATOMIC_DEC(&schemas[0]._sr_mem->obj_count) == 1) {
                 sr_mem_free(schemas[0]._sr_mem);
             }
             return;
@@ -120,7 +120,7 @@ sr_free_tree(sr_node_t *tree)
 {
     if (NULL != tree) {
         if (NULL != tree->_sr_mem) {
-            if (0 == --tree->_sr_mem->obj_count) {
+            if (ATOMIC_DEC(&tree->_sr_mem->obj_count) == 1) {
                 sr_mem_free(tree->_sr_mem);
             }
         } else {
@@ -142,7 +142,7 @@ sr_free_trees(sr_node_t *trees, size_t count)
 {
     if (NULL != trees) {
         if (NULL != trees[0]._sr_mem) {
-            if (0 == --trees[0]._sr_mem->obj_count) {
+            if (ATOMIC_DEC(&trees[0]._sr_mem->obj_count) == 1) {
                 sr_mem_free(trees[0]._sr_mem);
             }
         } else {

--- a/src/common/sr_constants.h.in
+++ b/src/common/sr_constants.h.in
@@ -48,8 +48,8 @@
 # define ATOMIC_DEC(x) atomic_fetch_sub(x, 1)
 #else
 # define ATOMIC_UINT32_T uint32_t
-# define ATOMIC_INC(x) __sync_add_and_fetch(x, 1)
-# define ATOMIC_DEC(x) __sync_sub_and_fetch(x, 1)
+# define ATOMIC_INC(x) __sync_fetch_and_add(x, 1)
+# define ATOMIC_DEC(x) __sync_fetch_and_sub(x, 1)
 #endif
 
 /** Use libavl (if defined) or libredblack (if not defined) for binary tree manipulations. */

--- a/src/common/sr_mem_mgmt.c
+++ b/src/common/sr_mem_mgmt.c
@@ -592,7 +592,7 @@ sr_msg_free(Sr__Msg *msg)
     sr_mem_ctx_t *sr_mem = (sr_mem_ctx_t *)msg->_sysrepo_mem_ctx;
 
     if (sr_mem) {
-        if (0 == --sr_mem->obj_count) {
+        if (ATOMIC_DEC(&sr_mem->obj_count) == 1) {
             sr_mem_free(sr_mem);
         }
     } else if (msg) {

--- a/src/common/sr_mem_mgmt.h
+++ b/src/common/sr_mem_mgmt.h
@@ -55,7 +55,7 @@ typedef struct sr_mem_ctx_s {
    size_t peak;             /**< Peak usage of the memory context. Resets only in ::sr_mem_free. */
    size_t piggy_back;       /**< Piggybacking.
                                  Used for threads to exchange information about the recent peak memory usage. */
-   unsigned obj_count;      /**< Object counter, i.e. how many values/trees/GPB messages use this context */
+   ATOMIC_UINT32_T obj_count; /**< Object counter, i.e. how many values/trees/GPB messages use this context */
 } sr_mem_ctx_t;
 
 /**

--- a/src/common/sr_protobuf.c
+++ b/src/common/sr_protobuf.c
@@ -368,7 +368,7 @@ sr_gpb_req_alloc(sr_mem_ctx_t *sr_mem, const Sr__Operation operation, const uint
 
     /* make association between the message and the context */
     if (sr_mem) {
-        ++sr_mem->obj_count;
+        ATOMIC_INC(&sr_mem->obj_count);
         msg->_sysrepo_mem_ctx = (uint64_t)sr_mem;
     }
 
@@ -636,7 +636,7 @@ sr_gpb_resp_alloc(sr_mem_ctx_t *sr_mem, const Sr__Operation operation, const uin
 
     /* make association between the message and the context */
     if (sr_mem) {
-        ++sr_mem->obj_count;
+        ATOMIC_INC(&sr_mem->obj_count);
         msg->_sysrepo_mem_ctx = (uint64_t)sr_mem;
     }
 
@@ -725,7 +725,7 @@ sr_gpb_notif_alloc(sr_mem_ctx_t *sr_mem, const Sr__SubscriptionType type, const 
 
     /* make association between the message and the context */
     if (sr_mem) {
-        ++sr_mem->obj_count;
+        ATOMIC_INC(&sr_mem->obj_count);
         msg->_sysrepo_mem_ctx = (uint64_t)sr_mem;
     }
 
@@ -774,7 +774,7 @@ sr_gpb_notif_ack_alloc(sr_mem_ctx_t *sr_mem, Sr__Msg *notification, Sr__Msg **ms
 
     /* make association between the message and the context */
     if (sr_mem) {
-        ++sr_mem->obj_count;
+        ATOMIC_INC(&sr_mem->obj_count);
         msg->_sysrepo_mem_ctx = (uint64_t)sr_mem;
     }
 
@@ -873,7 +873,7 @@ sr_gpb_internal_req_alloc(sr_mem_ctx_t *sr_mem, const Sr__Operation operation, S
 
     /* make association between the message and the context */
     if (sr_mem) {
-        ++sr_mem->obj_count;
+        ATOMIC_INC(&sr_mem->obj_count);
         msg->_sysrepo_mem_ctx = (uint64_t)sr_mem;
     }
 
@@ -1675,7 +1675,7 @@ sr_dup_gpb_to_val_t(sr_mem_ctx_t *sr_mem, const Sr__Value *gpb_value, sr_val_t *
     }
 
     if (sr_mem) {
-        ++sr_mem->obj_count;
+        ATOMIC_INC(&sr_mem->obj_count);
     }
     *value = val;
     return rc;
@@ -1753,7 +1753,7 @@ sr_values_gpb_to_sr(sr_mem_ctx_t *sr_mem, Sr__Value **gpb_values, size_t gpb_val
     }
 
     if (sr_mem && sr_values) {
-        ++sr_mem->obj_count;
+        ATOMIC_INC(&sr_mem->obj_count);
     }
     *sr_values_p = sr_values;
     *sr_value_cnt_p = gpb_value_cnt;
@@ -1869,7 +1869,7 @@ sr_dup_gpb_to_tree(sr_mem_ctx_t *sr_mem, const Sr__Node *gpb_tree, sr_node_t **s
     }
 
     if (sr_mem) {
-        ++sr_mem->obj_count;
+        ATOMIC_INC(&sr_mem->obj_count);
     }
     *sr_tree = tree;
     return rc;
@@ -1999,7 +1999,7 @@ sr_trees_gpb_to_sr(sr_mem_ctx_t *sr_mem, Sr__Node **gpb_trees, size_t gpb_tree_c
     }
 
     if (sr_mem && sr_trees) {
-        ++sr_mem->obj_count;
+        ATOMIC_INC(&sr_mem->obj_count);
     }
     *sr_trees_p = sr_trees;
     *sr_tree_cnt_p = gpb_tree_cnt;
@@ -2041,7 +2041,7 @@ sr_changes_sr_to_gpb(sr_list_t *sr_changes, sr_mem_ctx_t *sr_mem, Sr__Change ***
                 if (sr_mem) {
                     rc = sr_dup_val_ctx(ch->new_value, sr_mem, &value_dup);
                     CHECK_RC_MSG_GOTO(rc, cleanup, "Unable to duplicate sr_val_t.");
-                    --sr_mem->obj_count; /* do not treat value_dup as an object on its own */
+                    ATOMIC_DEC(&sr_mem->obj_count); /* do not treat value_dup as an object on its own */
                 } else {
                     value_dup = ch->new_value;
                 }
@@ -2052,7 +2052,7 @@ sr_changes_sr_to_gpb(sr_list_t *sr_changes, sr_mem_ctx_t *sr_mem, Sr__Change ***
                 if (sr_mem) {
                     rc = sr_dup_val_ctx(ch->old_value, sr_mem, &value_dup);
                     CHECK_RC_MSG_GOTO(rc, cleanup, "Unable to duplicate sr_val_t.");
-                    --sr_mem->obj_count; /* do not treat value_dup as an object on its own */
+                    ATOMIC_DEC(&sr_mem->obj_count); /* do not treat value_dup as an object on its own */
                 } else {
                     value_dup = ch->old_value;
                 }
@@ -2721,7 +2721,7 @@ sr_schemas_gpb_to_sr(sr_mem_ctx_t *sr_mem, const Sr__Schema **gpb_schemas, const
     }
 
     if (sr_mem && schemas) {
-        ++sr_mem->obj_count;
+        ATOMIC_INC(&sr_mem->obj_count);
     }
     *sr_schemas = schemas;
     return SR_ERR_OK;

--- a/src/common/sr_utils.c
+++ b/src/common/sr_utils.c
@@ -1800,7 +1800,7 @@ sr_nodes_to_tree_chunks(struct ly_set *nodes, size_t slice_offset, size_t slice_
     trees = sr_calloc(sr_mem, tree_cnt, sizeof *trees);
     CHECK_NULL_NOMEM_GOTO(trees, rc, cleanup);
     if (sr_mem) {
-        ++sr_mem->obj_count;
+        ATOMIC_INC(&sr_mem->obj_count);
     }
 
     for (i = j = 0; i < nodes->number && 0 == rc; ++i) {

--- a/src/connection_manager.c
+++ b/src/connection_manager.c
@@ -1020,7 +1020,7 @@ cm_conn_msg_process(cm_ctx_t *cm_ctx, sm_connection_t *conn, uint8_t *msg_data, 
     }
     if (NULL != sr_mem) {
         msg->_sysrepo_mem_ctx = (uint64_t)sr_mem;
-        ++sr_mem->obj_count;
+        ATOMIC_INC(&sr_mem->obj_count);
     } else {
         msg->_sysrepo_mem_ctx = (uint64_t) NULL;
     }

--- a/src/rp_dt_get.c
+++ b/src/rp_dt_get.c
@@ -150,7 +150,7 @@ rp_dt_get_values_from_nodes(sr_mem_ctx_t *sr_mem, struct ly_set *nodes, sr_val_t
     vals = sr_calloc(sr_mem, nodes->number, sizeof(*vals));
     CHECK_NULL_NOMEM_RETURN(vals);
     if (sr_mem) {
-        ++sr_mem->obj_count;
+        ATOMIC_INC(&sr_mem->obj_count);
     }
 
     for (size_t i = 0; i < nodes->number; i++) {
@@ -209,7 +209,7 @@ rp_dt_get_value(dm_ctx_t *dm_ctx, rp_session_t *rp_session, struct lyd_node *dat
 
     if (sr_mem) {
         val->_sr_mem = sr_mem;
-        sr_mem->obj_count += 1;
+        ATOMIC_INC(&sr_mem->obj_count);
     }
 
     rc = rp_dt_get_value_from_node(node, val);
@@ -290,7 +290,7 @@ rp_dt_get_subtree(dm_ctx_t *dm_ctx, rp_session_t *rp_session, struct lyd_node *d
 
     if (sr_mem) {
         tree->_sr_mem = sr_mem;
-        sr_mem->obj_count += 1;
+        ATOMIC_INC(&sr_mem->obj_count);
     }
 
     rc = sr_copy_node_to_tree(node, pruning_cb, (void *)pruning_ctx, tree);
@@ -340,7 +340,7 @@ rp_dt_get_subtree_chunk(dm_ctx_t *dm_ctx, rp_session_t *rp_session, struct lyd_n
 
     if (sr_mem) {
         tree->_sr_mem = sr_mem;
-        sr_mem->obj_count += 1;
+        ATOMIC_INC(&sr_mem->obj_count);
     }
 
     rc = sr_copy_node_to_tree_chunk(node, slice_offset, slice_width, child_limit, depth_limit, pruning_cb,

--- a/src/utils/trees.c
+++ b/src/utils/trees.c
@@ -101,7 +101,7 @@ sr_new_tree_ctx(sr_mem_ctx_t *sr_mem, const char *name, const char *module_name,
         }
     } else {
         if (sr_mem) {
-            sr_mem->obj_count += 1;
+            ATOMIC_INC(&sr_mem->obj_count);
         }
     }
 
@@ -143,7 +143,7 @@ sr_new_trees_ctx(sr_mem_ctx_t *sr_mem, size_t count, sr_node_t **trees_p)
         for (size_t i = 0; i < count; ++i) {
             trees[i]._sr_mem = sr_mem;
         }
-        sr_mem->obj_count += 1; /* 1 for the entire array */
+        ATOMIC_INC(&sr_mem->obj_count); /* 1 for the entire array */
     }
 
 cleanup:
@@ -210,7 +210,7 @@ sr_realloc_trees(size_t old_tree_cnt, size_t new_tree_cnt, sr_node_t **trees_p)
             trees[i]._sr_mem = sr_mem;
         }
         if (0 == old_tree_cnt) {
-            sr_mem->obj_count += 1; /* 1 for the entire array */
+            ATOMIC_INC(&sr_mem->obj_count); /* 1 for the entire array */
         }
     }
 

--- a/src/utils/values.c
+++ b/src/utils/values.c
@@ -103,7 +103,7 @@ sr_new_val_ctx(sr_mem_ctx_t *sr_mem, const char *xpath, sr_val_t **value_p)
     }
 
     if (sr_mem) {
-        sr_mem->obj_count += 1;
+        ATOMIC_INC(&sr_mem->obj_count);
     }
     *value_p = value;
     return SR_ERR_OK;
@@ -153,7 +153,7 @@ sr_new_values_ctx(sr_mem_ctx_t *sr_mem, size_t count, sr_val_t **values_p)
         for (size_t i = 0; i < count; ++i) {
             values[i]._sr_mem = sr_mem;
         }
-        sr_mem->obj_count += 1; /* 1 for the entire array */
+        ATOMIC_INC(&sr_mem->obj_count); /* 1 for the entire array */
     }
 
     *values_p = values;
@@ -209,7 +209,7 @@ sr_realloc_values(size_t old_value_cnt, size_t new_value_cnt, sr_val_t **values_
             values[i]._sr_mem = sr_mem;
         }
         if (0 == old_value_cnt) {
-            sr_mem->obj_count += 1; /* 1 for the entire array */
+            ATOMIC_INC(&sr_mem->obj_count); /* 1 for the entire array */
         }
     }
 


### PR DESCRIPTION
### Description
Atomic variable should be used for message reference counter to avoid data races.

### Closure
Refs #1450