### PR TITLE
Fixed rdlock issue causing SIGBUS when sr_event_notif_send_tree()

### DIFF
--- a/src/sysrepo.c
+++ b/src/sysrepo.c
@@ -4643,7 +4643,7 @@ sr_event_notif_send_tree(sr_session_ctx_t *session, struct lyd_node *notif)
      * can be invoked meaning its parent data node exists) */
     xpath = lys_data_path(notif_op->schema);
     SR_CHECK_MEM_GOTO(!xpath, err_info, cleanup_shm_unlock);
-    if ((err_info = sr_shmmod_modinfo_collect_op(&mod_info, xpath, notif_op, 0, &shm_deps, &shm_dep_count))) {
+    if ((err_info = sr_shmmod_modinfo_collect_op(&mod_info, xpath, notif_op, 1, &shm_deps, &shm_dep_count))) {
         goto cleanup_shm_unlock;
     }
 


### PR DESCRIPTION
We have seen SIGBUS crashes when sending notifications via `sr_event_notif_send_tree()` from an application while in parallel netopeer2 is performing  `sr_apply_changes()` / `sr_changes_notify_store()`.
More detailed, the applied change is an` ietf-interface:interfaces/interface` being edited while the applications is sending a notification of `ietf-alarms` with an identity-ref to ietf-interfaces:

> <notification xmlns="urn:ietf:params:xml:ns:netconf:notification:1.0"><eventTime>2020-08-26T19:22:58+00:00</eventTime><alarm-notification xmlns="urn:ietf:params:xml:ns:yang:ietf-alarms"><resource>/ietf-interfaces:interfaces/ietf-interfaces:interface[ietf-interfaces:name='ethernet 0/10:1']</resource><alarm-type-id xmlns:adtn-if-ns-al="http://www.adtran.com/ns/yang/adtran-ietf-interfaces-ns-ietf-alarms">adtn-if-ns-al:interface-oper-status-down-alarm</alarm-type-id><alarm-type-qualifier /><time>2020-08-26T19:22:58+00:00</time><perceived-severity>major</perceived-severity><alarm-text>interface is down</alarm-text></alarm-notification></notification>

with `<resources>` being an `identity-ref` in that case pointing to an instance of ietf-interfaces.

The crash occurred when the application was in  `sr_module_file_data_append()` (-> open O_RDONLY shmem path: sr_ietf-interfaces.running) and netopeer2 was in  `sr_cp_file2shm() `(-> open O_WRONLY shmem path sr_ietf-interfaces.running). 
Thus, re-creating shmem for sr_ietf-interfaces.running while it was read from caused that BUSERR.
Normally the shmem locking in sysrepo is supposed to prevent such case.
But, in the given case,  #4646` sr_shmmod_modinfo_collect_op(&mod_info, , , 0/*'output' parameter*/, ,)` only added `ietf-alarms` to the mod_info so that module `ietf-interfaces` was not being locked in #4651  `sr_shmmod_modinfo_rdlock(&mod_info)`. 
When I turned the 'output' parameter in `sr_shmmod_modinfo_collect_op(&mod_info )` to 1, this seem to fix the problem as `ietf-interfaces` was added to mod_info and then locked in #4651.