### PR TITLE
shm_sub BUGFIX skip process events when suspended

### DIFF
--- a/src/common_types.h
+++ b/src/common_types.h
@@ -238,6 +238,7 @@ struct sr_subscription_ctx_s {
 
             ATOMIC_T request_id;    /**< Request ID of the last processed request. */
             ATOMIC_T event;         /**< Type of the last processed event. */
+            ATOMIC_T suspended;     /**< Whether the subscription is suspended. */
         } *subs;                    /**< Configuration change subscriptions for each XPath. */
         uint32_t sub_count;         /**< Configuration change module XPath subscription count. */
 
@@ -257,6 +258,7 @@ struct sr_subscription_ctx_s {
 
             ATOMIC_T request_id;    /**< Request ID of the last processed request. */
             sr_shm_t sub_shm;       /**< Subscription SHM. */
+            ATOMIC_T suspended;     /**< Whether the subscription is suspended. */
         } *subs;                    /**< Operational subscriptions for each XPath. */
         uint32_t sub_count;         /**< Operational module XPath subscription count. */
     } *oper_get_subs;               /**< Operational get subscriptions for each module. */
@@ -270,6 +272,7 @@ struct sr_subscription_ctx_s {
             uint32_t valid_ms;      /**< Cached operational data validity interval in ms. */
             sr_subscr_options_t opts;   /**< Subscription options. */
             sr_session_ctx_t *sess; /**< Subscription session. */
+            ATOMIC_T suspended;     /**< Whether the subscription is suspended. */
         } *subs;                    /**< Operational subscriptions for each XPath. */
         uint32_t sub_count;         /**< Operational module XPath subscription count. */
     } *oper_poll_subs;              /**< Operational poll subscriptions for each module. */
@@ -290,6 +293,7 @@ struct sr_subscription_ctx_s {
             void *private_data;     /**< Subscription callback private data. */
             sr_session_ctx_t *sess; /**< Subscription session. */
             ATOMIC_T filtered_out;  /**< Number of notifications that were filtered out. */
+            ATOMIC_T suspended;     /**< Whether the subscription is suspended. */
         } *subs;                    /**< Notification subscriptions for each XPath. */
         uint32_t sub_count;         /**< Notification module XPath subscription count. */
 
@@ -312,6 +316,7 @@ struct sr_subscription_ctx_s {
 
             ATOMIC_T request_id;    /**< Request ID of the last processed request. */
             ATOMIC_T event;         /**< Type of the last processed event. */
+            ATOMIC_T suspended;     /**< Whether the subscription is suspended. */
         } *subs;                    /**< RPC/action subscription for each XPath. */
         uint32_t sub_count;         /**< RPC/action XPath subscription count. */
 

--- a/tests/test_multi_connection.c
+++ b/tests/test_multi_connection.c
@@ -48,6 +48,7 @@ setup_f(void **state)
         TESTS_SRC_DIR "/files/test.yang",
         TESTS_SRC_DIR "/files/ietf-interfaces.yang",
         TESTS_SRC_DIR "/files/iana-if-type.yang",
+        TESTS_SRC_DIR "/files/ops.yang",
         NULL
     };
 
@@ -93,6 +94,7 @@ teardown_f(void **state)
         "ietf-interfaces",
         "iana-if-type",
         "test",
+        "ops",
         NULL
     };
 
@@ -190,12 +192,241 @@ test_new(void **state)
     pthread_barrier_destroy(&st->barrier);
 }
 
+static void
+test_sub_suspend_helper(sr_subscription_ctx_t *subscr, int suspend)
+{
+    uint32_t sub_id;
+    int ret;
+
+    if (!suspend) {
+        return;
+    }
+    sub_id = sr_subscription_get_last_sub_id(subscr);
+    ret = sr_subscription_suspend(subscr, sub_id);
+    assert_int_equal(ret, 0);
+}
+
+struct cb_data {
+    int fail;
+};
+
+static int
+module_change_cb(sr_session_ctx_t *session, uint32_t sub_id, const char *module_name, const char *xpath, sr_event_t event,
+        uint32_t request_id, void *private_data)
+{
+    struct cb_data *pvt_data = (struct cb_data *)private_data;
+
+    (void)session;
+    (void)sub_id;
+    (void)module_name;
+    (void)xpath;
+    (void)event;
+    (void)request_id;
+    if (pvt_data->fail) {
+        /* was not expected to be called */
+        fail();
+    }
+    return SR_ERR_OK;
+}
+
+static int
+suspend_oper_get_cb(sr_session_ctx_t *session, uint32_t sub_id, const char *module_name, const char *xpath,
+        const char *request_xpath, uint32_t request_id, struct lyd_node **parent, void *private_data)
+{
+    struct cb_data *pvt_data = (struct cb_data *)private_data;
+
+    (void)session;
+    (void)sub_id;
+    (void)module_name;
+    (void)xpath;
+    (void)request_xpath;
+    (void)request_id;
+    (void)parent;
+    if (pvt_data->fail) {
+        /* was not expected to be called */
+        fail();
+    }
+    return SR_ERR_OK;
+}
+
+static void
+suspend_notif_cb(sr_session_ctx_t *session, uint32_t sub_id, const sr_ev_notif_type_t notif_type, const char *path,
+        const sr_val_t *values, const size_t values_cnt, struct timespec *timestamp, void *private_data)
+{
+    struct cb_data *pvt_data = (struct cb_data *)private_data;
+
+    (void)session;
+    (void)sub_id;
+    (void)notif_type;
+    (void)path;
+    (void)values;
+    (void)values_cnt;
+    (void)timestamp;
+    switch (notif_type) {
+    case SR_EV_NOTIF_TERMINATED:
+    case SR_EV_NOTIF_SUSPENDED:
+        /* Ignore these events as they are not on the handler thread */
+        return;
+    default:
+        break;
+    }
+
+    if (pvt_data->fail) {
+        /* was not expected to be called */
+        fail();
+    }
+}
+
+static int
+suspend_rpc_cb(sr_session_ctx_t *session, uint32_t sub_id, const char *op_path, const sr_val_t *input, const size_t input_cnt,
+        sr_event_t event, uint32_t request_id, sr_val_t **output, size_t *output_cnt, void *private_data)
+{
+    struct cb_data *pvt_data = (struct cb_data *)private_data;
+
+    (void)session;
+    (void)sub_id;
+    (void)op_path;
+    (void)input;
+    (void)input_cnt;
+    (void)event;
+    (void)request_id;
+    (void)output;
+    (void)output_cnt;
+    if (pvt_data->fail) {
+        /* was not expected to be called */
+        fail();
+    }
+    return SR_ERR_OK;
+}
+
+static void
+test_sub_suspend(void **state)
+{
+    struct state *st = (struct state *)*state;
+    int i, j, ret;
+    sr_subscription_ctx_t *subscr[5] = {NULL};
+    struct cb_data pvt_data[2];
+    char xpath[128] = "";
+    const char *rpc_xpath[] = {
+        "/ops:rpc3",
+        "/ops:rpc2"
+    };
+
+    sr_val_t input, *output;
+    size_t output_count;
+
+    sr_data_t *data;
+
+    /* Create two subscriptions of each kind and suspend the second */
+    for (i = 1; i >= 0; i--) {
+        j = 0;
+        /* make the first one fail if invoked in a suspended state */
+        pvt_data[i].fail = i;
+
+        /* change_sub */
+        ret = sr_module_change_subscribe(st->sess1, "ietf-interfaces", NULL, module_change_cb, &pvt_data[i], 0, 0, &subscr[j]);
+        assert_int_equal(ret, SR_ERR_OK);
+        test_sub_suspend_helper(subscr[j], i);
+        j++;
+        /* oper get sub */
+        sprintf(xpath, "/ietf-interfaces:interfaces-state/interface[name='eth%d']/statistics", i);
+        ret = sr_oper_get_subscribe(st->sess1, "ietf-interfaces", xpath, suspend_oper_get_cb,
+                &pvt_data[i], 0, &subscr[j]);
+        assert_int_equal(ret, SR_ERR_OK);
+        test_sub_suspend_helper(subscr[j], i);
+        j++;
+
+        /* oper poll sub */
+        ret = sr_oper_poll_subscribe(st->sess1, "ietf-interfaces", xpath, 3000, 0, &subscr[j]);
+        assert_int_equal(ret, SR_ERR_OK);
+        test_sub_suspend_helper(subscr[j], i);
+        j++;
+
+        /* notification subscriptions */
+        ret = sr_notif_subscribe(st->sess1, "ops", NULL, 0, 0, suspend_notif_cb, &pvt_data[i], 0, &subscr[j]);
+        assert_int_equal(ret, SR_ERR_OK);
+        test_sub_suspend_helper(subscr[j], i);
+        j++;
+
+        /* RPC/action subscriptions */
+        ret = sr_rpc_subscribe(st->sess1, rpc_xpath[i], suspend_rpc_cb, &pvt_data[i], 0, 0, &subscr[j]);
+        assert_int_equal(ret, SR_ERR_OK);
+        test_sub_suspend_helper(subscr[j], i);
+    }
+
+    /* for change_sub */
+    ret = sr_set_item_str(st->sess1, "/ietf-interfaces:interfaces/interface[name='eth0']/type",
+            "iana-if-type:ethernetCsmacd", NULL, 0);
+    assert_int_equal(ret, SR_ERR_OK);
+    ret = sr_set_item_str(st->sess1, "/ietf-interfaces:interfaces/interface[name='eth1']/type",
+            "iana-if-type:ethernetCsmacd", NULL, 0);
+    assert_int_equal(ret, SR_ERR_OK);
+    ret = sr_apply_changes(st->sess1, 0);
+    assert_int_equal(ret, SR_ERR_OK);
+
+    ret = sr_session_switch_ds(st->sess2, SR_DS_OPERATIONAL);
+    assert_int_equal(ret, SR_ERR_OK);
+
+    ret = sr_set_item_str(st->sess2, "/ietf-interfaces:interfaces-state/interface[name='eth0']/type",
+            "iana-if-type:ethernetCsmacd", NULL, 0);
+    assert_int_equal(ret, SR_ERR_OK);
+    ret = sr_set_item_str(st->sess2, "/ietf-interfaces:interfaces-state/interface[name='eth1']/type",
+            "iana-if-type:ethernetCsmacd", NULL, 0);
+    assert_int_equal(ret, SR_ERR_OK);
+    ret = sr_apply_changes(st->sess2, 0);
+    assert_int_equal(ret, SR_ERR_OK);
+
+    ret = sr_session_switch_ds(st->sess3, SR_DS_OPERATIONAL);
+    assert_int_equal(ret, SR_ERR_OK);
+
+    /* for oper get */
+    for (i = i; i < 10; i++) {
+        ret = sr_get_data(st->sess3, "/ietf-interfaces:*", 0, 0, 0, &data);
+        assert_int_equal(ret, SR_ERR_OK);
+        assert_non_null(data);
+        sr_release_data(data);
+    }
+
+    ret = sr_session_switch_ds(st->sess3, SR_DS_RUNNING);
+    assert_int_equal(ret, SR_ERR_OK);
+    /* notif sub */
+    ret = sr_notif_send(st->sess3, "/ops:notif4", NULL, 0, 0, 0);
+    assert_int_equal(ret, SR_ERR_OK);
+
+    /* rpc sub */
+    input.xpath = "/ops:rpc3/l4";
+    input.type = SR_STRING_T;
+    input.data.string_val = "dummy";
+    input.dflt = 0;
+
+    ret = sr_rpc_send(st->sess3, "/ops:rpc3", &input, 1, 0, &output, &output_count);
+    assert_int_equal(ret, SR_ERR_OK);
+
+    sr_free_values(output, output_count);
+    /* unsubscribe and clean up */
+    while (j >= 0) {
+        ret = sr_unsubscribe(subscr[j]);
+        assert_int_equal(ret, SR_ERR_OK);
+        j--;
+    }
+
+    /* discard all operational data */
+    ret = sr_discard_items(st->sess2, NULL);
+    assert_int_equal(ret, SR_ERR_OK);
+    ret = sr_apply_changes(st->sess2, 0);
+    assert_int_equal(ret, SR_ERR_OK);
+
+    ret = sr_session_switch_ds(st->sess2, SR_DS_RUNNING);
+    assert_int_equal(ret, SR_ERR_OK);
+}
+
 int
 main(void)
 {
     const struct CMUnitTest tests[] = {
         cmocka_unit_test_teardown(test_create1, clear_interfaces),
         cmocka_unit_test(test_new),
+        cmocka_unit_test_teardown(test_sub_suspend, clear_interfaces),
     };
 
     setenv("CMOCKA_TEST_ABORT", "1", 1);


### PR DESCRIPTION
When a specific subscription in a subscription context is suspended, it may still contain other active subscriptions.

When the handler thread is woken up to process some active subscription(s), we check for all available events to process.

However, we must not process events for suspended subscriptions. If we do, we would be stealing the event from the intended subscribers.

It can also cause asserts to fired when more subs than subscriber_count have processed the event.

To prevent this, we should also store the suspended state of a subscription within the subscription context and check it before processing any events.