### PR TITLE
sysrepo: allow use of SR_SUBSCR_ENABLED with SR_SUBSCR_PASSIVE

### DIFF
--- a/src/sysrepo.c
+++ b/src/sysrepo.c
@@ -3061,7 +3061,7 @@ sr_module_change_subscribe(sr_session_ctx_t *session, const char *module_name, c
     sr_mod_t *shm_mod;
 
     SR_CHECK_ARG_APIRET(!session || SR_IS_EVENT_SESS(session) || !module_name || !callback ||
-            ((opts & SR_SUBSCR_PASSIVE) && (opts & SR_SUBSCR_ENABLED)) || !subscription, session, err_info);
+            !subscription, session, err_info);
 
     if ((opts & SR_SUBSCR_CTX_REUSE) && !*subscription) {
         /* invalid option, remove */


### PR DESCRIPTION
This appears to be an API level restriction only, with passive
subscriptions correctly processing enabled events.