### PR TITLE
Do not let SR_SUBSCR_DONE_ONLY mask out SR_EV_ENABLED events

### DIFF
--- a/src/sysrepo.c
+++ b/src/sysrepo.c
@@ -3260,7 +3260,7 @@ sr_module_change_subscribe_running_enable(sr_session_ctx_t *session, const struc
     tmp_sess.ds = SR_DS_RUNNING;
     tmp_sess.dt[tmp_sess.ds].diff = enabled_data;
 
-    if (!(opts & SR_SUBSCR_DONE_ONLY)) {
+    if (opts & SR_SUBSCR_ENABLED) {
         tmp_sess.ev = SR_SUB_EV_ENABLED;
         SR_LOG_INF("Triggering \"%s\" \"%s\" event on enabled data.", ly_mod->name, sr_ev2str(tmp_sess.ev));
 

--- a/tests/test_operational.c
+++ b/tests/test_operational.c
@@ -814,7 +814,7 @@ test_enabled_partial(void **state)
 
     called = 0;
     ret = sr_module_change_subscribe(st->sess, "ietf-interfaces", "/ietf-interfaces:interfaces/interface[name='eth128']",
-            enabled_change_cb, &called, 0, SR_SUBSCR_ENABLED, &subscr);
+            enabled_change_cb, &called, 0, SR_SUBSCR_ENABLED | SR_SUBSCR_DONE_ONLY, &subscr);
     assert_int_equal(ret, SR_ERR_OK);
     assert_int_equal(called, 2);
 


### PR DESCRIPTION
The `SR_SUBSCR_DONE_ONLY` event is documented to control whether `SR_EV_CHANGE`/`SR_EV_ABORT` are sent. Since the rewrite, it used to also skip generating the initial `SR_EV_ENABLED` as well. That's surely a mistake because that one is supposed to be gated by the `SR_EV_ENABLED` flag.

Fixes: f36f312e ("sysrepo CHANGE add special enabled event")