### PR TITLE
Include stdint for newer cmocka

### DIFF
--- a/tests/test_apply_changes.c
+++ b/tests/test_apply_changes.c
@@ -21,6 +21,7 @@
 #include <sched.h>
 #include <setjmp.h>
 #include <stdarg.h>
+#include <stdint.h>
 #include <stdlib.h>
 #include <string.h>
 #include <sys/types.h>

--- a/tests/test_candidate.c
+++ b/tests/test_candidate.c
@@ -18,6 +18,7 @@
 
 #include <setjmp.h>
 #include <stdarg.h>
+#include <stdint.h>
 #include <stdlib.h>
 #include <string.h>
 #include <unistd.h>

--- a/tests/test_context_change.c
+++ b/tests/test_context_change.c
@@ -21,6 +21,7 @@
 #include <sched.h>
 #include <setjmp.h>
 #include <stdarg.h>
+#include <stdint.h>
 #include <stdlib.h>
 #include <string.h>
 #include <sys/types.h>

--- a/tests/test_copy_config.c
+++ b/tests/test_copy_config.c
@@ -19,7 +19,7 @@
 #include <pthread.h>
 #include <setjmp.h>
 #include <stdarg.h>
-#include <stdlib.h>
+#include <stdint.h>
 #include <stdlib.h>
 #include <string.h>
 #include <sys/types.h>

--- a/tests/test_edit.c
+++ b/tests/test_edit.c
@@ -18,6 +18,7 @@
 
 #include <setjmp.h>
 #include <stdarg.h>
+#include <stdint.h>
 #include <stdlib.h>
 #include <string.h>
 #include <unistd.h>

--- a/tests/test_get.c
+++ b/tests/test_get.c
@@ -19,6 +19,7 @@
 #include <pthread.h>
 #include <setjmp.h>
 #include <stdarg.h>
+#include <stdint.h>
 #include <stdlib.h>
 #include <string.h>
 #include <sys/types.h>

--- a/tests/test_lock.c
+++ b/tests/test_lock.c
@@ -19,7 +19,7 @@
 #include <pthread.h>
 #include <setjmp.h>
 #include <stdarg.h>
-#include <stdlib.h>
+#include <stdint.h>
 #include <stdlib.h>
 #include <string.h>
 #include <sys/types.h>

--- a/tests/test_modules.c
+++ b/tests/test_modules.c
@@ -21,6 +21,7 @@
 #include <pwd.h>
 #include <setjmp.h>
 #include <stdarg.h>
+#include <stdint.h>
 #include <stdlib.h>
 #include <string.h>
 #include <unistd.h>

--- a/tests/test_multi_connection.c
+++ b/tests/test_multi_connection.c
@@ -19,6 +19,7 @@
 #include <pthread.h>
 #include <setjmp.h>
 #include <stdarg.h>
+#include <stdint.h>
 #include <stdlib.h>
 #include <string.h>
 #include <unistd.h>

--- a/tests/test_nacm.c
+++ b/tests/test_nacm.c
@@ -18,6 +18,7 @@
 
 #include <setjmp.h>
 #include <stdarg.h>
+#include <stdint.h>
 #include <stdlib.h>
 #include <string.h>
 #include <unistd.h>

--- a/tests/test_notif.c
+++ b/tests/test_notif.c
@@ -21,6 +21,7 @@
 #include <pthread.h>
 #include <setjmp.h>
 #include <stdarg.h>
+#include <stdint.h>
 #include <stdlib.h>
 #include <string.h>
 #include <sys/stat.h>

--- a/tests/test_oper_pull.c
+++ b/tests/test_oper_pull.c
@@ -19,6 +19,7 @@
 #include <pthread.h>
 #include <setjmp.h>
 #include <stdarg.h>
+#include <stdint.h>
 #include <stdlib.h>
 #include <string.h>
 #include <unistd.h>

--- a/tests/test_oper_push.c
+++ b/tests/test_oper_push.c
@@ -19,6 +19,7 @@
 #include <pthread.h>
 #include <setjmp.h>
 #include <stdarg.h>
+#include <stdint.h>
 #include <stdlib.h>
 #include <string.h>
 #include <unistd.h>

--- a/tests/test_rotation.c
+++ b/tests/test_rotation.c
@@ -25,9 +25,11 @@
 #include <sys/wait.h>
 #include <signal.h>
 #include <errno.h>
+#include <stdint.h>
 #include <stdlib.h>
 #include <setjmp.h>
 #include <stdarg.h>
+
 #include <cmocka.h>
 
 #include <libyang/libyang.h>

--- a/tests/test_validation.c
+++ b/tests/test_validation.c
@@ -18,6 +18,7 @@
 
 #include <setjmp.h>
 #include <stdarg.h>
+#include <stdint.h>
 #include <stdlib.h>
 #include <string.h>
 #include <unistd.h>


### PR DESCRIPTION
Following up on https://github.com/sysrepo/sysrepo/pull/3064

Root cause of cmocka build issue is that on newer cmocka's `#include <stdint.h>` is no longer present in `cmocka.h`

Newer cmocka releases expect users to include stdint.h themselves prior to including cmocka.h or implement custom types.

[ cmocka 1.1.5](https://github.com/clibs/cmocka/blob/f5e2cd77c88d9f792562888d2b70c5a396bfbf7a/include/cmocka.h#L50)

[ cmocka 1.0.1](https://github.com/clibs/cmocka/blob/12ce9a800c6ff9189c004202f019723405003e1d/include/cmocka.h#L49)