### PR TITLE
reuse module sub_shm diff for multiple events

### DIFF
--- a/src/modinfo.h
+++ b/src/modinfo.h
@@ -58,6 +58,7 @@ struct sr_mod_info_s {
         uint32_t xpath_count;   /**< Count of XPaths. */
         uint32_t state;         /**< Module state (flags). */
         uint32_t request_id;    /**< Request ID of the published event. */
+        uint32_t reuse_diff;    /**< Whether a reusable diff has been written into the shm for this request_id. */
     } *mods;                    /**< Relevant modules. */
     uint32_t mod_count;         /**< Modules count. */
 };


### PR DESCRIPTION
Each commit can have multiple events published to subscribers:
1. UPDATE
2. CHANGE
3. DONE
4. ABORT (in case of failure)

These subscribers can also have different priorities.

A diff is shared with each subscriber as part of the notification
process. This diff maybe updated during the UPDATE phase, but is not
changed after that. (ABORT events use a reversed diff).

The shared diff is prepared by printing the libyang data tree for the
module in `LYD_LYB` format for each subscription priority, and for each
event including CHANGE and DONE events, first into memory, and then by
copying it into the shared memory (sub_data_shm).
At scale, this diff preparation can be expensive.

Since this diff does not change during CHANGE and DONE events, it can be
reused to save significant amount of time.

Since multiple locks are held during `sr_changes_notify_store` or
`sr_shmsub_oper_poll_listen_process_module_events`, the time saved is
even more valuable.

A new per-module flag `reuse_diff` is added to the mod_info structure to
allow reusing the diff for multiple notifications. This flag is set
after the diff is prepared by the first CHANGE event for a module and
is reused for all subsequent CHANGE and DONE events which will be
published afterwards.

Since ABORT events use a reversed diff, the `reuse_diff` flag is cleared
for all modules before looking up subscriptions to notify ABORT events.
The reversed diff once written in, can also be reused for all ABORT
events of that module at different priorities.

Since the flag resides in the `struct sr_mod_info_s`, it is local to the
publisher and for this commit, and does not affect other publishers or
future events as they will prepare a different mod_info structure.
The only exception to this is `sr_shmsub_rpc_internal_call_callback`
which reuses the mod_info structure, by manually resetting fields.

- handling SR_SUBSCR_CHANGE_ALL_MODULES subscription flag

Additional care must be taken due to the SR_SUBSCR_CHANGE_ALL_MODULES
flag. This allows for generation of two kinds of diffs:
1. per-module diff
2. all-modules diff

For example, It would be wrong to pass a per-module diff to a
subscription which has requested an `all-modules` diff.
To handle this case, only `per-module` diff is reused. `all-module` diff
will need to be copied into the sub_data_shm each time. However, the
libyang data tree is walked for printing only twice (once for the first
CHANGE event, and then again for the first DONE event).

This should be okay as SR_SUBSCR_CHANGE_ALL_MODULES is not very
performant anyway and making optimizations for its preparation will
probably not make much of a difference.

Note:
If "all-modules" subscriptions co-exists with "normal" subscriptions,
at the same priority, the full diff to be published.
This behaviour is not changed by this commit.
If the next priority subscriptions don't request "all-modules", the
per-module diff will need to be regenerated before notification.
