### PR TITLE
shm_sub ensure recovery on previous incomplete cleanup

### DIFF
--- a/src/shm_sub.c
+++ b/src/shm_sub.c
@@ -187,8 +187,8 @@ sr_shmsub_unlink(const char *name, const char *suffix1, int64_t suffix2)
         goto cleanup;
     }
 
-    /* unlink */
-    if (unlink(path) == -1) {
+    /* unlink and ignore non-fatal missing file as it may have been removed earlier or never created (on a crash) */
+    if ((unlink(path) == -1) && (errno != ENOENT)) {
         sr_errinfo_new(&err_info, SR_ERR_SYS, "Failed to unlink \"%s\" SHM (%s).", path, strerror(errno));
         goto cleanup;
     }
@@ -283,8 +283,8 @@ sr_shmsub_data_unlink(const char *name, const char *suffix1, int64_t suffix2)
         goto cleanup;
     }
 
-    /* unlink */
-    if (unlink(path) == -1) {
+    /* unlink and ignore non-fatal missing file as it may have been removed earlier or never created (on a crash) */
+    if ((unlink(path) == -1) && (errno != ENOENT)) {
         sr_errinfo_new(&err_info, SR_ERR_SYS, "Failed to unlink \"%s\" data SHM (%s).", path, strerror(errno));
         goto cleanup;
     }


### PR DESCRIPTION
A process holding a subscription could die for any number of reasons and not always have the opportunity to clean up completely.

Sometimes, we may end up with a incompletely cleaned subscription/SHM where the shm file is deleted but the subscription is not fully removed yet.

In this case, we should ensure the subscription SHM is recovered before adding a new subscription.

However, by checking the return value of `unlink` and not making allowance for the shm file to be missing, we may be forever stuck, being unable to add a new subscription.

For example, the below failure occurs when the process is restarted:

```
[app::sysrepo] Recovering module "ietf-interfaces" operational get subscription of CID 11.
[app::sysrepo] Failed to unlink "/dev/shm/srsub_ietf-interfaces.oper.f05e29e6" SHM (No such file or directory).
[app::session] sr_oper_get_subscribe() failed: 3
```

So, we should make an exception for `errno == ENOENT` while checking unlink return code.