### PR TITLE
CMakeLists.txt: install SR_PLUGINS_PATH directory

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -454,6 +454,7 @@ install(TARGETS sysrepoctl sysrepocfg sysrepo-plugind DESTINATION ${CMAKE_INSTAL
 install(FILES ${PROJECT_SOURCE_DIR}/src/executables/sysrepoctl.1 ${PROJECT_SOURCE_DIR}/src/executables/sysrepocfg.1
         DESTINATION ${CMAKE_INSTALL_MANDIR}/man1)
 install(FILES ${PROJECT_SOURCE_DIR}/src/executables/sysrepo-plugind.8 DESTINATION ${CMAKE_INSTALL_MANDIR}/man8)
+install(DIRECTORY DESTINATION ${SR_PLUGINS_PATH})
 install(DIRECTORY DESTINATION ${SRPD_PLUGINS_PATH})
 if(SR_HAVE_SYSTEMD)
     install(FILES ${PROJECT_BINARY_DIR}/sysrepo-plugind.service DESTINATION ${SYSTEMD_UNIT_DIR})


### PR DESCRIPTION
As with `SRPD_PLUGINS_PATH`, CMake should also install a stub directory for `SR_PLUGINS_PATH`.