### PR TITLE
Add PTHREAD_MUTEX_ERRORCHECK attr

### DIFF
--- a/src/common.c
+++ b/src/common.c
@@ -2174,15 +2174,23 @@ _sr_mutex_init(pthread_mutex_t *lock, int shared, int robust)
 
         if (shared && (ret = pthread_mutexattr_setpshared(&attr, PTHREAD_PROCESS_SHARED))) {
             pthread_mutexattr_destroy(&attr);
-            sr_errinfo_new(&err_info, SR_ERR_SYS, "Changing pthread attr failed (%s).", strerror(ret));
+            sr_errinfo_new(&err_info, SR_ERR_SYS, "Setting mutex shared failed (%s).", strerror(ret));
             return err_info;
         }
 
         if (robust && (ret = pthread_mutexattr_setrobust(&attr, PTHREAD_MUTEX_ROBUST))) {
             pthread_mutexattr_destroy(&attr);
-            sr_errinfo_new(&err_info, SR_ERR_SYS, "Changing pthread attr failed (%s).", strerror(ret));
+            sr_errinfo_new(&err_info, SR_ERR_SYS, "Setting mutex robust failed (%s).", strerror(ret));
             return err_info;
         }
+
+#ifndef NDEBUG
+        if ((ret = pthread_mutexattr_settype(&attr, PTHREAD_MUTEX_ERRORCHECK))) {
+            pthread_mutexattr_destroy(&attr);
+            sr_errinfo_new(&err_info, SR_ERR_SYS, "Setting mutex error_check failed (%s).", strerror(ret));
+            return err_info;
+        }
+#endif
 
         if ((ret = pthread_mutex_init(lock, &attr))) {
             pthread_mutexattr_destroy(&attr);


### PR DESCRIPTION
from the manpage of pthread_mutexattr_settype

This type of mutex provides error checking.
A thread attempting to relock this mutex without first unlocking it shall return with an error. A thread attempting to unlock a mutex which another thread has locked shall return with an error. A thread attempting to unlock an unlocked mutex shall return with an error.

It is good to have pthread mutex error checking enabled. It may have a performance impact, but it is not enabled in release builds.