### PR TITLE
NULL check for empty main_shm

### DIFF
--- a/src/shm_main.c
+++ b/src/shm_main.c
@@ -489,6 +489,10 @@ sr_shmmain_open(sr_shm_t *shm, int *created)
     }
 
     main_shm = (sr_main_shm_t *)shm->addr;
+
+    /* main_shm can never be NULL */
+    assert(main_shm);
+
     if (creat) {
         /* init the memory */
         main_shm->shm_ver = SR_SHM_VER;
@@ -519,6 +523,10 @@ sr_shmmain_open(sr_shm_t *shm, int *created)
 
 cleanup:
     if (err_info) {
+        if (creat) {
+            /* tried to create but could not setup fully, remove improper shm file */
+            unlink(shm_name);
+        }
         sr_shm_clear(shm);
     } else if (created) {
         *created = creat;


### PR DESCRIPTION
 In case a less priviliged process attempts to connect to sysrepo,
 before shm has been properly set up, main_shm file is created but the
 permissions aren't set up correctly. Upon detecting that failure, the
 process leaves an empty main_shm file.

 Any processes which try to connect later to sysrepo must not crash.

 Ideally `sr_open` must not leave a file it could not properly setup.