### PR TITLE
cmake FEATURE skip program_check when TAR_BINARY is an argument

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -402,7 +402,9 @@ check_symbol_exists(mkstemps "stdlib.h" SR_HAVE_MKSTEMPS)
 unset(CMAKE_REQUIRED_DEFINITIONS)
 
 # tar
-find_program(TAR_BINARY "tar")
+if(NOT DEFINED TAR_BINARY)
+    find_program(TAR_BINARY "tar")
+endif()
 if(NOT TAR_BINARY)
     message(FATAL_ERROR "tar binary was not found.")
 endif()


### PR DESCRIPTION
When cross-compiling the program_check finds a wrong tar executable. This patch adds a way to impose a TAR_BINARY path using a cmake argument.