### PR TITLE
ds_json BUGFIX avoid close after ly_out_free

### DIFF
--- a/src/plugins/ds_json.c
+++ b/src/plugins/ds_json.c
@@ -150,10 +150,16 @@ cleanup:
                 strerror(errno));
     }
 
-    ly_out_free(out, NULL, 1);
-    if (fd > -1) {
-        close(fd);
+    if (out) {
+        /* will call fclose(), so close() should not be called again */
+        ly_out_free(out, NULL, 1);
+    } else if (fd > -1) {
+        if (close(fd) < 0) {
+            srplg_log_errinfo(&err_info, srpds_name, NULL, SR_ERR_SYS, "Failed to close fd for \"%s\" (%s).", path,
+                    strerror(errno));
+        }
     }
+
     if (err_info && creat) {
         unlink(path);
     }


### PR DESCRIPTION
calling `ly_out_free()` with destroy flag, calls `fclose()`. This means that the underlying fd is also closed.

Calling `close()` on the now stale fd can lead to 2 scenarios:
1. EBADF, if the fd has not been reused already.
2. inadvertently closing another thread's fd which was just assigned due to reuse immediately after `fclose()`.

While scenario 1 is harmless, scenario 2 is problematic.