### PR TITLE
Fix -Wunused-result

### DIFF
--- a/src/plugins/common_lyb.c
+++ b/src/plugins/common_lyb.c
@@ -225,7 +225,7 @@ srlyb_open_error(const char *plg_name, const char *path)
         /* check kernel parameter value of fs.protected_regular */
         f = fopen("/proc/sys/fs/protected_regular", "r");
         if (f) {
-            fgets(buf, 8, f);
+            (void)fgets(buf, sizeof(buf), f);
             fclose(f);
         }
     }


### PR DESCRIPTION
My compiler warns about not checking the `fgets()`'s result. Since this is really an opportunistic check, nothing else, and since this thing can fail on some system configurations, simply silence that warning. The worst thing which can happen is a less useful warning.

Also, don't repeat a magic number (buffer size), use a `sizeof` for this.

Fixes: 39bc5adb9 (plugins FEATURE error message warning kernel param value)