### PR TITLE
Reorder cmocka.h include to fix build error

### DIFF
--- a/tests/test_apply_changes.c
+++ b/tests/test_apply_changes.c
@@ -25,6 +25,7 @@
 #include <string.h>
 #include <sys/types.h>
 #include <unistd.h>
+#include <stdint.h>
 
 #include <cmocka.h>
 #include <libyang/libyang.h>

--- a/tests/test_candidate.c
+++ b/tests/test_candidate.c
@@ -21,6 +21,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <unistd.h>
+#include <stdint.h>
 
 #include <cmocka.h>
 #include <libyang/libyang.h>

--- a/tests/test_context_change.c
+++ b/tests/test_context_change.c
@@ -25,6 +25,7 @@
 #include <string.h>
 #include <sys/types.h>
 #include <unistd.h>
+#include <stdint.h>
 
 #include <cmocka.h>
 #include <libyang/libyang.h>

--- a/tests/test_copy_config.c
+++ b/tests/test_copy_config.c
@@ -24,6 +24,7 @@
 #include <string.h>
 #include <sys/types.h>
 #include <unistd.h>
+#include <stdint.h>
 
 #include <cmocka.h>
 #include <libyang/libyang.h>

--- a/tests/test_edit.c
+++ b/tests/test_edit.c
@@ -21,6 +21,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <unistd.h>
+#include <stdint.h>
 
 #include <cmocka.h>
 #include <libyang/libyang.h>

--- a/tests/test_get.c
+++ b/tests/test_get.c
@@ -24,6 +24,7 @@
 #include <sys/types.h>
 #include <unistd.h>
 #include <unistd.h>
+#include <stdint.h>
 
 #include <cmocka.h>
 #include <libyang/libyang.h>

--- a/tests/test_lock.c
+++ b/tests/test_lock.c
@@ -25,6 +25,7 @@
 #include <sys/types.h>
 #include <time.h>
 #include <unistd.h>
+#include <stdint.h>
 
 #include <cmocka.h>
 #include <libyang/libyang.h>

--- a/tests/test_modules.c
+++ b/tests/test_modules.c
@@ -24,6 +24,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <unistd.h>
+#include <stdint.h>
 
 #include <cmocka.h>
 #include <libyang/libyang.h>

--- a/tests/test_multi_connection.c
+++ b/tests/test_multi_connection.c
@@ -22,6 +22,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <unistd.h>
+#include <stdint.h>
 
 #include <cmocka.h>
 #include <libyang/libyang.h>

--- a/tests/test_nacm.c
+++ b/tests/test_nacm.c
@@ -21,6 +21,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <unistd.h>
+#include <stdint.h>
 
 #include <cmocka.h>
 #include <libyang/libyang.h>

--- a/tests/test_notif.c
+++ b/tests/test_notif.c
@@ -27,6 +27,7 @@
 #include <sys/types.h>
 #include <time.h>
 #include <unistd.h>
+#include <stdint.h>
 
 #include <cmocka.h>
 #include <libyang/libyang.h>

--- a/tests/test_oper_pull.c
+++ b/tests/test_oper_pull.c
@@ -23,6 +23,7 @@
 #include <string.h>
 #include <unistd.h>
 #include <errno.h>
+#include <stdint.h>
 
 #include <cmocka.h>
 #include <libyang/libyang.h>

--- a/tests/test_oper_push.c
+++ b/tests/test_oper_push.c
@@ -23,6 +23,7 @@
 #include <string.h>
 #include <unistd.h>
 #include <errno.h>
+#include <stdint.h>
 
 #include <cmocka.h>
 #include <libyang/libyang.h>

--- a/tests/test_rotation.c
+++ b/tests/test_rotation.c
@@ -28,6 +28,8 @@
 #include <stdlib.h>
 #include <setjmp.h>
 #include <stdarg.h>
+#include <stdint.h>
+
 #include <cmocka.h>
 
 #include <libyang/libyang.h>

--- a/tests/test_validation.c
+++ b/tests/test_validation.c
@@ -21,6 +21,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <unistd.h>
+#include <stdint.h>
 
 #include <cmocka.h>
 #include <libyang/libyang.h>


### PR DESCRIPTION
On ubuntu 22.04,
After building libyang with -DENABLE_TESTS=ON, 
sysrepo fails to build with -DENABLE_TESTS=ON, with 'make' generating the error
```
[ 32%] Building C object tests/CMakeFiles/test_modules.dir/test_modules.c.o                                                                                                                                                                                                               
In file included from /home/ayin/tmp/sysrepo/tests/test_modules.c:28:                                                                                                                                                                                                                     
/usr/local/include/cmocka.h:2216:42: error: unknown type name 'uintmax_t'
```

Fix was to reorder `#include <cmocka.h>` as suggested by https://github.com/clibs/cmocka/issues/18

I built libyang via
```
cmake -DCMAKE_BUILD_TYPE:String="Release" -DENABLE_TESTS=ON ..
make -Wno -j8
sudo make install
```
and libnetconf2 via
```
cmake -DCMAKE_BUILD_TYPE:String="Release" ..
make -Wno -j8
sudo make install
```
then tried building sysrepo with
```
cmake -DCMAKE_BUILD_TYPE:String="Release" -DENABLE_TESTS=ON ..
make -Wno -j8
sudo make install
```
which worked only after reordering the headers. I ran into a similar problem with libnetconf2 tests, but haven't got a chance to look further.