### PR TITLE
ds json BUGFIX don't rename log files with old notification.

### DIFF
--- a/src/plugins/ntf_json.c
+++ b/src/plugins/ntf_json.c
@@ -331,9 +331,10 @@ srpntf_rename_file(const char *mod_name, time_t old_from_ts, time_t old_to_ts, t
     sr_error_info_t *err_info = NULL;
     char *old_path = NULL, *new_path = NULL;
 
-    assert(old_to_ts <= new_to_ts);
-
-    if (old_to_ts == new_to_ts) {
+    /* If the notification timestamp is older than the notification file
+     * don't rename the file. It can happen when there is a jump in realtime,
+     * because of NTP, for example. */
+    if (old_to_ts >= new_to_ts) {
         /* nothing to do */
         goto cleanup;
     }


### PR DESCRIPTION
sysrepo uses notification timestamps to rename the log files. The first timestamp in the name is the timestamp of the first notification and the second one is the timestamp of the last notification. However, if the timestamp is in the past, the new file name will be invalid. To avoid losing notification files, don't rename the file with an older timestamp. The file may contain notification with old timestamps.