### PR TITLE
edit_diff: fix (leaf-)list instance move checks

### DIFF
--- a/src/edit_diff.c
+++ b/src/edit_diff.c
@@ -960,7 +960,7 @@ sr_lyd_diff_apply_cb(const struct lyd_node *diff_node, struct lyd_node *data_nod
  *
  * @param[in] data_match Node instance in the data tree.
  * @param[in] insert Insert place.
- * @param[in] anchor_node Optional relative instance in the data tree.
+ * @param[in] anchor_node Optional relative instance in the data or edit tree.
  * @return 0 if not, non-zero if it was.
  */
 static int
@@ -979,7 +979,7 @@ sr_edit_userord_is_moved(const struct lyd_node *data_match, enum insert_val inse
     case INSERT_FIRST:
     case INSERT_AFTER:
         sibling = sr_edit_find_previous_instance(data_match);
-        if (sibling == anchor_node) {
+        if (!lyd_compare_single(sibling, anchor_node, 0)) {
             /* data_match is after the anchor node (or is the first) */
             return 0;
         }
@@ -1001,7 +1001,7 @@ sr_edit_userord_is_moved(const struct lyd_node *data_match, enum insert_val inse
                 }
             }
         }
-        if (sibling == anchor_node) {
+        if (!lyd_compare_single(sibling, anchor_node, 0)) {
             /* data_match is before the anchor node (or is the last) */
             return 0;
         }

--- a/tests/test_apply_changes.c
+++ b/tests/test_apply_changes.c
@@ -6255,6 +6255,7 @@ apply_change_userord_thread(void *arg)
 {
     struct state *st = (struct state *)arg;
     sr_session_ctx_t *sess;
+    sr_data_t *data;
     int ret;
 
     ret = sr_session_start(st->conn, SR_DS_RUNNING, &sess);
@@ -6288,6 +6289,16 @@ apply_change_userord_thread(void *arg)
 
     /* signal that we have finished applying changes */
     pthread_barrier_wait(&st->barrier);
+
+    /* get data and reapply, the module change callback should not be called
+    else the test fails */
+    ret = sr_get_data(sess, "/test:*", 0, 0, 0, &data);
+    assert_int_equal(ret, SR_ERR_OK);
+    assert_non_null(data);
+    sr_edit_batch(sess, data->tree, "replace");
+    assert_int_equal(ret, SR_ERR_OK);
+    ret = sr_apply_changes(sess, 0);
+    sr_release_data(data);
 
     /* wait for unsubscribe */
     pthread_barrier_wait(&st->barrier);


### PR DESCRIPTION
This test is never true except for the first element since the "sibling" is from data tree whereas the "anchor_node" is from "edit_node". Use "lyd_compare_single" to compare if nodes are equal.

Fix #3159 