### PR TITLE
test_apply_changes UPDATE sync with barrier

### DIFF
--- a/tests/test_apply_changes.c
+++ b/tests/test_apply_changes.c
@@ -6504,7 +6504,8 @@ apply_change_userord_thread(void *arg)
     sr_release_data(data);
     assert_int_equal(ATOMIC_LOAD_RELAXED(st->cb_called), 4);
 
-    /* signal that we have finished applying changes */
+    /* signal that we have finished applying changes and wait for unsubscribe */
+    pthread_barrier_wait(&st->barrier);
     pthread_barrier_wait(&st->barrier);
 
     /* cleanup */
@@ -6538,6 +6539,9 @@ subscribe_change_userord_thread(void *arg)
     pthread_barrier_wait(&st->barrier);
 
     sr_unsubscribe(subscr);
+
+    /* signal that subscription was removed */
+    pthread_barrier_wait(&st->barrier);
 
     sr_session_stop(sess);
     return NULL;

--- a/tests/test_modules.c
+++ b/tests/test_modules.c
@@ -132,7 +132,8 @@ test_install_module(void **state)
     lseek(fd, 0, SEEK_SET);
     data = malloc(size + 1);
     assert_non_null(data);
-    read(fd, data, size);
+    ret = read(fd, data, size);
+    assert_int_not_equal(ret, -1);
     close(fd);
     data[size] = '\0';
 


### PR DESCRIPTION
Additional fix is needed for apply_change_userord_thread where we must sync unsubscribe or else the subscription callback can be called for the clean up portion of the test.