### PR TITLE
CI: TSAN builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,6 +90,17 @@ jobs:
             ubsan-options: "print_stacktrace=1:halt_on_error=1",
           }
           - {
+            name: "TSAN",
+            os: "ubuntu-20.04",
+            build-type: "Debug",
+            dep-build-type: "Debug",
+            cc: "clang-12",
+            options: "-DCMAKE_C_FLAGS=-fsanitize=thread -DCMAKE_EXE_LINKER_FLAGS=-fsanitize=thread -DCMAKE_SHARED_LINKER_FLAGS=-fsanitize=thread -DENABLE_TESTS=ON -DENABLE_VALGRIND_TESTS=OFF",
+            packages: "libcmocka-dev clang-12",
+            snaps: "",
+            make-target: ""
+          }
+          - {
             name: "ABI Check",
             os: "ubuntu-latest",
             build-type: "ABICheck",


### PR DESCRIPTION
There was an ASAN+UBSAN build job, but it was running on an old clang, and UBSAN failures were being silently ignored. Make sure that we're on the latest & greatest so as not to hit too many compiler errors, and then enforce ASAN+UBSAN. We've been doing a similar thing for the libyang-v1+sysrepo internally, so let's make this available to the wider community. And while we're at that, enable TSAN as well now that the build is clean.

The last commit currently fails due to #2555. Once a fix for that UB is merged, this should start passing. All other commits [pass](https://github.com/jktjkt/sysrepo/commits/830964c26ad73545c1aeb77c34dc5de873196073) (there should be a green tick by all of them, hopefully).