### PR TITLE
[🐛 FIX] prevent warning `"__USE_XOPEN" redefined`

### DIFF
--- a/src/common/sr_utils.c
+++ b/src/common/sr_utils.c
@@ -33,7 +33,9 @@
 #include <pwd.h>
 #include <grp.h>
 //! @cond doxygen_suppress
+#ifndef __USE_XOPEN
 #define __USE_XOPEN
+#endif
 //! @endcond
 #include <time.h>
 #include <libyang/libyang.h>


### PR DESCRIPTION
Just a pesky warning solved with no side effects. Define symbol only if it is not defined.