### PR TITLE
tests BUGFIX test_mult_update sync threads

### DIFF
--- a/tests/test_apply_changes.c
+++ b/tests/test_apply_changes.c
@@ -7080,9 +7080,8 @@ test_write_starve(void **state)
 static void *
 apply_when1_thread(void *arg)
 {
+    struct state *st = (struct state *)arg;
     sr_conn_ctx_t *conn;
-
-    (void)arg;
     sr_session_ctx_t *sess;
     int ret;
 
@@ -7092,6 +7091,9 @@ apply_when1_thread(void *arg)
     assert_int_equal(ret, SR_ERR_OK);
 
     for (int i = 0; i < APPLY_ITERATIONS; i++) {
+        /* let other thread also run */
+        pthread_barrier_wait(&st->barrier);
+
         ret = sr_set_item_str(sess, "/when1:l1", "val", NULL, 0);
         assert_int_equal(ret, SR_ERR_OK);
 
@@ -7120,9 +7122,8 @@ apply_when1_thread(void *arg)
 static void *
 apply_when2_thread(void *arg)
 {
+    struct state *st = (struct state *)arg;
     sr_conn_ctx_t *conn;
-
-    (void)arg;
     sr_session_ctx_t *sess;
     int ret;
 
@@ -7138,6 +7139,9 @@ apply_when2_thread(void *arg)
     assert_int_equal(ret, SR_ERR_OK);
 
     for (int i = 0; i < APPLY_ITERATIONS; i++) {
+        /* let other thread also run */
+        pthread_barrier_wait(&st->barrier);
+
         ret = sr_set_item_str(sess, "/when2:ll", "val", NULL, 0);
         assert_int_equal(ret, SR_ERR_OK);
 


### PR DESCRIPTION
One of the threads can starve the other unless we make sure that after each iteration, the other thread is also given a chance to run. Also, for the purposes of the test, it is preferable if both threads are running in parallel, instead of one thread being starved.

Without this, valgrind test_apply_changes sometimes fail, where only one thread runs for an extended period of time.

One example of such a failure is the run https://github.com/sysrepo/sysrepo/actions/runs/9971257900/job/27551955360