### PR TITLE
Fix the error occurrs after get-config with filter-xpath for 2nd time

### DIFF
--- a/src/access_control.c
+++ b/src/access_control.c
@@ -108,6 +108,7 @@ ac_module_info_free_cb(void *item)
     ac_module_info_t *info = (ac_module_info_t *) item;
     if (NULL != info) {
         free((void*)info->module_name);
+        free((void*)info->xpath);
     }
     free(info);
 }
@@ -274,6 +275,8 @@ ac_check_module_node_permissions(ac_session_t *session, const char *module_name,
         rc = sr_btree_insert(session->module_info_btree, module_info);
         if (SR_ERR_OK != rc) {
             SR_LOG_ERR_MSG("Cannot insert new entry into binary tree for module access control info.");
+            free((void *)module_info->module_name);
+            free((void *)module_info->xpath);
             free(module_info);
             return SR_ERR_INTERNAL;
         }

--- a/src/access_control.c
+++ b/src/access_control.c
@@ -267,6 +267,9 @@ ac_check_module_node_permissions(ac_session_t *session, const char *module_name,
                 free(module_info);
                 return rc;
             }
+            if (NULL != node_xpath) {
+                module_info->xpath = strdup(node_xpath);
+            }
         }
         rc = sr_btree_insert(session->module_info_btree, module_info);
         if (SR_ERR_OK != rc) {


### PR DESCRIPTION
### Description
This pull request intends to solve an issue that with the following command 
```
get-config --source running --filter-xpath //ietf-netconf-server:listen[1]
```
on netopeer2-cli will successfully execute for the first time after connect to
server but fail afterwards with the following message : 
```
ERROR
	type:     application
	tag:      operation-failed
	severity: error
	message:  np2srv_sr_get_items_iter failed (sysrepo: Sysrepo-internal error).
```
`sysrepod` report the following log : 
```
[DBG] (rp_worker_thread_execute:3822) Thread id=140555455993600 signaled.
[DBG] (sr_cbuff_dequeue:532) Circular buffer dequeue, new buffer head=1, count=0.
[DBG] (rp_get_items_req_process:792) Processing get_items request.
[INF] (rp_dt_get_values_wrapper_with_opts:1348) Get items request running datastore, xpath: //ietf-netconf-server:listen[1]//., offset: 0, limit: 100
[ERR] (ac_check_module_node_permissions:273) Cannot insert new entry into binary tree for module access control info.
[ERR] (rp_dt_prepare_data:1203) Access control check failed for xpath '//ietf-netconf-server:listen[1]//.'
[ERR] (rp_dt_get_values_wrapper_with_opts:1361) rp_dt_prepare_data failed
[ERR] (rp_get_items_req_process:830) Get items failed for '//ietf-netconf-server:listen[1]//.', session id=1841680137.
[DBG] (sr_cbuff_enqueue:516) Circular buffer enqueue to position=78, current count=1.
[DBG] (rp_worker_thread_execute:3810) Thread id=140555455993600 will wait.
[DBG] (cm_msg_enqueue_cb:1791) New message enqueued into CM message queue.
[DBG] (sr_cbuff_dequeue:532) Circular buffer dequeue, new buffer head=79, count=0.
[DBG] (cm_conn_out_buff_flush:508) Sending 30 bytes of data.
[DBG] (cm_conn_out_buff_flush:514) 30 bytes of data sent.
```
After debug with gdb, it shows that the `module_info` does not record input `xpath`.
