### PR TITLE
Add datastore/notification plugin setup information to docs (see #3255)

### DIFF
--- a/doc/sr_plugins.dox
+++ b/doc/sr_plugins.dox
@@ -4,7 +4,9 @@
 Sysrepo itself supports 2 kinds of plugins not to be confused with `sysrepo-plugind` plugins. **Datastore plugins**
 define a set of callbacks that implement all the operations performed on a datastore allowing to implement a completely
 custom datastore. Every datastore for every YANG module can use a different datastore implementation. **Notification
-plugins** is the exact same concept used for implementing storage of notifications stored for replay.
+plugins** is the exact same concept used for implementing storage of notifications stored for replay. These plugins can
+be installed with `sysrepoctl --plugin-install`. Once installed, `sysrepoctl --module-plugin` can be used to specify
+which datastores and YANG modules will use each plugin.
 
 There are 2 main reasons for implementing a custom datastore plugin. Firstly, it is almost a necessity when adding
 Sysrepo support for an existing application/daemon with its own configuration. Normally, the configuration would have
@@ -21,7 +23,7 @@ on large data. In this case the whole data must be parsed, the change performed,
 back. Instead, another datastore may be able to store the change directly without parsing and printing all the other
 stored data. As for the space required, if implementing a datastore for a specific YANG module, the data structure can
 fully depend on the schema nodes defined in the module and hence avoid storing any redundant information. Finally,
-note that the internal LYB datastore is also implemented as a datastore plugin so it can be used as an example
+note that the internal JSON datastore is also implemented as a datastore plugin so it can be used as an example
 implementation.
 
 @ref dsplg_api


### PR DESCRIPTION
- Mention how to install and set up datastore/notification plugins.
- Correct internal LYB datastore to internal JSON datastore, since the latter has replaced the former.