### PR TITLE
test UPDATE use common logging for all tests

### DIFF
--- a/tests/perf.c
+++ b/tests/perf.c
@@ -25,7 +25,7 @@
 
 #include "sysrepo.h"
 #include "config.h"
-#include "tests/config.h"
+#include "tests_common.h"
 
 #ifdef SR_HAVE_CALLGRIND
 # include <valgrind/callgrind.h>

--- a/tests/perf.c
+++ b/tests/perf.c
@@ -25,7 +25,7 @@
 
 #include "sysrepo.h"
 #include "config.h"
-#include "tests_common.h"
+#include "test_common.h"
 
 #ifdef SR_HAVE_CALLGRIND
 # include <valgrind/callgrind.h>

--- a/tests/test_apply_changes.c
+++ b/tests/test_apply_changes.c
@@ -31,7 +31,7 @@
 
 #include "common.h"
 #include "sysrepo.h"
-#include "tests/config.h"
+#include "test_common.h"
 
 struct state {
     sr_conn_ctx_t *conn;
@@ -6420,6 +6420,6 @@ main(void)
     };
 
     setenv("CMOCKA_TEST_ABORT", "1", 1);
-    sr_log_stderr(SR_LL_INF);
+    test_log_init();
     return cmocka_run_group_tests(tests, setup, teardown);
 }

--- a/tests/test_candidate.c
+++ b/tests/test_candidate.c
@@ -26,7 +26,7 @@
 #include <libyang/libyang.h>
 
 #include "sysrepo.h"
-#include "tests/config.h"
+#include "test_common.h"
 
 struct state {
     sr_conn_ctx_t *conn;
@@ -488,6 +488,6 @@ main(void)
     };
 
     setenv("CMOCKA_TEST_ABORT", "1", 1);
-    sr_log_stderr(SR_LL_INF);
+    test_log_init();
     return cmocka_run_group_tests(tests, setup_f, teardown_f);
 }

--- a/tests/test_common.h
+++ b/tests/test_common.h
@@ -1,0 +1,93 @@
+/**
+ * @file test_common.h
+ * @author Irfan
+ * @brief common header file for all tests to facilitate uniform logging format
+ *
+ * @copyright
+ *
+ * This source code is licensed under BSD 3-Clause License (the "License").
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://opensource.org/licenses/BSD-3-Clause
+ */
+
+#ifndef SR_TEST_COMMON_H
+#define SR_TEST_COMMON_H
+
+#include <pthread.h>
+#include <assert.h>
+#include <stdarg.h>
+#include <stdio.h>
+#include "sysrepo.h"
+#include "tests/config.h"
+
+/**
+ * Only function that needs to be called from test code
+ * Initializes callback and facilitates logging to stderr
+ * with timestamps and thread-id
+ */
+static void test_log_init();
+
+#define LOG_INF(...) _test_log(SR_LL_INF, __VA_ARGS__)
+#define LOG_ERR(...) _test_log(SR_LL_ERR, __VA_ARGS__)
+#define LOG_WRN(...) _test_log(SR_LL_WRN, __VA_ARGS__)
+
+static void
+_test_log_cb(sr_log_level_t level, const char *message);
+
+static void _test_log(sr_log_level_t ll, ...);
+
+static void test_log_init()
+{
+    sr_log_set_cb(_test_log_cb);
+    LOG_INF("Initialized sysrepo logging for tests");
+}
+
+static void
+_test_log_cb(sr_log_level_t level, const char *message)
+{
+    const char *severity;
+
+    switch (level) {
+    case SR_LL_ERR:
+        severity = "ERR";
+        break;
+    case SR_LL_WRN:
+        severity = "WRN";
+        break;
+    case SR_LL_INF:
+        severity = "INF";
+        break;
+    case SR_LL_DBG:
+        /*severity = "DBG";
+        break;*/
+        return;
+    case SR_LL_NONE:
+        assert(0);
+        return;
+    }
+    struct timespec ts;
+    clock_gettime(CLOCK_MONOTONIC_RAW, &ts);
+    ts.tv_sec %= 1000;
+    ts.tv_nsec /= 1000;
+    fprintf(stderr, "%03ld.%06ld [%ld][%lu][%s]: %s\n", ts.tv_sec, ts.tv_nsec,
+                    (long)getpid(), (unsigned long)pthread_self(), severity, message);
+}
+
+static void
+_test_log(sr_log_level_t ll, ...)
+{
+    va_list ap;
+    char msg[1024];
+
+    va_start(ap, ll);
+    char *fmt = va_arg(ap, char *);
+
+    vsnprintf(msg, sizeof(msg), fmt, ap);
+    va_end(ap);
+    _test_log_cb(ll, msg);
+}
+
+#endif
+

--- a/tests/test_context_change.c
+++ b/tests/test_context_change.c
@@ -31,7 +31,7 @@
 
 #include "common.h"
 #include "sysrepo.h"
-#include "tests/config.h"
+#include "test_common.h"
 
 struct state {
     sr_conn_ctx_t *conn;
@@ -465,6 +465,6 @@ main(void)
     };
 
     setenv("CMOCKA_TEST_ABORT", "1", 1);
-    sr_log_stderr(SR_LL_INF);
+    test_log_init();
     return cmocka_run_group_tests(tests, setup, teardown);
 }

--- a/tests/test_copy_config.c
+++ b/tests/test_copy_config.c
@@ -30,7 +30,7 @@
 
 #include "common.h"
 #include "sysrepo.h"
-#include "tests/config.h"
+#include "test_common.h"
 
 struct state {
     sr_conn_ctx_t *conn;
@@ -2209,6 +2209,6 @@ main(void)
     };
 
     setenv("CMOCKA_TEST_ABORT", "1", 1);
-    sr_log_stderr(SR_LL_INF);
+    test_log_init();
     return cmocka_run_group_tests(tests, setup, teardown);
 }

--- a/tests/test_edit.c
+++ b/tests/test_edit.c
@@ -26,7 +26,7 @@
 #include <libyang/libyang.h>
 
 #include "sysrepo.h"
-#include "tests/config.h"
+#include "test_common.h"
 
 struct state {
     sr_conn_ctx_t *conn;
@@ -1189,6 +1189,6 @@ main(void)
     };
 
     setenv("CMOCKA_TEST_ABORT", "1", 1);
-    sr_log_stderr(SR_LL_INF);
+    test_log_init();
     return cmocka_run_group_tests(tests, setup_f, teardown_f);
 }

--- a/tests/test_get.c
+++ b/tests/test_get.c
@@ -28,7 +28,7 @@
 #include <libyang/libyang.h>
 
 #include "sysrepo.h"
-#include "tests/config.h"
+#include "test_common.h"
 
 struct state {
     sr_conn_ctx_t *conn;
@@ -490,6 +490,6 @@ main(void)
     };
 
     setenv("CMOCKA_TEST_ABORT", "1", 1);
-    sr_log_stderr(SR_LL_INF);
+    test_log_init();
     return cmocka_run_group_tests(tests, NULL, NULL);
 }

--- a/tests/test_lock.c
+++ b/tests/test_lock.c
@@ -30,7 +30,7 @@
 #include <libyang/libyang.h>
 
 #include "sysrepo.h"
-#include "tests/config.h"
+#include "test_common.h"
 
 struct state {
     sr_conn_ctx_t *conn;
@@ -447,6 +447,6 @@ main(void)
     };
 
     setenv("CMOCKA_TEST_ABORT", "1", 1);
-    sr_log_stderr(SR_LL_INF);
+    test_log_init();
     return cmocka_run_group_tests(tests, setup, teardown);
 }

--- a/tests/test_modules.c
+++ b/tests/test_modules.c
@@ -29,7 +29,7 @@
 #include <libyang/libyang.h>
 
 #include "sysrepo.h"
-#include "tests/config.h"
+#include "test_common.h"
 
 struct state {
     sr_conn_ctx_t *conn;
@@ -1491,6 +1491,6 @@ main(void)
     };
 
     setenv("CMOCKA_TEST_ABORT", "1", 1);
-    sr_log_stderr(SR_LL_INF);
+    test_log_init();
     return cmocka_run_group_tests(tests, NULL, NULL);
 }

--- a/tests/test_multi_connection.c
+++ b/tests/test_multi_connection.c
@@ -27,7 +27,7 @@
 #include <libyang/libyang.h>
 
 #include "sysrepo.h"
-#include "tests/config.h"
+#include "test_common.h"
 
 struct state {
     sr_conn_ctx_t *conn1;
@@ -194,6 +194,6 @@ main(void)
     };
 
     setenv("CMOCKA_TEST_ABORT", "1", 1);
-    sr_log_stderr(SR_LL_INF);
+    test_log_init();
     return cmocka_run_group_tests(tests, setup_f, teardown_f);
 }

--- a/tests/test_notif.c
+++ b/tests/test_notif.c
@@ -33,7 +33,7 @@
 
 #include "common.h"
 #include "sysrepo.h"
-#include "tests/config.h"
+#include "test_common.h"
 
 const time_t start_ts = 1550233816;
 
@@ -1564,6 +1564,6 @@ main(void)
     (void)test_oper_dep;
 
     setenv("CMOCKA_TEST_ABORT", "1", 1);
-    sr_log_stderr(SR_LL_INF);
+    test_log_init();
     return cmocka_run_group_tests(tests, setup, teardown);
 }

--- a/tests/test_operational.c
+++ b/tests/test_operational.c
@@ -28,7 +28,7 @@
 
 #include "common.h"
 #include "sysrepo.h"
-#include "tests/config.h"
+#include "test_common.h"
 
 struct state {
     sr_conn_ctx_t *conn;
@@ -4406,6 +4406,6 @@ main(void)
     };
 
     setenv("CMOCKA_TEST_ABORT", "1", 1);
-    sr_log_stderr(SR_LL_INF);
+    test_log_init();
     return cmocka_run_group_tests(tests, setup, teardown);
 }

--- a/tests/test_process.c
+++ b/tests/test_process.c
@@ -26,7 +26,7 @@
 #include <unistd.h>
 
 #include "sysrepo.h"
-#include "tests/config.h"
+#include "test_common.h"
 
 #define sr_assert(cond) if (!(cond)) { fprintf(stderr, "\"%s\" not true\n", #cond); sr_assert_line(); abort(); }
 
@@ -144,33 +144,6 @@ run_tests(struct test *tests, uint32_t test_count)
     close(pipes[1]);
     close(pipes[2]);
     close(pipes[3]);
-}
-
-static void
-test_log_cb(sr_log_level_t level, const char *message)
-{
-    const char *severity;
-
-    switch (level) {
-    case SR_LL_ERR:
-        severity = "ERR";
-        break;
-    case SR_LL_WRN:
-        severity = "WRN";
-        break;
-    case SR_LL_INF:
-        severity = "INF";
-        break;
-    case SR_LL_DBG:
-        /*severity = "DBG";
-        break;*/
-        return;
-    case SR_LL_NONE:
-        sr_assert(0);
-        return;
-    }
-
-    fprintf(stderr, "[%ld.%u][%s]: %s\n", (long)getpid(), (unsigned int)pthread_self(), severity, message);
 }
 
 /* TEST FUNCS */
@@ -916,8 +889,7 @@ main(void)
         {"conn create", test_conn_create, test_conn_create, setup, teardown},
         {"sub apply", test_sub, test_apply, setup, teardown},
     };
-
-    sr_log_set_cb(test_log_cb);
+    test_log_init();
     run_tests(tests, sizeof tests / sizeof *tests);
     return 0;
 }

--- a/tests/test_rpc_action.c
+++ b/tests/test_rpc_action.c
@@ -30,7 +30,7 @@
 
 #include "common.h"
 #include "sysrepo.h"
-#include "tests/config.h"
+#include "test_common.h"
 #include "utils/values.h"
 
 struct state {
@@ -1557,6 +1557,6 @@ main(void)
     };
 
     setenv("CMOCKA_TEST_ABORT", "1", 1);
-    sr_log_stderr(SR_LL_INF);
+    test_log_init();
     return cmocka_run_group_tests(tests, setup, teardown);
 }

--- a/tests/test_validation.c
+++ b/tests/test_validation.c
@@ -26,7 +26,7 @@
 #include <libyang/libyang.h>
 
 #include "sysrepo.h"
-#include "tests/config.h"
+#include "test_common.h"
 
 struct state {
     sr_conn_ctx_t *conn;
@@ -270,6 +270,6 @@ main(void)
     };
 
     setenv("CMOCKA_TEST_ABORT", "1", 1);
-    sr_log_stderr(SR_LL_INF);
+    test_log_init();
     return cmocka_run_group_tests(tests, setup_f, teardown_f);
 }


### PR DESCRIPTION
Make all tests use the same callback for logging sysrepo msgs
This allows more control in grepping for errors, and debugging failures, at a job level.
Also provides for timestamp with sec.usec and [pid][tid]
to understand timing issues.