### PR TITLE
travis FEATURE add sanitizer test job

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,22 +7,32 @@ matrix:
             dist: bionic
             sudo: required
             compiler: gcc
+            env: SANITIZE="OFF"
         -   os: linux
             dist: bionic
             sudo: required
             compiler: clang
+            env: SANITIZE="OFF"
+        -   os: linux
+            dist: bionic
+            sudo: required
+            compiler: clang
+            env: SANITIZE="ON"
         -   os: linux
             arch: arm64
             dist: bionic
             sudo: required
             compiler: gcc
+            env: SANITIZE="OFF"
         -   os: linux
             arch: ppc64le
             dist: bionic
             sudo: required
             compiler: gcc
+            env: SANITIZE="OFF"
         -   os: osx
             compiler: gcc
+            env: SANITIZE="OFF"
     allow_failures:
         -   os: osx
 
@@ -33,9 +43,10 @@ before_install:
   - if [ "$TRAVIS_OS_NAME" = "osx" ]; then sh deploy/travis/install-libs-osx.sh; fi
 
 script:
-  - if [ "$TRAVIS_OS_NAME" = "linux" -a "$TRAVIS_CPU_ARCH" = "amd64" ]; then mkdir build ; cd build ; cmake -DCMAKE_BUILD_TYPE=Debug -DCMAKE_PREFIX_PATH=$HOME/local -DCMAKE_C_FLAGS="-Werror -coverage" -DGEN_LANGUAGE_BINDINGS=ON .. && make -j2; fi
-  - if [ "$TRAVIS_OS_NAME" = "linux" -a "$TRAVIS_CPU_ARCH" != "amd64" ]; then mkdir build ; cd build ; cmake -DCMAKE_BUILD_TYPE=Debug -DCMAKE_PREFIX_PATH=$HOME/local -DGEN_LANGUAGE_BINDINGS=ON -DENABLE_VALGRIND_TESTS=OFF .. && make -j2; fi
-  - if [ "$TRAVIS_OS_NAME" = "osx" ]; then mkdir build ; cd build ; cmake -DCMAKE_BUILD_TYPE=Debug -DCMAKE_PREFIX_PATH=$HOME/local .. && make -j2; fi
+  - if [ "$TRAVIS_OS_NAME" = "linux" -a "$TRAVIS_CPU_ARCH" = "amd64" -a "$SANITIZE" = "OFF" ]; then mkdir build ; cd build ; cmake -DCMAKE_BUILD_TYPE=Debug -DCMAKE_PREFIX_PATH=$HOME/local -DCMAKE_C_FLAGS="-Werror -coverage" -DGEN_LANGUAGE_BINDINGS=ON .. && make -j2; fi
+  - if [ "$TRAVIS_OS_NAME" = "linux" -a "$TRAVIS_CPU_ARCH" != "amd64" -a "$SANITIZE" = "OFF" ]; then mkdir build ; cd build ; cmake -DCMAKE_BUILD_TYPE=Debug -DCMAKE_PREFIX_PATH=$HOME/local -DGEN_LANGUAGE_BINDINGS=ON -DENABLE_VALGRIND_TESTS=OFF .. && make -j2; fi
+  - if [ "$TRAVIS_OS_NAME" = "osx" -a "$SANITIZE" = "OFF" ]; then mkdir build ; cd build ; cmake -DCMAKE_BUILD_TYPE=Debug -DCMAKE_PREFIX_PATH=$HOME/local .. && make -j2; fi
+  - if [ "$SANITIZE" = "ON" ]; then mkdir build ; cd build ; cmake -DCMAKE_BUILD_TYPE=Debug -DCMAKE_PREFIX_PATH=$HOME/local -DCMAKE_C_FLAGS="-fsanitize=address,undefined" -DENABLE_VALGRIND_TESTS=OFF .. && make -j2; fi
   - ctest --output-on-failure
   - sudo make install
 


### PR DESCRIPTION
Hello,

this adds a Travis CI job to run unit tests with address and undefined behaviour sanitizers enabled.

It is based on the sanitizer job patch that was added to [libyang](https://github.com/CESNET/libyang/pull/1261). Valgrind tests are disabled when sysrepo is built with sanitizers. As the jobs are defined via the job matrix, and a single script is used, I've had to enable sanitizer tests with an ENV variable. If there is a better way to do that please let me know, and I will change the patch.

Thanks,
Juraj