### PR TITLE
test headers bugfix check_includes.sh

### DIFF
--- a/compat/check_includes.sh
+++ b/compat/check_includes.sh
@@ -1,5 +1,4 @@
-#!/bin/sh
-
+#!/bin/bash
 RETVAL=0
 
 # params - paths to the source files to search
@@ -7,10 +6,9 @@ SRC="$*"
 
 # param FUNC - name of the function in compat to check
 check_compat_func () {
-	FILES=`grep -rE "([^[:alnum:]]|^)$1\([^\)]+\)" --include=\*.{c,h} $SRC | cut -d: -f1 | uniq`
+	FILES=$(grep -rE "([^[:alnum:]]|^)$1\([^\)]+\)" --include=\*.{c,h} $SRC | cut -d: -f1 | uniq)
 	for f in $FILES; do
-		grep -q "#include \"compat.h\"" $f
-		if [ $? -ne 0 ]; then
+		if ! grep -q "#include \"compat.h\"" "$f"; then
 			echo "Missing #include \"compat.h\" in file $f for function $1()"
 			RETVAL=$((RETVAL+1))
 		fi
@@ -18,10 +16,9 @@ check_compat_func () {
 }
 
 check_compat_macro () {
-	FILES=`grep -rE "([^[:alnum:]]|^)$1([^[:alnum:]]|$)" --include=\*.{c,h} $SRC | cut -d: -f1 | uniq`
+	FILES=$(grep -rE "([^[:alnum:]]|^)$1([^[:alnum:]]|$)" --include=\*.{c,h} $SRC | cut -d: -f1 | uniq)
 	for f in $FILES; do
-		grep -q "#include \"compat.h\"" $f
-		if [ $? -ne 0 ]; then
+		if ! grep -q "#include \"compat.h\"" "$f"; then
 			echo "Missing #include \"compat.h\" in file $f for macro $1"
 			RETVAL=$((RETVAL+1))
 		fi

--- a/src/plugins/common_db.c
+++ b/src/plugins/common_db.c
@@ -17,6 +17,7 @@
 #define _GNU_SOURCE
 
 #include "common_db.h"
+#include "compat.h"
 
 #include <assert.h>
 #include <errno.h>


### PR DESCRIPTION
The script must be executed in bash and not sh as it uses bash brace expansion.

Also cleaning up the script.