### PR TITLE
shm_ext BUGFIX goto oper push order update

### DIFF
--- a/src/shm_ext.c
+++ b/src/shm_ext.c
@@ -2678,7 +2678,7 @@ sr_shmext_oper_push_update(sr_conn_ctx_t *conn, sr_mod_t *shm_mod, const char *m
 
     /* learn the index if entry exists. If order was not specified, learn/generate the order to use */
     if ((err_info = sr_shmext_oper_push_update_get_idx(conn, shm_mod, mod_name, sid, &order, &found_i))) {
-        goto cleanup_shmmod_unlock;
+        goto cleanup_ext_shmmod_unlock;
     }
 
     if (found_i == -1) {

--- a/tests/perf.c
+++ b/tests/perf.c
@@ -696,7 +696,7 @@ test_items_create_oper(struct test_state *state, struct timespec *ts_start, stru
 
     TEST_END(ts_end);
 
-    if ((r = sr_delete_items(state->sess, "/perf:cont/lst", 0))) {
+    if ((r = sr_delete_item(state->sess, "/perf:cont/lst", 0))) {
         return r;
     }
     if ((r = sr_apply_changes(state->sess, state->count * 100))) {


### PR DESCRIPTION
 - shm_ext BUGFIX goto oper push order update

    ext_lock was not unlocked on attempting to use an order already in use.
    This was because the goto was incorrect.

    Added a test to check the deadlock.

- perf BUGFIX typo incorrect sr_delete_items

    2bec9c1816ac8f5d6e7628fe02d6110e2d55db8c introduced a typo.
    The function is `sr_delete_item()` and not `sr_delete_items()`.
