### PR TITLE
downgrade mod locks to read after storing changes

### DIFF
--- a/src/shm_mod.c
+++ b/src/shm_mod.c
@@ -1394,16 +1394,17 @@ sr_shmmod_modinfo_wrlock_downgrade(struct sr_mod_info_s *mod_info, uint32_t sid,
         shm_lock = &mod->shm_mod->data_lock_info[mod_info->ds];
 
         /* downgrade only write-locked modules */
-        if (mod->state & MOD_INFO_WLOCK) {
+        if (mod->state & MOD_INFO_WLOCK || mod->state & MOD_INFO_RLOCK_UPGR) {
             /* MOD READ DOWNGRADE */
-            if ((err_info = sr_shmmod_lock(mod->ly_mod, mod_info->ds, shm_lock, timeout_ms, SR_LOCK_READ_UPGR,
+            if ((err_info = sr_shmmod_lock(mod->ly_mod, mod_info->ds, shm_lock, timeout_ms, SR_LOCK_READ,
                     0, mod_info->conn->cid, sid, mod->ds_handle[mod_info->ds], 1))) {
                 return err_info;
             }
 
             /* update the flag for unlocking */
             mod->state &= ~MOD_INFO_WLOCK;
-            mod->state |= MOD_INFO_RLOCK_UPGR;
+            mod->state &= ~MOD_INFO_RLOCK_UPGR;
+            mod->state |= MOD_INFO_RLOCK;
         }
     }
 


### PR DESCRIPTION
In `sr_changes_notify_store`, the mod locks we need are

Step 1. READ_UPGR lock until sr_modinfo_data_store.
    a. update, change and abort notifications.
Step 2. WRITE lock during sr_modinfo_data_store.
Step 3. READ (instead of READ_UPGR) lock after sr_modinfo_data_store.
    a. wait for done notifications

sr_shmmod_modinfo_wrlock_downgrade is called after Step 2. but we only downgrade to READ_UPGR, but only READ lock is necessary.

To enable a full downgrade to READ lock, we must prevent the below race.
1. `_sr_shmsub_notify_wait_wr` of a process P1 for done events. and
2. `sr_shmsub_notify_new_wrlock` of a process P2.

After P1 has notified subscribers, and they have finished processing, if P2 has acquired the sub_shm lock, before P1 has a chance to check.

In this case P2 will go ahead and publish it's own event, causing P1 to timeout incorrectly.

To prevent this, P2 must check that the previous event is not only processssed by subscribers but also that P1 has finished checking the result. We can use the orig_cid field of sr_sub_shm_t for this.

we clear the `orig_cid` field of `sub_shm` after P1 is finished waiting for the event. The next publisher P2 will wait for orig_cid to be 0, before publishing new events.