### PR TITLE
depoly: add docker ubuntu 18.04 files for sysrepo-netopeer2

### DIFF
--- a/deploy/docker/sysrepo-netopeer2/Dockerfile
+++ b/deploy/docker/sysrepo-netopeer2/Dockerfile
@@ -1,0 +1,170 @@
+FROM ubuntu:18.04
+
+# defaults
+RUN \
+	apt-get update && apt-get install -y \
+	git \
+	curl \
+	wget \
+	libssh-dev \
+	libssl-dev \
+	libtool \
+	build-essential \
+	vim \
+	libtool	\
+	autoconf \
+	automake \
+	pkg-config \
+	libgtk-3-dev \
+	make \
+	vim \
+	valgrind \
+	doxygen \
+	libev-dev \
+	libpcre3-dev \
+	unzip \
+	sudo \
+	python2.7 \
+	python3 \
+	python-pip \
+	python3-pip \
+	python-dev	\
+	python3-dev \
+	build-essential \
+	bison \
+	flex
+
+# pyang
+RUN pip install --upgrade pyang
+
+# Adding netconf user
+RUN adduser --system netconf
+RUN mkdir -p /home/netconf/.ssh
+RUN echo "netconf:netconf" | chpasswd && adduser netconf sudo
+
+
+# Clearing and setting authorized ssh keys
+RUN echo '' > /home/netconf/.ssh/authorized_keys
+RUN ssh-keygen -A
+RUN ssh-keygen -t dsa -P '' -f /home/netconf/.ssh/id_dsa
+RUN cat /home/netconf/.ssh/id_dsa.pub >> /home/netconf/.ssh/authorized_keys
+
+
+# Updating shell to bash
+RUN sed -i s#/home/netconf:/bin/false#/home/netconf:/bin/bash# /etc/passwd
+
+RUN mkdir /opt/dev && sudo chown -R netconf /opt/dev
+
+# set password for user (same as the username)
+RUN echo "root:root" | chpasswd
+
+# upgrade cmake to 3.10
+RUN \
+      cd /opt/dev && \
+      wget https://cmake.org/files/v3.10/cmake-3.10.0.tar.gz && \
+      tar -xvf cmake-3.10.0.tar.gz && rm cmake-3.10.0.tar.gz && cd cmake-3.10.0 && \
+      ./bootstrap && \
+      make -j2 && \
+      make install
+
+# swig
+RUN \
+      cd /opt/dev && \
+      wget http://downloads.sourceforge.net/swig/swig-4.0.1.tar.gz && \
+      tar -xvf swig-4.0.1.tar.gz && rm swig-4.0.1.tar.gz && cd swig-4.0.1 && \
+      ./configure --prefix=/usr --without-clisp --without-maximum-compile-warnings && \
+      make && \
+      make install && \
+      install -v -m755 -d /usr/share/doc/swig-4.0.1 && \
+      cp -v -R Doc/* /usr/share/doc/swig-4.0.1
+
+# cmoka
+RUN \
+      cd /opt/dev && \
+      git clone git://git.cryptomilk.org/projects/cmocka.git && cd cmocka && \
+      git checkout tags/cmocka-1.1.5 && \
+      mkdir build && cd build && \
+      cmake -DCMAKE_INSTALL_PREFIX:PATH=/usr .. && \
+      make -j2 && \
+      make install
+
+# protobuf
+RUN \
+      cd /opt/dev && \
+      git clone https://github.com/google/protobuf.git && cd protobuf && \
+      ./autogen.sh && \
+      ./configure --prefix=/usr && \
+      make -j2 && \
+      make install
+
+# protobuf-c
+RUN \
+      cd /opt/dev && \
+      git clone https://github.com/protobuf-c/protobuf-c.git && cd protobuf-c && \
+      ./autogen.sh && \
+      ./configure --prefix=/usr && \
+      make -j2 && \
+      make install
+
+
+# install lua
+RUN \
+      apt-get update && apt-get install -y \
+      luajit \
+      luarocks
+
+# install node v12.x
+RUN \
+     curl -sL https://deb.nodesource.com/setup_12.x | sudo -E bash - && \
+     sudo apt-get install -y nodejs && \
+     npm install -g node-gyp
+
+# libyang
+RUN \
+      cd /opt/dev && \
+      git clone https://github.com/CESNET/libyang.git && cd libyang && \
+      git checkout master && \
+      mkdir build && cd build && \
+      cmake -DCMAKE_BUILD_TYPE:String="Release" -DCMAKE_INSTALL_PREFIX:PATH=/usr -DENABLE_BUILD_TESTS=OFF .. && \
+      make -j2 && \
+      make install
+
+# libnetconf2
+RUN \
+      cd /opt/dev && \
+      git clone https://github.com/CESNET/libnetconf2.git && cd libnetconf2 && \
+      git checkout master && \
+      mkdir build && cd build && \
+      cmake  -DCMAKE_BUILD_TYPE:String="Release" -DCMAKE_INSTALL_PREFIX:PATH=/usr -DENABLE_BUILD_TESTS=OFF .. && \
+      make -j2 && \
+      make install
+
+# sysrepo
+RUN \
+      cd /opt/dev && \
+      git clone https://github.com/sysrepo/sysrepo.git && cd sysrepo && \
+      mkdir build && cd build && \
+      cmake -DENABLE_TESTS=OFF -DCMAKE_BUILD_TYPE="Release" -DCMAKE_INSTALL_PREFIX:PATH=/usr -DREPOSITORY_LOC:PATH=/etc/sysrepo .. && \
+      make -j2 && \
+      make install
+
+# netopeer 2
+RUN \
+      cd /opt/dev && git clone https://github.com/CESNET/Netopeer2.git && cd Netopeer2 && \
+      git checkout master && \
+      cd /opt/dev/Netopeer2/server && \
+      mkdir build && cd build && \
+      cmake -DCMAKE_BUILD_TYPE:String="Release" -DCMAKE_INSTALL_PREFIX:PATH=/usr .. && \
+      make -j2 && \
+      make install && \
+      cd /opt/dev/Netopeer2/cli && \
+      mkdir build && cd build && \
+      cmake -DCMAKE_BUILD_TYPE:String="Release" -DCMAKE_INSTALL_PREFIX:PATH=/usr .. && \
+      make -j2 && \
+      make install
+
+ENV EDITOR vim
+EXPOSE 830
+
+COPY supervisord.conf /etc/supervisord.conf
+CMD ["/usr/bin/supervisord", "-c", "/etc/supervisord.conf"]

--- a/deploy/docker/sysrepo-netopeer2/Dockerfile
+++ b/deploy/docker/sysrepo-netopeer2/Dockerfile
@@ -40,10 +40,11 @@ RUN echo "netconf:netconf" | chpasswd && adduser netconf sudo
 
 
 # Clearing and setting authorized ssh keys
-RUN echo '' > /home/netconf/.ssh/authorized_keys
-RUN ssh-keygen -A
-RUN ssh-keygen -t dsa -P '' -f /home/netconf/.ssh/id_dsa
-RUN cat /home/netconf/.ssh/id_dsa.pub >> /home/netconf/.ssh/authorized_keys
+RUN \
+	echo '' > /home/netconf/.ssh/authorized_keys && \
+	ssh-keygen -A && \
+	ssh-keygen -t dsa -P '' -f /home/netconf/.ssh/id_dsa && \
+	cat /home/netconf/.ssh/id_dsa.pub >> /home/netconf/.ssh/authorized_keys
 
 
 # Updating shell to bash
@@ -56,13 +57,11 @@ RUN echo "root:root" | chpasswd
 
 # libyang
 RUN \
-      cd /opt/dev && \
-      git clone https://github.com/CESNET/libyang.git && cd libyang && \
-      git checkout master && \
-      mkdir build && cd build && \
-      cmake -DCMAKE_BUILD_TYPE:String="Release" -DCMAKE_INSTALL_PREFIX:PATH=/usr -DENABLE_BUILD_TESTS=OFF .. && \
-      make -j2 && \
-      make install
+      sh -c "echo 'deb http://download.opensuse.org/repositories/home:/liberouter/xUbuntu_18.04/ /' > /etc/apt/sources.list.d/home:liberouter.list" && \
+      wget -nv https://download.opensuse.org/repositories/home:liberouter/xUbuntu_18.04/Release.key -O Release.key && \
+      apt-key add - < Release.key && \
+      apt-get update && \
+      apt-get install libyang libyang-dev
 
 # libnetconf2
 RUN \

--- a/deploy/docker/sysrepo-netopeer2/Dockerfile
+++ b/deploy/docker/sysrepo-netopeer2/Dockerfile
@@ -24,18 +24,14 @@ RUN \
 	libpcre3-dev \
 	unzip \
 	sudo \
-	python2.7 \
 	python3 \
-	python-pip \
-	python3-pip \
-	python-dev	\
-	python3-dev \
 	build-essential \
 	bison \
-	flex
-
-# pyang
-RUN pip install --upgrade pyang
+	flex \
+      swig \
+      libcmocka0 \
+      libcmocka-dev \
+      cmake
 
 # Adding netconf user
 RUN adduser --system netconf
@@ -57,67 +53,6 @@ RUN mkdir /opt/dev && sudo chown -R netconf /opt/dev
 
 # set password for user (same as the username)
 RUN echo "root:root" | chpasswd
-
-# upgrade cmake to 3.10
-RUN \
-      cd /opt/dev && \
-      wget https://cmake.org/files/v3.10/cmake-3.10.0.tar.gz && \
-      tar -xvf cmake-3.10.0.tar.gz && rm cmake-3.10.0.tar.gz && cd cmake-3.10.0 && \
-      ./bootstrap && \
-      make -j2 && \
-      make install
-
-# swig
-RUN \
-      cd /opt/dev && \
-      wget http://downloads.sourceforge.net/swig/swig-4.0.1.tar.gz && \
-      tar -xvf swig-4.0.1.tar.gz && rm swig-4.0.1.tar.gz && cd swig-4.0.1 && \
-      ./configure --prefix=/usr --without-clisp --without-maximum-compile-warnings && \
-      make && \
-      make install && \
-      install -v -m755 -d /usr/share/doc/swig-4.0.1 && \
-      cp -v -R Doc/* /usr/share/doc/swig-4.0.1
-
-# cmoka
-RUN \
-      cd /opt/dev && \
-      git clone git://git.cryptomilk.org/projects/cmocka.git && cd cmocka && \
-      git checkout tags/cmocka-1.1.5 && \
-      mkdir build && cd build && \
-      cmake -DCMAKE_INSTALL_PREFIX:PATH=/usr .. && \
-      make -j2 && \
-      make install
-
-# protobuf
-RUN \
-      cd /opt/dev && \
-      git clone https://github.com/google/protobuf.git && cd protobuf && \
-      ./autogen.sh && \
-      ./configure --prefix=/usr && \
-      make -j2 && \
-      make install
-
-# protobuf-c
-RUN \
-      cd /opt/dev && \
-      git clone https://github.com/protobuf-c/protobuf-c.git && cd protobuf-c && \
-      ./autogen.sh && \
-      ./configure --prefix=/usr && \
-      make -j2 && \
-      make install
-
-
-# install lua
-RUN \
-      apt-get update && apt-get install -y \
-      luajit \
-      luarocks
-
-# install node v12.x
-RUN \
-     curl -sL https://deb.nodesource.com/setup_12.x | sudo -E bash - && \
-     sudo apt-get install -y nodejs && \
-     npm install -g node-gyp
 
 # libyang
 RUN \

--- a/deploy/docker/sysrepo-netopeer2/Dockerfile
+++ b/deploy/docker/sysrepo-netopeer2/Dockerfile
@@ -31,7 +31,8 @@ RUN \
       swig \
       libcmocka0 \
       libcmocka-dev \
-      cmake
+      cmake \
+      supervisor
 
 # Adding netconf user
 RUN adduser --system netconf
@@ -43,8 +44,8 @@ RUN echo "netconf:netconf" | chpasswd && adduser netconf sudo
 RUN \
 	echo '' > /home/netconf/.ssh/authorized_keys && \
 	ssh-keygen -A && \
-	ssh-keygen -t dsa -P '' -f /home/netconf/.ssh/id_dsa && \
-	cat /home/netconf/.ssh/id_dsa.pub >> /home/netconf/.ssh/authorized_keys
+	ssh-keygen -t rsa -b 4096 -P '' -f /home/netconf/.ssh/id_rsa && \
+	cat /home/netconf/.ssh/id_rsa.pub >> /home/netconf/.ssh/authorized_keys
 
 
 # Updating shell to bash

--- a/deploy/docker/sysrepo-netopeer2/Dockerfile.devel
+++ b/deploy/docker/sysrepo-netopeer2/Dockerfile.devel
@@ -25,14 +25,13 @@ RUN \
 	unzip \
 	sudo \
 	python3 \
-	python3-pip \
-	python3-dev \
 	build-essential \
 	bison \
-	flex
-
-# pyang
-RUN pip3 install --upgrade pyang
+	flex \
+      swig \
+      libcmocka0 \
+      libcmocka-dev \
+      cmake
 
 # Adding netconf user
 RUN adduser --system netconf
@@ -55,67 +54,6 @@ RUN mkdir /opt/dev && sudo chown -R netconf /opt/dev
 
 # set password for user (same as the username)
 RUN echo "root:root" | chpasswd
-
-# upgrade cmake to 3.10
-RUN \
-      cd /opt/dev && \
-      wget https://cmake.org/files/v3.10/cmake-3.10.0.tar.gz && \
-      tar -xvf cmake-3.10.0.tar.gz && rm cmake-3.10.0.tar.gz && cd cmake-3.10.0 && \
-      ./bootstrap && \
-      make -j2 && \
-      make install
-
-# swig
-RUN \
-      cd /opt/dev && \
-      wget http://downloads.sourceforge.net/swig/swig-4.0.1.tar.gz && \
-      tar -xvf swig-4.0.1.tar.gz && rm swig-4.0.1.tar.gz && cd swig-4.0.1 && \
-      ./configure --prefix=/usr --without-clisp --without-maximum-compile-warnings && \
-      make && \
-      make install && \
-      install -v -m755 -d /usr/share/doc/swig-4.0.1 && \
-      cp -v -R Doc/* /usr/share/doc/swig-4.0.1
-
-# cmoka
-RUN \
-      cd /opt/dev && \
-      git clone git://git.cryptomilk.org/projects/cmocka.git && cd cmocka && \
-      git checkout tags/cmocka-1.1.5 && \
-      mkdir build && cd build && \
-      cmake -DCMAKE_INSTALL_PREFIX:PATH=/usr .. && \
-      make -j2 && \
-      make install
-
-# protobuf
-RUN \
-      cd /opt/dev && \
-      git clone https://github.com/google/protobuf.git && cd protobuf && \
-      ./autogen.sh && \
-      ./configure --prefix=/usr && \
-      make -j2 && \
-      make install
-
-# protobuf-c
-RUN \
-      cd /opt/dev && \
-      git clone https://github.com/protobuf-c/protobuf-c.git && cd protobuf-c && \
-      ./autogen.sh && \
-      ./configure --prefix=/usr && \
-      make -j2 && \
-      make install
-
-
-# install lua
-RUN \
-      apt-get update && apt-get install -y \
-      luajit \
-      luarocks
-
-# install node v12.x
-RUN \
-     curl -sL https://deb.nodesource.com/setup_12.x | sudo -E bash - && \
-     sudo apt-get install -y nodejs && \
-     npm install -g node-gyp
 
 # libyang
 RUN \

--- a/deploy/docker/sysrepo-netopeer2/Dockerfile.devel
+++ b/deploy/docker/sysrepo-netopeer2/Dockerfile.devel
@@ -1,0 +1,169 @@
+FROM ubuntu:18.04
+
+# defaults
+RUN \
+	apt-get update && apt-get install -y \
+	git \
+	curl \
+	wget \
+	libssh-dev \
+	libssl-dev \
+	libtool \
+	build-essential \
+	vim \
+	libtool	\
+	autoconf \
+	automake \
+	pkg-config \
+	libgtk-3-dev \
+	make \
+	vim \
+	valgrind \
+	doxygen \
+	libev-dev \
+	libpcre3-dev \
+	unzip \
+	sudo \
+	python3 \
+	python3-pip \
+	python3-dev \
+	build-essential \
+	bison \
+	flex
+
+# pyang
+RUN pip3 install --upgrade pyang
+
+# Adding netconf user
+RUN adduser --system netconf
+RUN mkdir -p /home/netconf/.ssh
+RUN echo "netconf:netconf" | chpasswd && adduser netconf sudo
+
+
+# Clearing and setting authorized ssh keys
+RUN \
+	echo '' > /home/netconf/.ssh/authorized_keys && \
+	ssh-keygen -A && \
+	ssh-keygen -t dsa -P '' -f /home/netconf/.ssh/id_dsa && \
+	cat /home/netconf/.ssh/id_dsa.pub >> /home/netconf/.ssh/authorized_keys
+
+
+# Updating shell to bash
+RUN sed -i s#/home/netconf:/bin/false#/home/netconf:/bin/bash# /etc/passwd
+
+RUN mkdir /opt/dev && sudo chown -R netconf /opt/dev
+
+# set password for user (same as the username)
+RUN echo "root:root" | chpasswd
+
+# upgrade cmake to 3.10
+RUN \
+      cd /opt/dev && \
+      wget https://cmake.org/files/v3.10/cmake-3.10.0.tar.gz && \
+      tar -xvf cmake-3.10.0.tar.gz && rm cmake-3.10.0.tar.gz && cd cmake-3.10.0 && \
+      ./bootstrap && \
+      make -j2 && \
+      make install
+
+# swig
+RUN \
+      cd /opt/dev && \
+      wget http://downloads.sourceforge.net/swig/swig-4.0.1.tar.gz && \
+      tar -xvf swig-4.0.1.tar.gz && rm swig-4.0.1.tar.gz && cd swig-4.0.1 && \
+      ./configure --prefix=/usr --without-clisp --without-maximum-compile-warnings && \
+      make && \
+      make install && \
+      install -v -m755 -d /usr/share/doc/swig-4.0.1 && \
+      cp -v -R Doc/* /usr/share/doc/swig-4.0.1
+
+# cmoka
+RUN \
+      cd /opt/dev && \
+      git clone git://git.cryptomilk.org/projects/cmocka.git && cd cmocka && \
+      git checkout tags/cmocka-1.1.5 && \
+      mkdir build && cd build && \
+      cmake -DCMAKE_INSTALL_PREFIX:PATH=/usr .. && \
+      make -j2 && \
+      make install
+
+# protobuf
+RUN \
+      cd /opt/dev && \
+      git clone https://github.com/google/protobuf.git && cd protobuf && \
+      ./autogen.sh && \
+      ./configure --prefix=/usr && \
+      make -j2 && \
+      make install
+
+# protobuf-c
+RUN \
+      cd /opt/dev && \
+      git clone https://github.com/protobuf-c/protobuf-c.git && cd protobuf-c && \
+      ./autogen.sh && \
+      ./configure --prefix=/usr && \
+      make -j2 && \
+      make install
+
+
+# install lua
+RUN \
+      apt-get update && apt-get install -y \
+      luajit \
+      luarocks
+
+# install node v12.x
+RUN \
+     curl -sL https://deb.nodesource.com/setup_12.x | sudo -E bash - && \
+     sudo apt-get install -y nodejs && \
+     npm install -g node-gyp
+
+# libyang
+RUN \
+      cd /opt/dev && \
+      git clone https://github.com/CESNET/libyang.git && cd libyang && \
+      git checkout devel && \
+      mkdir build && cd build && \
+      cmake -DCMAKE_BUILD_TYPE:String="Debug" -DCMAKE_INSTALL_PREFIX:PATH=/usr -DENABLE_BUILD_TESTS=OFF .. && \
+      make -j2 && \
+      make install
+
+# libnetconf2
+RUN \
+      cd /opt/dev && \
+      git clone https://github.com/CESNET/libnetconf2.git && cd libnetconf2 && \
+      git checkout devel && \
+      mkdir build && cd build && \
+      cmake  -DCMAKE_BUILD_TYPE:String="Debug" -DCMAKE_INSTALL_PREFIX:PATH=/usr -DENABLE_BUILD_TESTS=OFF .. && \
+      make -j2 && \
+      make install
+
+# sysrepo
+RUN \
+      cd /opt/dev && \
+      git clone https://github.com/sysrepo/sysrepo.git && cd sysrepo && \
+	  git checkout devel && \
+      mkdir build && cd build && \
+      cmake -DENABLE_TESTS=OFF -DCMAKE_BUILD_TYPE="Debug" -DCMAKE_INSTALL_PREFIX:PATH=/usr -DREPOSITORY_LOC:PATH=/etc/sysrepo .. && \
+      make -j2 && \
+      make install
+
+# netopeer 2
+RUN \
+      cd /opt/dev && git clone https://github.com/CESNET/Netopeer2.git && cd Netopeer2 && \
+      git checkout devel-server && \
+      cd /opt/dev/Netopeer2/server && \
+      mkdir build && cd build && \
+      cmake -DCMAKE_BUILD_TYPE:String="Debug" -DCMAKE_INSTALL_PREFIX:PATH=/usr .. && \
+      make -j2 && \
+      make install && \
+      cd /opt/dev/Netopeer2/cli && \
+      mkdir build && cd build && \
+      cmake -DCMAKE_BUILD_TYPE:String="Debug" -DCMAKE_INSTALL_PREFIX:PATH=/usr .. && \
+      make -j2 && \
+      make install
+
+ENV EDITOR vim
+EXPOSE 830
+
+COPY supervisord.conf /etc/supervisord.conf
+CMD ["/usr/bin/supervisord", "-c", "/etc/supervisord.conf"]

--- a/deploy/docker/sysrepo-netopeer2/Dockerfile.devel
+++ b/deploy/docker/sysrepo-netopeer2/Dockerfile.devel
@@ -31,7 +31,8 @@ RUN \
       swig \
       libcmocka0 \
       libcmocka-dev \
-      cmake
+      cmake \
+      supervisor
 
 # Adding netconf user
 RUN adduser --system netconf
@@ -43,8 +44,8 @@ RUN echo "netconf:netconf" | chpasswd && adduser netconf sudo
 RUN \
 	echo '' > /home/netconf/.ssh/authorized_keys && \
 	ssh-keygen -A && \
-	ssh-keygen -t dsa -P '' -f /home/netconf/.ssh/id_dsa && \
-	cat /home/netconf/.ssh/id_dsa.pub >> /home/netconf/.ssh/authorized_keys
+	ssh-keygen -t rsa -b 4096 -P '' -f /home/netconf/.ssh/id_rsa && \
+	cat /home/netconf/.ssh/id_rsa.pub >> /home/netconf/.ssh/authorized_keys
 
 
 # Updating shell to bash

--- a/deploy/docker/sysrepo-netopeer2/README.md
+++ b/deploy/docker/sysrepo-netopeer2/README.md
@@ -1,0 +1,51 @@
+# Docker image with Sysrepo & Netopeer2 setup
+
+Run `sysrepod` and `netopeer2-server` in the container:
+```
+docker run -it --name sysrepo -p 830:830 --rm sysrepo/sysrepo-netopeer2:latest
+```
+
+Connect to the NETCONF server via SSH to port `830` (username / password is `netconf`):
+```
+ssh netconf@localhost -p 830 -s netconf
+```
+
+In order to get running config via the SSH session use the following snippet:
+```
+<?xml version="1.0" encoding="UTF-8"?>
+<hello xmlns="urn:ietf:params:xml:ns:netconf:base:1.0">
+	<capabilities>
+		<capability>urn:ietf:params:neconf:base:1.0</capability>
+		<capability>urn:ietf:params:netconf:base:1.1</capability>
+		<capability>urn:ietf:params:netconf:capability:writable-running:1.0</capability>
+		<capability>urn:ietf:params:xml:ns:yang:ietf-netconf-monitoring?module=ietf-netconf-monitoring&amp;revision=2010-10-04</capability>
+	</capabilities>
+</hello>
+]]>]]>
+
+#139
+<rpc message-id="101" xmlns="urn:ietf:params:xml:ns:netconf:base:1.0">
+<get-config>
+	<source>
+		<running />
+	</source>
+</get-config>
+</rpc>
+##
+```
+
+To access `sysrepoctl` or `sysrepocfg` exec bash in the container:
+```
+docker exec -it sysrepo /bin/bash
+sysrepoctl -l
+sysrepocfg turing-machine
+```
+
+You can also connect to the NETCONF server via [testconf](https://hub.docker.com/r/sysrepo/testconf/):
+```
+docker run -it --link sysrepo --rm sysrepo/testconf:latest
+```
+
+asciinema demo:
+
+[![demo](https://asciinema.org/a/05cdmz78fhcl5jeo4xyiqqr33.png)](https://asciinema.org/a/05cdmz78fhcl5jeo4xyiqqr33?autoplay=1)

--- a/deploy/docker/sysrepo-netopeer2/README.md
+++ b/deploy/docker/sysrepo-netopeer2/README.md
@@ -1,16 +1,21 @@
 # Docker image with Sysrepo & Netopeer2 setup
 
-Run `sysrepod` and `netopeer2-server` in the container:
+Run `netopeer2-server` in the container:
 ```
 docker run -it --name sysrepo -p 830:830 --rm sysrepo/sysrepo-netopeer2:latest
 ```
 
 Connect to the NETCONF server via SSH to port `830` (username / password is `netconf`):
 ```
-ssh netconf@localhost -p 830 -s netconf
+ssh netconf@<docker_container_ip> -p 830 -s netconf
 ```
 
-In order to get running config via the SSH session use the following snippet:
+You can get the IP from the docker container with:
+```
+docker inspect sysrepo | grep -w "IPAddress"
+```
+
+In order to get running config via the SSH session use the following snippet. Paste this into the terminal where the ssh connection was esstablished:
 ```
 <?xml version="1.0" encoding="UTF-8"?>
 <hello xmlns="urn:ietf:params:xml:ns:netconf:base:1.0">
@@ -38,14 +43,10 @@ To access `sysrepoctl` or `sysrepocfg` exec bash in the container:
 ```
 docker exec -it sysrepo /bin/bash
 sysrepoctl -l
-sysrepocfg turing-machine
+sysrepocfg -E -f xml -d running -m <module_to_configure>
 ```
 
 You can also connect to the NETCONF server via [testconf](https://hub.docker.com/r/sysrepo/testconf/):
 ```
 docker run -it --link sysrepo --rm sysrepo/testconf:latest
 ```
-
-asciinema demo:
-
-[![demo](https://asciinema.org/a/05cdmz78fhcl5jeo4xyiqqr33.png)](https://asciinema.org/a/05cdmz78fhcl5jeo4xyiqqr33?autoplay=1)

--- a/deploy/docker/sysrepo-netopeer2/supervisord.conf
+++ b/deploy/docker/sysrepo-netopeer2/supervisord.conf
@@ -1,0 +1,22 @@
+[supervisord]
+nodaemon=true
+logfile=/var/log/supervisord.log
+loglevel=debug
+
+[program:sysrepod]
+command=/usr/local/bin/sysrepod -d
+autorestart=true
+redirect_stderr=true
+priority=1
+
+[program:sysrepo-plugind]
+command=/usr/local/bin/sysrepo-plugind -d
+autorestart=true
+redirect_stderr=true
+priority=2
+
+[program:netopeer2-server]
+command=/usr/local/bin/netopeer2-server -d
+autorestart=true
+redirect_stderr=true
+priority=3

--- a/deploy/docker/sysrepo-netopeer2/supervisord.conf
+++ b/deploy/docker/sysrepo-netopeer2/supervisord.conf
@@ -3,18 +3,6 @@ nodaemon=true
 logfile=/var/log/supervisord.log
 loglevel=debug
 
-[program:sysrepod]
-command=/usr/local/bin/sysrepod -d
-autorestart=true
-redirect_stderr=true
-priority=1
-
-[program:sysrepo-plugind]
-command=/usr/local/bin/sysrepo-plugind -d
-autorestart=true
-redirect_stderr=true
-priority=2
-
 [program:netopeer2-server]
 command=/usr/local/bin/netopeer2-server -d
 autorestart=true

--- a/deploy/docker/sysrepo-netopeer2/supervisord.conf
+++ b/deploy/docker/sysrepo-netopeer2/supervisord.conf
@@ -4,7 +4,7 @@ logfile=/var/log/supervisord.log
 loglevel=debug
 
 [program:netopeer2-server]
-command=/usr/local/bin/netopeer2-server -d
+command=/usr/bin/netopeer2-server -d
 autorestart=true
 redirect_stderr=true
 priority=3


### PR DESCRIPTION
Chagnes:
* add Dockerfile and Dockerfile.devel for ubuntu 18.04
* add supervisord.conf
* add README.md

Add docker files to enable local build of Docker images for sysrep-netopeer2 testing. Images are prebuild and can be found on [dockerhub](https://hub.docker.com/repository/docker/sysrepo/sysrepo-netopeer2)

