### PR TITLE
Do no routinely emit "info" messages

### DIFF
--- a/src/shm_sub.c
+++ b/src/shm_sub.c
@@ -529,7 +529,7 @@ sr_shmsub_multi_notify_write_event(sr_multi_sub_shm_t *multi_sub_shm, uint32_t r
     }
 
     if (event) {
-        SR_LOG_INF("Published event \"%s\" \"%s\" with ID %u priority %u for %u subscribers.", sr_ev2str(event),
+        SR_LOG_DBG("Published event \"%s\" \"%s\" with ID %u priority %u for %u subscribers.", sr_ev2str(event),
                 event_desc, request_id, priority, subscriber_count);
     }
     return NULL;

--- a/src/sysrepo.c
+++ b/src/sysrepo.c
@@ -1949,7 +1949,7 @@ sr_changes_notify_store(struct sr_mod_info_s *mod_info, sr_session_ctx_t *sessio
     *cb_err_info = NULL;
 
     if (!mod_info->diff) {
-        SR_LOG_INF("No datastore changes to apply.");
+        SR_LOG_DBG("No datastore changes to apply.");
         goto cleanup;
     }
 
@@ -2015,7 +2015,7 @@ sr_changes_notify_store(struct sr_mod_info_s *mod_info, sr_session_ctx_t *sessio
 
     if (!mod_info->diff) {
         /* diff can disappear after validation */
-        SR_LOG_INF("No datastore changes to apply.");
+        SR_LOG_DBG("No datastore changes to apply.");
         goto cleanup;
     }
 
@@ -2091,7 +2091,7 @@ sr_changes_notify_store(struct sr_mod_info_s *mod_info, sr_session_ctx_t *sessio
     }
 
     if (!mod_info->diff) {
-        SR_LOG_INF("No datastore changes to apply.");
+        SR_LOG_DBG("No datastore changes to apply.");
         goto cleanup_unlock;
     }
 


### PR DESCRIPTION
Our devices push operational data into sysrepo periodically, often several times a second. Here's how a log usually looks like on a production box:
```
May 16 15:56:07 line-qr79 sysrepo[459]: Published event "done" "czechlight-roadm-device" with ID 891 priority 0 for 1 subscribers.
May 16 15:56:07 line-qr79 sysrepo[459]: Published event "done" "czechlight-roadm-device" with ID 892 priority 0 for 1 subscribers.
May 16 15:56:07 line-qr79 sysrepo[459]: Published event "done" "czechlight-roadm-device" with ID 893 priority 0 for 1 subscribers.
May 16 15:56:08 line-qr79 sysrepo[459]: No datastore changes to apply.
May 16 15:56:09 line-qr79 sysrepo[459]: Published event "done" "czechlight-roadm-device" with ID 894 priority 0 for 1 subscribers.
May 16 15:56:09 line-qr79 sysrepo[459]: No datastore changes to apply.
May 16 15:56:10 line-qr79 sysrepo[459]: Published event "done" "czechlight-roadm-device" with ID 895 priority 0 for 1 subscribers.
May 16 15:56:10 line-qr79 sysrepo[459]: Published event "done" "czechlight-roadm-device" with ID 896 priority 0 for 1 subscribers.
May 16 15:56:10 line-qr79 sysrepo[459]: Published event "done" "czechlight-roadm-device" with ID 897 priority 0 for 1 subscribers.
```
These are produced via the sysrepo library and stored via our application code because of the `info` message severity.

Reduce the log verbosity a bit down to `debug` for those debugging messages.