### PR TITLE
ds_mongo support multiple discard-items

### DIFF
--- a/tests/test_oper_push.c
+++ b/tests/test_oper_push.c
@@ -1905,6 +1905,30 @@ test_discard(void **state)
     free(str1);
 
     sr_session_stop(sess);
+
+    /* discard multiple nodes */
+    ret = sr_set_item_str(st->sess, "/ietf-interfaces-new:interfaces/interface[name=\'eth1\']/type",
+            "ethernetCsmacd", NULL, 0);
+    assert_int_equal(ret, SR_ERR_OK);
+    ret = sr_set_item_str(st->sess, "/ietf-interfaces-new:interfaces/interface[name=\'eth1\']/speed",
+            "0", NULL, 0);
+    assert_int_equal(ret, SR_ERR_OK);
+
+    ret = sr_set_item_str(st->sess, "/ietf-interfaces-new:interfaces/interface[name=\'eth2\']/type",
+            "ethernetCsmacd", NULL, 0);
+    assert_int_equal(ret, SR_ERR_OK);
+    ret = sr_set_item_str(st->sess, "/ietf-interfaces-new:interfaces/interface[name=\'eth2\']/speed",
+            "0", NULL, 0);
+    assert_int_equal(ret, SR_ERR_OK);
+    ret = sr_apply_changes(st->sess, 0);
+    assert_int_equal(ret, SR_ERR_OK);
+
+    ret = sr_discard_items(st->sess, "/ietf-interfaces-new:interfaces/interface[name=\'eth1\']/speed");
+    assert_int_equal(ret, SR_ERR_OK);
+    ret = sr_discard_items(st->sess, "/ietf-interfaces-new:interfaces/interface[name=\'eth2\']/speed");
+    assert_int_equal(ret, SR_ERR_OK);
+    ret = sr_apply_changes(st->sess, 0);
+    assert_int_equal(ret, SR_ERR_OK);
 }
 
 /* TEST */


### PR DESCRIPTION
sysrepo discard-items are stored with the key /sysrepo:discard-items. This key (_id) should be unique.

But unlike other nodes, multiple sysrepo discard-items nodes can be present.

So, we should also add an index to make these nodes unique. This index is added with a prefix 'O' for easy detection.

While loading data back, look for the prefix 'O' to detect opaque keys and discard the prefix and index to get the original path back.