### PR TITLE
shm_sub BUGFIX update sub_count for DONE ABORT ev

### DIFF
--- a/src/shm_sub.c
+++ b/src/shm_sub.c
@@ -1880,6 +1880,7 @@ sr_shmsub_change_notify_change_done(struct sr_mod_info_s *mod_info, const char *
                 continue;
             }
 
+            nsub->sub_shm->subscriber_count = subscriber_count;
             nsub->pending_event = 1;
             pending_events = 1;
         }
@@ -2122,6 +2123,7 @@ sr_shmsub_change_notify_change_abort(struct sr_mod_info_s *mod_info, const char 
                 continue;
             }
 
+            nsub->sub_shm->subscriber_count = subscriber_count;
             nsub->pending_event = 1;
             pending_events = 1;
         }


### PR DESCRIPTION
`sr_shmsub_change_notify_evpipe()` updates the `subscriber_count` with the number of subscribers actually notified.

This updated count should be written into the subscription SHM for all change_sub events. Previously only `CHANGE` and `UPDATE` events accounted for this. However, this must be handled correctly for `DONE` and `ABORT` events as well.

This allows for avoiding unnecessary waiting for "dead" subscriptions which are discovered late during `evpipe` notify.