### PR TITLE
Fix operational-data behavior on choice/uses

### DIFF
--- a/src/common.c
+++ b/src/common.c
@@ -4206,6 +4206,7 @@ sr_lyd_cont_has_meaning(const struct lys_node *snode, const struct lyd_node *sib
 {
     const struct lys_node *schild;
     struct lyd_node *node;
+    struct lys_node *parent;
 
     assert(snode->nodetype == LYS_CONTAINER);
 
@@ -4214,12 +4215,18 @@ sr_lyd_cont_has_meaning(const struct lys_node *snode, const struct lyd_node *sib
         return 1;
     }
 
-    assert(!lys_parent(snode) || (lys_parent(snode)->nodetype != LYS_CHOICE));
-    if (lys_parent(snode) && (lys_parent(snode)->nodetype == LYS_CASE)) {
+    parent = lys_parent(snode);
+    assert(!parent || parent->nodetype != LYS_CHOICE);
+
+    if (parent && parent->nodetype == LYS_USES) {
+        parent = lys_parent(parent);
+    }
+
+    if (parent && parent->nodetype == LYS_CASE) {
         /* container is in a case and in case no other nodes from the case exist, it would carry
          * meaning of selecting the case */
         schild = NULL;
-        while ((schild = lys_getnext(schild, lys_parent(snode), NULL, 0))) {
+        while ((schild = lys_getnext(schild, parent, NULL, 0))) {
             if (schild == snode) {
                 continue;
             }


### PR DESCRIPTION
This PR fixes undefined behavior when an operational data callback returns data for a module containing a "choice" with nodes pulled in via "uses".

The attached test module has two containers with the same structure of operational data, one modeled with choice/case and one without, using groupings. The callback in the attached source file returns data for each case in sequence.

When running the test code against oper-data-direct (`oper_data_example oper-group-test /oper-group-test:oper-data-direct`), the following output is given:
```
$ sysrepocfg -fxml  --export -doperational -x /oper-group-test:oper-data-direct
<oper-data-direct xmlns="http://example.org/oper-group-test">
  <results-description>Grouping 1 values</results-description>
  <g1container>
    <g1leaf1>value2</g1leaf1>
  </g1container>
</oper-data-direct>
$ sysrepocfg -fxml  --export -doperational -x /oper-group-test:oper-data-direct
<oper-data-direct xmlns="http://example.org/oper-group-test">
  <results-description>Grouping 2 values</results-description>
  <g2container>
    <g2leaf1>value3</g2leaf1>
  </g2container>
</oper-data-direct>
$ sysrepocfg -fxml  --export -doperational -x /oper-group-test:oper-data-direct
<oper-data-direct xmlns="http://example.org/oper-group-test">
  <results-description>Non-grouping values</results-description>
  <nongroup>value4</nongroup>
</oper-data-direct>
$ 
```

When running against oper-data-choice (`oper_data_example oper-group-test /oper-group-test:oper-data-choice`):
```
$ sysrepocfg -fxml  --export -doperational -x /oper-group-test:oper-data-choice
<oper-data-choice xmlns="http://example.org/oper-group-test">
  <results-description>Grouping 1 values</results-description>
  <g2container/>
</oper-data-choice>
$ sysrepocfg -fxml  --export -doperational -x /oper-group-test:oper-data-choice
<oper-data-choice xmlns="http://example.org/oper-group-test">
  <results-description>Grouping 2 values</results-description>
  <g2container/>
</oper-data-choice>
$ sysrepocfg -fxml  --export -doperational -x /oper-group-test:oper-data-choice
<oper-data-choice xmlns="http://example.org/oper-group-test">
  <results-description>Non-grouping values</results-description>
  <g2container/>
</oper-data-choice>
$
```

The desired operation is for the results of oper-data-choice to be like oper-data-direct.
Credit to wdabbs@vcinity.io

[oper_group_test.zip](https://github.com/sysrepo/sysrepo/files/6288074/oper_group_test.zip)

