### PR TITLE
Valid characters for turing-machine RPC example

### DIFF
--- a/examples/rpc_example.c
+++ b/examples/rpc_example.c
@@ -190,7 +190,7 @@ rpc_caller(sr_session_ctx_t *session)
         if (SR_ERR_OK != rc) {
             return rc;
         }
-        sr_val_build_str_data(&input[i+2], SR_STRING_T, "%lu", 'A'+i);
+        sr_val_build_str_data(&input[i+2], SR_STRING_T, "%c", (char)('A'+i));
     }
 
     printf("\n\n ========== EXECUTING RPC ==========\n\n");

--- a/examples/rpc_tree_example.c
+++ b/examples/rpc_tree_example.c
@@ -195,7 +195,7 @@ rpc_caller(sr_session_ctx_t *session)
         if (SR_ERR_OK != rc) {
             return rc;
         }
-        sr_node_build_str_data(leaf, SR_STRING_T, "%lu", 'A'+i);
+        sr_node_build_str_data(leaf, SR_STRING_T, "%c", (char)('A'+i));
     }
 
     printf("\n\n ========== EXECUTING RPC ==========\n\n");


### PR DESCRIPTION
### Description
Use valid characters for turing-machine RPC example.

### Closure
Fixes #1659