### PR TITLE
sysrepo UPDATE don't check feature '*'

### DIFF
--- a/src/sysrepo.c
+++ b/src/sysrepo.c
@@ -1271,6 +1271,10 @@ sr_install_modules_check_features(const struct lys_module *ly_mod, const char **
     uint32_t i = 0, j;
     const char *feature;
 
+    if (!strcmp(features[0], "*")) {
+        return NULL;
+    }
+
     /* first check feature existence */
     for (j = 0; features && features[j]; ++j) {
         if (lys_feature_value(ly_mod, features[j]) == LY_ENOTFOUND) {


### PR DESCRIPTION
sysrepoctl returned an error when checking the feature '\*' in sr_install_modules_check_features. For example:
sysrepoctl -s yang_directory	-i file.yang -e '\*'
Now the function no longer returns an error anymore.
