### PR TITLE
Recognize updated `yang.yang` from libyang

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -77,8 +77,8 @@ set(SYSREPO_SOVERSION_FULL ${SYSREPO_MAJOR_SOVERSION}.${SYSREPO_MINOR_SOVERSION}
 set(SYSREPO_SOVERSION ${SYSREPO_MAJOR_SOVERSION})
 
 # Version of libyang library that this sysrepo depends on
-set(LIBYANG_DEP_VERSION 2.0.220)
-set(LIBYANG_DEP_SOVERSION 2.21.8)
+set(LIBYANG_DEP_VERSION 2.0.221)
+set(LIBYANG_DEP_SOVERSION 2.21.9)
 set(LIBYANG_DEP_SOVERSION_MAJOR 2)
 
 # generate only version header, it is needed for docs

--- a/src/common.c
+++ b/src/common.c
@@ -2174,7 +2174,7 @@ sr_ly_module_is_internal(const struct lys_module *ly_mod)
 
     if (!strcmp(ly_mod->name, "ietf-yang-metadata") && !strcmp(ly_mod->revision, "2016-08-05")) {
         return 1;
-    } else if (!strcmp(ly_mod->name, "yang") && !strcmp(ly_mod->revision, "2021-04-07")) {
+    } else if (!strcmp(ly_mod->name, "yang") && !strcmp(ly_mod->revision, "2022-06-16")) {
         return 1;
     } else if (!strcmp(ly_mod->name, "ietf-inet-types") && !strcmp(ly_mod->revision, "2013-07-15")) {
         return 1;


### PR DESCRIPTION
Found via [`CESNET/libnetconf2-cpp`'s test suite](https://github.com/CESNET/libnetconf2-cpp/blob/master/tests/mock_server.cpp).

Fixes: CESNET/libyang@79a7a87f76ca1a3ed3d2cb11626c0ee4dd647bc3