### PR TITLE
set change iter to NULL to prevent use after free

### DIFF
--- a/src/sysrepo.c
+++ b/src/sysrepo.c
@@ -6105,6 +6105,9 @@ _sr_get_changes_iter(sr_session_ctx_t *session, const char *xpath, int dup, sr_c
 
 error:
     sr_free_change_iter(*iter);
+    /* prevent use after free */
+    *iter = NULL;
+
     return sr_api_ret(session, err_info);
 }
 


### PR DESCRIPTION
In `_sr_get_changes_iter()`, if an error occurs, the calloc'd iterator is freed, but not set to `NULL`.

It should be set to `NULL` to prevent any use after free, or attempt to free the pointer again, by applications.