### PR TITLE
update _XOPEN_SOURCE to 600 in rpc_subscribe_example.c

### DIFF
--- a/examples/rpc_subscribe_example.c
+++ b/examples/rpc_subscribe_example.c
@@ -13,7 +13,6 @@
  *     https://opensource.org/licenses/BSD-3-Clause
  */
 #define _GNU_SOURCE
-#define _XOPEN_SOURCE 600
 
 #include <inttypes.h>
 #include <signal.h>

--- a/examples/rpc_subscribe_example.c
+++ b/examples/rpc_subscribe_example.c
@@ -13,7 +13,7 @@
  *     https://opensource.org/licenses/BSD-3-Clause
  */
 #define _GNU_SOURCE
-#define _XOPEN_SOURCE 500
+#define _XOPEN_SOURCE 600
 
 #include <inttypes.h>
 #include <signal.h>


### PR DESCRIPTION
This pull fixes following build failure on FreeBSD 11:
```
In file included from /home/snar/compile/sysrepo/examples/rpc_subscribe_example.c:25:
In file included from /usr/local/include/libyang/libyang.h:24:
In file included from /usr/local/include/libyang/context.h:22:
/usr/local/include/libyang/tree_data.h:644:21: error: field has incomplete type 'struct in6_addr'
    struct in6_addr addr;   /**< IPv6 address in binary */
                    ^
/usr/local/include/libyang/tree_data.h:644:12: note: forward declaration of 'struct in6_addr'
    struct in6_addr addr;   /**< IPv6 address in binary */
           ^
```

Root cause: _XOPEN_SOURCE of 500 leads to _POSIX_C_SOURCE 199506 (cdefs.h):
```
#elif _XOPEN_SOURCE - 0 >= 500
#define __XSI_VISIBLE           500
#undef _POSIX_C_SOURCE
#define _POSIX_C_SOURCE         199506
```
this in turn leads to 
```
#define __POSIX_VISIBLE         198808
```
and this value is too low for <netinet6/in6.h> to be included (netinet/in.h):
```
#if __POSIX_VISIBLE >= 200112
#define __KAME_NETINET_IN_H_INCLUDED_
#include <netinet6/in6.h>
#undef __KAME_NETINET_IN_H_INCLUDED_
#endif
```