### PR TITLE
scripts: don't hardcode `/bin/bash`

### DIFF
--- a/compat/check_includes.sh
+++ b/compat/check_includes.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 RETVAL=0
 
 # params - paths to the source files to search

--- a/distro/scripts/make-archive.sh
+++ b/distro/scripts/make-archive.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # create archive from current source using git
 
 VERSION=$(git log --oneline -n1 --grep="^VERSION" | rev | cut -d' ' -f1 | rev)

--- a/distro/scripts/upstream-version.sh
+++ b/distro/scripts/upstream-version.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # get latest upstream sysrepo version from github
 
 RLS_URL=https://api.github.com/repos/sysrepo/sysrepo/releases

--- a/distro/tests/test-pkg-config.sh
+++ b/distro/tests/test-pkg-config.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -ex
 
 version=`pkg-config --modversion sysrepo`

--- a/distro/tests/test-service.sh
+++ b/distro/tests/test-service.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -ex
 
 systemctl list-unit-files | grep 'sysrepo-plugind'

--- a/distro/tests/test-sysrepoctl.sh
+++ b/distro/tests/test-sysrepoctl.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -ex
 
 version=`sysrepoctl --version`


### PR DESCRIPTION
Any POSIX system has `/bin/sh`, but nothing says that BASH is at `/bin/bash`. The portable way of using BASH is to run `/usr/bin/env bash`. I'm on NixOS which uses a rather advanced way of supporting multiple versions of anything, and unless I perform some extra steps, there won't be any `/bin/bash` in my devel environment.

Fixes: 2d681b36
See-also: https://stackoverflow.com/questions/16365130/what-is-the-difference-between-usr-bin-env-bash-and-usr-bin-bash
Cc: @irfanHaslanded 