### PR TITLE
Add support for loading /etc/sysrepo/factory-default

### DIFF
--- a/src/common.c
+++ b/src/common.c
@@ -1316,6 +1316,35 @@ sr_path_conn_lockfile(sr_cid_t cid, int creat, char **path)
     return err_info;
 }
 
+sr_error_info_t *
+sr_path_factory_default(char **path)
+{
+    const char *fdpath = "%s/factory-default.xml";
+    sr_error_info_t *err_info = NULL;
+    int ret, once = 0;
+
+retry:
+    ret = asprintf(path, fdpath, sr_get_repo_path());
+    if (ret == -1) {
+        SR_ERRINFO_MEM(&err_info);
+        goto cleanup;
+    }
+
+    if (sr_file_exists(*path)) {
+        return NULL;
+    }
+
+    free(*path);
+    if (!once++) {
+        fdpath = "%s/factory-default.json";
+        goto retry;
+    }
+
+cleanup:
+    *path = NULL;
+    return err_info;
+}
+
 void
 sr_remove_evpipes(void)
 {

--- a/src/common.h
+++ b/src/common.h
@@ -480,6 +480,17 @@ sr_error_info_t *sr_path_yang_file(const char *mod_name, const char *mod_rev, ch
 sr_error_info_t *sr_path_conn_lockfile(sr_cid_t cid, int creat, char **path);
 
 /**
+ * @brief Get the path to system factory default input data used to init internal modules
+ *
+ * Looks for the file factory_default_config.xml, with fallback to
+ * factory_default_config.json in /etc/sysrepo/.
+ *
+ * @param[out] path Created path.
+ * @return err_info, NULL on success.
+ */
+sr_error_info_t *sr_path_factory_default(char **path);
+
+/**
  * @brief Remove any leftover event pipes after crashed subscriptions.
  * There should be none unless there was a subscription structure without subscriptions that crashed.
  */


### PR DESCRIPTION
For some use-cases a compile-time factory-default cannot be used.  E.g., the same firmware image used for multiple products/models where data like, hostname and number of interfaces, with varying defaults are a requested.  The defaults themselves are static and never change, but on factory-reset the devices should return to model specific default data known only at runtime rather than compile-time.

This is a draft PR since I'm not even sure this is functionality the sysrepo team would like to maintain.  I've omitted not just documentation, but also cmake support for selecting default filename/path to look for, and only JSON and XML is supported right now, with a preference to xml ... any comments welcome, but you can also just close it if it's not a feature you want to support.
