### PR TITLE
oper ds plugins - skip load and create diff on del

### DIFF
--- a/src/plugins/ds_json.c
+++ b/src/plugins/ds_json.c
@@ -968,4 +968,5 @@ const struct srplg_ds_s srpds_json = {
     .access_check_cb = srpds_json_access_check,
     .last_modif_cb = srpds_json_last_modif,
     .data_version_cb = NULL,
+    .oper_store_require_diff = 0,
 };

--- a/src/plugins/ds_mongo.c
+++ b/src/plugins/ds_mongo.c
@@ -3539,4 +3539,5 @@ const struct srplg_ds_s srpds_mongo = {
     .access_check_cb = srpds_mongo_access_check,
     .last_modif_cb = srpds_mongo_last_modif,
     .data_version_cb = NULL,
+    .oper_store_require_diff = 0,
 };

--- a/src/plugins/ds_redis.c
+++ b/src/plugins/ds_redis.c
@@ -4061,4 +4061,5 @@ const struct srplg_ds_s srpds_redis = {
     .access_check_cb = srpds_redis_access_check,
     .last_modif_cb = srpds_redis_last_modif,
     .data_version_cb = NULL,
+    .oper_store_require_diff = 0,
 };

--- a/src/plugins_datastore.h
+++ b/src/plugins_datastore.h
@@ -296,6 +296,7 @@ struct srplg_ds_s {
     srds_access_check access_check_cb;  /**< callback for checking user access to module data */
     srds_last_modif last_modif_cb;  /**< callback for getting the time of last modification */
     srds_data_version data_version_cb;  /**< optional callback for checking data version */
+    const int oper_store_require_diff;  /**< if a diff is required to store operational data */
 };
 
 /**


### PR DESCRIPTION
None of the operational datastore plugins work with a diff but actual data to be stored.

So, it is unnecessary to load the data and create a diff for storage.

A common scenario would be when a process with large operational data restarts abruptly, and when it comes back up, it has to clean up the previous data. This can be very CPU intensive and is easily avoided.