### PR TITLE
python3-bindings: SubscriptionTest.py increase sleep time

### DIFF
--- a/bindings/python/CMakeLists.txt
+++ b/bindings/python/CMakeLists.txt
@@ -35,6 +35,8 @@ if(ENABLE_PYTHON_TESTS)
         )
         set_property(TEST python_${TEST_NAME} PROPERTY ENVIRONMENT TESTS_DIR=${PROJECT_SOURCE_DIR}/tests)
         set_property(TEST python_${TEST_NAME} APPEND PROPERTY ENVIRONMENT PYTHONPATH=${CMAKE_CURRENT_BINARY_DIR})
+		# just not to pollute the repository, WARNING if PYTHONDONTWRITEBYTECODE is set the test do NOT work
+        # set_property(TEST python_${TEST_NAME} APPEND PROPERTY ENVIRONMENT PYTHONDONTWRITEBYTECODE=1)
     endmacro(ADD_PYTHON_TEST)
 
     ADD_PYTHON_TEST(SysrepoBasicTest)

--- a/bindings/python/CMakeLists.txt
+++ b/bindings/python/CMakeLists.txt
@@ -35,8 +35,6 @@ if(ENABLE_PYTHON_TESTS)
         )
         set_property(TEST python_${TEST_NAME} PROPERTY ENVIRONMENT TESTS_DIR=${PROJECT_SOURCE_DIR}/tests)
         set_property(TEST python_${TEST_NAME} APPEND PROPERTY ENVIRONMENT PYTHONPATH=${CMAKE_CURRENT_BINARY_DIR})
-        # just not to pollute the repository
-        set_property(TEST python_${TEST_NAME} APPEND PROPERTY ENVIRONMENT PYTHONDONTWRITEBYTECODE=1)
     endmacro(ADD_PYTHON_TEST)
 
     ADD_PYTHON_TEST(SysrepoBasicTest)

--- a/bindings/python/tests/NotificationTest.py
+++ b/bindings/python/tests/NotificationTest.py
@@ -40,7 +40,7 @@ class NotificationTester(SysrepoTester):
             ['python3','NotificationTestApp.py', module_name, xpath, self.filename])
         self.report_pid(self.process.pid)
         # wait for running data file to be copied
-        time.sleep(0.1)
+        time.sleep(1)
 
     def cancelSubscriptionStep(self):
         os.kill(self.process.pid, signal.SIGINT)

--- a/bindings/python/tests/SubscriptionTest.py
+++ b/bindings/python/tests/SubscriptionTest.py
@@ -34,7 +34,7 @@ class SubscriptionTester(SysrepoTester):
             ['python3','SubscriptionTestApp.py'])
         self.report_pid(self.process.pid)
         # wait for running data file to be copied
-        sleep(0.1)
+        sleep(1)
 
     def cancelSubscriptionStep(self):
         os.kill(self.process.pid, signal.SIGUSR1)

--- a/bindings/python/tests/SubscriptionTest.py
+++ b/bindings/python/tests/SubscriptionTest.py
@@ -34,7 +34,7 @@ class SubscriptionTester(SysrepoTester):
             ['python3','SubscriptionTestApp.py'])
         self.report_pid(self.process.pid)
         # wait for running data file to be copied
-        sleep(1)
+        sleep(2)
 
     def cancelSubscriptionStep(self):
         os.kill(self.process.pid, signal.SIGUSR1)


### PR DESCRIPTION

In order to fix the issue regarding Travis CI build test failure for the ARM 64 architecture, this quick fix is presented to solve the issue.
