### PR TITLE
sessions cache operational push data

### DIFF
--- a/src/common.c
+++ b/src/common.c
@@ -3267,6 +3267,8 @@ sr_conn_run_cache_flush(sr_conn_ctx_t *conn)
 /**
  * @brief Flush all cached oper data of a connection.
  *
+ * Must be called only with WRITE mode context lock or conn->mod_remap_lock.
+ *
  * @param[in] conn Connection to use.
  */
 static void
@@ -3304,6 +3306,15 @@ sr_conn_oper_cache_flush(sr_conn_ctx_t *conn)
 
     /* CONN OPER CACHE UNLOCK */
     sr_rwunlock(&conn->oper_cache_lock, SR_CONN_OPER_CACHE_LOCK_TIMEOUT, SR_LOCK_READ, conn->cid, __func__);
+
+    /* remove oper push data cache from all sessions */
+
+    /* safe because context_lock or conn->mod_remap_lock is WRITE locked, preventing all other operations */
+    /* conn->ptr_lock is always acquired after sr_lycc_lock, so conn->session_count cannot change */
+    for (i = 0; i < conn->session_count; i++) {
+        lyd_free_siblings(conn->sessions[i]->oper_push_cache);
+        conn->sessions[i]->oper_push_cache = NULL;
+    }
 }
 
 void

--- a/src/common.c
+++ b/src/common.c
@@ -3275,7 +3275,7 @@ static void
 sr_conn_oper_cache_flush(sr_conn_ctx_t *conn)
 {
     sr_error_info_t *err_info = NULL;
-    uint32_t i;
+    uint32_t i, j;
     struct sr_oper_poll_cache_s *cache;
 
     /* CONN OPER CACHE READ LOCK */
@@ -3312,8 +3312,10 @@ sr_conn_oper_cache_flush(sr_conn_ctx_t *conn)
     /* safe because context_lock or conn->mod_remap_lock is WRITE locked, preventing all other operations */
     /* conn->ptr_lock is always acquired after sr_lycc_lock, so conn->session_count cannot change */
     for (i = 0; i < conn->session_count; i++) {
-        lyd_free_siblings(conn->sessions[i]->oper_push_cache);
-        conn->sessions[i]->oper_push_cache = NULL;
+        for (j = 0; j < conn->sessions[i]->oper_push_mod_count; j++) {
+            lyd_free_siblings(conn->sessions[i]->oper_push_mods[j].cache);
+            conn->sessions[i]->oper_push_mods[j].cache = NULL;
+        }
     }
 }
 

--- a/src/common_types.h
+++ b/src/common_types.h
@@ -181,6 +181,8 @@ struct sr_session_ctx_s {
     char *nacm_user;                /**< Optional NACM user. If set, NACM is applied. */
     sr_error_info_t *err_info;      /**< Session error information. */
 
+    struct lyd_node *oper_push_cache;    /**< Cached operational push data from the last push.
+                                              Protected by sr_lycc_lock from flushing. */
     struct sr_oper_push_cache_s {
         char *name;                 /**< Module name whose push oper data were ever modified by this session. */
         int has_data;               /**< Flag if there are any actual data currently. */

--- a/src/common_types.h
+++ b/src/common_types.h
@@ -181,11 +181,13 @@ struct sr_session_ctx_s {
     char *nacm_user;                /**< Optional NACM user. If set, NACM is applied. */
     sr_error_info_t *err_info;      /**< Session error information. */
 
-    struct lyd_node *oper_push_cache;    /**< Cached operational push data from the last push.
-                                              Protected by sr_lycc_lock from flushing. */
     struct sr_oper_push_cache_s {
         char *name;                 /**< Module name whose push oper data were ever modified by this session. */
-        int has_data;               /**< Flag if there are any actual data currently. */
+        int has_data;               /**< Flag if there is any data from this session in the module datastore. */
+        struct lyd_node *cache;     /**< Cached operational push data from the last push.
+                                         Can be NULL even if has_data is true, for example,
+                                         after apply_changes failure or after a context change.
+                                         Protected by sr_lycc_lock from flushing. */
     } *oper_push_mods;
     uint32_t oper_push_mod_count;   /**< Count of modules with modified push oper data by this session. */
 

--- a/src/modinfo.h
+++ b/src/modinfo.h
@@ -229,12 +229,12 @@ void sr_modinfo_changesub_rdunlock(struct sr_mod_info_s *mod_info);
  * @brief Get specific oper DS data based on the params.
  *
  * @param[in] mod_info Mod info to use.
- * @param[in] sid If set, do not load oper data of sessions after this one, otherwise load oper data of all the sessions.
- * @param[in] oper_data Used only if @p sid is set. If set, replace the oper data of @p sid with these data, otherwise
+ * @param[in] sess Session whose oper push data should be loaded.
+ * @param[in] oper_data If set, replace the oper data of @p sess with these data, otherwise
  * use the stored data of this session.
  * @return err_info, NULL on success.
  */
-sr_error_info_t *sr_modinfo_get_oper_data(struct sr_mod_info_s *mod_info, uint32_t sid, struct lyd_node **oper_data);
+sr_error_info_t *sr_modinfo_get_oper_data(struct sr_mod_info_s *mod_info, sr_session_ctx_t *sess, struct lyd_node **oper_data);
 
 #define SR_MI_NEW_DEPS          0x01    /**< new modules are not required (MOD_INFO_REQ) but only dpendencies (MOD_INFO_DEP) */
 #define SR_MI_INV_DEPS          0x02    /**< add inverse dependencies for added modules */

--- a/src/sysrepo.c
+++ b/src/sysrepo.c
@@ -4222,7 +4222,7 @@ sr_apply_oper_changes(struct sr_mod_info_s *mod_info, sr_session_ctx_t *session,
     mod_info->data = NULL;
 
     /* get the operational DS data with the old push oper data */
-    if ((err_info = sr_modinfo_get_oper_data(mod_info, session->sid, NULL))) {
+    if ((err_info = sr_modinfo_get_oper_data(mod_info, session, NULL))) {
         goto cleanup;
     }
 
@@ -4231,7 +4231,7 @@ sr_apply_oper_changes(struct sr_mod_info_s *mod_info, sr_session_ctx_t *session,
     mod_info->data = NULL;
 
     /* get the operational DS data with the new push oper data */
-    if ((err_info = sr_modinfo_get_oper_data(mod_info, session->sid, &new_oper_data))) {
+    if ((err_info = sr_modinfo_get_oper_data(mod_info, session, &new_oper_data))) {
         goto cleanup;
     }
 
@@ -4258,6 +4258,14 @@ sr_apply_oper_changes(struct sr_mod_info_s *mod_info, sr_session_ctx_t *session,
         goto cleanup;
     }
 
+    /* remove any previous oper_push_cache */
+    lyd_free_siblings(session->oper_push_cache);
+    session->oper_push_cache = NULL;
+
+    /* store mod_info->data as the new oper_push_cache */
+    session->oper_push_cache = mod_info->data;
+    mod_info->data = NULL;
+
     if (update_sm_data) {
         /* operational schema-mount data were changed, update them in the connection */
         if ((err_info = sr_conn_ext_data_update(session->conn))) {
@@ -4266,10 +4274,17 @@ sr_apply_oper_changes(struct sr_mod_info_s *mod_info, sr_session_ctx_t *session,
     }
 
 cleanup:
+    /* flush previous oper_push_cache on errors */
+    if (err_info || *err_info2) {
+        lyd_free_siblings(session->oper_push_cache);
+        session->oper_push_cache = NULL;
+    }
+
     sr_release_data(old_oper_data);
     lyd_free_siblings(data_diff);
     lyd_free_siblings(old_oper_ds);
     lyd_free_siblings(new_oper_data);
+
     return err_info;
 }
 

--- a/src/sysrepo.c
+++ b/src/sysrepo.c
@@ -4258,14 +4258,6 @@ sr_apply_oper_changes(struct sr_mod_info_s *mod_info, sr_session_ctx_t *session,
         goto cleanup;
     }
 
-    /* remove any previous oper_push_cache */
-    lyd_free_siblings(session->oper_push_cache);
-    session->oper_push_cache = NULL;
-
-    /* store mod_info->data as the new oper_push_cache */
-    session->oper_push_cache = mod_info->data;
-    mod_info->data = NULL;
-
     if (update_sm_data) {
         /* operational schema-mount data were changed, update them in the connection */
         if ((err_info = sr_conn_ext_data_update(session->conn))) {
@@ -4274,12 +4266,6 @@ sr_apply_oper_changes(struct sr_mod_info_s *mod_info, sr_session_ctx_t *session,
     }
 
 cleanup:
-    /* flush previous oper_push_cache on errors */
-    if (err_info || *err_info2) {
-        lyd_free_siblings(session->oper_push_cache);
-        session->oper_push_cache = NULL;
-    }
-
     sr_release_data(old_oper_data);
     lyd_free_siblings(data_diff);
     lyd_free_siblings(old_oper_ds);

--- a/src/sysrepo_types.h
+++ b/src/sysrepo_types.h
@@ -105,7 +105,7 @@ typedef enum {
     SR_CONN_DEFAULT = 0x0,              /**< No special behaviour. */
     SR_CONN_CACHE_RUNNING = 0x1,        /**< Always cache running datastore data which makes mainly repeated retrieval
                                              of data much faster. Affects all sessions created on this connection. */
-    SR_CONN_CTX_SET_PRIV_PARSED = 0x2   /**< Use LY_CTX_SET_PRIV_PARSED option for the connection libyang context. */
+    SR_CONN_CTX_SET_PRIV_PARSED = 0x2,  /**< Use LY_CTX_SET_PRIV_PARSED option for the connection libyang context. */
 } sr_conn_flag_t;
 
 /**

--- a/src/sysrepo_types.h
+++ b/src/sysrepo_types.h
@@ -105,7 +105,7 @@ typedef enum {
     SR_CONN_DEFAULT = 0x0,              /**< No special behaviour. */
     SR_CONN_CACHE_RUNNING = 0x1,        /**< Always cache running datastore data which makes mainly repeated retrieval
                                              of data much faster. Affects all sessions created on this connection. */
-    SR_CONN_CTX_SET_PRIV_PARSED = 0x2,  /**< Use LY_CTX_SET_PRIV_PARSED option for the connection libyang context. */
+    SR_CONN_CTX_SET_PRIV_PARSED = 0x2   /**< Use LY_CTX_SET_PRIV_PARSED option for the connection libyang context. */
 } sr_conn_flag_t;
 
 /**


### PR DESCRIPTION
To edit a sessions operational push data there are 2 main steps
1. fetch previous oper push data
2. apply the changes by calling sr_apply_changes()

 ## Fetching operational push data to prepare a new edit
Most processes push operational data more than once in their lifetime.
For editing operational data, the previous push data is first fetched,
and a top level replace node is added.

This fetch involves the following operations:
1. reading the data from a datstore plugin (default JSON).
2. parsing the data into a libyang data tree `mod_info->data`

 ## sr_apply_oper_changes()
`sr_apply_oper_changes()` also fetches the previously stored oper push
data to generate the diff. This happens in 2 phases
1. `sr_modinfo_consolidate()` -> `sr_modinfo_data_load()`
2. `sr_modinfo_get_oper_data()` for diff generation.

After data is stored by calling `sr_modinfo_data_store()`, the `mod_info->data` is free'd by calling `lyd_free_siblings()` from `sr_modinfo_erase()`.

Both `lyd_parse()` and `lyd_free_siblings()` don't scale very well. This can be avoided by caching the previously pushed operational data.

This especially helps, when large operational data has been pushed already and a small edit needs to be performed (i.e. setting one leaf).

The `oper_push_data` cache must be flushed anytime context changes.

If additional memory footprint is a concern, the connection flag `SR_CONN_NO_OPER_PUSH_CACHE` can be passed to `sr_connect()` to disable caching for all sessions of the connection.