### PR TITLE
debugs sr_rwlock_t tracing

### DIFF
--- a/src/common.h
+++ b/src/common.h
@@ -63,6 +63,15 @@ struct srplg_ntf_s;
 /* macro for getting ext SHM from a connection */
 #define SR_CONN_EXT_SHM(conn) ((sr_ext_shm_t *)(conn)->ext_shm.addr)
 
+/* macro for getting next ID for rwlock from a connection using main_shm */
+#define SR_RWLOCK_NEW_ID(conn) ATOMIC_INC_RELAXED(SR_CONN_MAIN_SHM(conn)->new_rwlock_id)
+
+/* macro for checking whether a reader is valid */
+#define SR_IS_READER_VALID(rwlock, i) ((i < SR_RWLOCK_READ_LIMIT) && rwlock->readers[i])
+
+/* reserved lock ids to be used before main_shm is opened/created for process local locks */
+#define SR_RWLOCK_RESERVED_ID_MAX 100
+
 /** all ext SHM item sizes will be aligned to this number; also represents the allocation unit (B) */
 #define SR_SHM_MEM_ALIGN 8
 
@@ -789,7 +798,7 @@ void sr_munlock(pthread_mutex_t *lock);
  * @param[in] shared Whether the RW lock will be shared between processes or not.
  * @return err_info, NULL on success.
  */
-sr_error_info_t *sr_rwlock_init(sr_rwlock_t *rwlock, int shared);
+sr_error_info_t *sr_rwlock_init(sr_rwlock_t *rwlock, int shared, uint32_t id, const char *desc);
 
 /**
  * @brief Destroy a sysrepo RW lock.

--- a/src/common_types.h
+++ b/src/common_types.h
@@ -64,6 +64,7 @@ typedef struct {
     sr_cid_t upgr;                  /**< CID of the READ-UPGR lock owner if locked, 0 otherwise. */
     sr_cid_t writer;                /**< CID of the WRITE lock owner if locked, can be set if an WRITE-URGE lock
                                          is being waited on, 0 otherwise. */
+    uint32_t id;                    /**< system-wide unique ID of the lock */
 } sr_rwlock_t;
 
 /**

--- a/src/shm_main.c
+++ b/src/shm_main.c
@@ -496,15 +496,17 @@ sr_shmmain_open(sr_shm_t *shm, int *created)
     if (creat) {
         /* init the memory */
         main_shm->shm_ver = SR_SHM_VER;
+
         if ((err_info = sr_mutex_init(&main_shm->ext_lock, 1))) {
             goto cleanup;
         }
-        if ((err_info = sr_rwlock_init(&main_shm->context_lock, 1))) {
+        if ((err_info = sr_rwlock_init(&main_shm->context_lock, 1, SR_RWLOCK_RESERVED_ID_MAX - 1, "context"))) {
             goto cleanup;
         }
         if ((err_info = sr_mutex_init(&main_shm->lydmods_lock, 1))) {
             goto cleanup;
         }
+        ATOMIC_STORE_RELAXED(main_shm->new_rwlock_id, SR_RWLOCK_RESERVED_ID_MAX);
         ATOMIC_STORE_RELAXED(main_shm->new_sr_cid, 1);
         ATOMIC_STORE_RELAXED(main_shm->new_sr_sid, 1);
         ATOMIC_STORE_RELAXED(main_shm->new_sub_id, 1);

--- a/src/shm_mod.h
+++ b/src/shm_mod.h
@@ -62,11 +62,11 @@ sr_rpc_t *sr_shmmod_find_rpc(sr_mod_shm_t *mod_shm, const char *path);
  * @brief Remap mod SHM and store modules and all their static information (name, deps, ...) in it
  * overwriting any previous modules.
  *
- * @param[in] shm_mod Mod SHM structure.
+ * @param[in] conn Connection to use for shm_mod
  * @param[in] sr_mods SR internal module data to read from.
  * @return err_info, NULL on success.
  */
-sr_error_info_t *sr_shmmod_store_modules(sr_shm_t *shm_mod, const struct lyd_node *sr_mods);
+sr_error_info_t *sr_shmmod_store_modules(sr_conn_ctx_t *conn, const struct lyd_node *sr_mods);
 
 /**
  * @brief Load modules stored in mod SHM into a context.

--- a/src/shm_sub.c
+++ b/src/shm_sub.c
@@ -98,7 +98,7 @@ struct sr_shmsub_many_info_oper_get_s {
 };
 
 sr_error_info_t *
-sr_shmsub_create(const char *name, const char *suffix1, int64_t suffix2, size_t shm_struct_size)
+sr_shmsub_create(sr_conn_ctx_t *conn, const char *name, const char *suffix1, int64_t suffix2, size_t shm_struct_size)
 {
     sr_error_info_t *err_info = NULL;
     char *path = NULL;
@@ -126,7 +126,7 @@ sr_shmsub_create(const char *name, const char *suffix1, int64_t suffix2, size_t 
 
     /* initialize */
     sub_shm = (sr_sub_shm_t *)shm.addr;
-    if ((err_info = sr_rwlock_init(&sub_shm->lock, 1))) {
+    if ((err_info = sr_rwlock_init(&sub_shm->lock, 1, SR_RWLOCK_NEW_ID(conn), path))) {
         goto cleanup;
     }
 

--- a/src/shm_sub.h
+++ b/src/shm_sub.h
@@ -47,7 +47,7 @@ struct sr_mod_info_s;
  * @param[in] shm_struct_size Size of the used subscription SHM structure.
  * @return err_info, NULL on success.
  */
-sr_error_info_t *sr_shmsub_create(const char *name, const char *suffix1, int64_t suffix2, size_t shm_struct_size);
+sr_error_info_t *sr_shmsub_create(sr_conn_ctx_t *conn, const char *name, const char *suffix1, int64_t suffix2, size_t shm_struct_size);
 
 /**
  * @brief Open and map an existing subscription SHM.

--- a/src/shm_types.h
+++ b/src/shm_types.h
@@ -183,6 +183,7 @@ typedef struct {
     pthread_mutex_t lydmods_lock;   /**< Process-shared lock for modifying SR internal module data. */
     uint32_t content_id;        /**< Context content ID of the latest context. */
 
+    ATOMIC_T new_rwlock_id;     /**< New rwlock ID to track sr_rwlock_t locks */
     ATOMIC_T new_sr_cid;        /**< Connection ID for a new connection. */
     ATOMIC_T new_sr_sid;        /**< SID for a new session. */
     ATOMIC_T new_sub_id;        /**< Subscription ID of a new subscription. */


### PR DESCRIPTION
It is nice to have an ID associated with each sr_rwlock_t to make debugging complex locking issues easier, and for visualising the lock order.

It is also useful to have traceability to account for which locks are in contention.