### PR TITLE
log error when handler thread exits with failure

### DIFF
--- a/src/shm_sub.c
+++ b/src/shm_sub.c
@@ -4805,6 +4805,8 @@ sr_shmsub_listen_thread(void *arg)
              * another event is generated, our event pipe will not get notified */
             continue;
         } else if (ret) {
+            sr_errinfo_new(&err_info, ret, "Processing subscription events failed (%s).", sr_strerror(ret));
+            sr_errinfo_free(&err_info);
             goto error;
         }
 


### PR DESCRIPTION
Currently when a subscription handler thread exits due to an error, we do not write any log which could be helpful to diagnose that the subscription is no longer processing events.

Or, we should not exit the handler thread because there could be other subscriptions in the context that could still be processed. But there is no easy way of determining what has failed. Perhaps, the subscription should be removed but it may not be simple to convey this to the subscriber.