### PR TITLE
Let sysrepo-plugind write a pid file

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -304,6 +304,10 @@ target_link_libraries(sysrepocfg sysrepo)
 add_executable(sysrepo-plugind ${SYSREPOPLUGIND_SRC} ${compatsrc})
 target_link_libraries(sysrepo-plugind sysrepo)
 
+if(NOT SRPD_PIDFILE)
+    set(SRPD_PIDFILE "/var/run/sysrepo-plugind.pid")
+endif()
+
 # include repository files with highest priority
 include_directories("${PROJECT_SOURCE_DIR}/src")
 include_directories(${PROJECT_BINARY_DIR})

--- a/src/executables/bin_common.h.in
+++ b/src/executables/bin_common.h.in
@@ -29,6 +29,9 @@
 /** sysrepo-plugind plugins directory */
 #define SRPD_PLG_PATH "@SRPD_PLUGINS_PATH@"
 
+/** sysrepo-plugind pid file path */
+#define SRPD_PIDFILE "@SRPD_PIDFILE@"
+
 /** whether mkstemps is found on the system */
 #cmakedefine SR_HAVE_MKSTEMPS
 


### PR DESCRIPTION
In systems where daemons depend on each other, it is useful to leave pid
files under /var/run so that init (PID 1) can track dependencies between
daemons, and thus orchestrate their startup times.

The implementation is inspired by the implementation found in netopeer2.

Signed-off-by: Jörgen Sigvardsson <jorgen.sigvardsson@gmail.com>