### PR TITLE
C++: Rework subcriptions

### DIFF
--- a/bindings/cpp/examples/cpp_application_changes_example.cpp
+++ b/bindings/cpp/examples/cpp_application_changes_example.cpp
@@ -130,13 +130,13 @@ main(int argc, char **argv)
 
         cout << "Application will watch for changes in " << module_name << endl;
         /* connect to sysrepo */
-        sysrepo::S_Connection conn(new sysrepo::Connection());
+        auto conn = std::make_shared<sysrepo::Connection>();
 
         /* start session */
-        sysrepo::S_Session sess(new sysrepo::Session(conn));
+        auto sess = std::make_shared<sysrepo::Session>(conn);
 
         /* subscribe for changes in running config */
-        sysrepo::S_Subscribe subscribe(new sysrepo::Subscribe(sess));
+        auto subscribe = std::make_shared<sysrepo::Subscribe>(sess);
         auto cb = [] (sysrepo::S_Session sess, const char *module_name, const char *xpath, sr_event_t event,
             uint32_t request_id) {
             char change_path[MAX_LEN];

--- a/bindings/cpp/examples/cpp_application_changes_example.cpp
+++ b/bindings/cpp/examples/cpp_application_changes_example.cpp
@@ -109,40 +109,6 @@ const char *ev_to_str(sr_event_t ev) {
     }
 }
 
-class My_Callback:public sysrepo::Callback {
-    public:
-    /* Function to be called for subscribed client of given session whenever configuration changes. */
-    int module_change(sysrepo::S_Session sess, const char *module_name, const char *xpath, sr_event_t event, \
-            uint32_t request_id, void *private_data) override
-    {
-        char change_path[MAX_LEN];
-
-        try {
-            cout << "\n\n ========== Notification " << ev_to_str(event) << " =============================================";
-            if (SR_EV_CHANGE == event) {
-                cout << "\n\n ========== CONFIG HAS CHANGED, CURRENT RUNNING CONFIG: ==========\n" << endl;
-                print_current_config(sess, module_name);
-            }
-
-            cout << "\n\n ========== CHANGES: =============================================\n" << endl;
-
-            snprintf(change_path, MAX_LEN, "/%s:*//.", module_name);
-
-            auto it = sess->get_changes_iter(change_path);
-
-            while (auto change = sess->get_change_next(it)) {
-                print_change(change);
-            }
-
-            cout << "\n\n ========== END OF CHANGES =======================================\n" << endl;
-
-        } catch( const std::exception& e ) {
-            cout << e.what() << endl;
-        }
-        return SR_ERR_OK;
-    }
-};
-
 static void
 sigint_handler(int signum)
 {
@@ -171,8 +137,35 @@ main(int argc, char **argv)
 
         /* subscribe for changes in running config */
         sysrepo::S_Subscribe subscribe(new sysrepo::Subscribe(sess));
-        sysrepo::S_Callback cb(new My_Callback());
+        auto cb = [] (sysrepo::S_Session sess, const char *module_name, const char *xpath, sr_event_t event,
+            uint32_t request_id) {
+            char change_path[MAX_LEN];
 
+            try {
+                cout << "\n\n ========== Notification " << ev_to_str(event) << " =============================================";
+                if (SR_EV_CHANGE == event) {
+                    cout << "\n\n ========== CONFIG HAS CHANGED, CURRENT RUNNING CONFIG: ==========\n" << endl;
+                    print_current_config(sess, module_name);
+                }
+
+                cout << "\n\n ========== CHANGES: =============================================\n" << endl;
+
+                snprintf(change_path, MAX_LEN, "/%s:*//.", module_name);
+
+                auto it = sess->get_changes_iter(change_path);
+
+                while (auto change = sess->get_change_next(it)) {
+                    print_change(change);
+                }
+
+                cout << "\n\n ========== END OF CHANGES =======================================\n" << endl;
+
+            } catch( const std::exception& e ) {
+                cout << e.what() << endl;
+            }
+            return SR_ERR_OK;
+
+        };
         subscribe->module_change_subscribe(module_name, cb);
 
         /* read running config */

--- a/bindings/cpp/examples/cpp_application_example.cpp
+++ b/bindings/cpp/examples/cpp_application_example.cpp
@@ -74,10 +74,10 @@ main(int argc, char **argv)
         }
 
         cout << "Application will watch for changes in "<< module_name << endl;
-        sysrepo::S_Connection conn(new sysrepo::Connection());
-        sysrepo::S_Session sess(new sysrepo::Session(conn));
+        auto conn = std::make_shared<sysrepo::Connection>();
+        auto sess = std::make_shared<sysrepo::Session>(conn);
 
-        sysrepo::S_Subscribe subscribe(new sysrepo::Subscribe(sess));
+        auto subscribe = std::make_shared<sysrepo::Subscribe>(sess);
         auto cb = [] (sysrepo::S_Session sess, const char *module_name, const char *xpath, sr_event_t event,
             uint32_t request_id) {
 

--- a/bindings/cpp/examples/cpp_delete_item_example.cpp
+++ b/bindings/cpp/examples/cpp_delete_item_example.cpp
@@ -30,9 +30,9 @@ int
 main(int argc, char **argv)
 {
     try {
-        sysrepo::S_Connection conn(new sysrepo::Connection());
+        auto conn = std::make_shared<sysrepo::Connection>();
 
-        sysrepo::S_Session sess(new sysrepo::Session(conn));
+        auto sess = std::make_shared<sysrepo::Session>(conn);
 
         const char *xpath = "/ietf-interfaces:interfaces/interface[name='gigaeth0']/ietf-ip:ipv6/address[ip='fe80::ab8']";
 

--- a/bindings/cpp/examples/cpp_get_data_example.cpp
+++ b/bindings/cpp/examples/cpp_get_data_example.cpp
@@ -131,8 +131,8 @@ main(int argc, char **argv)
     }
 
     try {
-        sysrepo::S_Connection conn(new sysrepo::Connection());
-        sysrepo::S_Session sess(new sysrepo::Session(conn, ds));
+        auto conn = std::make_shared<sysrepo::Connection>();
+        auto sess = std::make_shared<sysrepo::Session>(conn, ds);
 
         libyang::S_Data_Node data = sess->get_data(xpath);
 

--- a/bindings/cpp/examples/cpp_get_item_example.cpp
+++ b/bindings/cpp/examples/cpp_get_item_example.cpp
@@ -34,9 +34,9 @@ main(int argc, char **argv)
         sysrepo::Logs log;
         log.set_stderr(SR_LL_DBG);
 
-        sysrepo::S_Connection conn(new sysrepo::Connection());
+        auto conn = std::make_shared<sysrepo::Connection>();
 
-        sysrepo::S_Session sess(new sysrepo::Session(conn));
+        auto sess = std::make_shared<sysrepo::Session>(conn);
 
         const char *xpath = "/ietf-interfaces:interfaces/interface[name='eth0']/enabled";
 

--- a/bindings/cpp/examples/cpp_get_items_example.cpp
+++ b/bindings/cpp/examples/cpp_get_items_example.cpp
@@ -30,9 +30,8 @@ int
 main(int argc, char **argv)
 {
     try {
-        sysrepo::S_Connection conn(new sysrepo::Connection());
-
-        sysrepo::S_Session sess(new sysrepo::Session(conn));
+        auto conn = std::make_shared<sysrepo::Connection>();
+        auto sess = std::make_shared<sysrepo::Session>(conn);
 
         const char *xpath = "/ietf-interfaces:interfaces/interface";
 

--- a/bindings/cpp/examples/cpp_notif_example.cpp
+++ b/bindings/cpp/examples/cpp_notif_example.cpp
@@ -105,13 +105,13 @@ main(int argc, char **argv)
 
         printf("Application will send notification in %s\n", module_name);
         /* connect to sysrepo */
-        sysrepo::S_Connection conn(new sysrepo::Connection());
+        auto conn = std::make_shared<sysrepo::Connection>();
 
         /* start session */
-        sysrepo::S_Session sess(new sysrepo::Session(conn));
+        auto sess = std::make_shared<sysrepo::Session>(conn);
 
         /* subscribe for changes in running config */
-        sysrepo::S_Subscribe subscribe(new sysrepo::Subscribe(sess));
+        auto subscribe = std::make_shared<sysrepo::Subscribe>(sess);
         auto cbVals = [] (sysrepo::S_Session session, const sr_ev_notif_type_t notif_type, const char *path,
             const sysrepo::S_Vals vals, time_t timestamp) {
             cout << "\n ========== NOTIF RECEIVED ==========\n" << endl;
@@ -131,7 +131,7 @@ main(int argc, char **argv)
 
         subscribe->event_notif_subscribe(module_name, cbVals);
 
-        sysrepo::S_Vals in_vals(new sysrepo::Vals(2));
+        auto in_vals = std::make_shared<sysrepo::Vals>(2);
 
         in_vals->val(0)->set("/test-examples:test-notif/val1", "some-value", SR_STRING_T);
         in_vals->val(1)->set("/test-examples:test-notif/val2", "some-other-value", SR_STRING_T);
@@ -144,7 +144,7 @@ main(int argc, char **argv)
 
         libyang::S_Context ctx = conn->get_context();
         libyang::S_Module mod = ctx->get_module(module_name);
-        libyang::S_Data_Node in_trees(new libyang::Data_Node(ctx, "/test-examples:test-notif", nullptr, LYD_ANYDATA_CONSTSTRING, 0));
+        auto in_trees = std::make_shared<libyang::Data_Node>(ctx, "/test-examples:test-notif", nullptr, LYD_ANYDATA_CONSTSTRING, 0);
         std::make_shared<libyang::Data_Node>(libyang::Data_Node(in_trees, mod, "val1", "some-value"));
         std::make_shared<libyang::Data_Node>(libyang::Data_Node(in_trees, mod, "val2", "some-other-value"));
 

--- a/bindings/cpp/examples/cpp_notif_example.cpp
+++ b/bindings/cpp/examples/cpp_notif_example.cpp
@@ -97,24 +97,6 @@ print_value(sysrepo::S_Val value)
     return;
 }
 
-class My_Callback:public sysrepo::Callback {
-    void event_notif(sysrepo::S_Session session, const sr_ev_notif_type_t notif_type, const char *path, \
-            const sysrepo::S_Vals vals, time_t timestamp, void *private_data) override
-    {
-        cout << "\n ========== NOTIF RECEIVED ==========\n" << endl;
-
-        for(size_t n = 0; n < vals->val_cnt(); ++n)
-            print_value(vals->val(n));
-    }
-
-    void event_notif_tree(sysrepo::S_Session session, const sr_ev_notif_type_t notif_type, \
-            const libyang::S_Data_Node notif, time_t timestamp, void *private_data) override
-    {
-        cout << "\n ========== NOTIF TREE RECEIVED ==========\n" << endl;
-        cout << notif->print_mem(LYD_XML, LYP_FORMAT);
-    }
-};
-
 int
 main(int argc, char **argv)
 {
@@ -130,11 +112,24 @@ main(int argc, char **argv)
 
         /* subscribe for changes in running config */
         sysrepo::S_Subscribe subscribe(new sysrepo::Subscribe(sess));
-        sysrepo::S_Callback cb(new My_Callback());
+        auto cbVals = [] (sysrepo::S_Session session, const sr_ev_notif_type_t notif_type, const char *path,
+            const sysrepo::S_Vals vals, time_t timestamp) {
+            cout << "\n ========== NOTIF RECEIVED ==========\n" << endl;
+
+            for(size_t n = 0; n < vals->val_cnt(); ++n) {
+                print_value(vals->val(n));
+            }
+        };
+
+        auto cbTree = [] (sysrepo::S_Session session, const sr_ev_notif_type_t notif_type,
+            const libyang::S_Data_Node notif, time_t timestamp) {
+            cout << "\n ========== NOTIF TREE RECEIVED ==========\n" << endl;
+            cout << notif->print_mem(LYD_XML, LYP_FORMAT);
+        };
 
         cout << "\n ========== SUBSCRIBE TO NOTIF ==========\n" << endl;
 
-        subscribe->event_notif_subscribe(module_name, cb);
+        subscribe->event_notif_subscribe(module_name, cbVals);
 
         sysrepo::S_Vals in_vals(new sysrepo::Vals(2));
 
@@ -145,7 +140,7 @@ main(int argc, char **argv)
         sess->event_notif_send("/test-examples:test-notif", in_vals);
 
         cout << "\n ========== SUBSCRIBE TO NOTIF TREE ==========\n" << endl;
-        subscribe->event_notif_subscribe_tree(module_name, cb, nullptr, 0, 0, nullptr, SR_SUBSCR_CTX_REUSE);
+        subscribe->event_notif_subscribe_tree(module_name, cbTree);
 
         libyang::S_Context ctx = conn->get_context();
         libyang::S_Module mod = ctx->get_module(module_name);

--- a/bindings/cpp/examples/cpp_oper_data_example.cpp
+++ b/bindings/cpp/examples/cpp_oper_data_example.cpp
@@ -47,10 +47,10 @@ main(int argc, char **argv)
     const char *module_name = "ietf-interfaces";
     try {
         cout << "Application will provide data of " << module_name << endl;
-        sysrepo::S_Connection conn(new sysrepo::Connection());
-        sysrepo::S_Session sess(new sysrepo::Session(conn));
+        auto conn = std::make_shared<sysrepo::Connection>();
+        auto sess = std::make_shared<sysrepo::Session>(conn);
 
-        sysrepo::S_Subscribe subscribe(new sysrepo::Subscribe(sess));
+        auto subscribe = std::make_shared<sysrepo::Subscribe>(sess);
         auto cb1 = [] (sysrepo::S_Session session, const char *module_name, const char *path, const char *request_xpath,
             uint32_t request_id, libyang::S_Data_Node &parent) {
 
@@ -90,9 +90,9 @@ main(int argc, char **argv)
             libyang::S_Context ctx = session->get_context();
             libyang::S_Module mod = ctx->get_module(module_name);
 
-            libyang::S_Data_Node stats(new libyang::Data_Node(parent, mod, "statistics"));
-            libyang::S_Data_Node dis_time(new libyang::Data_Node(stats, mod, "discontinuity-time", "2019-01-01T00:00:00Z"));
-            libyang::S_Data_Node in_oct(new libyang::Data_Node(stats, mod, "in-octets", "22"));
+            auto stats = std::make_shared<libyang::Data_Node>(parent, mod, "statistics");
+            auto dis_time = std::make_shared<libyang::Data_Node>(stats, mod, "discontinuity-time", "2019-01-01T00:00:00Z");
+            auto in_oct = std::make_shared<libyang::Data_Node>(stats, mod, "in-octets", "22");
 
             return SR_ERR_OK;
         };

--- a/bindings/cpp/examples/cpp_oper_data_example.cpp
+++ b/bindings/cpp/examples/cpp_oper_data_example.cpp
@@ -33,60 +33,6 @@ using namespace std;
 
 volatile int exit_application = 0;
 
-class My_Callback1:public sysrepo::Callback {
-    /* Function to be called whenever a client requests these state data. */
-    int oper_get_items(sysrepo::S_Session session, const char *module_name, const char *path, const char *request_xpath, \
-            uint32_t request_id, libyang::S_Data_Node &parent, void *private_data) override
-    {
-        cout << "\n\n ========== CALLBACK CALLED TO PROVIDE \"" << path << "\" DATA ==========\n" << endl;
-
-        libyang::S_Context ctx = session->get_context();
-        libyang::S_Module mod = ctx->get_module(module_name);
-
-        parent.reset(new libyang::Data_Node(ctx, "/ietf-interfaces:interfaces-state", nullptr, LYD_ANYDATA_CONSTSTRING, 0));
-
-        libyang::S_Data_Node ifc(new libyang::Data_Node(parent, mod, "interface"));
-        libyang::S_Data_Node name(new libyang::Data_Node(ifc, mod, "name", "eth100"));
-        libyang::S_Data_Node type(new libyang::Data_Node(ifc, mod, "type", "iana-if-type:ethernetCsmacd"));
-        libyang::S_Data_Node oper_status(new libyang::Data_Node(ifc, mod, "oper-status", "down"));
-
-        ifc.reset(new libyang::Data_Node(parent, mod, "interface"));
-        name.reset(new libyang::Data_Node(ifc, mod, "name", "eth101"));
-        type.reset(new libyang::Data_Node(ifc, mod, "type", "iana-if-type:ethernetCsmacd"));
-        oper_status.reset(new libyang::Data_Node(ifc, mod, "oper-status", "up"));
-
-        ifc.reset(new libyang::Data_Node(parent, mod, "interface"));
-        name.reset(new libyang::Data_Node(ifc, mod, "name", "eth102"));
-        type.reset(new libyang::Data_Node(ifc, mod, "type", "iana-if-type:ethernetCsmacd"));
-        oper_status.reset(new libyang::Data_Node(ifc, mod, "oper-status", "dormant"));
-
-        ifc.reset(new libyang::Data_Node(parent, mod, "interface"));
-        name.reset(new libyang::Data_Node(ifc, mod, "name", "eth105"));
-        type.reset(new libyang::Data_Node(ifc, mod, "type", "iana-if-type:ethernetCsmacd"));
-        oper_status.reset(new libyang::Data_Node(ifc, mod, "oper-status", "not-present"));
-
-        return SR_ERR_OK;
-    }
-};
-
-class My_Callback2:public sysrepo::Callback {
-    /* Function to be called whenever a client requests these state data. */
-    int oper_get_items(sysrepo::S_Session session, const char *module_name, const char *path, const char *request_xpath, \
-            uint32_t request_id, libyang::S_Data_Node &parent, void *private_data) override
-    {
-        cout << "\n\n ========== CALLBACK CALLED TO PROVIDE \"" << path << "\" DATA ==========\n" << endl;
-
-        libyang::S_Context ctx = session->get_context();
-        libyang::S_Module mod = ctx->get_module(module_name);
-
-        libyang::S_Data_Node stats(new libyang::Data_Node(parent, mod, "statistics"));
-        libyang::S_Data_Node dis_time(new libyang::Data_Node(stats, mod, "discontinuity-time", "2019-01-01T00:00:00Z"));
-        libyang::S_Data_Node in_oct(new libyang::Data_Node(stats, mod, "in-octets", "22"));
-
-        return SR_ERR_OK;
-    }
-};
-
 static void
 sigint_handler(int signum)
 {
@@ -105,12 +51,54 @@ main(int argc, char **argv)
         sysrepo::S_Session sess(new sysrepo::Session(conn));
 
         sysrepo::S_Subscribe subscribe(new sysrepo::Subscribe(sess));
-        sysrepo::S_Callback cb1(new My_Callback1());
-        sysrepo::S_Callback cb2(new My_Callback2());
+        auto cb1 = [] (sysrepo::S_Session session, const char *module_name, const char *path, const char *request_xpath,
+            uint32_t request_id, libyang::S_Data_Node &parent) {
 
-        subscribe->oper_get_items_subscribe(module_name, "/ietf-interfaces:interfaces-state", cb1);
-        subscribe->oper_get_items_subscribe(module_name, "/ietf-interfaces:interfaces-state/interface/statistics", cb2,
-                nullptr, SR_SUBSCR_CTX_REUSE);
+            cout << "\n\n ========== CALLBACK CALLED TO PROVIDE \"" << path << "\" DATA ==========\n" << endl;
+
+            libyang::S_Context ctx = session->get_context();
+            libyang::S_Module mod = ctx->get_module(module_name);
+
+            parent.reset(new libyang::Data_Node(ctx, "/ietf-interfaces:interfaces-state", nullptr, LYD_ANYDATA_CONSTSTRING, 0));
+
+            libyang::S_Data_Node ifc(new libyang::Data_Node(parent, mod, "interface"));
+            libyang::S_Data_Node name(new libyang::Data_Node(ifc, mod, "name", "eth100"));
+            libyang::S_Data_Node type(new libyang::Data_Node(ifc, mod, "type", "iana-if-type:ethernetCsmacd"));
+            libyang::S_Data_Node oper_status(new libyang::Data_Node(ifc, mod, "oper-status", "down"));
+
+            ifc.reset(new libyang::Data_Node(parent, mod, "interface"));
+            name.reset(new libyang::Data_Node(ifc, mod, "name", "eth101"));
+            type.reset(new libyang::Data_Node(ifc, mod, "type", "iana-if-type:ethernetCsmacd"));
+            oper_status.reset(new libyang::Data_Node(ifc, mod, "oper-status", "up"));
+
+            ifc.reset(new libyang::Data_Node(parent, mod, "interface"));
+            name.reset(new libyang::Data_Node(ifc, mod, "name", "eth102"));
+            type.reset(new libyang::Data_Node(ifc, mod, "type", "iana-if-type:ethernetCsmacd"));
+            oper_status.reset(new libyang::Data_Node(ifc, mod, "oper-status", "dormant"));
+
+            ifc.reset(new libyang::Data_Node(parent, mod, "interface"));
+            name.reset(new libyang::Data_Node(ifc, mod, "name", "eth105"));
+            type.reset(new libyang::Data_Node(ifc, mod, "type", "iana-if-type:ethernetCsmacd"));
+            oper_status.reset(new libyang::Data_Node(ifc, mod, "oper-status", "not-present"));
+
+            return SR_ERR_OK;
+        };
+        auto cb2 = [] (sysrepo::S_Session session, const char *module_name, const char *path, const char *request_xpath,
+            uint32_t request_id, libyang::S_Data_Node &parent) {
+            cout << "\n\n ========== CALLBACK CALLED TO PROVIDE \"" << path << "\" DATA ==========\n" << endl;
+
+            libyang::S_Context ctx = session->get_context();
+            libyang::S_Module mod = ctx->get_module(module_name);
+
+            libyang::S_Data_Node stats(new libyang::Data_Node(parent, mod, "statistics"));
+            libyang::S_Data_Node dis_time(new libyang::Data_Node(stats, mod, "discontinuity-time", "2019-01-01T00:00:00Z"));
+            libyang::S_Data_Node in_oct(new libyang::Data_Node(stats, mod, "in-octets", "22"));
+
+            return SR_ERR_OK;
+        };
+
+        subscribe->oper_get_items_subscribe(module_name, cb1, "/ietf-interfaces:interfaces-state");
+        subscribe->oper_get_items_subscribe(module_name, cb2, "/ietf-interfaces:interfaces-state/interface/statistics");
 
         /* loop until ctrl-c is pressed / SIGINT is received */
         signal(SIGINT, sigint_handler);

--- a/bindings/cpp/examples/cpp_rpc_example.cpp
+++ b/bindings/cpp/examples/cpp_rpc_example.cpp
@@ -108,13 +108,13 @@ main(int argc, char **argv)
 
         printf("Application will make an rpc call in %s\n", module_name);
         /* connect to sysrepo */
-        sysrepo::S_Connection conn(new sysrepo::Connection());
+        auto conn = std::make_shared<sysrepo::Connection>();
 
         /* start session */
-        sysrepo::S_Session sess(new sysrepo::Session(conn));
+        auto sess = std::make_shared<sysrepo::Session>(conn);
 
         /* subscribe for changes in running config */
-        sysrepo::S_Subscribe subscribe(new sysrepo::Subscribe(sess));
+        auto subscribe = std::make_shared<sysrepo::Subscribe>(sess);
         auto cbVals = [](sysrepo::S_Session session, const char* op_path, const sysrepo::S_Vals input, sr_event_t event, uint32_t request_id, sysrepo::S_Vals_Holder output) {
             cout << "\n ========== RPC CALLED ==========\n" << endl;
 
@@ -154,7 +154,7 @@ main(int argc, char **argv)
 
         subscribe->rpc_subscribe("/test-examples:activate-software-image", cbVals);
 
-        sysrepo::S_Vals in_vals(new sysrepo::Vals(2));
+        auto in_vals = std::make_shared<sysrepo::Vals>(2);
 
         in_vals->val(0)->set("/test-examples:activate-software-image/image-name",
                            "acmefw-2.3",
@@ -175,7 +175,7 @@ main(int argc, char **argv)
 
         libyang::S_Context ctx = conn->get_context();
         libyang::S_Module mod = ctx->get_module(module_name);
-        libyang::S_Data_Node in_trees(new libyang::Data_Node(ctx, "/test-examples:activate-software-image", nullptr, LYD_ANYDATA_CONSTSTRING, 0));
+        auto in_trees = std::make_shared<libyang::Data_Node>(ctx, "/test-examples:activate-software-image", nullptr, LYD_ANYDATA_CONSTSTRING, 0);
         std::make_shared<libyang::Data_Node>(libyang::Data_Node(in_trees, mod, "image-name", "acmefw-2.3"));
         std::make_shared<libyang::Data_Node>(libyang::Data_Node(in_trees, mod, "location", "/root/"));
 

--- a/bindings/cpp/examples/cpp_set_item_example.cpp
+++ b/bindings/cpp/examples/cpp_set_item_example.cpp
@@ -33,20 +33,20 @@ main(int argc, char **argv)
         sysrepo::Logs log;
         log.set_stderr(SR_LL_DBG);
 
-        sysrepo::S_Connection conn(new sysrepo::Connection());
-        sysrepo::S_Session sess(new sysrepo::Session(conn));
+        auto conn = std::make_shared<sysrepo::Connection>();
+        auto sess = std::make_shared<sysrepo::Session>(conn);
 
         /* create new interface named 'gigaeth0' of type 'ethernetCsmacd' */
         const char *xpath = "/ietf-interfaces:interfaces/interface[name='eth0']/type";
         const char *ethernet = "iana-if-type:ethernetCsmacd";
-        sysrepo::S_Val value(new sysrepo::Val((char *)ethernet, SR_IDENTITYREF_T));
+        auto value = std::make_shared<sysrepo::Val>((char *)ethernet, SR_IDENTITYREF_T);
         sess->set_item(xpath, value);
 
         /* set 'prefix-length' leaf inside of the 'address' list entry with key 'fe80::ab8'
         (list entry will be automatically created if it does not exist) */
         const char *xpath_num = "/ietf-interfaces:interfaces/interface[name='eth0']/ietf-ip:ipv6/address[ip='fe80::ab8']/prefix-length";
         uint8_t num = 64;
-        sysrepo::S_Val value_num(new sysrepo::Val(num));
+        auto value_num = std::make_shared<sysrepo::Val>(num);
         sess->set_item(xpath_num, value_num);
 
         sess->apply_changes();

--- a/bindings/cpp/examples/cpp_turing_rpc_example.cpp
+++ b/bindings/cpp/examples/cpp_turing_rpc_example.cpp
@@ -44,7 +44,7 @@ rpc_handler(sysrepo::S_Session sess)
 {
     int rc = SR_ERR_OK;
     try {
-        sysrepo::S_Subscribe subscribe(new sysrepo::Subscribe(sess));
+        auto subscribe = std::make_shared<sysrepo::Subscribe>(sess);
         auto cb = [] (sysrepo::S_Session session, const char *op_path, const sysrepo::S_Vals input, sr_event_t event,
             uint32_t request_id, sysrepo::S_Vals_Holder output) {
             sr_error_e rc = SR_ERR_OK;
@@ -133,7 +133,7 @@ rpc_caller(sysrepo::S_Session sess)
     try {
 
         /* allocate input values */
-        sysrepo::S_Vals input(new sysrepo::Vals(7));
+        auto input = std::make_shared<sysrepo::Vals>(7);
 
         /* set 'input/state' leaf */
         input->val(0)->set("/turing-machine:run-until/state", uint16_t{10});
@@ -176,10 +176,10 @@ main(int argc, char **argv)
     int rc = SR_ERR_OK;
     try {
         /* connect to sysrepo */
-        sysrepo::S_Connection conn(new sysrepo::Connection());
+        auto conn = std::make_shared<sysrepo::Connection>();
 
         /* start session */
-        sysrepo::S_Session sess(new sysrepo::Session(conn));
+        auto sess = std::make_shared<sysrepo::Session>(conn);
 
         if (1 == argc) {
             /* run as a RPC handler */

--- a/bindings/cpp/src/Session.hpp
+++ b/bindings/cpp/src/Session.hpp
@@ -168,6 +168,7 @@ class Subscribe
 public:
     /** Wrapper for [sr_subscription_ctx_t](@ref sr_subscription_ctx_t) */
     Subscribe(S_Session sess);
+    Subscribe(S_Session sess, const FdRegistration& reg, const FdUnregistration& unreg);
     /** Wrapper for [sr_module_change_subscribe](@ref sr_module_change_subscribe) */
     void module_change_subscribe(const char *module_name, ModuleChangeCb cb, const char *xpath = nullptr, uint32_t priority = 0, sr_subscr_options_t opts = SUBSCR_DEFAULT);
     /** Wrapper for [sr_rpc_subscribe](@ref sr_rpc_subscribe) */
@@ -181,8 +182,6 @@ public:
     /** Wrapper for [sr_oper_get_items_subscribe](@ref sr_oper_get_items_subscribe) */
     void oper_get_items_subscribe(const char *module_name, OperGetItemsCb cb, const char *path, sr_subscr_options_t opts = SUBSCR_DEFAULT);
 
-    /** Wrapper for [sr_get_event_pipe](@ref sr_get_event_pipe) */
-    int get_event_pipe();
     /** Wrapper for [sr_process_event](@ref sr_process_events) */
     time_t process_events(S_Session sess = nullptr);
     ~Subscribe();
@@ -208,6 +207,14 @@ private:
 
     S_Session sess;
     S_Deleter sess_deleter;
+
+    int get_event_pipe();
+    FdRegistration reg;
+    bool reg_called = false;
+    FdUnregistration unreg;
+    void check_custom_loop_options(sr_subscr_options_t opts);
+    void call_reg();
+
 };
 
 /** @} */

--- a/bindings/cpp/src/Session.hpp
+++ b/bindings/cpp/src/Session.hpp
@@ -24,6 +24,7 @@
 #define SESSION_H
 
 #include <iostream>
+#include <list>
 #include <memory>
 #include <map>
 #include <vector>
@@ -148,38 +149,14 @@ private:
     S_Deleter _deleter;
 };
 
-/**
- * @brief Helper class for calling C callbacks, C++ only.
- * @class Callback
- */
-class Callback
-{
-public:
-    Callback();
-    virtual ~Callback();
-
-    /** Wrapper for [sr_module_change_cb](@ref sr_module_change_cb) callback.*/
-    virtual int module_change(S_Session session, const char *module_name, const char *xpath, sr_event_t event, \
-            uint32_t request_id, void *private_data) {return SR_ERR_OK;};
-    /** Wrapper for [sr_rpc_cb](@ref sr_rpc_cb) callback.*/
-    virtual int rpc(S_Session session, const char *op_path, const S_Vals input, sr_event_t event, uint32_t request_id, \
-            S_Vals_Holder output, void *private_data) {return SR_ERR_OK;};
-    /** Wrapper for [sr_rpc_tree_cb](@ref sr_rpc_tree_cb) callback.*/
-    virtual int rpc_tree(S_Session session, const char *op_path, const libyang::S_Data_Node input, sr_event_t event, \
-            uint32_t request_id, libyang::S_Data_Node output, void *private_data) {return SR_ERR_OK;};
-    /** Wrapper for [sr_event_notif_cb](@ref sr_event_notif_cb) callback.*/
-    virtual void event_notif(S_Session session, const sr_ev_notif_type_t notif_type, const char *path, const S_Vals vals, \
-            time_t timestamp, void *private_data) {return;};
-    /** Wrapper for [sr_event_notif_tree_cb](@ref sr_event_notif_tree_cb) callback.*/
-    virtual void event_notif_tree(S_Session session, const sr_ev_notif_type_t notif_type, const libyang::S_Data_Node notif, \
-            time_t timestamp, void *private_data) {return;};
-    /** Wrapper for [sr_oper_get_items_cb](@ref sr_oper_get_items_cb) callback.*/
-    virtual int oper_get_items(S_Session session, const char *module_name, const char *path, const char *request_xpath, \
-            uint32_t request_id, libyang::S_Data_Node &parent, void *private_data) {return SR_ERR_OK;};
-    Callback *get() {return this;};
-
-    std::map<const char *, void *> private_data;
-};
+using FdRegistration = std::function<void(int, std::function<void()>)>;
+using FdUnregistration = std::function<void(int)>;
+using ModuleChangeCb = std::function<int(S_Session session, const char *module_name, const char *xpath, sr_event_t event, uint32_t request_id)>;
+using RpcCb = std::function<int(S_Session session, const char *op_path, const S_Vals input, sr_event_t event, uint32_t request_id, S_Vals_Holder output)>;
+using RpcTreeCb = std::function<int(S_Session session, const char *op_path, const libyang::S_Data_Node input, sr_event_t event, uint32_t request_id, libyang::S_Data_Node output)>;
+using EventNotifCb = std::function<void(S_Session session, const sr_ev_notif_type_t notif_type, const char *path, const S_Vals vals, time_t timestamp)>;
+using EventNotifTreeCb = std::function<void(S_Session session, const sr_ev_notif_type_t notif_type, const libyang::S_Data_Node notif, time_t timestamp)>;
+using OperGetItemsCb = std::function<int(S_Session session, const char *module_name, const char *path, const char *request_xpath, uint32_t request_id, libyang::S_Data_Node &parent)>;
 
 /**
  * @brief Class for wrapping sr_subscription_ctx_t.
@@ -191,47 +168,45 @@ class Subscribe
 public:
     /** Wrapper for [sr_subscription_ctx_t](@ref sr_subscription_ctx_t) */
     Subscribe(S_Session sess);
-
     /** Wrapper for [sr_module_change_subscribe](@ref sr_module_change_subscribe) */
-    void module_change_subscribe(const char *module_name, S_Callback callback, const char *xpath = nullptr, \
-            void *private_data = nullptr, uint32_t priority = 0, sr_subscr_options_t opts = SUBSCR_DEFAULT);
+    void module_change_subscribe(const char *module_name, ModuleChangeCb cb, const char *xpath = nullptr, uint32_t priority = 0, sr_subscr_options_t opts = SUBSCR_DEFAULT);
     /** Wrapper for [sr_rpc_subscribe](@ref sr_rpc_subscribe) */
-    void rpc_subscribe(const char *xpath, S_Callback callback, void *private_data = nullptr, uint32_t priority = 0, \
-            sr_subscr_options_t opts = SUBSCR_DEFAULT);
+    void rpc_subscribe(const char *xpath, RpcCb cb, uint32_t priority = 0, sr_subscr_options_t opts = SUBSCR_DEFAULT);
     /** Wrapper for [sr_rpc_subscribe_tree](@ref sr_rpc_subscribe_tree) */
-    void rpc_subscribe_tree(const char *xpath, S_Callback callback, void *private_data = nullptr, uint32_t priority = 0, \
-            sr_subscr_options_t opts = SUBSCR_DEFAULT);
+    void rpc_subscribe_tree(const char *xpath, RpcTreeCb cb, uint32_t priority = 0, sr_subscr_options_t opts = SUBSCR_DEFAULT);
     /** Wrapper for [sr_event_notif_subscribe](@ref sr_event_notif_subscribe) */
-    void event_notif_subscribe(const char *module_name, S_Callback callback, const char *xpath = nullptr, \
-            time_t start_time = 0, time_t stop_time = 0, void *private_data = nullptr, sr_subscr_options_t opts = SUBSCR_DEFAULT);
+    void event_notif_subscribe(const char *module_name, EventNotifCb cb, const char *xpath = nullptr, time_t start_time = 0, time_t stop_time = 0, sr_subscr_options_t opts = SUBSCR_DEFAULT);
     /** Wrapper for [sr_event_notif_subscribe_tree](@ref sr_event_notif_subscribe_tree) */
-    void event_notif_subscribe_tree(const char *module_name, S_Callback callback, const char *xpath = nullptr, \
-            time_t start_time = 0, time_t stop_time = 0, void *private_data = nullptr, sr_subscr_options_t opts = SUBSCR_DEFAULT);
+    void event_notif_subscribe_tree(const char *module_name, EventNotifTreeCb cb, const char *xpath = nullptr, time_t start_time = 0, time_t stop_time = 0, sr_subscr_options_t opts = SUBSCR_DEFAULT);
     /** Wrapper for [sr_oper_get_items_subscribe](@ref sr_oper_get_items_subscribe) */
-    void oper_get_items_subscribe(const char *module_name, const char *path, S_Callback callback, \
-            void *private_data = nullptr, sr_subscr_options_t opts = SUBSCR_DEFAULT);
-    std::vector<S_Callback > cb_list;
+    void oper_get_items_subscribe(const char *module_name, OperGetItemsCb cb, const char *path, sr_subscr_options_t opts = SUBSCR_DEFAULT);
 
     /** Wrapper for [sr_get_event_pipe](@ref sr_get_event_pipe) */
     int get_event_pipe();
     /** Wrapper for [sr_process_event](@ref sr_process_events) */
     time_t process_events(S_Session sess = nullptr);
-    /** Wrapper for [sr_unsubscribe](@ref sr_unsubscribe) */
-    void unsubscribe();
     ~Subscribe();
 
     /** SWIG specific, internal use only.*/
-    sr_subscription_ctx_t **swig_sub() { return &_sub;};
+    sr_subscription_ctx_t **swig_sub() { return &ctx;};
     /** SWIG specific, internal use only.*/
-    sr_session_ctx_t *swig_sess() {return _sess->_sess;};
+    sr_session_ctx_t *swig_sess() {return sess->_sess;};
     /** SWIG specific, internal use only.*/
     std::vector<void*> wrap_cb_l;
     /** SWIG specific, internal use only.*/
     void additional_cleanup(void *private_data) {return;};
 
 private:
-    sr_subscription_ctx_t *_sub;
-    S_Session _sess;
+    sr_subscription_ctx_t *ctx = nullptr;
+    std::list<ModuleChangeCb> module_change_cbs;
+    std::list<RpcCb> rpc_cbs;
+    std::list<RpcTreeCb> rpc_tree_cbs;
+    std::list<EventNotifCb> event_notif_cbs;
+    std::list<EventNotifTreeCb> event_notif_tree_cbs;
+    std::list<OperGetItemsCb> oper_get_items_cbs;
+
+
+    S_Session sess;
     S_Deleter sess_deleter;
 };
 

--- a/bindings/cpp/src/Session.hpp
+++ b/bindings/cpp/src/Session.hpp
@@ -34,7 +34,6 @@
 #include "Internal.hpp"
 #include "Struct.hpp"
 #include "Connection.hpp"
-#include "Session.hpp"
 
 #include "sysrepo.h"
 

--- a/bindings/cpp/src/Struct.cpp
+++ b/bindings/cpp/src/Struct.cpp
@@ -111,7 +111,7 @@ Val::Val(sr_val_t *val, S_Deleter deleter) {
 }
 Val::Val() {
     _val = nullptr;
-    _deleter = S_Deleter(new Deleter(_val));
+    _deleter = std::make_shared<Deleter>(_val);
 }
 Val::~Val() {}
 Val::Val(const char *value, sr_type_t type) {
@@ -119,7 +119,7 @@ Val::Val(const char *value, sr_type_t type) {
     if (_val == nullptr)
         throw_exception(SR_ERR_NOMEM);
     set(nullptr,value,type);
-    _deleter = S_Deleter(new Deleter(_val));
+    _deleter = std::make_shared<Deleter>(_val);
 }
 Val::Val(bool bool_val, sr_type_t type) {
     if (type != SR_BOOL_T)
@@ -128,70 +128,70 @@ Val::Val(bool bool_val, sr_type_t type) {
     if (_val == nullptr)
         throw_exception(SR_ERR_NOMEM);
     set(nullptr,bool_val,type);
-    _deleter = S_Deleter(new Deleter(_val));
+    _deleter = std::make_shared<Deleter>(_val);
 }
 Val::Val(double decimal64_val) {
     _val = (sr_val_t*) calloc(1, sizeof(sr_val_t));
     if (_val == nullptr)
         throw_exception(SR_ERR_NOMEM);
     set(nullptr,decimal64_val);
-    _deleter = S_Deleter(new Deleter(_val));
+    _deleter = std::make_shared<Deleter>(_val);
 }
 Val::Val(int8_t int8_val) {
     _val = (sr_val_t*) calloc(1, sizeof(sr_val_t));
     if (_val == nullptr)
         throw_exception(SR_ERR_NOMEM);
     set(nullptr,int8_val);
-    _deleter = S_Deleter(new Deleter(_val));
+    _deleter = std::make_shared<Deleter>(_val);
 }
 Val::Val(int16_t int16_val) {
     _val = (sr_val_t*) calloc(1, sizeof(sr_val_t));
     if (_val == nullptr)
         throw_exception(SR_ERR_NOMEM);
     set(nullptr,int16_val);
-    _deleter = S_Deleter(new Deleter(_val));
+    _deleter = std::make_shared<Deleter>(_val);
 }
 Val::Val(int32_t int32_val) {
     _val = (sr_val_t*) calloc(1, sizeof(sr_val_t));
     if (_val == nullptr)
         throw_exception(SR_ERR_NOMEM);
     set(nullptr,int32_val);
-    _deleter = S_Deleter(new Deleter(_val));
+    _deleter = std::make_shared<Deleter>(_val);
 }
 Val::Val(int64_t int64_val, sr_type_t type) {
     _val = (sr_val_t*) calloc(1, sizeof(sr_val_t));
     if (_val == nullptr)
         throw_exception(SR_ERR_NOMEM);
     set(nullptr,int64_val,type);
-    _deleter = S_Deleter(new Deleter(_val));
+    _deleter = std::make_shared<Deleter>(_val);
 }
 Val::Val(uint8_t uint8_val) {
     _val = (sr_val_t*) calloc(1, sizeof(sr_val_t));
     if (_val == nullptr)
         throw_exception(SR_ERR_NOMEM);
     set(nullptr,uint8_val);
-    _deleter = S_Deleter(new Deleter(_val));
+    _deleter = std::make_shared<Deleter>(_val);
 }
 Val::Val(uint16_t uint16_val) {
     _val = (sr_val_t*) calloc(1, sizeof(sr_val_t));
     if (_val == nullptr)
         throw_exception(SR_ERR_NOMEM);
     set(nullptr,uint16_val);
-    _deleter = S_Deleter(new Deleter(_val));
+    _deleter = std::make_shared<Deleter>(_val);
 }
 Val::Val(uint32_t uint32_val) {
     _val = (sr_val_t*) calloc(1, sizeof(sr_val_t));
     if (_val == nullptr)
         throw_exception(SR_ERR_NOMEM);
     set(nullptr,uint32_val);
-    _deleter = S_Deleter(new Deleter(_val));
+    _deleter = std::make_shared<Deleter>(_val);
 }
 Val::Val(uint64_t uint64_val) {
     _val = (sr_val_t*) calloc(1, sizeof(sr_val_t));
     if (_val == nullptr)
         throw_exception(SR_ERR_NOMEM);
     set(nullptr,uint64_val);
-    _deleter = S_Deleter(new Deleter(_val));
+    _deleter = std::make_shared<Deleter>(_val);
 }
 void Val::set(const char *xpath, const char *value, sr_type_t type) {
     switch (type)
@@ -368,8 +368,7 @@ void Val::dflt_set(bool data) {
     _val->dflt = data;
 }
 S_Data Val::data() {
-    S_Data data(new Data(_val->data, _val->type, _deleter));
-    return data;
+    return std::make_shared<Data>(_val->data, _val->type, _deleter);
 }
 bool Val::empty() {
     return !_val;
@@ -408,8 +407,8 @@ S_Val Val::dup() {
     if (ret != SR_ERR_OK)
         throw_exception(ret);
 
-    S_Deleter deleter(new Deleter(new_val));
-    S_Val val(new Val(new_val, deleter));
+    auto deleter = std::make_shared<Deleter>(new_val);
+    auto val = std::make_shared<Val>(new_val, deleter);
     return val;
 }
 
@@ -434,7 +433,7 @@ Vals::Vals(size_t cnt): Vals() {
             throw_exception(ret);
 
         _cnt = cnt;
-        _deleter = S_Deleter(new Deleter(_vals, _cnt));
+        _deleter = std::make_shared<Deleter>(_vals, _cnt);
     }
 }
 Vals::Vals(): _cnt(0), _vals(nullptr) {}
@@ -445,7 +444,7 @@ S_Val Vals::val(size_t n) {
     if (!_vals)
         throw std::logic_error("Vals::val: called on null Vals");
 
-    S_Val val(new Val(&_vals[n], _deleter));
+    auto val = std::make_shared<Val>(&_vals[n], _deleter);
     return val;
 }
 S_Vals Vals::dup() {
@@ -454,8 +453,8 @@ S_Vals Vals::dup() {
     if (ret != SR_ERR_OK)
         throw_exception(ret);
 
-    S_Deleter deleter(new Deleter(new_val, _cnt));
-    S_Vals vals(new Vals(new_val, _cnt, deleter));
+    auto deleter = std::make_shared<Deleter>(new_val, _cnt);
+    auto vals = std::make_shared<Vals>(new_val, _cnt, deleter);
     return vals;
 }
 sr_val_t* Vals::reallocate(size_t n) {
@@ -493,7 +492,7 @@ S_Vals Vals_Holder::allocate(size_t n) {
     *p_cnt = n;
     _allocate = false;
 
-    p_Vals = S_Vals(new Vals(p_vals, p_cnt, nullptr));
+    p_Vals = std::make_shared<Vals>(p_vals, p_cnt, nullptr);
     return p_Vals;
 }
 S_Vals Vals_Holder::reallocate(size_t n) {
@@ -524,19 +523,19 @@ Change::Change() {
     _new = nullptr;
     _old = nullptr;
 
-    _deleter_old = S_Deleter(new Deleter(_old));
-    _deleter_new = S_Deleter(new Deleter(_new));
+    _deleter_old = std::make_shared<Deleter>(_old);
+    _deleter_new = std::make_shared<Deleter>(_new);
 }
 S_Val Change::new_val() {
     if (_new == nullptr) return nullptr;
 
-    S_Val new_val(new Val(_new, _deleter_new));
+    auto new_val = std::make_shared<Val>(_new, _deleter_new);
     return new_val;
 }
 S_Val Change::old_val() {
     if (_old == nullptr) return nullptr;
 
-    S_Val old_val(new Val(_old, _deleter_old));
+    auto old_val = std::make_shared<Val>(_old, _deleter_old);
     return old_val;
 }
 Change::~Change() {

--- a/bindings/cpp/src/Sysrepo.hpp
+++ b/bindings/cpp/src/Sysrepo.hpp
@@ -52,7 +52,6 @@ class Xpath_Ctx;
 class Logs;
 class Change;
 class Tree_Change;
-class Callback;
 class Deleter;
 
 using S_Iter_Change      = std::shared_ptr<Iter_Change>;
@@ -69,7 +68,6 @@ using S_Xpath_Ctx        = std::shared_ptr<Xpath_Ctx>;
 using S_Logs             = std::shared_ptr<Logs>;
 using S_Change           = std::shared_ptr<Change>;
 using S_Tree_Change      = std::shared_ptr<Tree_Change>;
-using S_Callback         = std::shared_ptr<Callback>;
 using S_Deleter          = std::shared_ptr<Deleter>;
 
 /* this is a workaround for python not recognizing

--- a/bindings/python/sysrepo.i
+++ b/bindings/python/sysrepo.i
@@ -502,14 +502,6 @@ static const char *g_ly_module_imp_clb(const char *mod_name, const char *mod_rev
         }
 
     }
-
-    void unsubscribe()
-    {
-        self->unsubscribe(); // function in Connection.cpp
-        for (unsigned int i = 0; i < self->wrap_cb_l.size(); i++) {
-            static_cast<Wrap_cb*>(self->wrap_cb_l[i])->~Wrap_cb();
-        }
-    }
 };
 
 %extend libyang::Context {

--- a/bindings/python/tests/SubscriptionTestApp.py
+++ b/bindings/python/tests/SubscriptionTestApp.py
@@ -84,8 +84,6 @@ if __name__ == "__main__":
 
     sr.global_loop()
 
-    subscribe.unsubscribe()
-
     sess.session_stop()
 
     conn = None


### PR DESCRIPTION
Detailed info is in the commit message. Naming (especially `DelegatedSubscriptions`) can/should be changed.

In case you like the new std::function callbacks, I could also change the current `sysrepo::Subscribe` to use that (instead of overriding `sysrepo::Callback`).

cc @jktjkt 