### PR TITLE
ext_lock is not needed for oper push READ or DEL

### DIFF
--- a/src/modinfo.c
+++ b/src/modinfo.c
@@ -1264,7 +1264,7 @@ sr_module_oper_data_load(struct sr_mod_info_mod_s *mod, sr_conn_ctx_t *conn, uin
     int last_sid = 0, dead_cid = 0;
 
     /* EXT READ LOCK */
-    if ((err_info = sr_shmext_conn_remap_lock(conn, SR_LOCK_READ, 1, __func__))) {
+    if ((err_info = sr_shmext_conn_remap_lock(conn, SR_LOCK_READ, 0, __func__))) {
         goto cleanup;
     }
 
@@ -1288,7 +1288,7 @@ sr_module_oper_data_load(struct sr_mod_info_mod_s *mod, sr_conn_ctx_t *conn, uin
     }
 
     /* EXT READ UNLOCK */
-    sr_shmext_conn_remap_unlock(conn, SR_LOCK_READ, 1, __func__);
+    sr_shmext_conn_remap_unlock(conn, SR_LOCK_READ, 0, __func__);
 
     if (err_info) {
         goto cleanup;

--- a/src/shm_ext.c
+++ b/src/shm_ext.c
@@ -2740,7 +2740,7 @@ sr_shmext_oper_push_get(sr_conn_ctx_t *conn, sr_mod_t *shm_mod, const char *mod_
     }
 
     /* EXT READ LOCK */
-    if ((err_info = sr_shmext_conn_remap_lock(conn, SR_LOCK_READ, 1, __func__))) {
+    if ((err_info = sr_shmext_conn_remap_lock(conn, SR_LOCK_READ, 0, __func__))) {
         goto cleanup_shmmod_unlock;
     }
 
@@ -2759,7 +2759,7 @@ sr_shmext_oper_push_get(sr_conn_ctx_t *conn, sr_mod_t *shm_mod, const char *mod_
     }
 
     /* EXT READ UNLOCK */
-    sr_shmext_conn_remap_unlock(conn, SR_LOCK_READ, 1, __func__);
+    sr_shmext_conn_remap_unlock(conn, SR_LOCK_READ, 0, __func__);
 
 cleanup_shmmod_unlock:
     if (!has_mod_locks) {

--- a/src/shm_mod.c
+++ b/src/shm_mod.c
@@ -954,7 +954,7 @@ sr_shmmod_del_module_oper_data(sr_conn_ctx_t *conn, const struct lys_module *ly_
     SR_CHECK_MEM_GOTO(!oper_push_l, err_info, cleanup_unlock);
 
     /* EXT READ LOCK */
-    if ((err_info = sr_shmext_conn_remap_lock(conn, SR_LOCK_READ, 1, __func__))) {
+    if ((err_info = sr_shmext_conn_remap_lock(conn, SR_LOCK_READ, 0, __func__))) {
         goto cleanup_unlock;
     }
 
@@ -962,7 +962,7 @@ sr_shmmod_del_module_oper_data(sr_conn_ctx_t *conn, const struct lys_module *ly_
     memcpy(oper_push_l, conn->ext_shm.addr + shm_mod->oper_push_data, oper_push_count * sizeof *oper_push_l);
 
     /* EXT READ UNLOCK */
-    sr_shmext_conn_remap_unlock(conn, SR_LOCK_READ, 1, __func__);
+    sr_shmext_conn_remap_unlock(conn, SR_LOCK_READ, 0, __func__);
 
     for (i = 0; i < oper_push_count; ++i) {
         if (dead_only && sr_conn_is_alive(oper_push_l[i].cid)) {


### PR DESCRIPTION
The ***system-wide*** `ext_lock` is needed only when
1. ext SHM needs to be remapped or truncated
2. ext SHM holes are added/deleted/merged

Reading oper push data and deleting the oper push data from the mod shm does not cause either of the above two operations.

So, ***system-wide*** `ext_lock` is not needed.

The process specific (among different threads of the same process) lock `conn->ext_remap_lock` already ensures that reading the `ext_shm` is safe and the current process will not remap to learn new changes from other processes.

The appropriate module locks that are already held, ensure that the ext SHM locations do not change while being read.

This means that
1. `sr_module_oper_data_load`
2. `sr_shmext_oper_push_get`
3. `sr_shmmod_del_module_oper_data`

do not need to acquire the ***system-wide*** `ext_lock`.