### PR TITLE
BUGFIX: build failure on FreeBSD

### DIFF
--- a/tests/test_process.c
+++ b/tests/test_process.c
@@ -14,8 +14,6 @@
  *     https://opensource.org/licenses/BSD-3-Clause
  */
 
-#define _POSIX_C_SOURCE 199309L
-
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>


### PR DESCRIPTION
Setting  _POSIX_C_SOURCE to 199309L removes <netinet6/in6.h> from inclusion,
leading to build failure.