### PR TITLE
Add force functions for modules management

### DIFF
--- a/src/lyd_mods.c
+++ b/src/lyd_mods.c
@@ -2139,7 +2139,7 @@ cleanup:
 }
 
 sr_error_info_t *
-sr_lydmods_deferred_add_module(struct ly_ctx *ly_ctx, const struct lys_module *ly_mod, const char **features, int feat_count)
+sr_lydmods_deferred_add_module(struct ly_ctx *ly_ctx, const struct lys_module *ly_mod, const char **features, int feat_count, int force)
 {
     sr_error_info_t *err_info = NULL;
     struct lyd_node *sr_mods = NULL, *inst_mod;
@@ -2160,7 +2160,10 @@ sr_lydmods_deferred_add_module(struct ly_ctx *ly_ctx, const struct lys_module *l
     set = lyd_find_path(sr_mods, path);
     SR_CHECK_INT_GOTO(!set, err_info, cleanup);
     if (set->number == 1) {
-        sr_errinfo_new(&err_info, SR_ERR_EXISTS, NULL, "Module \"%s\" already scheduled for installation.", ly_mod->name);
+        if (!force) {
+            sr_errinfo_new(&err_info, SR_ERR_EXISTS, NULL,
+                "Module \"%s\" already scheduled for installation.", ly_mod->name);
+        }
         goto cleanup;
     }
 
@@ -2346,7 +2349,7 @@ cleanup:
 }
 
 sr_error_info_t *
-sr_lydmods_deferred_del_module(struct ly_ctx *ly_ctx, const char *mod_name)
+sr_lydmods_deferred_del_module(struct ly_ctx *ly_ctx, const char *mod_name, int force)
 {
     sr_error_info_t *err_info = NULL;
     struct lyd_node *sr_mods = NULL;
@@ -2366,7 +2369,10 @@ sr_lydmods_deferred_del_module(struct ly_ctx *ly_ctx, const char *mod_name)
     set = lyd_find_path(sr_mods, path);
     SR_CHECK_INT_GOTO(!set, err_info, cleanup);
     if (set->number == 1) {
-        sr_errinfo_new(&err_info, SR_ERR_EXISTS, NULL, "Module \"%s\" already scheduled for deletion.", mod_name);
+        if (!force) {
+            sr_errinfo_new(&err_info, SR_ERR_EXISTS, NULL,
+                "Module \"%s\" already scheduled for deletion.", mod_name);
+        }
         goto cleanup;
     }
 
@@ -2466,7 +2472,7 @@ cleanup:
 }
 
 sr_error_info_t *
-sr_lydmods_deferred_upd_module(struct ly_ctx *ly_ctx, const struct lys_module *ly_upd_mod)
+sr_lydmods_deferred_upd_module(struct ly_ctx *ly_ctx, const struct lys_module *ly_upd_mod, int force)
 {
     sr_error_info_t *err_info = NULL;
     struct lyd_node *sr_mods = NULL;
@@ -2486,7 +2492,10 @@ sr_lydmods_deferred_upd_module(struct ly_ctx *ly_ctx, const struct lys_module *l
     set = lyd_find_path(sr_mods, path);
     SR_CHECK_INT_GOTO(!set, err_info, cleanup);
     if (set->number == 1) {
-        sr_errinfo_new(&err_info, SR_ERR_EXISTS, NULL, "Module \"%s\" already scheduled for an update.", ly_upd_mod->name);
+        if (!force) {
+            sr_errinfo_new(&err_info, SR_ERR_EXISTS, NULL,
+                "Module \"%s\" already scheduled for an update.", ly_upd_mod->name);
+        }
         goto cleanup;
     }
 

--- a/src/lyd_mods.h
+++ b/src/lyd_mods.h
@@ -97,7 +97,7 @@ sr_error_info_t *sr_lydmods_sched_apply(struct lyd_node *sr_mods, struct ly_ctx 
  * @return err_info, NULL on success.
  */
 sr_error_info_t *sr_lydmods_deferred_add_module(struct ly_ctx *ly_ctx, const struct lys_module *ly_mod, const char **features,
-        int feat_count);
+        int feat_count, int force);
 
 /**
  * @brief Unschedule module installation from sysrepo module data.
@@ -138,7 +138,7 @@ sr_error_info_t *sr_lydmods_deferred_add_module_data(struct lyd_node *sr_mods, c
  * @param[in] mod_name Module name to delete.
  * @return err_info, NULL on success.
  */
-sr_error_info_t *sr_lydmods_deferred_del_module(struct ly_ctx *ly_ctx, const char *mod_name);
+sr_error_info_t *sr_lydmods_deferred_del_module(struct ly_ctx *ly_ctx, const char *mod_name, int force);
 
 /**
  * @brief Unschedule module deletion from sysrepo module data.
@@ -156,7 +156,7 @@ sr_error_info_t *sr_lydmods_unsched_del_module_with_imps(struct ly_ctx *ly_ctx, 
  * @param[in] ly_upd_mod Update module.
  * @return err_info, NULL on success.
  */
-sr_error_info_t *sr_lydmods_deferred_upd_module(struct ly_ctx *ly_ctx, const struct lys_module *ly_upd_mod);
+sr_error_info_t *sr_lydmods_deferred_upd_module(struct ly_ctx *ly_ctx, const struct lys_module *ly_upd_mod, int force);
 
 /**
  * @brief Unschedule module update from sysrepo module data.

--- a/src/sysrepo.h
+++ b/src/sysrepo.h
@@ -466,6 +466,24 @@ int sr_install_module(sr_conn_ctx_t *conn, const char *schema_path, const char *
         int feat_count);
 
 /**
+ * @brief Install a schema (module) into sysrepo.
+ * Update it if a different revision is already installed.
+ * Reinstall it if the revision is the same.
+ * Deferred until there are no connections!
+ *
+ * @warning For development use only.
+ *
+ * @param[in] conn Connection to use.
+ * @param[in] schema_path Path to the new schema. Can have either YANG or YIN extension/format.
+ * @param[in] search_dirs Optional search directories for import schemas, supports the format `<dir>[:<dir>]*`.
+ * @param[in] features Array of enabled features.
+ * @param[in] feat_count Number of enabled features.
+ * @return Error code (::SR_ERR_OK on success).
+ */
+int sr_install_module_force(sr_conn_ctx_t *conn, const char *schema_path, const char *search_dirs,
+        const char **features, int feat_count);
+
+/**
  * @brief Set newly installed module startup and running data. It is necessary in case empty data are not valid
  * for the particular schema (module).
  *
@@ -491,6 +509,21 @@ int sr_install_module_data(sr_conn_ctx_t *conn, const char *module_name, const c
 int sr_remove_module(sr_conn_ctx_t *conn, const char *module_name);
 
 /**
+ * @brief Remove an installed module from sysrepo.
+ * Ignore if the module is not installed.
+ * Deferred until there are no connections!
+ *
+ * Required WRITE access.
+ *
+ * @warning For development use only.
+ *
+ * @param[in] conn Connection to use.
+ * @param[in] module_name Name of the module to remove.
+ * @return Error code (::SR_ERR_OK on success).
+ */
+int sr_remove_module_force(sr_conn_ctx_t *conn, const char *module_name);
+
+/**
  * @brief Update an installed schema (module) to a new revision. Deferred until there are no connections!
  *
  * Required WRITE access.
@@ -501,6 +534,23 @@ int sr_remove_module(sr_conn_ctx_t *conn, const char *module_name);
  * @return Error code (::SR_ERR_OK on success).
  */
 int sr_update_module(sr_conn_ctx_t *conn, const char *schema_path, const char *search_dirs);
+
+/**
+ * @brief Update an installed schema (module) to a new revision.
+ * If the module is not installed, install it.
+ * If it is already installed with the same revision, update it anyway.
+ * Deferred until there are no connections!
+ *
+ * Required WRITE access.
+ *
+ * @warning For development use only.
+ *
+ * @param[in] conn Connection to use.
+ * @param[in] schema_path Path to the updated schema. Can have either YANG or YIN extension/format.
+ * @param[in] search_dirs Optional search directories for import schemas, supports the format `<dir>[:<dir>]*`.
+ * @return Error code (::SR_ERR_OK on success).
+ */
+int sr_update_module_force(sr_conn_ctx_t *conn, const char *schema_path, const char *search_dirs);
 
 /**
  * @brief Cancel scheduled update of a module.


### PR DESCRIPTION
Add new functions for YANG modules management.

`sr_install_module_force`

Does the same than sr_install_module but will ignore if the module is already installed (no error message will be logged). If a different version of the module is already installed, it will be updated.

`sr_remove_module_force`

Does the same than sr_remove_module but will ignore if the module is not installed or already scheduled for deletion (no error message will be logged).

`sr_update_module_force`

Does the same than sr_update_module but will ignore if the new module has the same revision than before. It will be updated anyway.

All these functions are only useful in development.

Add `-f/--force` option to sysrepoctl that uses these functions.

Fixes: #1917