### PR TITLE
cmake BUGFIX don't install ${LIB_HEADERS} in /usr/include

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -308,7 +308,7 @@ configure_file("${PROJECT_SOURCE_DIR}/sysrepo.pc.in" "${PROJECT_BINARY_DIR}/sysr
 
 # installation
 install(TARGETS sysrepo DESTINATION ${CMAKE_INSTALL_LIBDIR})
-install(FILES ${LIB_HEADERS} ${PROJECT_SOURCE_DIR}/src/sysrepo.h ${PROJECT_SOURCE_DIR}/src/sysrepo_types.h
+install(FILES ${PROJECT_SOURCE_DIR}/src/sysrepo.h ${PROJECT_SOURCE_DIR}/src/sysrepo_types.h
         DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
 install(FILES ${PROJECT_BINARY_DIR}/version.h ${PROJECT_SOURCE_DIR}/src/utils/values.h ${PROJECT_SOURCE_DIR}/src/utils/xpath.h
         DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/sysrepo)


### PR DESCRIPTION
* This shouldn't be installed there as `values.h` causes file collision with
  glibc, and we are already installing `sysrepo.h` and `sysrepo_types.h`
  in `/usr/include` anyway, so let's just remove it from the install
  command

Signed-off-by: Jakov Smolic <jakov.smolic@sartura.hr>