### PR TITLE
`srpd_rotation`: prevent UB in `closedir()`

### DIFF
--- a/src/executables/srpd_rotation.c
+++ b/src/executables/srpd_rotation.c
@@ -257,7 +257,9 @@ cleanup:
     free(arg2);
     free(remove_str);
     free(notif_dir_name);
-    closedir(d);
+    if (d) {
+        closedir(d);
+    }
     return NULL;
 }
 


### PR DESCRIPTION
During normal operation, the `d` directory handle is always closed and set to `NULL`. In glibc, the [signature of `closedir()` has `__nonnull((1))`](https://codebrowser.dev/gcc/include/dirent.h.html#closedir), and UBSAN catches that:

```
Jan 31 20:49:29 f34-metacentrum-0000088274 sysrepo-plugind[21264]: /home/ci/src/cesnet-gerrit-public/CzechLight/dependencies/sysrepo/src/executables/srpd_rotation.c:260:14: runtime error: null pointer passed as argument 1, which is declared to never be null
Jan 31 20:49:29 f34-metacentrum-0000088274 sysrepo-plugind[21264]: /usr/include/dirent.h:149:35: note: nonnull attribute specified here
Jan 31 20:49:29 f34-metacentrum-0000088274 sysrepo-plugind[21264]:     #0 0x4fd6ba in srpd_rotation_loop /home/ci/src/cesnet-gerrit-public/CzechLight/dependencies/sysrepo/src/executables/srpd_rotation.c:260:5
Jan 31 20:49:30 f34-metacentrum-0000088274 sysrepo-plugind[21264]:     #1 0x7f9dd9b47298 in start_thread /usr/src/debug/glibc-2.33/nptl/pthread_create.c:473:8
Jan 31 20:49:30 f34-metacentrum-0000088274 sysrepo-plugind[21264]:     #2 0x7f9dd99106a2 in clone /usr/src/debug/glibc-2.33/misc/../sysdeps/unix/sysv/linux/x86_64/clone.S:95
Jan 31 20:49:30 f34-metacentrum-0000088274 sysrepo-plugind[21264]:
Jan 31 20:49:30 f34-metacentrum-0000088274 sysrepo-plugind[21264]: SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior /home/ci/src/cesnet-gerrit-public/CzechLight/dependencies/sysrepo/src/executables/srpd_rotation.c:260:14 in
```

Cc: @Humblesaw  a93e689b