### PR TITLE
python binding BUGFIX global_loop should run more than once

### DIFF
--- a/bindings/python/sysrepo.i
+++ b/bindings/python/sysrepo.i
@@ -49,6 +49,7 @@ static void global_loop() {
     while (!exit_application) {
         sleep(1000);  /* or do some more useful work... */
     }
+    exit_application = 0;
 }
 
 class Wrap_cb {


### PR DESCRIPTION
Python environments such as jupyter notebooks allow modifying the
code on the fly, injecting a ctrl-c and re-running the same piece
of code.

The global_loop function should reset exit_application so that the
loop will not exit immediately in-case another call to global_loop
is made.