### PR TITLE
BUGFIX: Correct permissions check when mode_t is uint16_t.

### DIFF
--- a/src/common.c
+++ b/src/common.c
@@ -2309,7 +2309,7 @@ sr_chmodown(const char *path, const char *owner, const char *group, mode_t perm)
 
     assert(path);
 
-    if ((int)perm != -1) {
+    if (perm != (mode_t)(-1)) {
         if (perm > 00777) {
             sr_errinfo_new(&err_info, SR_ERR_INVAL_ARG, "Invalid permissions 0%.3o.", perm);
             return err_info;
@@ -2341,7 +2341,7 @@ sr_chmodown(const char *path, const char *owner, const char *group, mode_t perm)
     }
 
     /* apply permission changes, if any */
-    if (((int)perm != -1) && (chmod(path, perm) == -1)) {
+    if ((perm != (mode_t)(-1)) && (chmod(path, perm) == -1)) {
         if ((errno == EACCES) || (errno == EPERM)) {
             err_code = SR_ERR_UNAUTHORIZED;
         } else {

--- a/src/executables/sysrepoctl.c
+++ b/src/executables/sysrepoctl.c
@@ -603,7 +603,7 @@ main(int argc, char **argv)
                 error_print(0, "Invalid parameter -%c for the operation", opt);
                 goto cleanup;
             }
-            if ((int)perms != -1) {
+            if (perms != (mode_t)(-1)) {
                 error_print(0, "Permissions already specified");
                 goto cleanup;
             }
@@ -693,7 +693,7 @@ main(int argc, char **argv)
         /* change */
 
         /* change owner, group, and/or permissions */
-        if (owner || group || ((int)perms != -1)) {
+        if (owner || group || (perms != (mode_t)(-1))) {
             if (!strcmp(module_name, ":ALL")) {
                 /* all the modules */
                 module_name = NULL;
@@ -789,7 +789,7 @@ main(int argc, char **argv)
     }
 
     /* change permissions for a newly installed/updated module */
-    if (((operation == 'i') || (operation == 'U')) && (owner || group || ((int)perms != -1))) {
+    if (((operation == 'i') || (operation == 'U')) && (owner || group || (perms != (mode_t)(-1)))) {
         if ((r = sr_set_module_access(conn, inst_module_name, owner, group, perms)) != SR_ERR_OK) {
             error_print(r, "Failed to change module \"%s\" access", inst_module_name);
             goto cleanup;


### PR DESCRIPTION

Currently permissions (of type mode_t) are initialized with (mode_t)-1 and then 
(int)perms checked against -1. Unfortunately, when mode_t is defined as uint16_t 
(FreeBSD 11), perms became 65535, and (int)65535 never equals -1.