### PR TITLE
INSTALL.md: correct libavl

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -9,7 +9,7 @@
 - [Google Protocol Buffers](https://github.com/google/protobuf)
 - [protobuf-c](https://github.com/protobuf-c/protobuf-c)
 - [libev](http://software.schmorp.de/pkg/libev.html)
-- [libredblack](http://libredblack.sourceforge.net/) or [GNU libavl](http://adtinfo.org/) (either of these two)
+- [libredblack](http://libredblack.sourceforge.net/) or [libavl](https://packages.debian.org/source/buster/libavl) (either of these two)
 
 #### (Optional) Tools for running tests and building documentation:
 - [CMocka](https://cmocka.org/)


### PR DESCRIPTION
The installation manual mentions the GNU avl library. This is wrong,
sysrepo depends on libavl by Wessel Dankers. The only source seems to be
the debian repository.