### PR TITLE
Replace malloc(...) by calloc(1, ...) in sr_get_item()

### DIFF
--- a/src/sysrepo.c
+++ b/src/sysrepo.c
@@ -1399,7 +1399,7 @@ sr_get_item(sr_session_ctx_t *session, const char *path, uint32_t timeout_ms, sr
     }
 
     /* create return value */
-    *value = malloc(sizeof **value);
+    *value = calloc(1, sizeof **value);
     SR_CHECK_MEM_GOTO(!*value, err_info, cleanup);
 
     if ((err_info = sr_val_ly2sr(set->set.d[0], *value))) {

--- a/tests/test_get.c
+++ b/tests/test_get.c
@@ -347,12 +347,23 @@ test_union(void **state)
     char *str1;
     const char *str2;
     int ret;
+    sr_val_t *val = NULL;
 
     /* set some configuration data */
     ret = sr_set_item_str(st->sess, "/simple-aug:bc1/bcl1[bcs1='key']", NULL, NULL, 0);
     assert_int_equal(ret, SR_ERR_OK);
     ret = sr_apply_changes(st->sess, 0, 0);
     assert_int_equal(ret, SR_ERR_OK);
+
+    /* get the configuration data */
+    ret = sr_get_item(st->sess, "/simple-aug:bc1/bcl1[bcs1='key']", 0, &val);
+    assert_int_equal(ret, SR_ERR_OK);
+    assert_non_null(val);
+    if (val->origin != NULL) {
+        /* this is just to make sure that origin ptr is valid */
+        assert_int_equal(val->origin[0], val->origin[0]);
+    }
+    sr_free_val(val);
 
     /* subscribe to both modules so they are present in operational */
     ret = sr_module_change_subscribe(st->sess, "simple", NULL, dummy_change_cb, NULL, 0, 0, &subscr);


### PR DESCRIPTION
This ensures that the origin field is initialized.

Fixes https://github.com/sysrepo/sysrepo/issues/2657