### PR TITLE
steps to repro

### DIFF
--- a/tests/tcommon.c
+++ b/tests/tcommon.c
@@ -53,6 +53,9 @@ _test_log_msg(sr_log_level_t level, const char *message, const char *prefix)
     fprintf(stderr, "%03ld.%06ld [%ld][%lu][%s]%s: %s\n", ts.tv_sec, ts.tv_nsec,
             (long)getpid(), (unsigned long)pthread_self(), severity,
             prefix, message);
+    if (level == SR_LL_ERR) {
+        abort();
+    }
 }
 
 static void


### PR DESCRIPTION
clear;make -j sr_clean test_clean all && gdb tests/test_oper_push -ex r

[ RUN      ] test_oper_new
[New Thread 0x7ffff79ef6c0 (LWP 2771247)]
253.440735 [2771244][140737347783424][WRN]: EV ORIGIN: "ietf-interfaces" "change" ID 6 priority 0 failed (Operation failed).

Thread 1 "test_oper_push" hit Breakpoint 1, lyd_diff_reverse_default (node=0x5555555cbfa0, mod=0x55555556eb60) at /home/irfan/intake/libyang/src/diff.c:2158
2158        meta = lyd_find_meta(node->meta, mod, "orig-default");
(gdb) bt
 #0  lyd_diff_reverse_default (node=0x5555555cbfa0, mod=0x55555556eb60) at /home/irfan/intake/libyang/src/diff.c:2158
 #1  0x00007ffff7d73634 in lyd_diff_reverse_all (src_diff=0x5555555ddad0, diff=0x7fffffffced0) at /home/irfan/intake/libyang/src/diff.c:2331
 #2  0x00007ffff7f125ff in sr_lyd_diff_reverse_all (diff=0x5555555ddad0, rdiff=0x7fffffffced0) at /home/irfan/opensource/sysrepo/src/ly_wrap.c:1425
 #3  0x00007ffff7f473a8 in sr_shmsub_change_notify_change_abort (mod_info=0x7fffffffd080, orig_name=0x0, orig_data=0x0, timeout_ms=5000)
    at /home/irfan/opensource/sysrepo/src/shm_sub.c:2053
 #4  0x00007ffff7ef747b in sr_changes_notify_store (mod_info=0x7fffffffd080, session=0x5555555cb5a0, shmmod_session_del=0, timeout_ms=5000, err_info2=0x7fffffffd0c8)
    at /home/irfan/opensource/sysrepo/src/sysrepo.c:4128
 #5  0x00007ffff7ef78be in sr_apply_oper_changes (mod_info=0x7fffffffd080, session=0x5555555cb5a0, ly_mod=0x0, shmmod_session_del=0, timeout_ms=5000, err_info2=0x7fffffffd0c8)
    at /home/irfan/opensource/sysrepo/src/sysrepo.c:4255
 #6  0x00007ffff7ef7ada in sr_apply_changes (session=0x5555555cb5a0, timeout_ms=5000) at /home/irfan/opensource/sysrepo/src/sysrepo.c:4303
 #7  0x0000555555562195 in test_oper_new (state=0x55555556b490) at /home/irfan/opensource/sysrepo/tests/test_oper_push.c:3167
 #8  0x00007ffff7fa38f8 in ?? () from /lib/x86_64-linux-gnu/libcmocka.so.0
 #9  0x00007ffff7fa3fdb in _cmocka_run_group_tests () from /lib/x86_64-linux-gnu/libcmocka.so.0
 #10 0x0000555555562239 in main () at /home/irfan/opensource/sysrepo/tests/test_oper_push.c:3201
(gdb) f 2
 #2  0x00007ffff7f125ff in sr_lyd_diff_reverse_all (diff=0x5555555ddad0, rdiff=0x7fffffffced0) at /home/irfan/opensource/sysrepo/src/ly_wrap.c:1425
1425        if (lyd_diff_reverse_all(diff, rdiff)) {
(gdb) call lyd_print_fd(1, diff, 1, 1)
<interfaces xmlns="urn:ietf:params:xml:ns:yang:ietf-interfaces" xmlns:yang="urn:ietf:params:xml:ns:yang:1" yang:operation="none">
  <interface yang:operation="none">
    <name>eth1</name>
    <type xmlns:or="urn:ietf:params:xml:ns:yang:ietf-origin" or:origin="or:unknown" xmlns:ianaift="urn:ietf:params:xml:ns:yang:iana-if-type">ianaift:ethernetCsmacd</type>
  </interface>
  <interface yang:operation="create">
    <name>eth2</name>
    <type xmlns:ianaift="urn:ietf:params:xml:ns:yang:iana-if-type">ianaift:ethernetCsmacd</type>
  </interface>
</interfaces>
$1 = LY_SUCCESS
(gdb) f 0
 #0  lyd_diff_reverse_default (node=0x5555555cbfa0, mod=0x55555556eb60) at /home/irfan/intake/libyang/src/diff.c:2158
2158        meta = lyd_find_meta(node->meta, mod, "orig-default");
(gdb) call lyd_print_fd(1, node, 1, 1)
<type xmlns="urn:ietf:params:xml:ns:yang:ietf-interfaces" xmlns:or="urn:ietf:params:xml:ns:yang:ietf-origin" or:origin="or:unknown" xmlns:ianaift="urn:ietf:params:xml:ns:yang:iana-if-type">ianaift:ethernetCsmacd</type>
$2 = LY_SUCCESS