### PR TITLE
Irfan/logging improv

### DIFF
--- a/src/sysrepo.c
+++ b/src/sysrepo.c
@@ -411,6 +411,7 @@ sr_disconnect(sr_conn_ctx_t *conn)
         return sr_api_ret(NULL, err_info);
     }
 
+    SR_LOG_INF("Connection %" PRIu32 " destroyed", conn->cid);
     /* free attributes */
     sr_conn_free(conn);
 

--- a/src/sysrepo.c
+++ b/src/sysrepo.c
@@ -724,11 +724,6 @@ _sr_session_start(sr_conn_ctx_t *conn, const sr_datastore_t datastore, sr_sub_ev
         goto error;
     }
 
-    if (!event) {
-        SR_LOG_INF("Session %" PRIu32 " (user \"%s\", CID %" PRIu32 ") created.", (*session)->sid, (*session)->user,
-                conn->cid);
-    }
-
     return NULL;
 
 error:


### PR DESCRIPTION
### **1. remove log for session_start**

According to the documentation

> a session is not synchronized at all so it must not be shared among
multiple threads. Each thread should always create its own session
to ensure correct behavior.

and

> Then, an arbitrary number of sessions can be created.
Most importantly, the threading model needs to be considered.
Other than that there are no inherent restrictions in Sysrepo and
because every session requires only little resources,
having many of them should not cause any problems.

However, emitting an `INFO` level log each time a session is started is
quite noisy. This is especially true for applications which use worker
threads which start sessions and complete the task and end the session.

It doesn't seem to be very useful to have this log and processes that
want to log this can explicitly print it as all the info is available
through `API`.

### **2. log when connection is destroyed**

A log is emitted when a connection is created, and it is equally useful
to know when it disconnects. This is especially useful to debug any
delays during system shutdown caused by `sr_disconnect` operations taking
a longer time.

This also helps to debug short-lived processes that use Sysrepo by
reading the logs.