### PR TITLE
build BUGFIX link libatomic when found

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -506,7 +506,9 @@ include_directories(${PROJECT_BINARY_DIR})
 # dependencies
 # libatomic
 check_library_exists(atomic __atomic_fetch_add_4 "" LIBATOMIC)
-if(NOT LIBATOMIC)
+if(LIBATOMIC)
+    target_link_libraries(sysrepo atomic)
+else()
     # we may need to link it explicitly
     list(APPEND CMAKE_REQUIRED_LIBRARIES atomic)
     check_library_exists(atomic __atomic_fetch_add_4 "" LIBATOMIC)


### PR DESCRIPTION
The `libatomic` is not linked when found by the first `check_library_exists` call.
The bug was introduced by commit bf79330.