### PR TITLE
run cache BUGFIX avoid flush when no CID

### DIFF
--- a/src/sysrepo.c
+++ b/src/sysrepo.c
@@ -165,7 +165,12 @@ sr_conn_free(sr_conn_ctx_t *conn)
 
     /* unlocked data destroy */
     lyd_free_siblings(conn->ly_ext_data);
-    sr_conn_run_cache_flush(conn);
+
+    /* free run cache only if connection was fully setup */
+    if (conn->cid) {
+        sr_conn_run_cache_flush(conn);
+    }
+
     for (i = 0; i < conn->oper_cache_count; ++i) {
         lyd_free_siblings(conn->oper_caches[i].data);
     }


### PR DESCRIPTION
`sr_connect()` can fail to open the main_shm, if there are no adequate
permissions, or if there was a SHM version mismatch.

In such cases, a CID has not been assigned yet. So
`sr_conn_run_cache_flush(conn)` cannot be called as it calls
`sr_rwlock(&conn->run_cache_lock)` which fails the assertion:

`assert(mode && timeout_abs && cid);`