### PR TITLE
sysrepo BUGFIX build with musl libc fails due to unknown type name 'm…

### DIFF
--- a/src/plugins_datastore.h
+++ b/src/plugins_datastore.h
@@ -18,6 +18,7 @@
 #define _SYSREPO_PLUGINS_DATASTORE_H
 
 #include <stdint.h>
+#include <sys/types.h>
 
 #include <libyang/libyang.h>
 

--- a/src/plugins_notification.h
+++ b/src/plugins_notification.h
@@ -18,6 +18,7 @@
 #define _SYSREPO_PLUGINS_NOTIFICATION_H
 
 #include <stdint.h>
+#include <sys/types.h>
 
 #include <libyang/libyang.h>
 


### PR DESCRIPTION
while updating buildroot package this failure was observed with musl libc