### PR TITLE
Add SR_SUBSCR_OPER_ONCE option for oper subscr

### DIFF
--- a/src/sysrepo.c
+++ b/src/sysrepo.c
@@ -6599,7 +6599,7 @@ sr_oper_get_subscribe(sr_session_ctx_t *session, const char *module_name, const 
 
     conn = session->conn;
     /* only these options are relevant outside this function and will be stored */
-    sub_opts = opts & SR_SUBSCR_OPER_MERGE;
+    sub_opts = opts & (SR_SUBSCR_OPER_MERGE | SR_SUBSCR_OPER_ONCE);
 
     /* CONTEXT LOCK */
     if ((err_info = sr_lycc_lock(conn, SR_LOCK_READ, 0, __func__))) {

--- a/src/sysrepo_types.h
+++ b/src/sysrepo_types.h
@@ -432,7 +432,14 @@ typedef enum {
      * @brief On every data retrieval additionally compute diff with the previous data and report the changes to any
      * operational data module change subscriptions. Accepted only for ::sr_oper_poll_subscribe().
      */
-    SR_SUBSCR_OPER_POLL_DIFF = 0x80
+    SR_SUBSCR_OPER_POLL_DIFF = 0x80,
+
+    /**
+     * @brief For a given "get" operation on the operational datastore, this option ensures that a subscriber
+     * is called no more than once, regardless of whether the subscription path is a child of a list.
+     * When this option is specified, a parent node is not passed to the subscriber's callback.
+     */
+    SR_SUBSCR_OPER_ONCE = 0x100
 
 } sr_subscr_flag_t;
 


### PR DESCRIPTION
This option causes a component subscribing to provide operational pull data to be called no more than once per-subscription for a given get on the operational datastore.

This can be used to optimise certain usecases. For example, if a component is subscribed to provide pull state below a list, the default behaviour causes a component to be called for each element in the list (unless the request was for a specific element in the list).

As the number of elements in the parent list(s) grows it can take a significant amount of time, proportional to the time required to actually collect the data, to issue and handle a callback for each element when data for all (or a large subset of) elements is requested.

This option therefore gives the capability to handle pull requests in a "one shot" fashion where it is more performant to do so.