### PR TITLE
fix log macros to allow empty variable arguments

### DIFF
--- a/src/sysrepo.h
+++ b/src/sysrepo.h
@@ -1796,7 +1796,7 @@ typedef void (*srp_cleanup_cb_t)(sr_session_ctx_t *session, void *private_data);
  * @param[in] format Message format.
  * @param[in] ... Format arguments.
  */
-#define SRP_LOG_ERR(format, ...) srp_log(SR_LL_ERR, format, __VA_ARGS__)
+#define SRP_LOG_ERR(format, ...) srp_log(SR_LL_ERR, format, ##__VA_ARGS__)
 
 /**
  * @brief Log a plugin warning message with format arguments.
@@ -1804,7 +1804,7 @@ typedef void (*srp_cleanup_cb_t)(sr_session_ctx_t *session, void *private_data);
  * @param[in] format Message format.
  * @param[in] ... Format arguments.
  */
-#define SRP_LOG_WRN(format, ...) srp_log(SR_LL_WRN, format, __VA_ARGS__)
+#define SRP_LOG_WRN(format, ...) srp_log(SR_LL_WRN, format, ##__VA_ARGS__)
 
 /**
  * @brief Log a plugin info message with format arguments.
@@ -1812,7 +1812,7 @@ typedef void (*srp_cleanup_cb_t)(sr_session_ctx_t *session, void *private_data);
  * @param[in] format Message format.
  * @param[in] ... Format arguments.
  */
-#define SRP_LOG_INF(format, ...) srp_log(SR_LL_INF, format, __VA_ARGS__)
+#define SRP_LOG_INF(format, ...) srp_log(SR_LL_INF, format, ##__VA_ARGS__)
 
 /**
  * @brief Log a plugin debug message with format arguments.
@@ -1820,7 +1820,7 @@ typedef void (*srp_cleanup_cb_t)(sr_session_ctx_t *session, void *private_data);
  * @param[in] format Message format.
  * @param[in] ... Format arguments.
  */
-#define SRP_LOG_DBG(format, ...) srp_log(SR_LL_DBG, format, __VA_ARGS__)
+#define SRP_LOG_DBG(format, ...) srp_log(SR_LL_DBG, format, ##__VA_ARGS__)
 
 /**
  * @brief Log a simple plugin error message.


### PR DESCRIPTION
With this the SRP_LOG_xxxMSG macros aren't needed anymore.

see: https://gcc.gnu.org/onlinedocs/cpp/Variadic-Macros.html

Signed-off-by: Heiko Thiery <heiko.thiery@gmail.com>