### PR TITLE
[🐛 FIX] cmake policy warnings: CMP0075, CMP0086

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -153,6 +153,11 @@ else(USE_AVL_LIB)
     endif(REDBLACK_FOUND)
 endif(USE_AVL_LIB)
 
+# CMAKE_REQUIRED_LIBRARIES policy
+if(POLICY CMP0075)
+    cmake_policy(SET CMP0075 OLD)
+endif()
+
 # check for non-portable functions and headers
 set(CMAKE_REQUIRED_LIBRARIES pthread)
 include(CheckFunctionExists)
@@ -366,9 +371,14 @@ add_custom_target(uninstall_with_repo "${CMAKE_COMMAND}" -P "${CMAKE_MODULE_PATH
     COMMAND rm -rf ${REPOSITORY_LOC})
 
 if(GEN_LANGUAGE_BINDINGS)
+    # UseSWIG policies
     if(POLICY CMP0078)
         cmake_policy(SET CMP0078 OLD)
     endif()
+    if(POLICY CMP0086)
+        cmake_policy(SET CMP0086 OLD)
+    endif()
+
     add_subdirectory(swig)
 endif()
 


### PR DESCRIPTION
Hello,

Similar to #1630. While this doesn't solve the deprecation, it's important to me to have clean build output so that I can solve future warnings which might cause actual problems. What do you think?

Regards,
Andrei

![image](https://user-images.githubusercontent.com/6838492/66544788-c27ec400-eb41-11e9-91c8-8b3e477bf76e.png)

![image](https://user-images.githubusercontent.com/6838492/66544802-cd395900-eb41-11e9-82b5-cde62b1867b6.png)