### PR TITLE
reproducible builds and bugfix strncpy length

### DIFF
--- a/distro/pkg/deb/rules
+++ b/distro/pkg/deb/rules
@@ -7,16 +7,20 @@ include /usr/share/dpkg/default.mk
 # determine number of processors to enable parallel tests
 NPROCS:=$(shell grep -c ^processor /proc/cpuinfo)
 
+# Use the build directory to set LD_LIBRARY_PATH for tests
+SR_BUILD_DIR:=$(shell pwd)/obj-$(DEB_HOST_GNU_TYPE)
+
 %:
 	dh $@ -j
 
 override_dh_auto_configure:
 	dh_auto_configure -- \
 		-DCMAKE_BUILD_TYPE:String="RelWithDebInfo" \
+		-DCMAKE_BUILD_WITH_INSTALL_RPATH=ON \
 		-DSYSREPO_UMASK=007 \
 		-DSYSREPO_GROUP=sysrepo \
 		-DNACM_SRMON_DATA_PERM=660
 
 override_dh_auto_test:
-	make -C obj-$(DEB_HOST_GNU_TYPE) test ARGS=' -j $(NPROCS) -V'
+	LD_LIBRARY_PATH="$(SR_BUILD_DIR)" make -C obj-$(DEB_HOST_GNU_TYPE) test ARGS=' -j $(NPROCS) -V'
 	make -C obj-$(DEB_HOST_GNU_TYPE) test_clean

--- a/src/common.c
+++ b/src/common.c
@@ -215,7 +215,7 @@ sr_ds_handle_init(struct sr_ds_handle_s **ds_handles, uint32_t *ds_handle_count)
         }
 
         if ((len = strlen(tmp)) < SR_PATH_MAX) {
-            strncpy(plugins_dir, tmp, SR_PATH_MAX);
+            snprintf(plugins_dir, SR_PATH_MAX, "%s", tmp);
         } else {
             sr_errinfo_new(&err_info, SR_ERR_INVAL_ARG, "SR_PLUGINS_PATH (%s) cannot be longer than %u.", tmp, SR_PATH_MAX);
             goto cleanup;
@@ -398,7 +398,7 @@ sr_ntf_handle_init(struct sr_ntf_handle_s **ntf_handles, uint32_t *ntf_handle_co
         }
 
         if ((len = strlen(tmp)) < SR_PATH_MAX) {
-            strncpy(plugins_dir, tmp, SR_PATH_MAX);
+            snprintf(plugins_dir, SR_PATH_MAX, "%s", tmp);
         } else {
             sr_errinfo_new(&err_info, SR_ERR_INVAL_ARG, "SR_PLUGINS_PATH (%s) cannot be longer than %u.", tmp, SR_PATH_MAX);
             goto cleanup;
@@ -1070,7 +1070,7 @@ sr_shm_dir_get(void)
         }
     }
 
-    strncpy(sr_shm_dir_str, tmp, SR_PATH_MAX);
+    snprintf(sr_shm_dir_str, SR_PATH_MAX, "%s", tmp);
 
     return sr_shm_dir_str;
 }
@@ -1108,7 +1108,7 @@ sr_shm_prefix(const char **prefix)
     if (err_info) {
         *prefix = NULL;
     } else {
-        strncpy(sr_shm_prefix_val, tmp, SR_PATH_MAX);
+        snprintf(sr_shm_prefix_val, SR_PATH_MAX, "%s", tmp);
         *prefix = sr_shm_prefix_val;
     }
     return err_info;

--- a/src/common.c
+++ b/src/common.c
@@ -210,15 +210,15 @@ sr_ds_handle_init(struct sr_ds_handle_s **ds_handles, uint32_t *ds_handle_count)
     if (!plugins_dir[0]) {
         /* get plugins dir from environment variable, or use default one */
         tmp = getenv("SR_PLUGINS_PATH");
-        if (tmp) {
-            if ((len = strlen(tmp)) < SR_PATH_MAX) {
-                strncpy(plugins_dir, tmp, len);
-            } else {
-                sr_errinfo_new(&err_info, SR_ERR_INVAL_ARG, "SR_PLUGINS_PATH (%s) cannot be longer than %u.", tmp, SR_PATH_MAX);
-                goto cleanup;
-            }
+        if (!tmp) {
+            tmp = SR_PLG_PATH;
+        }
+
+        if ((len = strlen(tmp)) < SR_PATH_MAX) {
+            strncpy(plugins_dir, tmp, SR_PATH_MAX);
         } else {
-            strncpy(plugins_dir, SR_PLG_PATH, SR_PATH_MAX - 1);
+            sr_errinfo_new(&err_info, SR_ERR_INVAL_ARG, "SR_PLUGINS_PATH (%s) cannot be longer than %u.", tmp, SR_PATH_MAX);
+            goto cleanup;
         }
     }
 
@@ -393,15 +393,15 @@ sr_ntf_handle_init(struct sr_ntf_handle_s **ntf_handles, uint32_t *ntf_handle_co
     if (!plugins_dir[0]) {
         /* get plugins dir from environment variable, or use default one */
         tmp = getenv("SR_PLUGINS_PATH");
-        if (tmp) {
-            if ((len = strlen(tmp)) < SR_PATH_MAX) {
-                strncpy(plugins_dir, tmp, len);
-            } else {
-                sr_errinfo_new(&err_info, SR_ERR_INVAL_ARG, "SR_PLUGINS_PATH (%s) cannot be longer than %u.", tmp, SR_PATH_MAX);
-                goto cleanup;
-            }
+        if (!tmp) {
+            tmp = SR_PLG_PATH;
+        }
+
+        if ((len = strlen(tmp)) < SR_PATH_MAX) {
+            strncpy(plugins_dir, tmp, SR_PATH_MAX);
         } else {
-            strncpy(plugins_dir, SR_PLG_PATH, SR_PATH_MAX - 1);
+            sr_errinfo_new(&err_info, SR_ERR_INVAL_ARG, "SR_PLUGINS_PATH (%s) cannot be longer than %u.", tmp, SR_PATH_MAX);
+            goto cleanup;
         }
     }
 
@@ -1054,13 +1054,23 @@ sr_shm_dir_get(void)
 
     /* first time only */
     if (!(tmp = getenv("SYSREPO_SHM_DIR"))) {
-        tmp = SR_SHM_DIR;
+        tmp = NULL;
     } else if (strlen(tmp) >= SR_PATH_MAX) {
         SR_LOG_WRN("SYSREPO_SHM_DIR env variable longer than %u, using default %s instead",
                 SR_PATH_MAX, SR_SHM_DIR);
-        tmp = SR_SHM_DIR;
+        tmp = NULL;
     }
-    strncpy(sr_shm_dir_str, tmp, SR_PATH_MAX - 1);
+
+    if (!tmp) {
+        tmp = SR_SHM_DIR;
+        if (strlen(tmp) >= SR_PATH_MAX) {
+            tmp = "/dev/shm";
+            sr_log(SR_LL_ERR, "SR_SHM_DIR (%s) is longer than maximum allowed %u - defaulting to %s",
+                    SR_SHM_DIR, SR_PATH_MAX, tmp);
+        }
+    }
+
+    strncpy(sr_shm_dir_str, tmp, SR_PATH_MAX);
 
     return sr_shm_dir_str;
 }
@@ -1087,7 +1097,9 @@ sr_shm_prefix(const char **prefix)
     tmp = getenv(SR_SHM_PREFIX_ENV);
     if (tmp == NULL) {
         tmp = SR_SHM_PREFIX_DEFAULT;
-    } else if (strlen(tmp) >= SR_PATH_MAX) {
+    }
+
+    if (strlen(tmp) >= SR_PATH_MAX) {
         sr_errinfo_new(&err_info, SR_ERR_INVAL_ARG, "%s cannot be longer than %u.", SR_SHM_PREFIX_ENV, SR_PATH_MAX);
     } else if (strchr(tmp, '/') != NULL) {
         sr_errinfo_new(&err_info, SR_ERR_INVAL_ARG, "%s cannot contain slashes.", SR_SHM_PREFIX_ENV);
@@ -1096,7 +1108,7 @@ sr_shm_prefix(const char **prefix)
     if (err_info) {
         *prefix = NULL;
     } else {
-        strncpy(sr_shm_prefix_val, tmp, SR_PATH_MAX - 1);
+        strncpy(sr_shm_prefix_val, tmp, SR_PATH_MAX);
         *prefix = sr_shm_prefix_val;
     }
     return err_info;

--- a/src/context_change.c
+++ b/src/context_change.c
@@ -482,6 +482,7 @@ sr_lycc_check_upd_modules(sr_conn_ctx_t *conn, const struct ly_set *old_mod_set,
     const struct lys_module *upd_mod = NULL, *old_mod;
     uint32_t i;
 
+    assert(upd_mod_set->count);
     for (i = 0; i < upd_mod_set->count; ++i) {
         upd_mod = upd_mod_set->objs[i];
         old_mod = old_mod_set->objs[i];
@@ -505,6 +506,8 @@ sr_lycc_check_upd_modules(sr_conn_ctx_t *conn, const struct ly_set *old_mod_set,
             }
         }
     }
+
+    assert(upd_mod);
 
     /* check subscriptions in the new context */
     if ((err_info = sr_shmext_check_sub_all(conn, upd_mod->ctx))) {

--- a/src/edit_diff.c
+++ b/src/edit_diff.c
@@ -4024,7 +4024,7 @@ static sr_error_info_t *
 sr_edit_oper_del_node(struct lyd_node *node, struct lyd_node **change_edit)
 {
     sr_error_info_t *err_info = NULL;
-    struct lyd_node *iter, *new_parent, *parent, *match, *to_free = NULL;
+    struct lyd_node *iter, *new_parent, *parent, *match = NULL, *to_free = NULL;
     enum edit_op op, cur_op;
 
     if (!change_edit) {

--- a/src/executables/srpd_common.c
+++ b/src/executables/srpd_common.c
@@ -80,7 +80,7 @@ srpd_exec(const char *plugin_name, const char *cmd, uint32_t num_of_args, ...)
 {
     pid_t pid;
     int ret, rc = 0;
-    char **args = NULL;
+    char **args = NULL, **tmp;
     uint32_t i;
     va_list ap;
 
@@ -89,7 +89,13 @@ srpd_exec(const char *plugin_name, const char *cmd, uint32_t num_of_args, ...)
     pid = fork();
     if (pid == 0) {
         for (i = 0; i < num_of_args; ++i) {
-            args = realloc(args, (i + 2) * sizeof *args);
+            tmp = realloc(args, (i + 2) * sizeof *args);
+            if (!tmp) {
+                SRPLG_LOG_ERR(plugin_name, "realloc failed (%s).", strerror(errno));
+                exit(1);
+            } else {
+                args = tmp;
+            }
             args[i] = va_arg(ap, char *);
         }
         args[i] = NULL;

--- a/src/executables/sysrepo-plugind.c
+++ b/src/executables/sysrepo-plugind.c
@@ -201,7 +201,7 @@ get_plugins_dir(const char **plugins_dir)
             return -1;
         }
     }
-    strncpy(sr_plugins_dir, tmp, SR_PATH_MAX);
+    snprintf(sr_plugins_dir, SR_PATH_MAX, "%s", tmp);
     *plugins_dir = sr_plugins_dir;
     return 0;
 }

--- a/src/executables/sysrepo-plugind.c
+++ b/src/executables/sysrepo-plugind.c
@@ -201,7 +201,7 @@ get_plugins_dir(const char **plugins_dir)
             return -1;
         }
     }
-    strncpy(sr_plugins_dir, tmp, SR_PATH_MAX - 1);
+    strncpy(sr_plugins_dir, tmp, SR_PATH_MAX);
     *plugins_dir = sr_plugins_dir;
     return 0;
 }

--- a/src/plugins/common_json.c
+++ b/src/plugins/common_json.c
@@ -146,7 +146,7 @@ srpjson_shm_prefix(const char *plg_name, const char **prefix)
         srplg_log_errinfo(&err_info, plg_name, NULL, SR_ERR_INVAL_ARG, "%s cannot contain slashes.", SR_SHM_PREFIX_ENV);
         tmp = "";
     }
-    strncpy(sr_shm_prefix_val, tmp, SR_PATH_MAX);
+    snprintf(sr_shm_prefix_val, SR_PATH_MAX, "%s", tmp);
     *prefix = sr_shm_prefix_val;
 
     return err_info;

--- a/src/plugins/common_json.c
+++ b/src/plugins/common_json.c
@@ -135,15 +135,20 @@ srpjson_shm_prefix(const char *plg_name, const char **prefix)
 
     /* first time */
     tmp = getenv(SR_SHM_PREFIX_ENV);
-    if (tmp == NULL) {
+    if (!tmp) {
         tmp = SR_SHM_PREFIX_DEFAULT;
-    } else if (strlen(tmp) >= SR_PATH_MAX) {
+    }
+
+    if (strlen(tmp) >= SR_PATH_MAX) {
         srplg_log_errinfo(&err_info, plg_name, NULL, SR_ERR_INVAL_ARG, "%s cannot be longer than %u.", SR_SHM_PREFIX_ENV, SR_PATH_MAX);
+        tmp = "";
     } else if (strchr(tmp, '/') != NULL) {
         srplg_log_errinfo(&err_info, plg_name, NULL, SR_ERR_INVAL_ARG, "%s cannot contain slashes.", SR_SHM_PREFIX_ENV);
+        tmp = "";
     }
-    strncpy(sr_shm_prefix_val, tmp, SR_PATH_MAX - 1);
+    strncpy(sr_shm_prefix_val, tmp, SR_PATH_MAX);
     *prefix = sr_shm_prefix_val;
+
     return err_info;
 }
 

--- a/src/sysrepo.c
+++ b/src/sysrepo.c
@@ -1230,7 +1230,7 @@ sr_get_repo_path(void)
     value = getenv(SR_REPO_PATH_ENV);
     if (value) {
         if (strlen(value) < SR_PATH_MAX) {
-            strncpy(sr_repo_path, value, SR_PATH_MAX);
+            snprintf(sr_repo_path, SR_PATH_MAX, "%s", value);
         } else {
             SR_LOG_WRN(SR_REPO_PATH_ENV " (%s) longer than %u, using default %s instead",
                     value, SR_PATH_MAX, SR_REPO_PATH);
@@ -1245,7 +1245,7 @@ sr_get_repo_path(void)
         } else {
             value = SR_REPO_PATH;
         }
-        strncpy(sr_repo_path, value, SR_PATH_MAX);
+        snprintf(sr_repo_path, SR_PATH_MAX, "%s", value);
     }
 
     return sr_repo_path;

--- a/src/sysrepo.c
+++ b/src/sysrepo.c
@@ -1230,14 +1230,22 @@ sr_get_repo_path(void)
     value = getenv(SR_REPO_PATH_ENV);
     if (value) {
         if (strlen(value) < SR_PATH_MAX) {
-            strncpy(sr_repo_path, value, SR_PATH_MAX - 1);
+            strncpy(sr_repo_path, value, SR_PATH_MAX);
         } else {
             SR_LOG_WRN(SR_REPO_PATH_ENV " (%s) longer than %u, using default %s instead",
                     value, SR_PATH_MAX, SR_REPO_PATH);
         }
     }
     if (!sr_repo_path[0]) {
-        strncpy(sr_repo_path, SR_REPO_PATH, SR_PATH_MAX - 1);
+        if (strlen(SR_REPO_PATH) >= SR_PATH_MAX) {
+            value = "/etc/sysrepo";
+            sr_log(SR_LL_ERR, "SR_REPO_PATH (%s) is longer than maximum allowed %u - defaulting to %s",
+                    SR_REPO_PATH, SR_PATH_MAX, value);
+
+        } else {
+            value = SR_REPO_PATH;
+        }
+        strncpy(sr_repo_path, value, SR_PATH_MAX);
     }
 
     return sr_repo_path;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -84,7 +84,8 @@ if(ENABLE_TESTS)
         # avoid loading installed plugins by sysrepo-plugind
         if(${test_name} STREQUAL "test_rotation")
             set_property(TEST ${test_name} APPEND PROPERTY ENVIRONMENT
-                "SRPD_PLUGINS_PATH=${PROJECT_BINARY_DIR}/test_repositories/${test_name}/testing")
+                "SRPD_PLUGINS_PATH=${PROJECT_BINARY_DIR}/test_repositories/${test_name}/testing"
+            )
         endif()
 
         if(${CMAKE_VERSION} VERSION_GREATER "3.7")
@@ -105,6 +106,7 @@ if(ENABLE_PERF_TESTS)
     set_property(TEST sr_perf_1000_10 APPEND PROPERTY ENVIRONMENT
         "SYSREPO_REPOSITORY_PATH=${PROJECT_BINARY_DIR}/test_repositories/sr_perf"
         "SYSREPO_SHM_PREFIX=_tests_sr_sr_perf"
+        "SR_ENV_RUN_TESTS=1"
     )
 
     if(${CMAKE_VERSION} VERSION_GREATER "3.7")
@@ -126,7 +128,8 @@ if(ENABLE_VALGRIND_TESTS)
         # avoid loading installed plugins by sysrepo-plugind
         if(${test_name} STREQUAL "test_rotation_valgrind")
             set_property(TEST ${test_name} APPEND PROPERTY ENVIRONMENT
-                "SRPD_PLUGINS_PATH=${PROJECT_BINARY_DIR}/test_repositories/${test_name}/testing")
+                "SRPD_PLUGINS_PATH=${PROJECT_BINARY_DIR}/test_repositories/${test_name}/testing"
+            )
         endif()
 
         if(${CMAKE_VERSION} VERSION_GREATER "3.7")

--- a/tests/test_process.c
+++ b/tests/test_process.c
@@ -1388,7 +1388,8 @@ fork_and_create_subs(subscr_type_t subscr_type, uint32_t priority, uint32_t fail
     char xpath[512];
     uint32_t opts = SR_SUBSCR_NO_THREAD;
 
-    pipe(pipe_fds);
+    ret = pipe(pipe_fds);
+    sr_assert(ret == 0);
     sr_data_t *sr_data = NULL;
 
     switch (fork()) {
@@ -1402,7 +1403,8 @@ fork_and_create_subs(subscr_type_t subscr_type, uint32_t priority, uint32_t fail
     default:
         /* parent */
         close(pipe_fds[1]);
-        read(pipe_fds[0], &data, sizeof("sub-ready"));
+        ret = read(pipe_fds[0], &data, sizeof("sub-ready"));
+        sr_assert(ret == sizeof("sub-ready"));
         close(pipe_fds[0]);
         return;
     }
@@ -1438,7 +1440,8 @@ fork_and_create_subs(subscr_type_t subscr_type, uint32_t priority, uint32_t fail
         ret = sr_oper_poll_subscribe(sess, "ietf-interfaces", xpath, 300, opts, &subscr);
         sr_assert(ret == SR_ERR_OK);
         if (fail_ev != SR_EV_NONE) {
-            write(pipe_fds[1], "sub-ready", sizeof("sub-ready"));
+            ret = write(pipe_fds[1], "sub-ready", sizeof("sub-ready"));
+            sr_assert(ret == sizeof("sub-ready"));
             close(pipe_fds[1]);
             conditional_exit(&pvt_data, fail_ev, sess, NULL);
         }
@@ -1454,7 +1457,8 @@ fork_and_create_subs(subscr_type_t subscr_type, uint32_t priority, uint32_t fail
     default:
         break;
     }
-    write(pipe_fds[1], "sub-ready", sizeof("sub-ready"));
+    ret = write(pipe_fds[1], "sub-ready", sizeof("sub-ready"));
+    sr_assert(ret == sizeof("sub-ready"));
     close(pipe_fds[1]);
     TLOG_INF("Created subscription %s failing for event %s priority %u", subscr_type_strings[subscr_type], ev_to_str(fail_ev), priority);
 


### PR DESCRIPTION
- **debian rules set CMAKE_BUILD_WITH_INSTALL_RPATH ON**
    Make the build reproducible by fixing the remapping compiled
    references to __FILE__ and by avoiding RPATH insertions.

- **tests - set LD_LIBRARY_PATH to locate libsysrepo7.so**
    With rpath enabled in cmake, the unit-tests may not discover where the
    shared object of libsysrepo is located after the build.

- **bugfix strncpy null term of maxlen SR_PATH_MAX**
    `strncpy` does not result in a destination string but a character
    sequence. If 'dst' is not long enough to contain the null byte,
    'dst' will not be null-terminated.

    `stlcpy` does this but is not portable.

    `strncpy` expects us to pass the size of the destination buffer as the
    limiting size for copying.

    It also expects that the source string fits into the destination
    buffer including the null-termination byte, if the result is to be a
    string and not a character sequence.

    The strlen() function calculates the length of the string pointed
    to by s, excluding the terminating null byte ('\0').

    So, the correct way to use `strncpy()` is:
```c
    char dst[DST_SZ];
    char src[SRC_SZ];
    ...
    if (strnlen(src, SRC_SZ) < DST_SZ) {
        strncpy(dst, src, DST_SZ);
    }
```

    See `String vs character sequence` in manpage of `string_copying`.
    strlcpy or strscpy maybe alternatives, but with other challenges such as
    portability or availability.

- **bugfix Wunused-result in test_process.c**
