### PR TITLE
sysrepo_types.h: Add missing sys/stat.h include for musl

### DIFF
--- a/src/sysrepo_types.h
+++ b/src/sysrepo_types.h
@@ -19,6 +19,7 @@
 
 #include <inttypes.h>
 #include <stddef.h>
+#include <sys/stat.h>
 
 struct lyd_node;
 struct timespec;


### PR DESCRIPTION
Bug: https://bugs.gentoo.org/828916