### PR TITLE
shm_ext locking improvements

### DIFF
--- a/src/common.c
+++ b/src/common.c
@@ -5569,7 +5569,7 @@ sr_generate_notif_has_subs_or_replay(sr_conn_ctx_t *conn, sr_mod_t *shm_mod, int
     sr_mod_notif_sub_t *notif_subs;
     uint32_t notif_sub_count;
 
-    /* EXT READ LOCK */
+    /* CONN EXT REMAP READ LOCK */
     if ((err_info = sr_shmext_conn_remap_lock(conn, SR_LOCK_READ, 0, __func__))) {
         goto cleanup;
     }
@@ -5577,7 +5577,7 @@ sr_generate_notif_has_subs_or_replay(sr_conn_ctx_t *conn, sr_mod_t *shm_mod, int
     /* get subscriber count */
     err_info = sr_notif_find_subscriber(conn, "sysrepo-notifications", &notif_subs, &notif_sub_count, NULL);
 
-    /* EXT READ UNLOCK */
+    /* CONN EXT REMAP READ UNLOCK */
     sr_shmext_conn_remap_unlock(conn, SR_LOCK_READ, 0, __func__);
 
     if (err_info) {

--- a/src/modinfo.c
+++ b/src/modinfo.c
@@ -1263,7 +1263,7 @@ sr_module_oper_data_load(struct sr_mod_info_mod_s *mod, sr_conn_ctx_t *conn, uin
     uint32_t i, j, merge_opts, oper_push_count = 0;
     int last_sid = 0, dead_cid = 0;
 
-    /* EXT READ LOCK */
+    /* CONN EXT REMAP READ LOCK */
     if ((err_info = sr_shmext_conn_remap_lock(conn, SR_LOCK_READ, 0, __func__))) {
         goto cleanup;
     }
@@ -1287,7 +1287,7 @@ sr_module_oper_data_load(struct sr_mod_info_mod_s *mod, sr_conn_ctx_t *conn, uin
         }
     }
 
-    /* EXT READ UNLOCK */
+    /* CONN EXT REMAP READ UNLOCK */
     sr_shmext_conn_remap_unlock(conn, SR_LOCK_READ, 0, __func__);
 
     if (err_info) {
@@ -1479,7 +1479,7 @@ sr_module_oper_data_update(struct sr_mod_info_mod_s *mod, const char *orig_name,
         return err_info;
     }
 
-    /* EXT READ LOCK */
+    /* CONN EXT REMAP READ LOCK */
     if ((err_info = sr_shmext_conn_remap_lock(conn, SR_LOCK_READ, 0, __func__))) {
         goto cleanup_opergetsub_unlock;
     }
@@ -1593,7 +1593,7 @@ next_iter:
     }
 
 cleanup_opergetsub_ext_unlock:
-    /* EXT READ UNLOCK */
+    /* CONN EXT REMAP READ UNLOCK */
     sr_shmext_conn_remap_unlock(conn, SR_LOCK_READ, 0, __func__);
 
 cleanup_opergetsub_unlock:
@@ -1646,7 +1646,7 @@ sr_module_oper_data_get_enabled(sr_conn_ctx_t *conn, struct lyd_node **data, str
         return err_info;
     }
 
-    /* EXT READ LOCK */
+    /* CONN EXT REMAP READ LOCK */
     if ((err_info = sr_shmext_conn_remap_lock(conn, SR_LOCK_READ, 0, __func__))) {
         goto error_sub_unlock;
     }
@@ -1690,7 +1690,7 @@ sr_module_oper_data_get_enabled(sr_conn_ctx_t *conn, struct lyd_node **data, str
         }
     }
 
-    /* EXT READ UNLOCK */
+    /* CONN EXT REMAP READ UNLOCK */
     sr_shmext_conn_remap_unlock(conn, SR_LOCK_READ, 0, __func__);
 
     /* CHANGE SUB READ UNLOCK */
@@ -1720,7 +1720,7 @@ sr_module_oper_data_get_enabled(sr_conn_ctx_t *conn, struct lyd_node **data, str
     return NULL;
 
 error_ext_sub_unlock:
-    /* EXT READ UNLOCK */
+    /* CONN EXT REMAP READ UNLOCK */
     sr_shmext_conn_remap_unlock(conn, SR_LOCK_READ, 0, __func__);
 
 error_sub_unlock:
@@ -2035,7 +2035,7 @@ sr_modinfo_module_srmon_module_subs(sr_conn_ctx_t *conn, sr_mod_t *shm_mod, stru
             return err_info;
         }
 
-        /* EXT READ LOCK */
+        /* CONN EXT REMAP READ LOCK */
         if ((err_info = sr_shmext_conn_remap_lock(conn, SR_LOCK_READ, 0, __func__))) {
             goto change_sub_unlock;
         }
@@ -2084,7 +2084,7 @@ sr_modinfo_module_srmon_module_subs(sr_conn_ctx_t *conn, sr_mod_t *shm_mod, stru
         }
 
 change_ext_sub_unlock:
-        /* EXT READ UNLOCK */
+        /* CONN EXT REMAP READ UNLOCK */
         sr_shmext_conn_remap_unlock(conn, SR_LOCK_READ, 0, __func__);
 
 change_sub_unlock:
@@ -2106,7 +2106,7 @@ change_sub_unlock:
         return err_info;
     }
 
-    /* EXT READ LOCK */
+    /* CONN EXT REMAP READ LOCK */
     if ((err_info = sr_shmext_conn_remap_lock(conn, SR_LOCK_READ, 0, __func__))) {
         goto operget_sub_unlock;
     }
@@ -2146,7 +2146,7 @@ change_sub_unlock:
     }
 
 operget_ext_sub_unlock:
-    /* EXT READ UNLOCK */
+    /* CONN EXT REMAP READ UNLOCK */
     sr_shmext_conn_remap_unlock(conn, SR_LOCK_READ, 0, __func__);
 
 operget_sub_unlock:
@@ -2167,7 +2167,7 @@ operget_sub_unlock:
         return err_info;
     }
 
-    /* EXT READ LOCK */
+    /* CONN EXT REMAP READ LOCK */
     if ((err_info = sr_shmext_conn_remap_lock(conn, SR_LOCK_READ, 0, __func__))) {
         goto operpoll_sub_unlock;
     }
@@ -2199,7 +2199,7 @@ operget_sub_unlock:
     }
 
 operpoll_ext_sub_unlock:
-    /* EXT READ UNLOCK */
+    /* CONN EXT REMAP READ UNLOCK */
     sr_shmext_conn_remap_unlock(conn, SR_LOCK_READ, 0, __func__);
 
 operpoll_sub_unlock:
@@ -2220,7 +2220,7 @@ operpoll_sub_unlock:
         return err_info;
     }
 
-    /* EXT READ LOCK */
+    /* CONN EXT REMAP READ LOCK */
     if ((err_info = sr_shmext_conn_remap_lock(conn, SR_LOCK_READ, 0, __func__))) {
         goto notif_sub_unlock;
     }
@@ -2251,7 +2251,7 @@ operpoll_sub_unlock:
     }
 
 notif_ext_sub_unlock:
-    /* EXT READ UNLOCK */
+    /* CONN EXT REMAP READ UNLOCK */
     sr_shmext_conn_remap_unlock(conn, SR_LOCK_READ, 0, __func__);
 
 notif_sub_unlock:
@@ -2411,7 +2411,7 @@ sr_modinfo_module_srmon_rpc(sr_conn_ctx_t *conn, sr_rpc_t *shm_rpc, struct lyd_n
         return err_info;
     }
 
-    /* EXT READ LOCK */
+    /* CONN EXT REMAP READ LOCK */
     if ((err_info = sr_shmext_conn_remap_lock(conn, SR_LOCK_READ, 0, __func__))) {
         goto rpc_sub_unlock;
     }
@@ -2458,7 +2458,7 @@ sr_modinfo_module_srmon_rpc(sr_conn_ctx_t *conn, sr_rpc_t *shm_rpc, struct lyd_n
     }
 
 ext_sub_unlock:
-    /* EXT READ UNLOCK */
+    /* CONN EXT REMAP READ UNLOCK */
     sr_shmext_conn_remap_unlock(conn, SR_LOCK_READ, 0, __func__);
 
 rpc_sub_unlock:
@@ -3677,7 +3677,7 @@ sr_modinfo_generate_config_change_notif(struct sr_mod_info_s *mod_info, sr_sessi
         return NULL;
     }
 
-    /* EXT READ LOCK */
+    /* CONN EXT REMAP READ LOCK */
     if ((err_info = sr_shmext_conn_remap_lock(mod_info->conn, SR_LOCK_READ, 0, __func__))) {
         return err_info;
     }
@@ -3685,7 +3685,7 @@ sr_modinfo_generate_config_change_notif(struct sr_mod_info_s *mod_info, sr_sessi
     /* get subscriber count */
     err_info = sr_notif_find_subscriber(mod_info->conn, "ietf-netconf-notifications", &notif_subs, &notif_sub_count, NULL);
 
-    /* EXT READ UNLOCK */
+    /* CONN EXT REMAP READ UNLOCK */
     sr_shmext_conn_remap_unlock(mod_info->conn, SR_LOCK_READ, 0, __func__);
 
     if (err_info) {

--- a/src/shm_ext.h
+++ b/src/shm_ext.h
@@ -51,12 +51,19 @@ void sr_shmext_conn_remap_unlock(sr_conn_ctx_t *conn, sr_lock_mode_t mode, int e
 sr_error_info_t *sr_shmext_open(sr_shm_t *shm, int zero);
 
 /**
- * @brief Debug print the contents of ext SHM.
+ * @brief Debug check and print the contents of extended SHM.
  *
- * @param[in] mod_shm Mod SHM.
- * @param[in] shm_ext Ext SHM.
+ * @details This function prints the contents of the extended SHM (shared memory)
+ * for debugging purposes.
+ * The `validate` parameter should only be set if the remap was done with the ext_lock held.
+ * This is because data in the ext SHM could refer to larger offset than what we have currently mapped.
+ * And we don't want to try and read data beyond our map.
+ *
+ * @param[in] mod_shm The Mod SHM structure.
+ * @param[in] shm_ext The extended SHM structure.
+ * @param[in] validate Flag indicating whether ext SHM should be validated.
  */
-void sr_shmext_print(sr_mod_shm_t *mod_shm, sr_shm_t *shm_ext);
+void sr_shmext_print(sr_mod_shm_t *mod_shm, sr_shm_t *shm_ext, int validate);
 
 /**
  * @brief Add main SHM module change subscription and create sub SHM if the first subscription was added.

--- a/src/shm_ext.h
+++ b/src/shm_ext.h
@@ -52,18 +52,12 @@ sr_error_info_t *sr_shmext_open(sr_shm_t *shm, int zero);
 
 /**
  * @brief Debug check and print the contents of extended SHM.
- *
- * @details This function prints the contents of the extended SHM (shared memory)
- * for debugging purposes.
- * The `validate` parameter should only be set if the remap was done with the ext_lock held.
- * This is because data in the ext SHM could refer to larger offset than what we have currently mapped.
- * And we don't want to try and read data beyond our map.
+ * It will also perform validation if the latest Ext SHM was mapped.
  *
  * @param[in] mod_shm The Mod SHM structure.
  * @param[in] shm_ext The extended SHM structure.
- * @param[in] validate Flag indicating whether ext SHM should be validated.
  */
-void sr_shmext_print(sr_mod_shm_t *mod_shm, sr_shm_t *shm_ext, int validate);
+void sr_shmext_print(sr_mod_shm_t *mod_shm, sr_shm_t *shm_ext);
 
 /**
  * @brief Add main SHM module change subscription and create sub SHM if the first subscription was added.

--- a/src/shm_mod.c
+++ b/src/shm_mod.c
@@ -953,7 +953,7 @@ sr_shmmod_del_module_oper_data(sr_conn_ctx_t *conn, const struct lys_module *ly_
     oper_push_l = malloc(oper_push_count * sizeof *oper_push_l);
     SR_CHECK_MEM_GOTO(!oper_push_l, err_info, cleanup_unlock);
 
-    /* EXT READ LOCK */
+    /* CONN EXT REMAP READ LOCK */
     if ((err_info = sr_shmext_conn_remap_lock(conn, SR_LOCK_READ, 0, __func__))) {
         goto cleanup_unlock;
     }
@@ -961,7 +961,7 @@ sr_shmmod_del_module_oper_data(sr_conn_ctx_t *conn, const struct lys_module *ly_
     /* get local copy of push oper data, they cannot change because we are holding mod write lock */
     memcpy(oper_push_l, conn->ext_shm.addr + shm_mod->oper_push_data, oper_push_count * sizeof *oper_push_l);
 
-    /* EXT READ UNLOCK */
+    /* CONN EXT REMAP READ UNLOCK */
     sr_shmext_conn_remap_unlock(conn, SR_LOCK_READ, 0, __func__);
 
     for (i = 0; i < oper_push_count; ++i) {

--- a/src/shm_sub.c
+++ b/src/shm_sub.c
@@ -961,7 +961,7 @@ sr_shmsub_change_notify_has_subscription(sr_conn_ctx_t *conn, struct sr_mod_info
     uint32_t i;
     sr_mod_change_sub_t *shm_sub;
 
-    /* EXT READ LOCK */
+    /* CONN EXT REMAP READ LOCK */
     if ((err_info = sr_shmext_conn_remap_lock(conn, SR_LOCK_READ, 0, __func__))) {
         sr_errinfo_free(&err_info);
         return 0;
@@ -996,7 +996,7 @@ sr_shmsub_change_notify_has_subscription(sr_conn_ctx_t *conn, struct sr_mod_info
         }
     }
 
-    /* EXT READ UNLOCK */
+    /* CONN EXT REMAP READ UNLOCK */
     sr_shmext_conn_remap_unlock(conn, SR_LOCK_READ, 0, __func__);
 
     return has_sub;
@@ -1026,7 +1026,7 @@ sr_shmsub_change_notify_next_subscription(sr_conn_ctx_t *conn, struct sr_mod_inf
     sr_mod_change_sub_t *shm_sub;
     int opts = 0;
 
-    /* EXT READ LOCK */
+    /* CONN EXT REMAP READ LOCK */
     if ((err_info = sr_shmext_conn_remap_lock(conn, SR_LOCK_READ, 0, __func__))) {
         return err_info;
     }
@@ -1078,7 +1078,7 @@ sr_shmsub_change_notify_next_subscription(sr_conn_ctx_t *conn, struct sr_mod_inf
         *opts_p = opts;
     }
 
-    /* EXT READ UNLOCK */
+    /* CONN EXT REMAP READ UNLOCK */
     sr_shmext_conn_remap_unlock(conn, SR_LOCK_READ, 0, __func__);
 
     return NULL;
@@ -1141,7 +1141,7 @@ sr_shmsub_change_notify_evpipe(struct sr_mod_info_s *mod_info, struct sr_mod_inf
 
     *sub_count = 0;
 
-    /* EXT READ LOCK */
+    /* CONN EXT REMAP READ LOCK */
     if ((err_info = sr_shmext_conn_remap_lock(mod_info->conn, SR_LOCK_READ, 0, __func__))) {
         return err_info;
     }
@@ -1179,7 +1179,7 @@ sr_shmsub_change_notify_evpipe(struct sr_mod_info_s *mod_info, struct sr_mod_inf
     }
 
 cleanup:
-    /* EXT READ UNLOCK */
+    /* CONN EXT REMAP READ UNLOCK */
     sr_shmext_conn_remap_unlock(mod_info->conn, SR_LOCK_READ, 0, __func__);
     return err_info;
 }
@@ -2573,7 +2573,7 @@ sr_shmsub_rpc_notify_has_subscription(sr_conn_ctx_t *conn, off_t *subs, uint32_t
     uint32_t i;
     int has_sub = 0;
 
-    /* EXT READ LOCK */
+    /* CONN EXT REMAP READ LOCK */
     if ((err_info = sr_shmext_conn_remap_lock(conn, SR_LOCK_READ, 0, __func__))) {
         sr_errinfo_free(&err_info);
         return 0;
@@ -2603,7 +2603,7 @@ sr_shmsub_rpc_notify_has_subscription(sr_conn_ctx_t *conn, off_t *subs, uint32_t
         }
     }
 
-    /* EXT READ UNLOCK */
+    /* CONN EXT REMAP READ UNLOCK */
     sr_shmext_conn_remap_unlock(conn, SR_LOCK_READ, 0, __func__);
 
     return has_sub;
@@ -2636,7 +2636,7 @@ sr_shmsub_rpc_notify_next_subscription(sr_conn_ctx_t *conn, off_t *subs, uint32_
     *evpipes_p = NULL;
     *sub_count_p = 0;
 
-    /* EXT READ LOCK */
+    /* CONN EXT REMAP READ LOCK */
     if ((err_info = sr_shmext_conn_remap_lock(conn, SR_LOCK_READ, 0, __func__))) {
         return err_info;
     }
@@ -2688,7 +2688,7 @@ sr_shmsub_rpc_notify_next_subscription(sr_conn_ctx_t *conn, off_t *subs, uint32_
     }
 
 cleanup:
-    /* EXT READ UNLOCK */
+    /* CONN EXT REMAP READ UNLOCK */
     sr_shmext_conn_remap_unlock(conn, SR_LOCK_READ, 0, __func__);
 
     if (!err_info && opts_p) {
@@ -3007,7 +3007,7 @@ sr_shmsub_notif_notify(sr_conn_ctx_t *conn, const struct lyd_node *notif, struct
 
     ly_mod = lyd_owner_module(notif);
 
-    /* EXT READ LOCK */
+    /* CONN EXT REMAP READ LOCK */
     if ((err_info = sr_shmext_conn_remap_lock(conn, SR_LOCK_READ, 0, __func__))) {
         goto cleanup;
     }
@@ -3044,7 +3044,7 @@ sr_shmsub_notif_notify(sr_conn_ctx_t *conn, const struct lyd_node *notif, struct
     }
     sub_shm = (sr_sub_shm_t *)shm_sub.addr;
 
-    /* EXT READ UNLOCK */
+    /* CONN EXT REMAP READ UNLOCK */
     sr_shmext_conn_remap_unlock(conn, SR_LOCK_READ, 0, __func__);
 
     /* do not wait for previous events with EXT lock */
@@ -3054,7 +3054,7 @@ sr_shmsub_notif_notify(sr_conn_ctx_t *conn, const struct lyd_node *notif, struct
         goto cleanup;
     }
 
-    /* EXT READ LOCK */
+    /* CONN EXT REMAP READ LOCK */
     if ((err_info = sr_shmext_conn_remap_lock(conn, SR_LOCK_READ, 0, __func__))) {
         goto cleanup_sub_unlock;
     }
@@ -3094,7 +3094,7 @@ sr_shmsub_notif_notify(sr_conn_ctx_t *conn, const struct lyd_node *notif, struct
         }
     }
 
-    /* EXT READ UNLOCK */
+    /* CONN EXT REMAP READ UNLOCK */
     sr_shmext_conn_remap_unlock(conn, SR_LOCK_READ, 0, __func__);
 
     if (wait) {
@@ -3130,7 +3130,7 @@ cleanup_ext_sub_unlock:
     sr_rwunlock(&sub_shm->lock, 0, SR_LOCK_WRITE, conn->cid, __func__);
 
 cleanup_ext_unlock:
-    /* EXT READ UNLOCK */
+    /* CONN EXT REMAP READ UNLOCK */
     sr_shmext_conn_remap_unlock(conn, SR_LOCK_READ, 0, __func__);
 
 cleanup:
@@ -3873,7 +3873,7 @@ sr_shmsub_oper_poll_listen_find_get_sub(sr_conn_ctx_t *conn, const char *module_
         goto cleanup;
     }
 
-    /* EXT READ LOCK */
+    /* CONN EXT REMAP READ LOCK */
     if ((err_info = sr_shmext_conn_remap_lock(conn, SR_LOCK_READ, 0, __func__))) {
         goto cleanup_opergetsub_unlock;
     }
@@ -3893,7 +3893,7 @@ sr_shmsub_oper_poll_listen_find_get_sub(sr_conn_ctx_t *conn, const char *module_
         }
     }
 
-    /* EXT READ UNLOCK */
+    /* CONN EXT REMAP READ UNLOCK */
     sr_shmext_conn_remap_unlock(conn, SR_LOCK_READ, 0, __func__);
 
 cleanup_opergetsub_unlock:
@@ -4146,7 +4146,7 @@ sr_shmsub_oper_poll_get_sub_change_notify_evpipe(sr_conn_ctx_t *conn, const char
         goto cleanup;
     }
 
-    /* EXT READ LOCK */
+    /* CONN EXT REMAP READ LOCK */
     if ((err_info = sr_shmext_conn_remap_lock(conn, SR_LOCK_READ, 0, __func__))) {
         goto cleanup_opergetsub_unlock;
     }
@@ -4171,7 +4171,7 @@ sr_shmsub_oper_poll_get_sub_change_notify_evpipe(sr_conn_ctx_t *conn, const char
         }
     }
 
-    /* EXT READ UNLOCK */
+    /* CONN EXT REMAP READ UNLOCK */
     sr_shmext_conn_remap_unlock(conn, SR_LOCK_READ, 0, __func__);
 
 cleanup_opergetsub_unlock:

--- a/tests/tcommon.c
+++ b/tests/tcommon.c
@@ -39,8 +39,8 @@ _test_log_msg(sr_log_level_t level, const char *message, const char *prefix)
         severity = "INF";
         break;
     case SR_LL_DBG:
-        /*severity = "DBG";
-        break;*/
+        severity = "DBG";
+        break;
         return;
     case SR_LL_NONE:
         assert(0);

--- a/tests/tcommon.c
+++ b/tests/tcommon.c
@@ -39,8 +39,8 @@ _test_log_msg(sr_log_level_t level, const char *message, const char *prefix)
         severity = "INF";
         break;
     case SR_LL_DBG:
-        severity = "DBG";
-        break;
+        /*severity = "DBG";
+        break;*/
         return;
     case SR_LL_NONE:
         assert(0);


### PR DESCRIPTION
## shm_ext - take ext_lock only when needed

Many shm_ext functions don't require *system-wide* `ext_lock` to be
acquired before changing the data in the ext SHM.

This lock is only required when manipulating ext SHM holes, or
changing the size of the ext SHM (truncate/enlarge).

So, in many cases, it suffices to acquire `ext_lock` just before
calling `sr_shmrealloc_del`, and releasing it immediately after.

This further shortens the window where `ext_lock` is held.

## Lock order `conn->ext_remap_lock` then `SR_CONN_MAIN_SHM(conn)->ext_lock`

`sr_shmext_conn_remap_lock()` acquires `ext_lock` first and then
the connection specific `ext_remap_lock`.

However, The other functions which directly acquire `ext_lock` hold the
`ext_remap_lock` already. This is causes lock-order-inversion!

So, `sr_shmext_conn_remap_lock()` is changed to have the correct order.

This also seems logical:
1. First, Prevent sessions of our connection.
2. Next, Prevent other connections if required.

## sr_shmext_print()

`sr_shmext_print()` may see that there is ext data stored beyond the
currently mapped ext SHM size.
This is because no remap was done after the `ext_lock` was acquired.

This is fixed by only validating if the currently mapped size is the same as the actual ext SHM file size.
```C
validate = (shm_file_size == shm_ext->size);
```

It is important for `sr_shmext_print()` to skip reading *new* data
from *yet-to-be-mapped* offsets.

## shm_ext - add locks for reading suspended state

No lock was obtained while reading the suspended state of subscriptions.
The dedicated READ lock must be obtained to prevent data races.
For instance, another process may remove the data concurrently.

- do not need WRITE remap lock to remove subscriptions even for
`sr_shmext_FOO_sub_check()`. a READ ext remap lock is enough.

- for sub_check() functions, also remember when all locks are unlocked
and we fail to obtain a WRITE lock. We should not try to unlock.
A correct `goto cleanup` is used, but add this to be clear.

### fix-up comments for the ext lock being acquired and released.
explicitly use the term `CONN EXT REMAP` for the connection specific
`rwlock` that guards various sessions of the same connection.

The term `EXT LOCK` only refers to the *process-shared* (across multiple
connections) `mutex` from now.

When `ext_remap_lock` is acquired in WRITE mode along with ext_lock, it is
referred to as `REMAP(WRITE) AND EXT LOCK`.
