### PR TITLE
Fix undefined behavior

### DIFF
--- a/src/common.c
+++ b/src/common.c
@@ -1652,7 +1652,8 @@ sr_remove_module_file_r(const struct lys_module *ly_mod, const struct ly_ctx *ne
 
     /* remove all submodule files */
     LY_ARRAY_FOR(pmod->includes, u) {
-        if ((err_info = sr_path_yang_file(pmod->includes[u].submodule->name, pmod->includes[u].submodule->revs[0].date,
+        if ((err_info = sr_path_yang_file(pmod->includes[u].submodule->name,
+					pmod->includes[u].submodule->revs ? pmod->includes[u].submodule->revs[0].date : NULL,
                 &path))) {
             return err_info;
         }


### PR DESCRIPTION
The `test_modules` was failing on UBSAN from clang 12 because the code tried to access something through a null pointer:
```
sysrepo/src/common.c:1655:78: runtime error: member access within null pointer of type 'struct lysp_revision'
    #0 0x7f3aa03ef3fd in sr_remove_module_file_r sysrepo/src/common.c:1655:115
    #1 0x7f3aa047887c in sr_lydmods_sched_finalize_module_remove sysrepo/src/lyd_mods.c:1546:25
    #2 0x7f3aa0469deb in sr_lydmods_sched_apply sysrepo/src/lyd_mods.c:2092:41
    #3 0x7f3aa0464900 in sr_lydmods_conn_ctx_update sysrepo/src/lyd_mods.c:2201:33
    #4 0x7f3aa03957c9 in sr_connect sysrepo/src/sysrepo.c:183:21
    #5 0x4fbc3f in setup_f sysrepo/tests/test_modules.c:46:9
    #6 0x7f3aa05c5412 in cmocka_run_one_test_or_fixture (/nix/store/cyxdjbcc9b0c9zm22l65raicv6xd62lb-cmocka-1.1.5/lib/libcmocka.so.0+0x6412)
    #7 0x7f3aa05c5f55 in _cmocka_run_group_tests (/nix/store/cyxdjbcc9b0c9zm22l65raicv6xd62lb-cmocka-1.1.5/lib/libcmocka.so.0+0x6f55)
    #8 0x4fb33d in main sysrepo/tests/test_modules.c:1669:12
    #9 0x7f3a9f4fc77f in __libc_start_main (/nix/store/9bh3986bpragfjmr32gay8p95k91q4gy-glibc-2.33-47/lib/libc.so.6+0x2777f)
    #10 0x420659 in _start /build/glibc-2.33/csu/../sysdeps/x86_64/start.S:120

SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior /home/jkt/work/cesnet/gerrit/github/sysrepo/sysrepo/src/common.c:1655:78 in
```
Due to the way how UBSAN works, this was by default only printed to stderr. Unless one used something like `UBSAN_OPTIONS=print_stacktrace=1:halt_on_error=1`, this was a silent failure.