### PR TITLE
Swig is not required for C++ bindings

### DIFF
--- a/swig/CMakeLists.txt
+++ b/swig/CMakeLists.txt
@@ -5,7 +5,7 @@ set(TEST_REPOSITORY_LOC "${CMAKE_BINARY_DIR}/repository")
 
 # find SWIG package
 if(GEN_LANGUAGE_BINDINGS)
-    find_package(SWIG 3.0.12 REQUIRED)
+    find_package(SWIG 3.0.12)
     if(NOT SWIG_FOUND)
         message(WARNING "SWIG library not found")
     else()


### PR DESCRIPTION
### Description
Swig should not be required to build C++ bindings.

### Closure
Fixes #1460