### PR TITLE
Do not trigger pull callbacks with SR_SUBSCR_ENABLED

### DIFF
--- a/src/sysrepo.c
+++ b/src/sysrepo.c
@@ -2905,7 +2905,7 @@ sr_module_change_subscribe_enable(sr_session_ctx_t *session, struct sr_mod_info_
      * (avoid dead-lock) */
     ly_set_add(&mod_set, (void *)ly_mod, 0);
     if ((err_info = sr_modinfo_add_modules(mod_info, &mod_set, 0, SR_LOCK_READ, SR_MI_PERM_NO, session->sid, NULL,
-            0, 0))) {
+            0, SR_OPER_NO_SUBS))) {
         goto cleanup;
     }
 


### PR DESCRIPTION
Currently if module_change_subscribe() is used to subscribe to a module
in the operational datastore, all operational data pull callbacks are
invoked for the module (even if not included by the subscription XPath)
if SR_SUBSCR_ENABLED is used.

This is not very intuitive since you cannot subscribe to changes to
pull data, only push data, and the change callbacks are unlikely to
be expecting the pull data. So this causes un-necessary system load
to collect data that is not used.

Therefore we prevent any pull callbacks from being invoked by using
SR_OPER_NO_SUBS when collecting data for the enabled callback.

Fixes #2651