### PR TITLE
First step to supporting access to sysrepo across multiple containers

### DIFF
--- a/src/common.c
+++ b/src/common.c
@@ -2521,7 +2521,7 @@ sr_cp_file2shm(const char *to, const char *from, mode_t perm)
     mode_t um;
 
     /* open "from" file */
-    fd_from = open(from, O_RDONLY);
+    fd_from = SR_OPEN(from, O_RDONLY, 0);
     if (fd_from < 0) {
         sr_errinfo_new(&err_info, SR_ERR_SYS, NULL, "Opening \"%s\" file failed (%s).", from, strerror(errno));
         goto cleanup;
@@ -2531,7 +2531,7 @@ sr_cp_file2shm(const char *to, const char *from, mode_t perm)
     um = umask(SR_UMASK);
 
     /* open "to" */
-    fd_to = open(to, O_WRONLY | O_TRUNC | O_CREAT, perm);
+    fd_to = SR_OPEN(to, O_WRONLY | O_TRUNC | O_CREAT, perm);
     umask(um);
     if (fd_to < 0) {
         sr_errinfo_new(&err_info, SR_ERR_SYS, NULL, "Opening \"%s\" failed (%s).", to, strerror(errno));
@@ -4259,7 +4259,7 @@ retry_open:
     }
 
     /* open fd */
-    fd = open(path, O_RDONLY);
+    fd = SR_OPEN(path, O_RDONLY, 0);
     if (fd == -1) {
         if ((errno == ENOENT) && (ds == SR_DS_CANDIDATE)) {
             /* no candidate exists, just use running */
@@ -4339,7 +4339,7 @@ sr_module_file_data_set(const char *mod_name, sr_datastore_t ds, struct lyd_node
     um = umask(SR_UMASK);
 
     /* open */
-    fd = open(path, O_WRONLY | O_TRUNC | create_flags, create_mode);
+    fd = SR_OPEN(path, O_WRONLY | O_TRUNC | create_flags, create_mode);
     umask(um);
     if (fd == -1) {
         sr_errinfo_new(&err_info, SR_ERR_SYS, NULL, "Failed to open \"%s\" (%s).", path, strerror(errno));

--- a/src/common.c
+++ b/src/common.c
@@ -1276,26 +1276,26 @@ sr_remove_data_files(const char *mod_name)
     }
     free(path);
 
-    if ((err_info = sr_path_ds_shm(mod_name, SR_DS_RUNNING, 0, &path))) {
+    if ((err_info = sr_path_ds_shm(mod_name, SR_DS_RUNNING, &path))) {
         return err_info;
     }
-    if ((shm_unlink(path) == -1) && (errno != ENOENT)) {
+    if ((unlink(path) == -1) && (errno != ENOENT)) {
         SR_LOG_WRN("Failed to unlink \"%s\" (%s).", path, strerror(errno));
     }
     free(path);
 
-    if ((err_info = sr_path_ds_shm(mod_name, SR_DS_OPERATIONAL, 0, &path))) {
+    if ((err_info = sr_path_ds_shm(mod_name, SR_DS_OPERATIONAL, &path))) {
         return err_info;
     }
-    if ((shm_unlink(path) == -1) && (errno != ENOENT)) {
+    if ((unlink(path) == -1) && (errno != ENOENT)) {
         SR_LOG_WRN("Failed to unlink \"%s\" (%s).", path, strerror(errno));
     }
     free(path);
 
-    if ((err_info = sr_path_ds_shm(mod_name, SR_DS_CANDIDATE, 0, &path))) {
+    if ((err_info = sr_path_ds_shm(mod_name, SR_DS_CANDIDATE, &path))) {
         return err_info;
     }
-    if ((shm_unlink(path) == -1) && (errno != ENOENT)) {
+    if ((unlink(path) == -1) && (errno != ENOENT)) {
         SR_LOG_WRN("Failed to unlink \"%s\" (%s).", path, strerror(errno));
     }
     free(path);
@@ -1447,7 +1447,7 @@ sr_path_main_shm(char **path)
         return err_info;
     }
 
-    if (asprintf(path, "/%s_main", prefix) == -1) {
+    if (asprintf(path, "%s/%s_main", SR_SHM_DIR, prefix) == -1) {
         SR_ERRINFO_MEM(&err_info);
         *path = NULL;
     }
@@ -1466,7 +1466,7 @@ sr_path_ext_shm(char **path)
         return err_info;
     }
 
-    if (asprintf(path, "/%s_ext", prefix) == -1) {
+    if (asprintf(path, "%s/%s_ext", SR_SHM_DIR, prefix) == -1) {
         SR_ERRINFO_MEM(&err_info);
         *path = NULL;
     }
@@ -1475,7 +1475,7 @@ sr_path_ext_shm(char **path)
 }
 
 sr_error_info_t *
-sr_path_sub_shm(const char *mod_name, const char *suffix1, int64_t suffix2, int abs_path, char **path)
+sr_path_sub_shm(const char *mod_name, const char *suffix1, int64_t suffix2, char **path)
 {
     sr_error_info_t *err_info = NULL;
     const char *prefix;
@@ -1487,10 +1487,10 @@ sr_path_sub_shm(const char *mod_name, const char *suffix1, int64_t suffix2, int 
     }
 
     if (suffix2 > -1) {
-        ret = asprintf(path, "%s/%ssub_%s.%s.%08x", abs_path ? SR_SHM_DIR : "",
+        ret = asprintf(path, "%s/%ssub_%s.%s.%08x", SR_SHM_DIR,
                 prefix, mod_name, suffix1, (uint32_t)suffix2);
     } else {
-        ret = asprintf(path, "%s/%ssub_%s.%s", abs_path ? SR_SHM_DIR : "",
+        ret = asprintf(path, "%s/%ssub_%s.%s", SR_SHM_DIR,
                 prefix, mod_name, suffix1);
     }
 
@@ -1501,7 +1501,7 @@ sr_path_sub_shm(const char *mod_name, const char *suffix1, int64_t suffix2, int 
 }
 
 sr_error_info_t *
-sr_path_ds_shm(const char *mod_name, sr_datastore_t ds, int abs_path, char **path)
+sr_path_ds_shm(const char *mod_name, sr_datastore_t ds, char **path)
 {
     sr_error_info_t *err_info = NULL;
     const char *prefix;
@@ -1514,7 +1514,7 @@ sr_path_ds_shm(const char *mod_name, sr_datastore_t ds, int abs_path, char **pat
         return err_info;
     }
 
-    ret = asprintf(path, "%s/%s_%s.%s", abs_path ? SR_SHM_DIR : "",
+    ret = asprintf(path, "%s/%s_%s.%s", SR_SHM_DIR,
             prefix, mod_name, sr_ds2str(ds));
     if (ret == -1) {
         *path = NULL;
@@ -1940,7 +1940,7 @@ sr_perm_get(const char *mod_name, sr_datastore_t ds, char **owner, char **group,
             return err_info;
         }
     } else {
-        if ((err_info = sr_path_ds_shm(mod_name, ds, 1, &path))) {
+        if ((err_info = sr_path_ds_shm(mod_name, ds, &path))) {
             return err_info;
         }
     }
@@ -2530,11 +2530,11 @@ sr_cp_file2shm(const char *to, const char *from, mode_t perm)
     /* set umask so that the correct permissions are really set */
     um = umask(SR_UMASK);
 
-    /* open "to" SHM */
-    fd_to = shm_open(to, O_WRONLY | O_TRUNC | O_CREAT, perm);
+    /* open "to" */
+    fd_to = open(to, O_WRONLY | O_TRUNC | O_CREAT, perm);
     umask(um);
     if (fd_to < 0) {
-        sr_errinfo_new(&err_info, SR_ERR_SYS, NULL, "Opening \"%s\" SHM failed (%s).", to, strerror(errno));
+        sr_errinfo_new(&err_info, SR_ERR_SYS, NULL, "Opening \"%s\" failed (%s).", to, strerror(errno));
         goto cleanup;
     }
 
@@ -4252,18 +4252,14 @@ retry_open:
     if (ds == SR_DS_STARTUP) {
         err_info = sr_path_startup_file(ly_mod->name, &path);
     } else {
-        err_info = sr_path_ds_shm(ly_mod->name, ds, 0, &path);
+        err_info = sr_path_ds_shm(ly_mod->name, ds, &path);
     }
     if (err_info) {
         goto error;
     }
 
     /* open fd */
-    if (ds == SR_DS_STARTUP) {
-        fd = open(path, O_RDONLY);
-    } else {
-        fd = shm_open(path, O_RDONLY, 0);
-    }
+    fd = open(path, O_RDONLY);
     if (fd == -1) {
         if ((errno == ENOENT) && (ds == SR_DS_CANDIDATE)) {
             /* no candidate exists, just use running */
@@ -4332,7 +4328,7 @@ sr_module_file_data_set(const char *mod_name, sr_datastore_t ds, struct lyd_node
     case SR_DS_RUNNING:
     case SR_DS_CANDIDATE:
     case SR_DS_OPERATIONAL:
-        err_info = sr_path_ds_shm(mod_name, ds, 0, &path);
+        err_info = sr_path_ds_shm(mod_name, ds, &path);
         break;
     }
     if (err_info) {
@@ -4343,11 +4339,7 @@ sr_module_file_data_set(const char *mod_name, sr_datastore_t ds, struct lyd_node
     um = umask(SR_UMASK);
 
     /* open */
-    if (ds == SR_DS_STARTUP) {
-        fd = open(path, O_WRONLY | O_TRUNC | create_flags, create_mode);
-    } else {
-        fd = shm_open(path, O_WRONLY | O_TRUNC | create_flags, create_mode);
-    }
+    fd = open(path, O_WRONLY | O_TRUNC | create_flags, create_mode);
     umask(um);
     if (fd == -1) {
         sr_errinfo_new(&err_info, SR_ERR_SYS, NULL, "Failed to open \"%s\" (%s).", path, strerror(errno));

--- a/src/common.h.in
+++ b/src/common.h.in
@@ -728,22 +728,20 @@ sr_error_info_t *sr_path_ext_shm(char **path);
  * @param[in] mod_name Module name.
  * @param[in] suffix1 First suffix.
  * @param[in] suffix2 Second suffix, none if equals -1.
- * @param[in] abs_path Whether to return absolute path or SHM path (name).
  * @param[out] path Created path.
  * @return err_info, NULL on success.
  */
-sr_error_info_t *sr_path_sub_shm(const char *mod_name, const char *suffix1, int64_t suffix2, int abs_path, char **path);
+sr_error_info_t *sr_path_sub_shm(const char *mod_name, const char *suffix1, int64_t suffix2, char **path);
 
 /**
  * @brief Get the path to a volatile datastore SHM.
  *
  * @param[in] mod_name Module name.
  * @param[in] ds Target datastore.
- * @param[in] abs_path Whether to return absolute path or SHM path (name).
  * @param[out] path Created path.
  * @return err_info, NULL on success.
  */
-sr_error_info_t *sr_path_ds_shm(const char *mod_name, sr_datastore_t ds, int abs_path, char **path);
+sr_error_info_t *sr_path_ds_shm(const char *mod_name, sr_datastore_t ds, char **path);
 
 /**
  * @brief Get the path to an event pipe.

--- a/src/common.h.in
+++ b/src/common.h.in
@@ -93,6 +93,14 @@ int pthread_mutex_timedlock(pthread_mutex_t *mutex, const struct timespec *absti
 /** macro for checking session type */
 #define SR_IS_EVENT_SESS(session) (session->ev != SR_SUB_EV_NONE)
 
+/** macro for opening files.
+ * O_NOFOLLOW enforces that files are not symlinks -- all opened
+ *   files are created by sysrepo so there cannot be any symlinks.
+ * O_CLOEXEC enforces that forking with an open sysrepo connection
+ *   is forbidden.
+ */
+#define SR_OPEN(path, oflag, ...) open(path, oflag | O_NOFOLLOW | O_CLOEXEC, __VA_ARGS__)
+
 /** macro for getting the first SHM module */
 #define SR_FIRST_SHM_MOD(main_shm_addr) ((sr_mod_t *)(((char *)main_shm_addr) + sizeof(sr_main_shm_t)))
 

--- a/src/lyd_mods.c
+++ b/src/lyd_mods.c
@@ -1684,7 +1684,7 @@ sr_lydmods_sched_update_data(const struct lyd_node *sr_mods, const struct ly_ctx
         }
 
         /* check that running data file exists */
-        if ((err_info = sr_path_ds_shm(ly_mod->name, SR_DS_RUNNING, 1, &path))) {
+        if ((err_info = sr_path_ds_shm(ly_mod->name, SR_DS_RUNNING, &path))) {
             goto cleanup;
         }
         exists = sr_file_exists(path);

--- a/src/modinfo.c
+++ b/src/modinfo.c
@@ -2288,11 +2288,11 @@ sr_modinfo_candidate_reset(struct sr_mod_info_s *mod_info)
         mod = &mod_info->mods[i];
         if (mod->state & MOD_INFO_REQ) {
             /* just remove the candidate SHM files */
-            if ((err_info = sr_path_ds_shm(mod->ly_mod->name, SR_DS_CANDIDATE, 0, &path))) {
+            if ((err_info = sr_path_ds_shm(mod->ly_mod->name, SR_DS_CANDIDATE, &path))) {
                 return err_info;
             }
 
-            if ((shm_unlink(path) == -1) && (errno != ENOENT)) {
+            if ((unlink(path) == -1) && (errno != ENOENT)) {
                 SR_LOG_WRN("Failed to unlink \"%s\" (%s).", path, strerror(errno));
             }
             free(path);

--- a/src/replay.c
+++ b/src/replay.c
@@ -149,7 +149,7 @@ sr_replay_open_file(const char *mod_name, time_t from_ts, time_t to_ts, int flag
     /* set umask so that the correct permissions are really set */
     um = umask(SR_UMASK);
 
-    *notif_fd = open(path, flags, perm);
+    *notif_fd = SR_OPEN(path, flags, perm);
     umask(um);
     if (*notif_fd == -1) {
         sr_errinfo_new(&err_info, SR_ERR_SYS, NULL, "Failed to open file \"%s\" (%s).", path, strerror(errno));

--- a/src/shm_main.c
+++ b/src/shm_main.c
@@ -1230,7 +1230,7 @@ sr_shmmain_files_startup2running(sr_conn_ctx_t *conn, int replace)
 
     SR_SHM_MOD_FOR(conn->main_shm.addr, conn->main_shm.size, shm_mod) {
         mod_name = conn->ext_shm.addr + shm_mod->name;
-        if ((err_info = sr_path_ds_shm(mod_name, SR_DS_RUNNING, 1, &running_path))) {
+        if ((err_info = sr_path_ds_shm(mod_name, SR_DS_RUNNING, &running_path))) {
             goto error;
         }
 
@@ -1238,11 +1238,6 @@ sr_shmmain_files_startup2running(sr_conn_ctx_t *conn, int replace)
             /* there are some running data, keep them */
             free(running_path);
             continue;
-        }
-        free(running_path);
-
-        if ((err_info = sr_path_ds_shm(mod_name, SR_DS_RUNNING, 0, &running_path))) {
-            goto error;
         }
 
         if ((err_info = sr_path_startup_file(mod_name, &startup_path))) {
@@ -1731,7 +1726,7 @@ sr_shmmain_main_open(sr_shm_t *shm, int *created)
     }
 
     /* try to open the shared memory */
-    shm->fd = shm_open(shm_name, O_RDWR, SR_MAIN_SHM_PERM);
+    shm->fd = open(shm_name, O_RDWR, SR_MAIN_SHM_PERM);
     if ((shm->fd == -1) && (errno == ENOENT)) {
         if (!created) {
             /* we do not want to create the memory now */
@@ -1743,7 +1738,7 @@ sr_shmmain_main_open(sr_shm_t *shm, int *created)
         um = umask(SR_UMASK);
 
         /* create shared memory */
-        shm->fd = shm_open(shm_name, O_RDWR | O_CREAT | O_EXCL, SR_MAIN_SHM_PERM);
+        shm->fd = open(shm_name, O_RDWR | O_CREAT | O_EXCL, SR_MAIN_SHM_PERM);
         umask(um);
         creat = 1;
     }
@@ -1808,7 +1803,7 @@ sr_shmmain_ext_open(sr_shm_t *shm, int zero)
     /* set umask so that the correct permissions are really set */
     um = umask(SR_UMASK);
 
-    shm->fd = shm_open(shm_name, O_RDWR | O_CREAT, SR_MAIN_SHM_PERM);
+    shm->fd = open(shm_name, O_RDWR | O_CREAT, SR_MAIN_SHM_PERM);
     free(shm_name);
     umask(um);
     if (shm->fd == -1) {
@@ -2108,12 +2103,12 @@ sr_shmmain_rpc_subscription_stop(sr_conn_ctx_t *conn, sr_rpc_t *shm_rpc, const c
             mod_name = sr_get_first_ns(op_path);
 
             /* delete the SHM file itself so that there is no leftover event */
-            err_info = sr_path_sub_shm(mod_name, "rpc", sr_str_hash(op_path), 0, &path);
+            err_info = sr_path_sub_shm(mod_name, "rpc", sr_str_hash(op_path), &path);
             free(mod_name);
             if (err_info) {
                 break;
             }
-            if (shm_unlink(path) == -1) {
+            if (unlink(path) == -1) {
                 SR_LOG_WRN("Failed to unlink SHM \"%s\" (%s).", path, strerror(errno));
             }
             free(path);
@@ -2269,7 +2264,7 @@ sr_shmmain_check_data_files(sr_conn_ctx_t *conn)
 
         if (cur_owner || cur_group || cur_perm) {
             /* set correct values on the file */
-            if ((err_info = sr_path_ds_shm(mod_name, SR_DS_RUNNING, 1, &path))) {
+            if ((err_info = sr_path_ds_shm(mod_name, SR_DS_RUNNING, &path))) {
                 goto error;
             }
             err_info = sr_chmodown(path, cur_owner, cur_group, cur_perm);
@@ -2282,7 +2277,7 @@ sr_shmmain_check_data_files(sr_conn_ctx_t *conn)
         /*
          * operational file, may not exist
          */
-        if ((err_info = sr_path_ds_shm(mod_name, SR_DS_OPERATIONAL, 1, &path))) {
+        if ((err_info = sr_path_ds_shm(mod_name, SR_DS_OPERATIONAL, &path))) {
             goto error;
         }
         exists = sr_file_exists(path);
@@ -2318,7 +2313,7 @@ sr_shmmain_check_data_files(sr_conn_ctx_t *conn)
 
         if (cur_owner || cur_group || cur_perm) {
             /* set correct values on the file */
-            if ((err_info = sr_path_ds_shm(mod_name, SR_DS_OPERATIONAL, 1, &path))) {
+            if ((err_info = sr_path_ds_shm(mod_name, SR_DS_OPERATIONAL, &path))) {
                 goto error;
             }
             err_info = sr_chmodown(path, cur_owner, cur_group, cur_perm);

--- a/src/shm_main.c
+++ b/src/shm_main.c
@@ -723,7 +723,7 @@ sr_shmmain_createlock_open(int *shm_lock)
     /* set umask so that the correct permissions are really set */
     um = umask(SR_UMASK);
 
-    *shm_lock = open(path, O_RDWR | O_CREAT, SR_MAIN_SHM_PERM);
+    *shm_lock = SR_OPEN(path, O_RDWR | O_CREAT, SR_MAIN_SHM_PERM);
     free(path);
     umask(um);
     if (*shm_lock == -1) {
@@ -1726,7 +1726,7 @@ sr_shmmain_main_open(sr_shm_t *shm, int *created)
     }
 
     /* try to open the shared memory */
-    shm->fd = open(shm_name, O_RDWR, SR_MAIN_SHM_PERM);
+    shm->fd = SR_OPEN(shm_name, O_RDWR, SR_MAIN_SHM_PERM);
     if ((shm->fd == -1) && (errno == ENOENT)) {
         if (!created) {
             /* we do not want to create the memory now */
@@ -1738,7 +1738,7 @@ sr_shmmain_main_open(sr_shm_t *shm, int *created)
         um = umask(SR_UMASK);
 
         /* create shared memory */
-        shm->fd = open(shm_name, O_RDWR | O_CREAT | O_EXCL, SR_MAIN_SHM_PERM);
+        shm->fd = SR_OPEN(shm_name, O_RDWR | O_CREAT | O_EXCL, SR_MAIN_SHM_PERM);
         umask(um);
         creat = 1;
     }
@@ -1803,7 +1803,7 @@ sr_shmmain_ext_open(sr_shm_t *shm, int zero)
     /* set umask so that the correct permissions are really set */
     um = umask(SR_UMASK);
 
-    shm->fd = open(shm_name, O_RDWR | O_CREAT, SR_MAIN_SHM_PERM);
+    shm->fd = SR_OPEN(shm_name, O_RDWR | O_CREAT, SR_MAIN_SHM_PERM);
     free(shm_name);
     umask(um);
     if (shm->fd == -1) {

--- a/src/shm_mod.c
+++ b/src/shm_mod.c
@@ -794,10 +794,10 @@ sr_shmmod_change_subscription_stop(sr_conn_ctx_t *conn, sr_mod_t *shm_mod, const
 
         if (last_removed) {
             /* delete the SHM file itself so that there is no leftover event */
-            if ((err_info = sr_path_sub_shm(mod_name, sr_ds2str(ds), -1, 0, &path))) {
+            if ((err_info = sr_path_sub_shm(mod_name, sr_ds2str(ds), -1, &path))) {
                 break;
             }
-            if (shm_unlink(path) == -1) {
+            if (unlink(path) == -1) {
                 SR_LOG_WRN("Failed to unlink SHM \"%s\" (%s).", path, strerror(errno));
             }
             free(path);
@@ -910,10 +910,10 @@ sr_shmmod_oper_subscription_stop(char *ext_shm_addr, sr_mod_t *shm_mod, const ch
         }
 
         /* delete the SHM file itself so that there is no leftover event */
-        if ((err_info = sr_path_sub_shm(mod_name, "oper", sr_str_hash(xpath), 0, &path))) {
+        if ((err_info = sr_path_sub_shm(mod_name, "oper", sr_str_hash(xpath), &path))) {
             break;
         }
-        if (shm_unlink(path) == -1) {
+        if (unlink(path) == -1) {
             SR_LOG_WRN("Failed to unlink SHM \"%s\" (%s).", path, strerror(errno));
         }
         free(path);
@@ -1001,10 +1001,10 @@ sr_shmmod_notif_subscription_stop(char *ext_shm_addr, sr_mod_t *shm_mod, uint32_
 
         if (last_removed) {
             /* delete the SHM file itself so that there is no leftover event */
-            if ((err_info = sr_path_sub_shm(mod_name, "notif", -1, 0, &path))) {
+            if ((err_info = sr_path_sub_shm(mod_name, "notif", -1, &path))) {
                 break;
             }
-            if (shm_unlink(path) == -1) {
+            if (unlink(path) == -1) {
                 SR_LOG_WRN("Failed to unlink SHM \"%s\" (%s).", path, strerror(errno));
             }
             free(path);
@@ -1040,7 +1040,7 @@ sr_shmmod_oper_stored_del_conn(sr_conn_ctx_t *conn, sr_conn_ctx_t *del_conn, pid
 
         /* check we have permissions to open operational file */
         free(path);
-        if ((err_info = sr_path_ds_shm(mod->ly_mod->name, SR_DS_OPERATIONAL, 1, &path))) {
+        if ((err_info = sr_path_ds_shm(mod->ly_mod->name, SR_DS_OPERATIONAL, &path))) {
             goto cleanup;
         }
         errno = 0;

--- a/src/shm_sub.c
+++ b/src/shm_sub.c
@@ -49,7 +49,7 @@ sr_shmsub_open_map(const char *name, const char *suffix1, int64_t suffix2, sr_sh
     }
 
     /* create/open shared memory */
-    if ((err_info = sr_path_sub_shm(name, suffix1, suffix2, 0, &path))) {
+    if ((err_info = sr_path_sub_shm(name, suffix1, suffix2, &path))) {
         return err_info;
     }
     created = 1;
@@ -57,11 +57,11 @@ sr_shmsub_open_map(const char *name, const char *suffix1, int64_t suffix2, sr_sh
     /* set umask so that the correct permissions are really set */
     um = umask(SR_UMASK);
 
-    shm->fd = shm_open(path, O_RDWR | O_CREAT | O_EXCL, SR_SUB_SHM_PERM);
+    shm->fd = open(path, O_RDWR | O_CREAT | O_EXCL, SR_SUB_SHM_PERM);
     umask(um);
     if ((shm->fd == -1) && (errno == EEXIST)) {
         created = 0;
-        shm->fd = shm_open(path, O_RDWR, SR_SUB_SHM_PERM);
+        shm->fd = open(path, O_RDWR, SR_SUB_SHM_PERM);
     }
     free(path);
     if (shm->fd == -1) {

--- a/src/shm_sub.c
+++ b/src/shm_sub.c
@@ -57,11 +57,11 @@ sr_shmsub_open_map(const char *name, const char *suffix1, int64_t suffix2, sr_sh
     /* set umask so that the correct permissions are really set */
     um = umask(SR_UMASK);
 
-    shm->fd = open(path, O_RDWR | O_CREAT | O_EXCL, SR_SUB_SHM_PERM);
+    shm->fd = SR_OPEN(path, O_RDWR | O_CREAT | O_EXCL, SR_SUB_SHM_PERM);
     umask(um);
     if ((shm->fd == -1) && (errno == EEXIST)) {
         created = 0;
-        shm->fd = open(path, O_RDWR, SR_SUB_SHM_PERM);
+        shm->fd = SR_OPEN(path, O_RDWR, SR_SUB_SHM_PERM);
     }
     free(path);
     if (shm->fd == -1) {
@@ -483,7 +483,7 @@ sr_shmsub_notify_evpipe(uint32_t evpipe_num)
     }
 
     /* open pipe for writing */
-    if ((fd = open(path, O_WRONLY | O_NONBLOCK)) == -1) {
+    if ((fd = SR_OPEN(path, O_WRONLY | O_NONBLOCK, 0)) == -1) {
         sr_errinfo_new(&err_info, SR_ERR_SYS, NULL, "Opening \"%s\" for writing failed (%s).", path, strerror(errno));
         goto cleanup;
     }

--- a/src/sysrepo.c
+++ b/src/sysrepo.c
@@ -3345,7 +3345,7 @@ sr_subs_new(sr_conn_ctx_t *conn, sr_subscr_options_t opts, sr_subscription_ctx_t
 
     /* open it for reading AND writing (just so that there always is a "writer", otherwise it is always ready
      * for reading by select() but returns just EOF on read) */
-    (*subs_p)->evpipe = open(path, O_RDWR | O_NONBLOCK);
+    (*subs_p)->evpipe = SR_OPEN(path, O_RDWR | O_NONBLOCK, 0);
     if ((*subs_p)->evpipe == -1) {
         SR_ERRINFO_SYSERRNO(&err_info, "open");
         goto error;

--- a/src/sysrepo.c
+++ b/src/sysrepo.c
@@ -357,13 +357,13 @@ cleanup:
             if ((tmp_err = sr_path_main_shm(&shm_name))) {
                 sr_errinfo_merge(&err_info, tmp_err);
             } else {
-                shm_unlink(shm_name);
+                unlink(shm_name);
                 free(shm_name);
             }
             if ((tmp_err = sr_path_ext_shm(&shm_name))) {
                 sr_errinfo_merge(&err_info, tmp_err);
             } else {
-                shm_unlink(shm_name);
+                unlink(shm_name);
                 free(shm_name);
             }
         }
@@ -1406,7 +1406,7 @@ sr_set_module_access(sr_conn_ctx_t *conn, const char *module_name, const char *o
     }
 
     /* get running SHM file path */
-    if ((err_info = sr_path_ds_shm(module_name, SR_DS_RUNNING, 1, &path))) {
+    if ((err_info = sr_path_ds_shm(module_name, SR_DS_RUNNING, &path))) {
         goto cleanup_unlock;
     }
 
@@ -1418,7 +1418,7 @@ sr_set_module_access(sr_conn_ctx_t *conn, const char *module_name, const char *o
     }
 
     /* get operational SHM file path */
-    if ((err_info = sr_path_ds_shm(module_name, SR_DS_OPERATIONAL, 1, &path))) {
+    if ((err_info = sr_path_ds_shm(module_name, SR_DS_OPERATIONAL, &path))) {
         goto cleanup_unlock;
     }
 
@@ -2736,7 +2736,7 @@ sr_change_dslock(struct sr_mod_info_s *mod_info, int lock, sr_sid_t sid)
             goto error;
         } else if (lock && (mod_info->ds == SR_DS_CANDIDATE)) {
             /* candidate DS file cannot exist */
-            if ((err_info = sr_path_ds_shm(mod->ly_mod->name, SR_DS_CANDIDATE, 1, &path))) {
+            if ((err_info = sr_path_ds_shm(mod->ly_mod->name, SR_DS_CANDIDATE, &path))) {
                 goto error;
             }
             r = access(path, F_OK);


### PR DESCRIPTION
Convert all shm_open and shm_unlink calls to open() and unlink().  This allows the sysrepo shared-memory directory to be a shared-memory filesystem mounted from "host" to container.  This is the first step towards allowing full cooperative access to sysrepo by multiple containers. 

By using open() and unlink(), all handles to the shared memory objects (main/ext files, subscriptions, etc) can all use absolute path references.

A quick look at the glibc implementations of shm_open and shm_unlink show a couple notable differences, all of which I believe don't impact sysrepo:
- shm_open adds the O_NOFOLLOw flag to the open() call.  This flag causes a failure if the opened "file" is a symbolic link.  None of the sysrepo files in shared memory are (as far as I can tell) symbolic links.
- shm_open adds the O_CLOEXEC flag to the open() call.  This flag closes the file descriptor across execve system calls (forked child process).  Running "nm" on the libsysrepo and libyang libraries does not reveal any exec* calls.
- shm_open searches the filesystem for a shared memory mount point.  The search starts at /dev/shm then moves on to mounts in /proc/mounts or /etc/fstab. For sysrepo the mount point is specified in common.h.in, so the search in this case is not beneficial.
- shm_open verifies the filesystem is a shared memory filesystem by checking the superblock "magic" number (for SHMFS or TMPFS).  This validation will be lost by this change-set, but the #define in common.h.in is set to /dev/shm which should always be a shared memory filesystem.
- shm_unlink() performs the same filesystem search as shm_open to locate the path, but is otherwise just a passthrough to unlink().

Please let me know if you have any questions or if anything needs to be re-worked.  Other changes for allowing access across container boundaries will be pushed "soon".
Thanks!