### PR TITLE
sr_shmsub_change_notify_evpipe must track the number of subscribers notified

### DIFF
--- a/src/shm_sub.c
+++ b/src/shm_sub.c
@@ -1338,7 +1338,7 @@ sr_shmsub_change_notify_update(struct sr_mod_info_s *mod_info, const char *orig_
             /* prepare the diff to write into subscription SHM */
             if ((err_info = sr_shmsub_change_notify_get_diff(mod_info->diff, mod->ly_mod, opts, NULL,
                     &full_diff_lyb, &full_diff_lyb_len, &diff_lyb, &diff_lyb_len, &free_diff))) {
-                goto cleanup;
+                goto cleanup_wrunlock;
             }
 
             /* write "update" event */


### PR DESCRIPTION
- sr_shmsub_change_notify_evpipe track num_notified

    `sr_shmsub_change_notify_evpipe` must track the number of subscribers
    notified which can be lesser than the expected `subscriber_count`
    written into the SHM, if any subscribers exit without cleaning up.

    In this case, we must update the expected `subscriber_count`.

    However, if no subscribers were notified, we must cancel the written
    event and clear up the sub SHM.

- bugfix goto in sr_shmsub_change_notify_update

    A write lock is held at the point, and the goto should be
    cleanup_wrunlock and not cleanup.
