### PR TITLE
sr_module_oper_data_load remap lock if data exists

### DIFF
--- a/src/modinfo.c
+++ b/src/modinfo.c
@@ -1263,6 +1263,7 @@ sr_module_oper_data_load(struct sr_mod_info_mod_s *mod, sr_conn_ctx_t *conn, uin
     uint32_t i, j, merge_opts, oper_push_count = 0;
     int last_sid = 0, dead_cid = 0;
 
+    /* oper_push_data_count is protected by operational DS module data locks */
     if (mod->shm_mod->oper_push_data_count) {
         /* EXT READ LOCK */
         if ((err_info = sr_shmext_conn_remap_lock(conn, SR_LOCK_READ, 0, __func__))) {

--- a/src/modinfo.c
+++ b/src/modinfo.c
@@ -1263,12 +1263,12 @@ sr_module_oper_data_load(struct sr_mod_info_mod_s *mod, sr_conn_ctx_t *conn, uin
     uint32_t i, j, merge_opts, oper_push_count = 0;
     int last_sid = 0, dead_cid = 0;
 
-    /* EXT READ LOCK */
-    if ((err_info = sr_shmext_conn_remap_lock(conn, SR_LOCK_READ, 0, __func__))) {
-        goto cleanup;
-    }
-
     if (mod->shm_mod->oper_push_data_count) {
+        /* EXT READ LOCK */
+        if ((err_info = sr_shmext_conn_remap_lock(conn, SR_LOCK_READ, 0, __func__))) {
+            goto cleanup;
+        }
+
         /* make a local copy of the array, with only alive connections */
         oper_push_dup = malloc(mod->shm_mod->oper_push_data_count * sizeof *oper_push_dup);
         if (!oper_push_dup) {
@@ -1285,10 +1285,9 @@ sr_module_oper_data_load(struct sr_mod_info_mod_s *mod, sr_conn_ctx_t *conn, uin
                 }
             }
         }
+        /* EXT READ UNLOCK */
+        sr_shmext_conn_remap_unlock(conn, SR_LOCK_READ, 0, __func__);
     }
-
-    /* EXT READ UNLOCK */
-    sr_shmext_conn_remap_unlock(conn, SR_LOCK_READ, 0, __func__);
 
     if (err_info) {
         goto cleanup;

--- a/src/shm_ext.c
+++ b/src/shm_ext.c
@@ -313,7 +313,7 @@ sr_shmext_print(sr_mod_shm_t *mod_shm, sr_shm_t *shm_ext)
     for (idx = 0; idx < mod_shm->mod_count; ++idx) {
         shm_mod = SR_SHM_MOD_IDX(mod_shm, idx);
 
-        if (shm_mod->oper_push_data) {
+        if (shm_mod->oper_push_data_count) {
             /* add oper push data sessions */
             if (sr_shmext_print_add_item(&items, &item_count, shm_mod->oper_push_data,
                     SR_SHM_SIZE(shm_mod->oper_push_data_count * sizeof(sr_mod_oper_push_t)),

--- a/src/shm_mod.c
+++ b/src/shm_mod.c
@@ -1886,6 +1886,7 @@ sr_shmmod_session_oper_order(sr_session_ctx_t *session, const struct lys_module 
         for (i = 0; i < mod_shm->mod_count; ++i) {
             shm_mod = SR_SHM_MOD_IDX(mod_shm, i);
 
+            /* oper_push_data_count is protected by operational DS module data locks */
             if (!shm_mod->oper_push_data_count) {
                 continue;
             }

--- a/src/shm_types.h
+++ b/src/shm_types.h
@@ -148,7 +148,8 @@ typedef struct {
 
     off_t oper_push_data;       /**< Array of oper push data entries (offset in ext SHM), protected by operational DS
                                      mod data locks. */
-    uint32_t oper_push_data_count;  /**< Number of oper poush data entries. */
+    uint32_t oper_push_data_count;  /**< Number of oper push data entries, also protected by operational DS
+                                     mod data locks */
 
     struct {
         sr_rwlock_t lock;       /**< Process-shared lock for reading or preventing changes (READ) or modifying (WRITE)


### PR DESCRIPTION
In `sr_module_oper_data_load()`, we can skip acquiring the ext remap lock unless push operational data exists.

Also, in `sr_shmext_print()` check for `shm_mod->oper_push_data_count`, rather than `shm_mod->oper_push_data`, which is the ext_shm offset. While it is okay to check the offset, it's not consistent with all the other similar checks.