### PR TITLE
Simplify GNU C / LLVM clang check

### DIFF
--- a/compat/compat.h.in
+++ b/compat/compat.h.in
@@ -46,7 +46,7 @@
 #  endif
 #endif
 
-#if (@CMAKE_C_COMPILER_ID@ == GNU) || (@CMAKE_C_COMPILER_ID@ == Clang)
+#if defined (__GNUC__) || defined (__llvm__)
 # define UNUSED(x) UNUSED_ ## x __attribute__((__unused__))
 # define _PACKED __attribute__((__packed__))
 #else


### PR DESCRIPTION
The CMAKE_C_COMPILER_ID won't work out of the box when this compat.h.in is translated via Zigs ConfigHeader, whereas this simpler style does and as I believe they are equivalent / have the same purpose, I opted for the simpler variant.