### PR TITLE
[🐛 FIX] `unused parameter` warnings when including Session.hpp

### DIFF
--- a/swig/cpp/src/Session.cpp
+++ b/swig/cpp/src/Session.cpp
@@ -446,8 +446,74 @@ Subscribe::~Subscribe()
     }
 }
 
-Callback::Callback() {}
-Callback::~Callback() {}
+int Callback::module_change(S_Session /* session */,
+                            const char * /* module_name */,
+                            sr_notif_event_t /* event */,
+                            void * /* private_ctx */) {
+  return SR_ERR_OK;
+}
+
+int Callback::subtree_change(S_Session /* session */, const char * /* xpath */,
+                             sr_notif_event_t /* event */,
+                             void * /* private_ctx */) {
+  return SR_ERR_OK;
+}
+
+void Callback::module_install(const char * /* module_name */,
+                             const char * /* revision */,
+                             sr_module_state_t /* state */,
+                             void * /* private_ctx */) {
+  return;
+}
+
+void Callback::feature_enable(const char * /* module_name */,
+                             const char * /* feature_name */,
+                             bool /* enabled */, void * /* private_ctx */) {
+  return;
+}
+
+int Callback::rpc(const char * /* xpath */, const S_Vals /* input */,
+                  S_Vals_Holder /* output */, void * /* private_ctx */) {
+  return SR_ERR_OK;
+}
+
+int Callback::action(const char * /* xpath */, const S_Vals /* input */,
+                     S_Vals_Holder /* output */, void * /* private_ctx */) {
+  return SR_ERR_OK;
+}
+
+int Callback::rpc_tree(const char * /* xpath */, const S_Trees /* input */,
+                       S_Trees_Holder /* output */, void * /* private_ctx */) {
+  return SR_ERR_OK;
+}
+
+int Callback::action_tree(const char * /* xpath */, const S_Trees /* input */,
+                          S_Trees_Holder /* output */,
+                          void * /* private_ctx */) {
+  return SR_ERR_OK;
+}
+
+int Callback::dp_get_items(const char * /* xpath */, S_Vals_Holder /* vals */,
+                           uint64_t /* request_id */,
+                           const char * /* original_xpath */,
+                           void * /* private_ctx */) {
+  return SR_ERR_OK;
+}
+
+void Callback::event_notif(const sr_ev_notif_type_t /* notif_type */,
+                           const char * /* xpath */, S_Vals /* vals */,
+                           time_t /* timestamp */, void * /* private_ctx */) {
+  return;
+}
+
+void Callback::event_notif_tree(const sr_ev_notif_type_t /* notif_type */,
+                                const char * /* xpath */, S_Trees /* trees */,
+                                time_t /* timestamp */,
+                                void * /* private_ctx */) {
+  return;
+}
+
+Callback *Callback::get() { return this; }
 
 static int module_change_cb(sr_session_ctx_t *session, const char *module_name, sr_notif_event_t event, void *private_ctx) {
     S_Session sess(new Session(session));

--- a/swig/cpp/src/Session.hpp
+++ b/swig/cpp/src/Session.hpp
@@ -158,32 +158,31 @@ private:
 class Callback
 {
 public:
-    Callback();
-    virtual ~Callback();
+    virtual ~Callback() = default;
 
     /** Wrapper for [sr_module_change_cb](@ref sr_module_change_cb) callback.*/
-    virtual int module_change(S_Session session, const char *module_name, sr_notif_event_t event, void *private_ctx) {return SR_ERR_OK;};
+    virtual int module_change(S_Session session, const char *module_name, sr_notif_event_t event, void *private_ctx);
     /** Wrapper for [sr_subtree_change_cb](@ref sr_subtree_change_cb) callback.*/
-    virtual int subtree_change(S_Session session, const char *xpath, sr_notif_event_t event, void *private_ctx) {return SR_ERR_OK;};
+    virtual int subtree_change(S_Session session, const char *xpath, sr_notif_event_t event, void *private_ctx);
     /** Wrapper for [sr_module_install_cb](@ref sr_module_install_cb) callback.*/
-    virtual void module_install(const char *module_name, const char *revision, sr_module_state_t state, void *private_ctx) {return;};
+    virtual void module_install(const char *module_name, const char *revision, sr_module_state_t state, void *private_ctx);
     /** Wrapper for [sr_feature_enable_cb](@ref sr_feature_enable_cb) callback.*/
-    virtual void feature_enable(const char *module_name, const char *feature_name, bool enabled, void *private_ctx) {return;};
+    virtual void feature_enable(const char *module_name, const char *feature_name, bool enabled, void *private_ctx);
     /** Wrapper for [sr_rpc_cb](@ref sr_rpc_cb) callback.*/
-    virtual int rpc(const char *xpath, const S_Vals input, S_Vals_Holder output, void *private_ctx) {return SR_ERR_OK;};
+    virtual int rpc(const char *xpath, const S_Vals input, S_Vals_Holder output, void *private_ctx);
     /** Wrapper for [sr_action_cb](@ref sr_action_cb) callback.*/
-    virtual int action(const char *xpath, const S_Vals input, S_Vals_Holder output, void *private_ctx) {return SR_ERR_OK;};
+    virtual int action(const char *xpath, const S_Vals input, S_Vals_Holder output, void *private_ctx);
     /** Wrapper for [sr_rpc_tree_cb](@ref sr_rpc_tree_cb) callback.*/
-    virtual int rpc_tree(const char *xpath, const S_Trees input, S_Trees_Holder output, void *private_ctx) {return SR_ERR_OK;};
+    virtual int rpc_tree(const char *xpath, const S_Trees input, S_Trees_Holder output, void *private_ctx);
     /** Wrapper for [sr_action_tree_cb](@ref sr_action_tree_cb) callback.*/
-    virtual int action_tree(const char *xpath, const S_Trees input, S_Trees_Holder output, void *private_ctx) {return SR_ERR_OK;};
+    virtual int action_tree(const char *xpath, const S_Trees input, S_Trees_Holder output, void *private_ctx);
     /** Wrapper for [sr_dp_get_items_cb](@ref sr_dp_get_items_cb) callback.*/
-    virtual int dp_get_items(const char *xpath, S_Vals_Holder vals, uint64_t request_id, const char *original_xpath, void *private_ctx) {return SR_ERR_OK;};
+    virtual int dp_get_items(const char *xpath, S_Vals_Holder vals, uint64_t request_id, const char *original_xpath, void *private_ctx);
     /** Wrapper for [sr_event_notif_cb](@ref sr_event_notif_cb) callback.*/
-    virtual void event_notif(const sr_ev_notif_type_t notif_type, const char *xpath, S_Vals vals, time_t timestamp, void *private_ctx) {return;};
+    virtual void event_notif(const sr_ev_notif_type_t notif_type, const char *xpath, S_Vals vals, time_t timestamp, void *private_ctx);
     /** Wrapper for [sr_event_notif_tree_cb](@ref sr_event_notif_tree_cb) callback.*/
-    virtual void event_notif_tree(const sr_ev_notif_type_t notif_type, const char *xpath, S_Trees trees, time_t timestamp, void *private_ctx) {return;};
-    Callback *get() {return this;};
+    virtual void event_notif_tree(const sr_ev_notif_type_t notif_type, const char *xpath, S_Trees trees, time_t timestamp, void *private_ctx);
+    Callback *get();
 
     std::map<const char *, void*> private_ctx;
 };


### PR DESCRIPTION
Continued #1558
 @jktjkt 

You'll also see the empty destructor turned into default constructors and destructors. This is a slight performance improvement. As you can see at https://godbolt.org/z/4SUN6l, defining them empty does result in a few extra instructions. The only design disadvantage is that you should define all structors in the header if you want consistency when they're not trivial, because when they are `= default` is only possible for the declaration of the structor.

What's better than this is actually omitting the structor when you don't need it which I did for the constructor.

Ping-pong :ping_pong: away