### PR TITLE
install: create SRPD_PLUGINS_PATH directory

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -390,6 +390,7 @@ install(TARGETS sysrepoctl sysrepocfg sysrepo-plugind DESTINATION ${CMAKE_INSTAL
 install(FILES ${PROJECT_SOURCE_DIR}/src/executables/sysrepoctl.1 ${PROJECT_SOURCE_DIR}/src/executables/sysrepocfg.1
         DESTINATION ${CMAKE_INSTALL_MANDIR}/man1)
 install(FILES ${PROJECT_SOURCE_DIR}/src/executables/sysrepo-plugind.8 DESTINATION ${CMAKE_INSTALL_MANDIR}/man8)
+install(DIRECTORY DESTINATION ${SRPD_PLUGINS_PATH})
 if(SR_HAVE_SYSTEMD)
     install(FILES ${PROJECT_BINARY_DIR}/sysrepo-plugind.service DESTINATION ${SYSTEMD_UNIT_DIR})
 endif()


### PR DESCRIPTION
Sysrepo should install the directories it needs, especially when they
are by default in /usr which can be read-only.

Also the directory should be owned by sysrepo packages.