### PR TITLE
install: Respect installation prefix for systemd unit file

### DIFF
--- a/CMakeModules/FindLibSystemd.cmake
+++ b/CMakeModules/FindLibSystemd.cmake
@@ -67,7 +67,7 @@ else()
     )
 
     if(NOT SYSTEMD_UNIT_DIR)
-        execute_process(COMMAND ${PKG_CONFIG_EXECUTABLE} --variable=systemdsystemunitdir systemd
+        execute_process(COMMAND ${PKG_CONFIG_EXECUTABLE} --define-variable=rootprefix=${CMAKE_INSTALL_PREFIX} --variable=systemdsystemunitdir systemd
                 OUTPUT_VARIABLE SYSTEMD_UNIT_DIR)
         string(REGEX REPLACE "[ \t\n]+" "" SYSTEMD_UNIT_DIR "${SYSTEMD_UNIT_DIR}")
     endif()


### PR DESCRIPTION
When invoking `pkg-config`, make sure that we substitute the target root with the intended location of the installation. Trying to install into a location where systemd itself lives does not work when:

- installing into any staging dir in general (e.g., package builds)
- the developer is using their own non-system prefixes
- the rootfs is read-only (such as when using ostree)
- on NixOS or any distro which puts each package into a spearate root

Rather than requiring everyone to override this variable, make sure it's relative to the installation target.

See-also: https://www.bassi.io/articles/2018/03/15/pkg-config-and-paths/
Bug: https://gitlab.kitware.com/cmake/cmake/-/issues/19632
Fixes: c98389a7 sysrepo-plugind BUGFIX generate systemd service file
Fixes: 832e1428 sysrepo-plugind UPDATE proper systemd service file
Fixes: 040e3964 sysrepo-plugind BUGFIX missing service file