### PR TITLE
sysrepocfg: build-time select default LYD_FORMAT

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -228,6 +228,11 @@ if(NOT SRPD_PLUGINS_PATH)
 endif()
 message(STATUS "SRPD plugins path:  ${SRPD_PLUGINS_PATH}")
 
+if(NOT SYSREPOCFG_DEFAULT_LYD_FORMAT)
+    set(SYSREPOCFG_DEFAULT_LYD_FORMAT LYD_XML)
+endif()
+message(STATUS "sysrepocfg default data format: ${SYSREPOCFG_DEFAULT_LYD_FORMAT}")
+
 #
 # sources
 #

--- a/src/executables/bin_common.h.in
+++ b/src/executables/bin_common.h.in
@@ -35,6 +35,9 @@
 /** path to tar executable */
 #define SRPD_TAR_BINARY "@TAR_BINARY@"
 
+/** default data format for sysrepocfg */
+#define SRCFG_DEFAULT_FORMAT @SYSREPOCFG_DEFAULT_LYD_FORMAT@
+
 /** whether mkstemps is found on the system */
 #cmakedefine SR_HAVE_MKSTEMPS
 


### PR DESCRIPTION
It is useful to be able to choose the default file format for sysrepocfg at build time.

For instance, if most users prefer `JSON` over `XML`, it can be tedious to specify `-f json` for each `sysrepocfg` invocation.

With this change, it will be possible to build sysrepo using `-DSYSREPOCFG_DEFAULT_LYD_FORMAT=LYD_JSON` and use sysrepocfg.