### PR TITLE
Maintain a list of well-known originator data

### DIFF
--- a/doc/conn_sess.dox
+++ b/doc/conn_sess.dox
@@ -24,7 +24,7 @@ the output, for example.
 Also, every session has a **unique ID** among all Sysrepo sessions. This is useful when an operation fails because of
 another session (locked module, for instance). In addition, it is possible to learn what session initiated an event
 that is being processed in a subscription callback. In this case there is even an information about the NETCONF
-session (its ID) if the originator application stored it into the Sysrepo session.
+session (its ID) if the originator application [stored it](@ref sr_session_push_orig_data) into the Sysrepo session.
 
 Next, session **user** can be changed to an arbitrary one present on the system. This is useful for applications that serve
 only as an (remote) interface to Sysrepo. However, as this allows for a complete [access control](@ref access_control)

--- a/src/sysrepo.h
+++ b/src/sysrepo.h
@@ -289,6 +289,8 @@ sr_datastore_t sr_session_get_ds(sr_session_ctx_t *session);
  * The following originator names are well-known:
  *
  * - `netopeer2` for the [NETCONF server](https://github.com/CESNET/Netopeer2/#sysrepo-callbacks)
+ * - `rousette` for the [RESTCONF server](https://github.com/CESNET/rousette)
+ * - `sysrepo-cli` for the direct sysrepo mode of the [interactive CLI](https://github.com/CESNET/netconf-cli)
  *
  * @param[in] session Session (not [DS](@ref sr_datastore_t)-specific) to use.
  * @param[in] orig_name Arbitrary originator name.

--- a/src/sysrepo.h
+++ b/src/sysrepo.h
@@ -302,8 +302,9 @@ const char *sr_session_get_orig_name(sr_session_ctx_t *session);
 
 /**
  * @brief Push (add) another chunk of event originator data used for all events sent on this session.
- * Its meaning is specific to the originator name (which must be set prior to calling this function) and can be read
- * from the implicit event session in the callbacks using ::sr_session_get_orig_data().
+ * Its meaning is specific to the originator name (which must be [set](@ref sr_session_set_orig_name)
+ * prior to calling this function) and can be read from the implicit event session in the callbacks
+ * using ::sr_session_get_orig_data().
  *
  * @param[in] session Session (not [DS](@ref sr_datastore_t)-specific) to use.
  * @param[in] size Size of the @p data chunk.

--- a/src/sysrepo.h
+++ b/src/sysrepo.h
@@ -286,6 +286,10 @@ sr_datastore_t sr_session_get_ds(sr_session_ctx_t *session);
  * It can then be read from the implicit event session in the callbacks using ::sr_session_get_orig_name().
  * This name should be used for interpreting the data set by ::sr_session_push_orig_data().
  *
+ * The following originator names are well-known:
+ *
+ * - `netopeer2` for the [NETCONF server](https://github.com/CESNET/Netopeer2/#sysrepo-callbacks)
+ *
  * @param[in] session Session (not [DS](@ref sr_datastore_t)-specific) to use.
  * @param[in] orig_name Arbitrary originator name.
  * @return Error code (::SR_ERR_OK on success).


### PR DESCRIPTION
My end goal is to have something which tells [`sysrepo-ietf-alarms`](https://github.com/CESNET/sysrepo-ietf-alarms) whether the requesting session is a "local application" that has connected directly to sysrepo, or whether it's something that talks a standard protocol such as NETCONF or RESTCONF. In this alarm daemon, the remote users should not have access to the [`/sysrepo-ietf-alarms:create-or-update-alarm` RPC](https://github.com/CESNET/sysrepo-ietf-alarms/blob/adce6761831797fcbb60554591c91352cdaf791d/yang/sysrepo-ietf-alarms%402022-02-17.yang#L16) because this RPC is only intended as a way for local applications to publish alarms. In other words, it should not be invocable through NETCONF or RESTCONF, or even from the local CLI application, but it's OK to trigger it from a daemon which, e.g., [measures voltages of PSUs or fan speeds](https://github.com/CESNET/velia).