### PR TITLE
Fix XPath trimming predidcates heap overflow

### DIFF
--- a/src/common.c
+++ b/src/common.c
@@ -2557,14 +2557,14 @@ sr_get_trim_predicates(const char *expr, char **expr2)
         }
     }
 
-    /* copy last expr chunk */
-    strncat(str, start, ptr - start);
-
     if (quot || pred) {
         sr_errinfo_new(&err_info, SR_ERR_INVAL_ARG, NULL, "Unterminated %s in expression.", quot ? "literal" : "predicate");
         free(str);
         return err_info;
     }
+
+    /* copy last expr chunk */
+    strncat(str, start, ptr - start);
 
     *expr2 = str;
     return NULL;

--- a/tests/test_rpc_action.c
+++ b/tests/test_rpc_action.c
@@ -177,7 +177,7 @@ test_fail(void **state)
     struct lyd_node *input, *output;
     int ret;
 
-    /* subscribe /*/
+    /* subscribe */
     ret = sr_rpc_subscribe_tree(st->sess, "/ops:rpc1", rpc_fail_cb, NULL, 0, 0, &subscr);
     assert_int_equal(ret, SR_ERR_OK);
 
@@ -1400,6 +1400,18 @@ test_rpc_shelve(void **state)
     pthread_join(tid[1], NULL);
 }
 
+static void
+test_input_parameters(void **state)
+{
+    struct state *st = (struct state *)*state;
+    sr_subscription_ctx_t *subscr;
+    int ret;
+
+    /* invalid xpath */
+    ret = sr_rpc_subscribe_tree(st->sess, "/ops:cont/list1[[k='one']/cont2/act1", rpc_action_cb, NULL, 0, 0, &subscr);
+    assert_int_equal(ret, SR_ERR_INVAL_ARG);
+}
+
 /* MAIN */
 int
 main(void)
@@ -1415,6 +1427,7 @@ main(void)
         cmocka_unit_test(test_action_deps),
         cmocka_unit_test_teardown(test_action_change_config, clear_ops),
         cmocka_unit_test(test_rpc_shelve),
+        cmocka_unit_test(test_input_parameters),
     };
 
     setenv("CMOCKA_TEST_ABORT", "1", 1);


### PR DESCRIPTION
Hi Michal,
  I'm implementing the test cases of rpc and xpath part. I find a heap overflow issue for the invalid xpath  as following. I tried to fix it by this PR. Please review it.