### PR TITLE
Add editorconfig file

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,18 @@
+# ex: ft=dosini
+
+root = true
+
+[*]
+end_of_line = lf
+insert_final_newline = true
+charset = utf-8
+indent_style = space
+indent_size = 4
+
+[*.yml]
+indent_size = 2
+
+[packages/debian.rules.in]
+indent_style = tabs
+indent_size = 1
+tab_width = 8


### PR DESCRIPTION
EditorConfig is a file format and collection of text editor plugins for maintaining consistent coding styles between different editors and IDEs.

Initialize the file following the current coding style in existing files.

In order for this file to be taken into account (unless they use an editor with built-in EditorConfig support), developers will have to install a plugin.

See the following links for more details.

https://editorconfig.org/
https://github.com/editorconfig/editorconfig-emacs
https://github.com/editorconfig/editorconfig-vim