### PR TITLE
CI: ASAN+UBSAN

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,7 +86,8 @@ jobs:
             options: "-DCMAKE_C_FLAGS=-fsanitize=address,undefined -DENABLE_TESTS=ON -DENABLE_VALGRIND_TESTS=OFF",
             packages: "libcmocka-dev clang-12",
             snaps: "",
-            make-target: ""
+            make-target: "",
+            ubsan-options: "print_stacktrace=1:halt_on_error=1",
           }
           - {
             name: "ABI Check",
@@ -99,6 +100,8 @@ jobs:
             snaps: "core universal-ctags",
             make-target: "abi-check"
           }
+    env:
+      UBSAN_OPTIONS: ${{ matrix.config.ubsan-options }}
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,7 +79,7 @@ jobs:
           }
           - {
             name: "ASAN and UBSAN",
-            os: "ubuntu-18.04",
+            os: "ubuntu-20.04",
             build-type: "Debug",
             dep-build-type: "Debug",
             cc: "clang",

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,6 @@ jobs:
             options: "-DENABLE_TESTS=ON",
             packages: "libcmocka-dev",
             snaps: "",
-            make-prepend: "",
             make-target: ""
           }
           - {
@@ -54,7 +53,6 @@ jobs:
             options: "-DENABLE_TESTS=ON",
             packages: "libcmocka-dev",
             snaps: "",
-            make-prepend: "",
             make-target: ""
           }
           - {
@@ -66,7 +64,6 @@ jobs:
             options: "",
             packages: "libcmocka-dev valgrind",
             snaps: "",
-            make-prepend: "",
             make-target: ""
           }
           - {
@@ -78,7 +75,6 @@ jobs:
             options: "",
             packages: "libcmocka-dev valgrind",
             snaps: "",
-            make-prepend: "",
             make-target: ""
           }
           - {
@@ -90,7 +86,6 @@ jobs:
             options: "-DCMAKE_C_FLAGS=-fsanitize=address,undefined -DENABLE_TESTS=ON -DENABLE_VALGRIND_TESTS=OFF",
             packages: "libcmocka-dev",
             snaps: "",
-            make-prepend: "",
             make-target: ""
           }
           - {
@@ -102,7 +97,6 @@ jobs:
             options: "",
             packages: "libcmocka-dev abi-dumper abi-compliance-checker",
             snaps: "core universal-ctags",
-            make-prepend: "",
             make-target: "abi-check"
           }
 
@@ -158,7 +152,7 @@ jobs:
         run: |
           export LC_ALL=C.UTF-8
           export PATH=/snap/bin:${{ github.workspace }}/coverity-tools/bin:$PATH
-          ${{ matrix.config.make-prepend }} make ${{ matrix.config.make-target }}
+          make ${{ matrix.config.make-target }}
 
       - name: Test
         shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,9 +82,9 @@ jobs:
             os: "ubuntu-20.04",
             build-type: "Debug",
             dep-build-type: "Debug",
-            cc: "clang",
+            cc: "clang-12",
             options: "-DCMAKE_C_FLAGS=-fsanitize=address,undefined -DENABLE_TESTS=ON -DENABLE_VALGRIND_TESTS=OFF",
-            packages: "libcmocka-dev",
+            packages: "libcmocka-dev clang-12",
             snaps: "",
             make-target: ""
           }

--- a/.github/workflows/devel-push.yml
+++ b/.github/workflows/devel-push.yml
@@ -27,6 +27,7 @@ jobs:
     name: ${{ matrix.config.name }}
     runs-on: ${{ matrix.config.os }} # mac-OS does not implement robust mutexes so it is not supported
     needs: git-branch
+    if: ${{ github.repository.owner == 'sysrepo' }}
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
A version of #2556 which only implements ASAN+UBSAN, see the other PR for context. TSAN is left due to a possible false positive related to sysrepo's hand-rolled locking.