### PR TITLE
Fix build when not using CMake's make generator

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -92,6 +92,5 @@ endif()
 
 # phony target for clearing all sysrepo test data
 add_custom_target(test_clean
-    COMMAND rm -rf ${PROJECT_BINARY_DIR}/test_repositories
-    COMMAND rm -rf /dev/shm/_tests_sr_*
+    COMMAND rm -rf ${PROJECT_BINARY_DIR}/test_repositories /dev/shm/_tests_sr_*
 )

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -28,9 +28,12 @@ endif()
 # generate config
 configure_file("${PROJECT_SOURCE_DIR}/tests/config.h.in" "${PROJECT_BINARY_DIR}/tests/config.h" ESCAPE_QUOTES @ONLY)
 
+set(TEST_CLEAR_STATE_COMMAND rm -rf ${PROJECT_BINARY_DIR}/test_repositories /dev/shm/_tests_sr_*)
 if(${CMAKE_VERSION} VERSION_GREATER "3.7")
     # tests cleanup fixture
-    add_test(NAME tests_done COMMAND make test_clean)
+    add_test(NAME tests_done
+        COMMAND ${TEST_CLEAR_STATE_COMMAND}
+    )
     set_tests_properties(tests_done PROPERTIES FIXTURES_CLEANUP tests_cleanup)
 endif()
 
@@ -92,5 +95,5 @@ endif()
 
 # phony target for clearing all sysrepo test data
 add_custom_target(test_clean
-    COMMAND rm -rf ${PROJECT_BINARY_DIR}/test_repositories /dev/shm/_tests_sr_*
+    COMMAND ${TEST_CLEAR_STATE_COMMAND}
 )


### PR DESCRIPTION
CMake is a generator which can be used with other tools than just `make` -- `ninja` is a good candidate which tends to build a little faster. It's therefore a bug to try invoking `make` on some target directly.

Test fixtures were introduced to CMake in 3.7 (which means that the version comparison operator was too pessimistic). Since they only work on top of other tests, not targets, the `tests_clean` needs to become a test. However, in that case it might get happily executed in parallel to the usual testing process, which needs to be avoided via that `RUN_SERIAL` test property. That is not an equivalent to fixtures, but at least it's enough to serialize its execution with the rest of the test suite. As long as it is listed as the last test in this file, it should work reasonably even on older CMake.

Fixes: 08659bdf tests FEATURE clean all files created by tests