### PR TITLE
Qualify lock directory with repository prefix

### DIFF
--- a/src/common.c
+++ b/src/common.c
@@ -1673,6 +1673,25 @@ sr_path_yang_file(const char *mod_name, const char *mod_rev, char **path)
     return err_info;
 }
 
+sr_error_info_t *
+sr_path_conn_lockfile(sr_cid_t cid, char **path)
+{
+    sr_error_info_t *err_info = NULL;
+    const char *prefix;
+
+    err_info = sr_shm_prefix(&prefix);
+    if (err_info) {
+        return err_info;
+    }
+
+    if (cid == 0) {
+        asprintf(path, "%s/%s%s", SR_SHM_DIR, prefix, SR_CONN_LOCK_DIR);
+    } else {
+        asprintf(path, "%s/%s%s/conn_%"PRIu32".lock", SR_SHM_DIR, prefix, SR_CONN_LOCK_DIR, cid);
+    }
+    return NULL;
+}
+
 void
 sr_remove_evpipes(void)
 {

--- a/src/common.h.in
+++ b/src/common.h.in
@@ -827,6 +827,18 @@ sr_error_info_t *sr_path_notif_file(const char *mod_name, time_t from_ts, time_t
 sr_error_info_t *sr_path_yang_file(const char *mod_name, const char *mod_rev, char **path);
 
 /**
+ * @brief Populate the lockfile path for a given Connection ID.
+ * When called with cid of 0 the path will be set to the lock file directory
+ * path. The path parameter is set to newly allocated memory. Caller is
+ * responsible for freeing memory.
+ *
+ * @param[in] cid Connection ID for which the lockfile path is constructed.
+ * @param[out] path Lockfile directory if cid is 0, path of lockfile otherwise.
+ * @return err_info, NULL on success.
+ */
+sr_error_info_t *sr_path_conn_lockfile(sr_cid_t cid, char **path);
+
+/**
  * @brief Remove any leftover event pipes after crashed subscriptions.
  */
 void sr_remove_evpipes(void);


### PR DESCRIPTION
Bug Fix: Qualify connection lock directory with prefix for unique locks per sysrepo instance.

The environment variable SYSREPO_SHM_PREFIX can be used to create unique instances of the sysrepo repository. The lock directory (and thus lockfiles) should be qualified by this prefix.

The calculation of lock file path is moved to common.c so that it is co-located with other file/path calculations.