### PR TITLE
support delete of multi-key lists without key

### DIFF
--- a/src/ly_wrap.c
+++ b/src/ly_wrap.c
@@ -398,7 +398,7 @@ sr_lys_find_xpath(const struct ly_ctx *ctx, const char *xpath, uint32_t options,
         *valid = 1;
     }
 
-    if (lys_find_xpath(ctx, NULL, xpath, options, set)) {
+    if (lys_find_xpath(ctx, NULL, xpath, options, set) || !(*set)->count) {
         if (valid) {
             *valid = 0;
         } else {

--- a/src/sysrepo.h
+++ b/src/sysrepo.h
@@ -953,9 +953,10 @@ int sr_set_item_str(sr_session_ctx_t *session, const char *path, const char *val
  * If the @p path of list/leaf-list does not include keys/value, all instances are deleted but there can be no further
  * changes merged into the list, use ::SR_EDIT_ISOLATE in such a case.
  *
- * For ::SR_DS_OPERATIONAL, this function deletes the selected node from the session push oper data. To delete the node
+ * For ::SR_DS_OPERATIONAL, this function deletes the selected nodes from the session push oper data. To delete the nodes
  * from the final operational datastore, use ::sr_discard_items() instead. Only ::SR_EDIT_STRICT option is allowed
- * causing the function to return an error if the deleted node does not exist in the session push oper data.
+ * causing the function to return an error if the deleted nodes do not exist in the session push oper data.
+ * If the path is invalid, an error is returned even without ::SR_EDIT_STRICT option.
  *
  * @param[in] session Session ([DS](@ref sr_datastore_t)-specific) to use.
  * @param[in] path [Path](@ref paths) identifier of the data element to be deleted.

--- a/tests/test_edit.c
+++ b/tests/test_edit.c
@@ -865,6 +865,29 @@ test_purge(void **state)
     assert_int_equal(ret, SR_ERR_OK);
     ret = sr_delete_item(st->sess, "/test:ll1", 0);
     assert_int_equal(ret, SR_ERR_OK);
+
+    ret = sr_set_item_str(st->sess, "/mod:container/list-enh[label='0'][date-and-time='1970-01-01T00:00:00Z']", NULL, NULL, 0);
+    assert_int_equal(ret, SR_ERR_OK);
+
+    ret = sr_apply_changes(st->sess, 0);
+    assert_int_equal(ret, SR_ERR_OK);
+
+    /* typo in xpath, should be caught */
+    ret = sr_delete_item(st->sess, "/mod:container/list-enha[label='0']", 0);
+    assert_int_equal(ret, SR_ERR_LY);
+
+    /* one key given in multi-key list, should be deleted */
+    ret = sr_delete_item(st->sess, "/mod:container/list-enh[label='0']", 0);
+    assert_int_equal(ret, SR_ERR_OK);
+
+    ret = sr_apply_changes(st->sess, 0);
+    assert_int_equal(ret, SR_ERR_OK);
+
+    /* test that the data was actually deleted */
+    ret = sr_get_subtree(st->sess, "/mod:container/list-enh[label='0']", 0, &subtree);
+    assert_int_equal(ret, SR_ERR_OK);
+    assert_null(subtree);
+
     sr_session_switch_ds(st->sess, SR_DS_RUNNING);
 }
 


### PR DESCRIPTION
`sr_delete_item()` should be able to delete pushed operational data even without having all the keys specified.

In this case, it should simply delete all entries that would normally match.