### PR TITLE
Add sr_xpath_parent to retrieve the parent path

### DIFF
--- a/src/utils/xpath.c
+++ b/src/utils/xpath.c
@@ -582,6 +582,52 @@ sr_xpath_node_name_eq(const char *xpath, const char *node_name)
     }
 }
 
+API char *
+sr_xpath_parent(const char *xpath)
+{
+    const char *last_slash = NULL, *quot = NULL;
+    size_t parent_length = 0;
+    char *parent_xpath = NULL;
+
+    if ((NULL == xpath) || ('\0' == *xpath)) {
+        return NULL;
+    }
+
+    last_slash = xpath + strlen(xpath) - 1;
+
+    // find the last `/` while skipping quoted parts
+    quot = NULL;
+    while (last_slash != xpath && ((NULL != quot) || ('/' !=  *last_slash ))) {
+        if ((NULL != quot) && (*last_slash == *quot)) {
+            // quote ended
+            quot = NULL;
+        } else if ((NULL == quot) && (('\'' == *last_slash ) || ('\"' == *last_slash))) {
+            // quote started
+            quot = last_slash;
+        }
+        --last_slash;
+    }
+
+    if (last_slash == xpath) {
+        // no parent xpath, return NULL
+        return NULL;
+    }
+
+    parent_length = last_slash - xpath;
+
+    // allocate memory for the parent xpath
+    parent_xpath = (char *)malloc(parent_length + 1);
+    if (parent_xpath == NULL) {
+        return NULL;
+    }
+
+    // copy the parent xpath
+    strncpy(parent_xpath, xpath, parent_length);
+    parent_xpath[parent_length] = '\0';
+
+    return parent_xpath;
+}
+
 API void
 sr_xpath_recover(sr_xpath_ctx_t *state)
 {

--- a/src/utils/xpath.h
+++ b/src/utils/xpath.h
@@ -212,6 +212,16 @@ char *sr_xpath_node_name(const char *xpath);
 int sr_xpath_node_name_eq(const char *xpath, const char *node_str);
 
 /**
+ * @brief Returns the parent path of the specified xpath string.
+ *
+ * @param [in] xpath Input xpath string.
+ * @return Pointer to a newly allocated string containing the parent xpath,
+ *         or NULL if the input xpath has no parent or an error occurred.
+ *         The caller is responsible for freeing the allocated memory.
+ */
+char *sr_xpath_parent(const char *xpath);
+
+/**
  * @brief Recovers the xpath string to the original state (puts back the character
  * that was replaced by termination zero).
  *


### PR DESCRIPTION
Added a new function sr_xpath_parent to allow the retrieval of the parent path from an xpath expression.
