### PR TITLE
Update doc on subscriptions

### DIFF
--- a/doc/subs.dox
+++ b/doc/subs.dox
@@ -21,6 +21,12 @@ These are the most common kinds of subscriptions. A callback can be set to be ca
 changes occur so that it can appropriately react and adjust the system or whatever it manages accordingly. There can
 be many subscribers for the same data and arbitrary XPath filters can be applied.
 
+Any datastore can be subscribed to (startup, running and operational). The datastore is determined by the current
+datastore at the time of subscription (that is, the call to @ref sr_module_change_subscribe). Changing the active
+datastore after that does not have an effect on subscriptions that have already been made. For example, it is possible
+to subscribe to running datastore, switch to the startup datastore, subscribe to it, and then switch back to edit the
+running datastore all with one session and one subscription context.
+
 On changes, the callback is called with an event. By default, there are always 2 events following one after
 the other. On _change_, the new datastore content is prepared but not written yet and so the changes can be refused
 for any reason. If they are not, the changes are committed and hence visible for any subsequent operations. Right


### PR DESCRIPTION
Hi, I did a small research on creating subscriptions and found out that it is possible to subscribe to different types of datastores with just one session and context. So, this patch updates the doc to explain how it works.

Also, feel free to update my patch, if you don't like the wording or if it's wrong. Thanks.

These are the tests I made:
```cpp
#include <fmt/core.h>
#include <iostream>
#include <sysrepo-cpp/Session.hpp>
#include <unistd.h>

auto dsToString = [] (auto ds) {
    switch (ds) {
        case SR_DS_STARTUP: return "startup";
        case SR_DS_RUNNING: return "running";
        case SR_DS_CANDIDATE: return "candidate";
        case SR_DS_OPERATIONAL: return "operational";
    }
};

auto createExpectedCallback = [] (auto expected) {

    return [expected] (sysrepo::S_Session sess, const char *, const char *,
            sr_event_t, uint32_t) {

        fmt::print("  expected {} got {}\n", expected, dsToString(sess->session_get_ds()));

        return SR_ERR_OK;
    };

};

auto reset_value()
{
    auto conn = std::make_shared<sysrepo::Connection>();
    auto sess = std::make_shared<sysrepo::Session>(conn);
    sess->delete_item("/example-schema:leafInt32");
    sess->apply_changes(1000, 1);
    sess->session_switch_ds(SR_DS_STARTUP);
    sess->delete_item("/example-schema:leafInt32");
    sess->apply_changes(1000, 1);
}

auto set_value_running()
{
    std::cout << "setting running\n";
    auto conn = std::make_shared<sysrepo::Connection>();
    auto sess = std::make_shared<sysrepo::Session>(conn);
    sess->set_item_str("/example-schema:leafInt32", "1");
    sess->apply_changes(1000, 1);
}

auto set_value_startup()
{
    std::cout << "setting startup\n";
    auto conn = std::make_shared<sysrepo::Connection>();
    auto sess = std::make_shared<sysrepo::Session>(conn, SR_DS_STARTUP);
    sess->set_item_str("/example-schema:leafInt32", "1");
    sess->apply_changes(1000, 1);
}


int main(void)
{
    // TEST 1:
    // 1) create a sysrepo::Subscribe when DS is running
    // 2) switch datastore to startup
    // 3) create a sysrepo::Subscribe when DS is startup
    // 4) sub with the first Subscribe
    // 5) sub with the second Subscribe
    {
        reset_value();

        auto conn = std::make_shared<sysrepo::Connection>();
        auto sess = std::make_shared<sysrepo::Session>(conn);
        auto sub = std::make_shared<sysrepo::Subscribe>(sess);
        sess->session_switch_ds(SR_DS_STARTUP);
        auto subStartup = std::make_shared<sysrepo::Subscribe>(sess);
        sub->module_change_subscribe("example-schema", createExpectedCallback("running"), "/example-schema:leafInt32", 0, SR_SUBSCR_DONE_ONLY);
        subStartup->module_change_subscribe("example-schema", createExpectedCallback("startup"), "/example-schema:leafInt32", 0, SR_SUBSCR_DONE_ONLY);

        set_value_running();
        set_value_startup();
    }
    // RESULT:
    // Doesn't work, because sysrepo::Subscribe is empty upon creation and only holds a `session` variable. If you
    // change the datastore, both `sub` and `subStartup` change. So, both these callbacks subbed to the startup
    // datastore.

    // TEST 2:
    // 1) create a sysrepo::Subscribe when DS is running
    // 4) sub with the first Subscribe
    // 2) switch datastore to startup
    // 3) create a sysrepo::Subscribe when DS is startup
    // 5) sub with the second Subscribe
    {
        reset_value();

        auto conn = std::make_shared<sysrepo::Connection>();
        auto sess = std::make_shared<sysrepo::Session>(conn);
        auto sub = std::make_shared<sysrepo::Subscribe>(sess);
        sub->module_change_subscribe("example-schema", createExpectedCallback("running"), "/example-schema:leafInt32", 0, SR_SUBSCR_DONE_ONLY);
        sess->session_switch_ds(SR_DS_STARTUP);
        auto subStartup = std::make_shared<sysrepo::Subscribe>(sess);
        subStartup->module_change_subscribe("example-schema", createExpectedCallback("startup"), "/example-schema:leafInt32", 0, SR_SUBSCR_DONE_ONLY);

        set_value_running();
        set_value_startup();
    }
    // RESULT:
    // Works as one would think (more like `could`, it's not documented). The first sub is to the running DS and the
    // second one is to the startup DS.

    // TEST 3:
    // 1) create two sysrepo::Subscribe at the same time when DS is running
    // 2) sub with the first one
    // 3) switch datastore to startup
    // 4) sub with the second one
    {
        reset_value();

        auto conn = std::make_shared<sysrepo::Connection>();
        auto sess = std::make_shared<sysrepo::Session>(conn);
        auto sub = std::make_shared<sysrepo::Subscribe>(sess);
        auto subStartup = std::make_shared<sysrepo::Subscribe>(sess);
        sub->module_change_subscribe("example-schema", createExpectedCallback("running"), "/example-schema:leafInt32", 0, SR_SUBSCR_DONE_ONLY);
        sess->session_switch_ds(SR_DS_STARTUP);
        subStartup->module_change_subscribe("example-schema", createExpectedCallback("startup"), "/example-schema:leafInt32", 0, SR_SUBSCR_DONE_ONLY);

        set_value_running();
        set_value_startup();
    }
    // RESULT:
    // Works as "expected". This pretty much makes sense. This isn't too different from TEST 2. The creation of
    // sysrepo::Subscribe doesn't matter because it doesn't do anything by itself.

    // TEST 4:
    // 1) create a sysrepo::Subscribe when DS is running
    // 2) sub with it
    // 3) change datastore to startup
    // 4) sub again with the same sysrepo::Subscribe
    //
    {
        reset_value();

        auto conn = std::make_shared<sysrepo::Connection>();
        auto sess = std::make_shared<sysrepo::Session>(conn);
        auto sub = std::make_shared<sysrepo::Subscribe>(sess);
        sub->module_change_subscribe("example-schema", createExpectedCallback("running"), "/example-schema:leafInt32", 0, SR_SUBSCR_DONE_ONLY);
        sess->session_switch_ds(SR_DS_STARTUP);
        sub->module_change_subscribe("example-schema", createExpectedCallback("startup"), "/example-schema:leafInt32", 0, SR_SUBSCR_DONE_ONLY);

        set_value_running();
        set_value_startup();
    }
    // RESULT:
    // Works as expected.

    // TEST 5:
    // 1) do the same as TEST 4
    // 2) switch datastore back to running
    {
        reset_value();

        auto conn = std::make_shared<sysrepo::Connection>();
        auto sess = std::make_shared<sysrepo::Session>(conn);
        auto sub = std::make_shared<sysrepo::Subscribe>(sess);
        sub->module_change_subscribe("example-schema", createExpectedCallback("running"), "/example-schema:leafInt32", 0, SR_SUBSCR_DONE_ONLY);
        sess->session_switch_ds(SR_DS_STARTUP);
        sub->module_change_subscribe("example-schema", createExpectedCallback("startup"), "/example-schema:leafInt32", 0, SR_SUBSCR_DONE_ONLY);
        sess->session_switch_ds(SR_DS_RUNNING);

        set_value_running();
        set_value_startup();
    }
    // RESULT:
    // Works the same as TEST 4.
    //
    //
    // CONCLUSIONS:
    // 1) The point where you create the sysrepo::Subscribe doesn't matter because it is empty by default. Only the
    // calls to the subscribe methods matter. So, creating multiple sysrepo::Subscribe objects isn't necessary.
    //
    // 2) Changing the datastore DOESN'T affect previous subscriptions and it DOES affect new subscriptions.
    //
    // 3) The subscriptions do remember current datastore at the time of subscribing.
    //
    // 4) It is possible to use the same Session and Subscribe even if subscribing to different datastores.
    return 0;
}
```