### PR TITLE
Fix UB in srpntf_find_file

### DIFF
--- a/src/plugins/ntf_lyb.c
+++ b/src/plugins/ntf_lyb.c
@@ -312,7 +312,9 @@ srpntf_find_file(const char *mod_name, time_t from_ts, time_t to_ts, time_t *fil
 cleanup:
     free(dir_path);
     free(prefix);
-    closedir(dir);
+    if (dir) {
+        closedir(dir);
+    }
     return rc;
 }
 


### PR DESCRIPTION
ASAN complains that the argument to closedir must non-null. Fixes this kind of error:
```
2021-11-25 03:10:27.636917 | w | /home/ci/src/cesnet-gerrit-public/CzechLight/dependencies/sysrepo/src/plugins/ntf_lyb.c:315:14: runtime error: null pointer passed as argument 1, which is declared to never be null
2021-11-25 03:10:27.636989 | w | /usr/include/dirent.h:149:35: note: nonnull attribute specified here
2021-11-25 03:10:27.713450 | w |     #0 0x7f18b4061682 in srpntf_find_file /home/ci/src/cesnet-gerrit-public/CzechLight/dependencies/sysrepo/src/plugins/ntf_lyb.c:315:5
2021-11-25 03:10:27.713631 | w |     #1 0x7f18b405f6b5 in srpntf_lyb_access_set /home/ci/src/cesnet-gerrit-public/CzechLight/dependencies/sysrepo/src/plugins/ntf_lyb.c:644:15
2021-11-25 03:10:27.719498 | w |     #2 0x7f18b3f0b000 in _sr_set_module_ds_access /home/ci/src/cesnet-gerrit-public/CzechLight/dependencies/sysrepo/src/sysrepo.c:1817:19
2021-11-25 03:10:27.719553 | w |     #3 0x7f18b3f0a932 in sr_set_module_ds_access /home/ci/src/cesnet-gerrit-public/CzechLight/dependencies/sysrepo/src/sysrepo.c:1867:25
2021-11-25 03:10:27.751217 | w |     #4 0x4fcc3a in main /home/ci/src/cesnet-gerrit-public/CzechLight/dependencies/sysrepo/src/executables/sysrepoctl.c:604:30
2021-11-25 03:10:27.925890 | w |     #5 0x7f18b2f8fb74 in __libc_start_main /usr/src/debug/glibc-2.33/csu/../csu/libc-start.c:332:16
2021-11-25 03:10:27.925959 | w |     #6 0x41c4fd in _start (/home/ci/target/bin/sysrepoctl+0x41c4fd)
```