### PR TITLE
oper push - delete ext shm data at sr_session_stop

### DIFF
--- a/src/shm_ext.c
+++ b/src/shm_ext.c
@@ -2796,8 +2796,14 @@ sr_shmext_oper_push_del(sr_conn_ctx_t *conn, sr_mod_t *shm_mod, const char *UNUS
     }
     SR_CHECK_INT_GOTO(i == shm_mod->oper_push_data_count, err_info, cleanup_ext_unlock);
 
+    SR_LOG_DBG("#SHM before (removing oper push session)");
+    sr_shmext_print(SR_CONN_MOD_SHM(conn), &conn->ext_shm);
+
     /* free the item */
     sr_shmrealloc_del(&conn->ext_shm, &shm_mod->oper_push_data, &shm_mod->oper_push_data_count, sizeof *oper_push, i, 0, 0);
+
+    SR_LOG_DBG("#SHM after (removing oper push session)");
+    sr_shmext_print(SR_CONN_MOD_SHM(conn), &conn->ext_shm);
 
 cleanup_ext_unlock:
     /* EXT READ UNLOCK */

--- a/src/sysrepo.c
+++ b/src/sysrepo.c
@@ -3990,7 +3990,8 @@ sr_changes_notify_store(struct sr_mod_info_s *mod_info, sr_session_ctx_t *sessio
     }
 
     if (!mod_info->notify_diff) {
-        if (!sr_modinfo_is_changed(mod_info)) {
+        /* Only log if called by sr_apply_changes not sr_session_stop and have no changes to apply */
+        if (!sr_modinfo_is_changed(mod_info) && !shmmod_session_del) {
             SR_LOG_DBG("No \"%s\" datastore changes to apply.", sr_ds2str(mod_info->ds));
         }
         goto store;
@@ -4101,8 +4102,8 @@ sr_changes_notify_store(struct sr_mod_info_s *mod_info, sr_session_ctx_t *sessio
     }
 
 store:
-    if (!mod_info->notify_diff && !sr_modinfo_is_changed(mod_info)) {
-        /* there is no diff and no changed modules, nothing to store */
+    if (!mod_info->notify_diff && !sr_modinfo_is_changed(mod_info) && !shmmod_session_del) {
+        /* there is no diff and no changed modules, and we are not stopping the session, nothing to store */
         goto cleanup;
     }
 
@@ -4111,7 +4112,7 @@ store:
         goto cleanup;
     }
 
-    /* store updated datastore */
+    /* store updated datastore or remove left over session in Ext SHM if deleting */
     if ((err_info = sr_modinfo_data_store(mod_info, session, shmmod_session_del))) {
         goto cleanup;
     }


### PR DESCRIPTION
If the session has no oper push data but it has pushed some data in the past, the Ext SHM has entries for this, which must be deleted on stopping the session.

- also don't log "No operational datastore changes to apply" message when stopping the session.