### PR TITLE
test UPDATE use common logging for all tests (#2717)

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -9,16 +9,16 @@ get_filename_component(TESTS_DIR "${CMAKE_SOURCE_DIR}/tests" REALPATH)
 include_directories(SYSTEM ${CMOCKA_INCLUDE_DIR})
 include_directories(${CMAKE_CURRENT_SOURCE_DIR})
 
+set(test_sources "test_common.c")
+
 # check for pthread_barrier existence
 check_function_exists(pthread_barrier_init SR_HAVE_PTHREAD_BARRIER)
-if(SR_HAVE_PTHREAD_BARRIER)
-    set(test_sources "")
-else()
-    set(test_sources "pthread_barrier.c")
+if(NOT SR_HAVE_PTHREAD_BARRIER)
+    list(APPEND test_sources "pthread_barrier.c")
 endif()
 
 # generate config
-configure_file("${PROJECT_SOURCE_DIR}/tests/config.h.in" "${PROJECT_BINARY_DIR}/tests/config.h" ESCAPE_QUOTES @ONLY)
+configure_file("${PROJECT_SOURCE_DIR}/tests/test_common.h.in" "${PROJECT_BINARY_DIR}/tests/test_common.h" ESCAPE_QUOTES @ONLY)
 
 # lists of all the tests
 set(tests test_modules test_validation test_edit test_candidate test_operational test_lock test_apply_changes

--- a/tests/measure_performance.c
+++ b/tests/measure_performance.c
@@ -32,7 +32,7 @@
 #include <stdbool.h>
 #include <libyang/libyang.h>
 
-#include "tests/config.h"
+#include "tests/test_common.h"
 #include "sysrepo.h"
 
 /* Constants defining how many times the operation is performed to compute an average ops/sec */

--- a/tests/test_apply_changes.c
+++ b/tests/test_apply_changes.c
@@ -34,8 +34,8 @@
 #include <libyang/libyang.h>
 
 #include "common.h"
-#include "tests/config.h"
 #include "sysrepo.h"
+#include "tests/test_common.h"
 
 struct state {
     sr_conn_ctx_t *conn;
@@ -6250,6 +6250,6 @@ main(void)
     };
 
     setenv("CMOCKA_TEST_ABORT", "1", 1);
-    sr_log_stderr(SR_LL_INF);
+    test_log_init();
     return cmocka_run_group_tests(tests, setup, teardown);
 }

--- a/tests/test_candidate.c
+++ b/tests/test_candidate.c
@@ -30,8 +30,8 @@
 #include <cmocka.h>
 #include <libyang/libyang.h>
 
-#include "tests/config.h"
 #include "sysrepo.h"
+#include "tests/test_common.h"
 
 struct state {
     sr_conn_ctx_t *conn;
@@ -503,6 +503,6 @@ main(void)
     };
 
     setenv("CMOCKA_TEST_ABORT", "1", 1);
-    sr_log_stderr(SR_LL_INF);
+    test_log_init();
     return cmocka_run_group_tests(tests, setup_f, teardown_f);
 }

--- a/tests/test_common.c
+++ b/tests/test_common.c
@@ -1,0 +1,85 @@
+/**
+ * @file test_common.c
+ * @author Irfan
+ * @brief common header file for all tests to facilitate uniform logging format
+ *
+ * @copyright
+ *
+ * This source code is licensed under BSD 3-Clause License (the "License").
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://opensource.org/licenses/BSD-3-Clause
+ */
+#define _GNU_SOURCE
+
+#include <pthread.h>
+#include <assert.h>
+#include <stdio.h>
+#include <stdarg.h>
+#include <time.h>
+#include <sys/types.h>
+#include <unistd.h>
+
+#include "sysrepo.h"
+#include "tests/test_common.h"
+
+static void
+_test_log_msg(sr_log_level_t level, const char *message, const char* prefix)
+{
+    const char *severity;
+    struct timespec ts;
+
+    switch (level) {
+    case SR_LL_ERR:
+        severity = "ERR";
+        break;
+    case SR_LL_WRN:
+        severity = "WRN";
+        break;
+    case SR_LL_INF:
+        severity = "INF";
+        break;
+    case SR_LL_DBG:
+        /*severity = "DBG";
+        break;*/
+        return;
+    case SR_LL_NONE:
+        assert(0);
+        return;
+    }
+
+    clock_gettime(CLOCK_REALTIME, &ts);
+    ts.tv_sec %= 1000;
+    ts.tv_nsec /= 1000;
+    fprintf(stderr, "%03ld.%06ld [%ld][%lu][%s] %s: %s\n", ts.tv_sec, ts.tv_nsec,
+            (long)getpid(), (unsigned long)pthread_self(), severity,
+            prefix, message);
+}
+
+static void
+_test_sr_log_cb(sr_log_level_t level, const char *message)
+{
+    _test_log_msg(level, message, "");
+}
+
+void
+test_log_init(void)
+{
+    sr_log_set_cb(_test_sr_log_cb);
+}
+
+void
+_test_log(sr_log_level_t ll, ...)
+{
+    va_list ap;
+    char msg[1024] = "";
+    char *fmt = NULL;
+    va_start(ap, ll);
+    fmt = va_arg(ap, char *);
+
+    vsnprintf(msg, sizeof(msg), fmt, ap);
+    va_end(ap);
+    _test_log_msg(ll, msg, "[TestLog]");
+}
+

--- a/tests/test_common.h.in
+++ b/tests/test_common.h.in
@@ -1,5 +1,5 @@
 /**
- * @file config.h
+ * @file test_common.h
  * @author Michal Vasko <mvasko@cesnet.cz>
  * @brief test configuration header
  *
@@ -19,8 +19,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#ifndef SRTEST_CONFIG_H_
-#define SRTEST_CONFIG_H_
+#ifndef SRTEST_COMMON_H_
+#define SRTEST_COMMON_H_
 
 #define TESTS_DIR "@TESTS_DIR@"
 
@@ -32,4 +32,25 @@
 # include "pthread_barrier.h"
 #endif
 
-#endif /* SRTEST_CONFIG_H_ */
+/**
+ * @brief Macro for support of callgrind header and macros.
+ */
+#cmakedefine SR_HAVE_CALLGRIND
+
+#include "sysrepo.h"
+
+/**
+ * Only function that needs to be called from test code
+ * Initializes callback and facilitates logging to stderr
+ * with timestamps and thread-id
+ */
+void test_log_init(void);
+
+/* Test Logging macros */
+#define TLOG_ERR(...) _test_log(SR_LL_ERR, __VA_ARGS__)
+#define TLOG_WRN(...) _test_log(SR_LL_WRN, __VA_ARGS__)
+#define TLOG_INF(...) _test_log(SR_LL_INF, __VA_ARGS__)
+
+void _test_log(sr_log_level_t ll, ...);
+
+#endif /* SRTEST_COMMON_H_ */

--- a/tests/test_copy_config.c
+++ b/tests/test_copy_config.c
@@ -34,8 +34,8 @@
 #include <libyang/libyang.h>
 
 #include "common.h"
-#include "tests/config.h"
 #include "sysrepo.h"
+#include "tests/test_common.h"
 
 struct state {
     sr_conn_ctx_t *conn;
@@ -2224,6 +2224,6 @@ main(void)
     };
 
     setenv("CMOCKA_TEST_ABORT", "1", 1);
-    sr_log_stderr(SR_LL_INF);
+    test_log_init();
     return cmocka_run_group_tests(tests, setup, teardown);
 }

--- a/tests/test_edit.c
+++ b/tests/test_edit.c
@@ -30,8 +30,8 @@
 #include <cmocka.h>
 #include <libyang/libyang.h>
 
-#include "tests/config.h"
 #include "sysrepo.h"
+#include "tests/test_common.h"
 
 struct state {
     sr_conn_ctx_t *conn;
@@ -1219,6 +1219,6 @@ main(void)
     };
 
     setenv("CMOCKA_TEST_ABORT", "1", 1);
-    sr_log_stderr(SR_LL_INF);
+    test_log_init();
     return cmocka_run_group_tests(tests, setup_f, teardown_f);
 }

--- a/tests/test_get.c
+++ b/tests/test_get.c
@@ -32,8 +32,8 @@
 #include <cmocka.h>
 #include <libyang/libyang.h>
 
-#include "tests/config.h"
 #include "sysrepo.h"
+#include "tests/test_common.h"
 
 struct state {
     sr_conn_ctx_t *conn;
@@ -478,6 +478,6 @@ main(void)
     };
 
     setenv("CMOCKA_TEST_ABORT", "1", 1);
-    sr_log_stderr(SR_LL_INF);
+    test_log_init();
     return cmocka_run_group_tests(tests, NULL, NULL);
 }

--- a/tests/test_lock.c
+++ b/tests/test_lock.c
@@ -33,8 +33,8 @@
 #include <cmocka.h>
 #include <libyang/libyang.h>
 
-#include "tests/config.h"
 #include "sysrepo.h"
+#include "tests/test_common.h"
 
 struct state {
     sr_conn_ctx_t *conn;
@@ -377,6 +377,6 @@ main(void)
     };
 
     setenv("CMOCKA_TEST_ABORT", "1", 1);
-    sr_log_stderr(SR_LL_INF);
+    test_log_init();
     return cmocka_run_group_tests(tests, setup, teardown);
 }

--- a/tests/test_modules.c
+++ b/tests/test_modules.c
@@ -33,8 +33,8 @@
 #include <cmocka.h>
 #include <libyang/libyang.h>
 
-#include "tests/config.h"
 #include "sysrepo.h"
+#include "tests/test_common.h"
 
 struct state {
     sr_conn_ctx_t *conn;
@@ -1548,6 +1548,6 @@ main(void)
     };
 
     setenv("CMOCKA_TEST_ABORT", "1", 1);
-    sr_log_stderr(SR_LL_INF);
+    test_log_init();
     return cmocka_run_group_tests(tests, NULL, NULL);
 }

--- a/tests/test_multi_connection.c
+++ b/tests/test_multi_connection.c
@@ -29,8 +29,8 @@
 #include <cmocka.h>
 #include <libyang/libyang.h>
 
-#include "tests/config.h"
 #include "sysrepo.h"
+#include "tests/test_common.h"
 
 struct state {
     sr_conn_ctx_t *conn1;
@@ -201,6 +201,6 @@ main(void)
     };
 
     setenv("CMOCKA_TEST_ABORT", "1", 1);
-    sr_log_stderr(SR_LL_INF);
+    test_log_init();
     return cmocka_run_group_tests(tests, setup_f, teardown_f);
 }

--- a/tests/test_notif.c
+++ b/tests/test_notif.c
@@ -36,8 +36,8 @@
 #include <libyang/libyang.h>
 
 #include "common.h"
-#include "tests/config.h"
 #include "sysrepo.h"
+#include "tests/test_common.h"
 
 const time_t start_ts = 1550233816;
 
@@ -1279,6 +1279,6 @@ main(void)
     };
 
     setenv("CMOCKA_TEST_ABORT", "1", 1);
-    sr_log_stderr(SR_LL_INF);
+    test_log_init();
     return cmocka_run_group_tests(tests, setup, teardown);
 }

--- a/tests/test_operational.c
+++ b/tests/test_operational.c
@@ -32,8 +32,8 @@
 #include <libyang/libyang.h>
 
 #include "common.h"
-#include "tests/config.h"
 #include "sysrepo.h"
+#include "tests/test_common.h"
 
 struct state {
     sr_conn_ctx_t *conn;
@@ -4115,6 +4115,6 @@ main(void)
     };
 
     setenv("CMOCKA_TEST_ABORT", "1", 1);
-    sr_log_stderr(SR_LL_INF);
+    test_log_init();
     return cmocka_run_group_tests(tests, setup, teardown);
 }

--- a/tests/test_rpc_action.c
+++ b/tests/test_rpc_action.c
@@ -34,8 +34,8 @@
 #include <libyang/libyang.h>
 
 #include "common.h"
-#include "tests/config.h"
 #include "sysrepo.h"
+#include "tests/test_common.h"
 #include "utils/values.h"
 
 struct state {
@@ -1604,6 +1604,6 @@ main(void)
     };
 
     setenv("CMOCKA_TEST_ABORT", "1", 1);
-    sr_log_stderr(SR_LL_INF);
+    test_log_init();
     return cmocka_run_group_tests(tests, setup, teardown);
 }

--- a/tests/test_validation.c
+++ b/tests/test_validation.c
@@ -30,8 +30,8 @@
 #include <cmocka.h>
 #include <libyang/libyang.h>
 
-#include "tests/config.h"
 #include "sysrepo.h"
+#include "tests/test_common.h"
 
 struct state {
     sr_conn_ctx_t *conn;
@@ -280,6 +280,6 @@ main(void)
     };
 
     setenv("CMOCKA_TEST_ABORT", "1", 1);
-    sr_log_stderr(SR_LL_INF);
+    test_log_init();
     return cmocka_run_group_tests(tests, setup_f, teardown_f);
 }


### PR DESCRIPTION
* test UPDATE use common logging for all tests

Make all tests use the same callback for logging sysrepo msgs
This allows more control in grepping for errors, and debugging failures
Also provides for timestamp with sec.usec and [pid][tid]
to understand timing issues.

* incorporate review changes

* Rename config.h to common.h

* Rename common.h to test_common.h

* Minor changes remove excess newlines

Co-authored-by: Irfan Mohammad <irfan@graphiant.com>