### PR TITLE
Fix setting replay_start_time in srsn_subscribe

### DIFF
--- a/src/utils/sn_common.c
+++ b/src/utils/sn_common.c
@@ -1558,7 +1558,9 @@ srsn_sn_sr_subscribe(sr_session_ctx_t *sess, struct srsn_sub *sub, int sub_no_th
             sr_errinfo_new(&err_info, tmp_err->err[0].err_code, "%s", tmp_err->err[0].message);
             goto error;
         }
-        if (sr_time_cmp(replay_start, &ts) > 0) {
+
+        /* update the earliest stored notif */
+        if (!replay_start->tv_sec || (ts.tv_sec && (sr_time_cmp(replay_start, &ts) > 0))) {
             *replay_start = ts;
         }
 


### PR DESCRIPTION
The original code always zeroed variable `replay_start` and then, the assignment to `replay_start` was never done because the condition was always false. This resulted in  `srsn_subscribe` always returning 0 in `replay_start_time`.

The second commit adds a test to check that `replay_start_time` is set to 0 when there are notifications older than `start_time` of the subscription.
