### PR TITLE
sysrepocfg BUGFIX add null byte after stdin config

### DIFF
--- a/src/executables/sysrepocfg.c
+++ b/src/executables/sysrepocfg.c
@@ -189,6 +189,8 @@ step_read_file(FILE *file, char **mem)
         mem_used += fread(*mem + mem_used, 1, mem_size - mem_used, file);
     } while (mem_used == mem_size);
 
+    (*mem)[mem_used] = '\0';
+
     if (ferror(file)) {
         free(*mem);
         error_print(0, "Error reading from file (%s)", strerror(errno));


### PR DESCRIPTION
Hi, I found a bug when reading sysrepocfg config from stdin:
```
$ echo -ne "lol" | /opt/cesnet-au/sysrepo/bin/sysrepocfg -I --format=xml -m ietf-netconf-acm 
sysrepocfg error: libyang: Encountered invalid character sequence "lol�������".
sysrepocfg error: Data parsing failed
$ echo -ne "lol\0" | /opt/cesnet-au/sysrepo/bin/sysrepocfg -I --format=xml -m ietf-netconf-acm 
sysrepocfg error: libyang: Encountered invalid character sequence "lol".
sysrepocfg error: Data parsing failed
```
Pretty straightforward fix. But feel free to change it however you like.