### PR TITLE
doc UPDATE make it clear when a subscribed callback will not be called twice

### DIFF
--- a/src/sysrepo_types.h
+++ b/src/sysrepo_types.h
@@ -380,7 +380,8 @@ typedef enum {
      * - the subscriber is the "owner" of the subscribed data tree and it will appear in the operational
      *   datastore while this subscription is alive (if not already, can be changed using ::SR_SUBSCR_PASSIVE flag),
      * - the callback will be called twice, once with ::SR_EV_CHANGE event and once with ::SR_EV_DONE / ::SR_EV_ABORT
-     *   event passed in (can be changed with ::SR_SUBSCR_DONE_ONLY flag).
+     *   event passed in (can be changed with ::SR_SUBSCR_DONE_ONLY flag). The callback that failed will not get
+     *   ::SR_EV_ABORT and therefore be called only once.
      */
     SR_SUBSCR_DEFAULT = 0x00,
 


### PR DESCRIPTION
There is also a note here: https://github.com/sysrepo/sysrepo/blob/master/src/sysrepo_types.h#L471

but if someone misses that note, and only reads the doc for `sr_subscr_flag_t()`, it will be wrongly assumed that `SR_EV_ABORT` is also passed to the callback even if it failed as that is how it's mentioned here