### PR TITLE
sr_modinfo_data_store avoid ext wrlock if possible

### DIFF
--- a/src/shm_ext.h
+++ b/src/shm_ext.h
@@ -405,4 +405,15 @@ sr_error_info_t *sr_shmext_oper_push_get(sr_conn_ctx_t *conn, sr_mod_t *shm_mod,
 sr_error_info_t *sr_shmext_oper_push_del(sr_conn_ctx_t *conn, sr_mod_t *shm_mod, const char *mod_name, uint32_t sid,
         sr_lock_mode_t has_mod_locks);
 
+/**
+ * @brief Change a push oper data entry's has_data flag of a module for a session.
+ *
+ * @param[in] conn Connection to use.
+ * @param[in] shm_mod SHM mod.
+ * @param[in] sid Session ID of the push oper data.
+ * @param[in] has_data Whether any push data is stored.
+ * @return err_info, NULL on success.
+ */
+sr_error_info_t *sr_shmext_oper_push_change_has_data(sr_conn_ctx_t *conn, sr_mod_t *shm_mod, uint32_t sid, int has_data);
+
 #endif /* _SHM_EXT_H */


### PR DESCRIPTION
A `WRITE ext_lock` is needed only when creating the oper push data for a module by a session the first time, or when changing the order.

Just updating the `has_data` flag does not need a `WRITE ext_lock`. A `READ` lock is sufficient for this.

Most sessions which have once pushed data to a module, will always have some data until the session is stopped.
So, even the `has_data` flag rarely ever changes.

Optimize this by enhancing `sr_modinfo_push_oper_mod_update_sess()` to learn whether the ext SHM data for this oper_push needs to be created or if the has_data flag needs to be changed.

Only the necessary ext SHM operation if any is performed.

A dedicated `sr_shmext_oper_push_change_has_data()` is added for just updating `has_data` flag.