### PR TITLE
Ensure that feature test macros work correctly

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -168,6 +168,9 @@ if(HAVE_MKSTEMPS)
 endif(HAVE_MKSTEMPS)
 CHECK_STRUCT_HAS_MEMBER("struct stat" st_mtim "sys/stat.h" HAVE_STAT_ST_MTIM)
 CHECK_SYMBOL_EXISTS("F_OFD_SETLKW" "fcntl.h" HAVE_LINUX_OFD_LOCK)
+if (HAVE_LINUX_OFD_LOCK)
+    add_definitions(-D_GNU_SOURCE)
+endif()
 
 # user options
 set(ENABLE_NACM 0 CACHE BOOL

--- a/src/common/sr_utils.c
+++ b/src/common/sr_utils.c
@@ -21,9 +21,6 @@
  */
 
 #include "sr_constants.h"
-#ifdef HAVE_LINUX_OFD_LOCK
-#define _GNU_SOURCE
-#endif
 #include <sys/types.h>
 #include <sys/socket.h>
 #include <unistd.h>

--- a/src/module_dependencies.c
+++ b/src/module_dependencies.c
@@ -19,7 +19,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+#ifndef _GNU_SOURCE
 #define _GNU_SOURCE
+#endif
 
 #include <sys/types.h>
 #include <sys/stat.h>


### PR DESCRIPTION
These feature test macros are [required to be defined prior to including any standard headers](http://man7.org/linux/man-pages/man7/feature_test_macros.7.html). This is a transitive requirement because headers are, in general, free to include other headers. The sysrepo's code violated this because it included `<stdatomic.h>`.

This fixes a build failure when using clang on Fedora 29. Apparently, the order of `#include` is different from using GCC. By the time `sr_utils.c` defined `_GNU_SOURCE`, the `<features.h>` was already processed, and therefore `_GNU_SOURCE` was not turned into `__USE_GNU` (which is what `<bits/fcntl-linux.h>` uses as a guard for the `F_OFD_GETLK` etc.