### PR TITLE
docs: clarify sr_get_node's return value

### DIFF
--- a/src/sysrepo.h
+++ b/src/sysrepo.h
@@ -824,8 +824,8 @@ int sr_get_data(sr_session_ctx_t *session, const char *xpath, uint32_t max_depth
  * @brief Retrieve a single value matching the provided XPath.
  * Data are represented as a single _libyang_ node.
  *
- * Compared to ::sr_get_data() or ::sr_get_subtree() this function returns only the selected node
- * without any of its parents so it is more efficient.
+ * Compared to ::sr_get_data() or ::sr_get_subtree() this function is a bit more efficient because it returns
+ * only the selected node which is *disconnected* from its parents.
  *
  * Required READ access, but if the access check fails, the module data are simply ignored without an error.
  *


### PR DESCRIPTION
I was writing a C++ wrapper around this, and was surprised by what lyd_path() said about the returned value (instead of the expected `/example:a/b`, I just got `/example:b`). Of course this makes sense when the reader is intimately familiar with how libyang works, but it's better to be explicit about what exactly the implications are here. I got curious enough to write a test for this, my colleague who reviewed the bindings were surprised as well, so let's improve the docs.

Since this is probably the only function which returns a "disconnected" `lyd_node` and there's no explanation of what a "disconnected node" means, let's just be very succinct here, and improve `lyd_path()`'s docs in libyang as well.