### PR TITLE
sr_session_stop BUGFIX drop staged oper changes before dropping pushed operational data

### DIFF
--- a/src/sysrepo.c
+++ b/src/sysrepo.c
@@ -4687,6 +4687,11 @@ sr_discard_oper_changes(sr_conn_ctx_t *UNUSED(conn), sr_session_ctx_t *session, 
 
     SR_CHECK_ARG_APIRET(!session, NULL, err_info);
 
+    if (session->dt[SR_DS_OPERATIONAL].edit) {
+        sr_errinfo_new(&err_info, SR_ERR_UNSUPPORTED, "There are already staged changes. Call 'sr_discard_changes()' to remove them first.");
+        return sr_api_ret(session, err_info);
+    }
+
     return _sr_discard_oper_changes(session, module_name, 0, timeout_ms);
 }
 


### PR DESCRIPTION
`sr_session_stop` should first drop all staged changes, before calling `_sr_discard_oper_changes()` to drop pushed operational changes.

Otherwise, it ends up pushing staged changes into the datastore on it's way out.

- discard_oper_changes give error if staged exist

sr_discard_oper_changes() should give an error if there are already
staged changes for the session.
These must be first removed by calling sr_discard_changes(), and only
then sr_discard_oper_changes() can be called.
