### PR TITLE
sysrepo BUGFIX run_cache realloc wrong array index

### DIFF
--- a/src/common.c
+++ b/src/common.c
@@ -3178,7 +3178,7 @@ sr_conn_run_cache_update(sr_conn_ctx_t *conn, const struct sr_mod_info_s *mod_in
             SR_CHECK_MEM_GOTO(!mem, err_info, cleanup);
             conn->run_cache_mods = mem;
 
-            cmod = &conn->run_cache_mods[j];
+            cmod = &conn->run_cache_mods[conn->run_cache_mod_count];
             cmod->mod = mod->ly_mod;
             cmod->id = UINT32_MAX;
 


### PR DESCRIPTION
When we realloc the run_cache in `sr_conn_run_cache_update`, we first unlock a read lock and then reacquire a write lock. During this process another writer could have added more modules to the cache. In this case the index `j` would no longer point to the last element of the `run_cache_mods` array.

So, the new initialization would overwrite the older module, and in addition leave the newly extended memory uninitialized.