### PR TITLE
python binding BUGFIX Should be taking global lock before calling back to python code

### DIFF
--- a/bindings/python/sysrepo.i
+++ b/bindings/python/sysrepo.i
@@ -49,6 +49,7 @@ static void global_loop() {
     while (!exit_application) {
         sleep(1000);  /* or do some more useful work... */
     }
+    exit_application = 0;
 }
 
 class Wrap_cb {

--- a/bindings/python/sysrepo.i
+++ b/bindings/python/sysrepo.i
@@ -360,6 +360,9 @@ static int g_oper_get_items_cb(sr_session_ctx_t *session, const char *module_nam
 
 static const char *g_ly_module_imp_clb(const char *mod_name, const char *mod_rev, const char *submod_name, const char *sub_rev,
                                    void *user_data, LYS_INFORMAT *format, void (**free_module_data)(void *model_data, void *user_data)) {
+#if defined(SWIG_PYTHON_THREADS)
+    SWIG_Python_Thread_Block safety;
+#endif
     Wrap_cb *ctx = (Wrap_cb *) user_data;
     (void)free_module_data;
     auto pair = ctx->ly_module_imp_clb(mod_name, mod_rev, submod_name, sub_rev, ctx->private_data);


### PR DESCRIPTION
Should have python global lock before executing function `ly_module_imp_clb`, as this calls python code and handles python reference counts