### PR TITLE
shm CHANGE allow setting a custom prefix for SHM files

### DIFF
--- a/src/common.h.in
+++ b/src/common.h.in
@@ -131,6 +131,12 @@ int pthread_mutex_timedlock(pthread_mutex_t *mutex, const struct timespec *absti
 /** where SHM files are stored */
 #define SR_SHM_DIR "/dev/shm"
 
+/** default prefix for SHM files in /dev/shm */
+#define SR_SHM_PREFIX_DEFAULT "sr"
+
+/** environment variable for setting a custom prefix for SHM files */
+#define SR_SHM_PREFIX_ENV "SYSREPO_SHM_PREFIX"
+
 /** all ext SHM item sizes will be aligned to this number (B) */
 #define SR_SHM_MEM_ALIGN (sizeof(void *))
 
@@ -689,6 +695,22 @@ sr_error_info_t *sr_create_startup_file(const struct lys_module *ly_mod);
  * @return err_info, NULL on success.
  */
 sr_error_info_t *sr_create_module_imps_incs_r(const struct lys_module *ly_mod);
+
+/**
+ * @brief Get the path the main SHM.
+ *
+ * @param[out] path Created path. Should be freed by the caller.
+ * @return err_info, NULL on success.
+ */
+sr_error_info_t *sr_path_main_shm(char **path);
+
+/**
+ * @brief Get the path the external SHM.
+ *
+ * @param[out] path Created path. Should be freed by the caller.
+ * @return err_info, NULL on success.
+ */
+sr_error_info_t *sr_path_ext_shm(char **path);
 
 /**
  * @brief Get the path to a subscription SHM.

--- a/src/shm.h
+++ b/src/shm.h
@@ -30,8 +30,6 @@
 
 #include "common.h"
 
-#define SR_MAIN_SHM "/sr_main"              /**< Main SHM name. */
-#define SR_EXT_SHM "/sr_ext"                /**< External SHM name. */
 #define SR_MAIN_SHM_LOCK "sr_main_lock"     /**< Main SHM file lock name. */
 #define SR_SHM_VER 1                        /**< Main and ext SHM version of their expected content structures. */
 

--- a/src/sysrepo.c
+++ b/src/sysrepo.c
@@ -352,8 +352,20 @@ cleanup:
         sr_conn_free(conn);
         if (created) {
             /* remove any created SHM so it is not considered properly created */
-            shm_unlink(SR_MAIN_SHM);
-            shm_unlink(SR_EXT_SHM);
+            sr_error_info_t *tmp_err = NULL;
+            char *shm_name = NULL;
+            if ((tmp_err = sr_path_main_shm(&shm_name))) {
+                sr_errinfo_merge(&err_info, tmp_err);
+            } else {
+                shm_unlink(shm_name);
+                free(shm_name);
+            }
+            if ((tmp_err = sr_path_ext_shm(&shm_name))) {
+                sr_errinfo_merge(&err_info, tmp_err);
+            } else {
+                shm_unlink(shm_name);
+                free(shm_name);
+            }
         }
     } else {
         *conn_p = conn;


### PR DESCRIPTION
Allow exporting a `SYSREPO_SHM_PREFIX` environment variable. When that variable is set, all files created under `/dev/shm` will use that prefix. If unset, the files wille have their "default" names.

This can be useful for testing purposes, or to run multiple "groups" of sysrepo applications in concordance with the `SYSREPO_REPOSITORY_PATH` environment variable.