### PR TITLE
bugfix shm_sub event type finished instead of none

### DIFF
--- a/src/common.c
+++ b/src/common.c
@@ -3904,6 +3904,8 @@ sr_ev2str(sr_sub_event_t ev)
         return "success";
     case SR_SUB_EV_ERROR:
         return "error";
+    case SR_SUB_EV_FINISHED:
+        return "finished";
     case SR_SUB_EV_UPDATE:
         return "update";
     case SR_SUB_EV_CHANGE:

--- a/src/common_types.h
+++ b/src/common_types.h
@@ -69,9 +69,15 @@ typedef struct {
  * @brief Subscription event.
  */
 typedef enum {
-    SR_SUB_EV_NONE = 0,         /**< No event. */
+    SR_SUB_EV_NONE = 0,         /**< No event. The last event was cleared by the notifier
+                                     and the shm is ready for the next event. */
     SR_SUB_EV_SUCCESS,          /**< Event processed successfully by subscribers. */
     SR_SUB_EV_ERROR,            /**< Event failed to be processed by a subscriber. */
+    SR_SUB_EV_FINISHED,         /**< Done and abort event processing finished by subscribers.
+                                     Notifier will wait for subscribers to finish (set event to SR_SUB_EV_FINISHED)
+                                     and then clear the event (by setting event to SR_SUB_EV_NONE).
+                                     If subscribers set event to SR_SUB_EV_NONE, a new event can be published before
+                                     the previous notifier sees the event was finished. */
 
     SR_SUB_EV_UPDATE,           /**< New update event ready. */
     SR_SUB_EV_CHANGE,           /**< New change event ready. */

--- a/src/shm_types.h
+++ b/src/shm_types.h
@@ -41,7 +41,7 @@
         || (ev == SR_SUB_EV_NOTIF))
 
 /** Whether an event is one to be processed by the originators. */
-#define SR_IS_NOTIFY_EVENT(ev) ((ev == SR_SUB_EV_SUCCESS) || (ev == SR_SUB_EV_ERROR))
+#define SR_IS_NOTIFY_EVENT(ev) ((ev == SR_SUB_EV_SUCCESS) || (ev == SR_SUB_EV_ERROR) || (ev == SR_SUB_EV_FINISHED))
 
 /**
  * @brief Mod SHM dependency type.


### PR DESCRIPTION
change_sub event listeners should use `SR_SUB_EV_FINISHED` instead of `SR_SUB_EV_NONE` to signal that they are done. Only the originators of the event should set it to `SR_SUB_EV_NONE`.

`sr_shmsub_notify_new_wrlock` waits for `SR_SUB_EV_NONE`, and it can assume that the previous event is finished but it's originator may not have seen it yet.

To prevent this, previously `orig_cid` was used, but this is not reliable. If a timeout happens while the listeners have the read lock, the originator cannot clear `orig_cid`. The shm becomes unusable after this as `new_wrlock` will wait forever for `orig_cid == 0`.

Since `sub_shm->event` is an atomic type, we can always set it even though we don't have a WRITE lock, and we already do this.

RPCs will continue to use `SR_SUB_EV_NONE` for `SR_SUB_EV_NOTIF` as the originators don't always wait, and setting event to `SR_SUB_EV_FINISHED` is not needed.