### PR TITLE
Work around a paranoid kernel protection for sticky-bit directories

### DIFF
--- a/66-sysrepo-disable-fs-protected_regular.conf
+++ b/66-sysrepo-disable-fs-protected_regular.conf
@@ -1,0 +1,4 @@
+# Make sure that systemd's and kernel's settings still allow other users to
+# access sysrepo SHM files
+# Bug: https://github.com/sysrepo/sysrepo/issues/2080
+fs.protected_regular = 0

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -284,6 +284,8 @@ install(TARGETS sysrepoctl sysrepocfg sysrepo-plugind DESTINATION ${CMAKE_INSTAL
 
 install(FILES "${PROJECT_BINARY_DIR}/sysrepo.pc" DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig")
 
+install(FILES "${PROJECT_SOURCE_DIR}/66-sysrepo-disable-fs-protected_regular.conf" DESTINATION "${CMAKE_INSTALL_PREFIX}/lib/sysctl.d/")
+
 # examples
 if(BUILD_EXAMPLES)
     add_subdirectory(examples)


### PR DESCRIPTION
Since the Linux kernel 4.19+ and systemd v241, there's a new sysctl knob which prevents users from overwriting "someone else's files" that are located in world-writable directories with the sticky bit set. That goes directly against sysrepo's permission model (which might become irrelevant anyway because it sits in parallel to the NACM).

When this change was made upstream, they cited a list of CVEs which are supposed to be preventable via that change. I believe that it turns out that all of them are actually *other*, serious bugs, but I acknowledge that it's true that `fs.protected_regular = 1` can indeed help against something stupid like `exec /tmp/install.sh`:

- CVE-2000-1134: Insecure file creation under /tmp.
- CVE-2007-3852: Insecure file creation of /tmp/sysstat.run.
- CVE-2008-0525: Symlinks below /tmp.
- CVE-2009-0416: Symlinks below /var/tmp.
- CVE-2011-4834: Symlink attack, and then content spoofing via a FIFO.
- CVE-2015-1838: Download & execute /tmp/install.sh.
- CVE-2015-7442: Insecure file creation in /tmp.
- CVE-2016-7489: Insecure file creation in /tmp.

Looking at that list, I still think that the upstream decision is nonsense, but hey, I've been postponing that mail to linux-fsdevel for four months already, so let's solve this within sysrepo. Just provide a drop-in file for systemd to undo this nonsensical (IMHO, anyway) policy change.

Bug: https://github.com/sysrepo/sysrepo/issues/2080
Cc: @syyyr @peckato1