### PR TITLE
docker BUGFIX switch to libssh 0.9.2

### DIFF
--- a/deploy/docker/sysrepo-netopeer2/legacy/Dockerfile
+++ b/deploy/docker/sysrepo-netopeer2/legacy/Dockerfile
@@ -67,10 +67,10 @@ RUN \
       apt-get update && \
       apt-get install libyang1 libyang-dev
 
-# libssh 0.8.0
+# libssh
 RUN \
       cd /opt/dev && \
-      git clone https://git.libssh.org/projects/libssh.git && cd libssh && \
+      git clone https://git.libssh.org/projects/libssh.git && cd libssh && git checkout libssh-0.9.2 && \
       mkdir build && cd build && \
       cmake -DCMAKE_INSTALL_PREFIX=/usr -DCMAKE_BUILD_TYPE="Debug" -DWITH_ZLIB=ON -DWITH_NACL=OFF -DWITH_PCAP=OFF .. && \
       make -j2 && \


### PR DESCRIPTION
- Build libssh 0.9.2 in sysrepo-netopeer2:legacy image instead of directly
  from git to resolve build issue