### PR TITLE
examples CHANGE add feature flag for sleep on QNX

### DIFF
--- a/examples/application_changes_example.c
+++ b/examples/application_changes_example.c
@@ -12,6 +12,7 @@
  *
  *     https://opensource.org/licenses/BSD-3-Clause
  */
+#define _QNX_SOURCE /* sleep */
 #define _GNU_SOURCE
 
 #include <stdio.h>

--- a/examples/notif_subscribe_example.c
+++ b/examples/notif_subscribe_example.c
@@ -12,6 +12,7 @@
  *
  *     https://opensource.org/licenses/BSD-3-Clause
  */
+#define _QNX_SOURCE /* sleep */
 #define _GNU_SOURCE
 
 #include <stdio.h>

--- a/examples/oper_data_example.c
+++ b/examples/oper_data_example.c
@@ -12,6 +12,7 @@
  *
  *     https://opensource.org/licenses/BSD-3-Clause
  */
+#define _QNX_SOURCE /* sleep */
 #define _GNU_SOURCE
 
 #include <stdio.h>

--- a/examples/plugin/oven.c
+++ b/examples/plugin/oven.c
@@ -12,6 +12,7 @@
  *
  *     https://opensource.org/licenses/BSD-3-Clause
  */
+#define _QNX_SOURCE /* sleep */
 
 #include <stdlib.h>
 #include <string.h>


### PR DESCRIPTION
fixes #1898 
Adds feature flags for `sleep()` required on QNX only.