### PR TITLE
Check sr_diff_ly2sr() return to avoid segfault

### DIFF
--- a/src/edit_diff.c
+++ b/src/edit_diff.c
@@ -3164,6 +3164,8 @@ sr_diff_ly2sr(struct lyd_difflist *ly_diff, struct lyd_node **diff_p)
     enum edit_op op;
     char *attr_val, *prev_attr_val;
 
+    *diff_p = NULL;
+
     /* just a shortcut to context */
     if (ly_diff->type[0] != LYD_DIFF_END) {
         if (ly_diff->first[0]) {

--- a/src/modinfo.c
+++ b/src/modinfo.c
@@ -219,11 +219,12 @@ sr_modinfo_replace(struct sr_mod_info_s *mod_info, struct lyd_node **src_data)
                 mod->state |= MOD_INFO_CHANGED;
 
                 /* create a single sysrepo diff */
-                err_info = sr_diff_ly2sr(ly_diff, &diff);
-                if (mod_info->diff) {
-                    sr_ly_link(mod_info->diff, diff);
-                } else {
-                    mod_info->diff = diff;
+                if (!(err_info = sr_diff_ly2sr(ly_diff, &diff))) {
+                    if (mod_info->diff) {
+                        sr_ly_link(mod_info->diff, diff);
+                    } else {
+                        mod_info->diff = diff;
+                    }
                 }
 
                 /* update data */


### PR DESCRIPTION
 - sr_diff_ly2sr: initially set return pointer to NULL Help protect against
   memory corruption by ensuring the returned pointer value does not contain
   garbage.

 - sr_modinfo_replace: don't link diff if there was an error Check for an
   error generating a sysrepo diff from a libyang diff, before linking the
   diff with the sr_mod_info_s.

   In this error case the sysrepo diff pointer may not be valid, causing 
   memory corruption and possible segfault.

Diff generation and segfault was observed due to https://github.com/CESNET/libyang/pull/1833