### PR TITLE
c++ BUGFIX oper_data output

### DIFF
--- a/bindings/cpp/src/Session.cpp
+++ b/bindings/cpp/src/Session.cpp
@@ -473,10 +473,9 @@ static int oper_get_items_cb(sr_session_ctx_t *session, const char *module_name,
         tree = std::make_shared<libyang::Data_Node>(*parent);
         ret = wrap->oper_get_items(sess, module_name, path, request_xpath, request_id, tree, wrap->private_data["oper_get_items"]);
     } else {
-        tree = std::make_shared<libyang::Data_Node>(nullptr);
         ret = wrap->oper_get_items(sess, module_name, path, request_xpath, request_id, tree, wrap->private_data["oper_get_items"]);
         if (tree) {
-            *parent = lyd_dup(tree->swig_node(), LYD_DUP_OPT_RECURSIVE);
+            *parent = lyd_dup_withsiblings(tree->swig_node(), LYD_DUP_OPT_RECURSIVE);
         }
     }
     return ret;


### PR DESCRIPTION
If subscribing to a list type top-level node, all siblings need to be
duplicated.

Also, I deleted a line which was (probably) supposed to create a nullptr
shared_ptr, but instead created a valid libyang::Data_Node with an
invalid lyd_node inside. That broke the duping algorithm if the `parent`/`tree`
variable wasn't reassigned inside the callback.

Sorry, I don't have a test, but I found out about this when porting to new sysrepo.