### PR TITLE
ds JSON OPTIMIZE store with shortest WRITE lock

### DIFF
--- a/src/common.c
+++ b/src/common.c
@@ -273,7 +273,8 @@ sr_ds_handle_init(struct sr_ds_handle_s **ds_handles, uint32_t *ds_handle_count)
             SR_LOG_WRN("DS plugin \"%s\" missing the callback structure.", path);
             goto next_file;
         }
-        if (!srpds->name || !srpds->install_cb || !srpds->uninstall_cb || !srpds->init_cb || !srpds->store_cb ||
+        if (!srpds->name || !srpds->install_cb || !srpds->uninstall_cb || !srpds->init_cb ||
+                !srpds->store_prepare_cb || !srpds->store_commit_cb ||
                 !srpds->load_cb || !srpds->copy_cb || !srpds->candidate_modified_cb || !srpds->candidate_reset_cb ||
                 !srpds->access_set_cb || !srpds->access_get_cb || !srpds->access_check_cb || !srpds->last_modif_cb) {
             SR_LOG_WRN("DS plugin \"%s\" with incomplete callback structure.", path);

--- a/src/context_change.c
+++ b/src/context_change.c
@@ -987,7 +987,11 @@ sr_lycc_store_data_ds_if_differ(sr_conn_ctx_t *conn, const struct ly_ctx *new_ct
 
         if (diff) {
             /* store new data */
-            if ((err_info = ds_handle->plugin->store_cb(new_ly_mod, ds, 0, 0, mod_diff, new_mod_data, ds_handle->plg_data))) {
+            if ((err_info = ds_handle->plugin->store_prepare_cb(new_ly_mod, ds, 0, 0, mod_diff, new_mod_data, ds_handle->plg_data))) {
+                break;
+            }
+
+            if ((err_info = ds_handle->plugin->store_commit_cb(new_ly_mod, ds, 0, 0, mod_diff, new_mod_data, ds_handle->plg_data))) {
                 break;
             }
         }

--- a/src/lyd_mods.c
+++ b/src/lyd_mods.c
@@ -894,7 +894,11 @@ sr_lydmods_print(struct lyd_node **sr_mods)
     lyd_change_term_bin(node, &hash, sizeof hash);
 
     /* store the data using the internal JSON plugin */
-    if ((err_info = srpds_json.store_cb(sr_ly_mod, SR_DS_STARTUP, 0, 0, NULL, *sr_mods, NULL))) {
+    if ((err_info = srpds_json.store_prepare_cb(sr_ly_mod, SR_DS_STARTUP, 0, 0, NULL, *sr_mods, NULL))) {
+        return err_info;
+    }
+
+    if ((err_info = srpds_json.store_commit_cb(sr_ly_mod, SR_DS_STARTUP, 0, 0, NULL, *sr_mods, NULL))) {
         return err_info;
     }
 

--- a/src/modinfo.h
+++ b/src/modinfo.h
@@ -341,9 +341,10 @@ sr_error_info_t *sr_modinfo_generate_config_change_notif(struct sr_mod_info_s *m
  * @param[in] mod_info Mod info to use.
  * @param[in] session Session to use, if operational DS.
  * @param[in] shmmod_session_del Set if @p session oper data entry should be deleted from mod SHM.
+ * @param[in] commit Whether to prepare to store the data or commit it.
  * @return err_info, NULL on success.
  */
-sr_error_info_t *sr_modinfo_data_store(struct sr_mod_info_s *mod_info, sr_session_ctx_t *session, int shmmod_session_del);
+sr_error_info_t *sr_modinfo_data_store(struct sr_mod_info_s *mod_info, sr_session_ctx_t *session, int shmmod_session_del, int commit);
 
 /**
  * @brief Reset (unlock SHM files) all candidate data for mod info.

--- a/src/plugins/common_json.h
+++ b/src/plugins/common_json.h
@@ -28,6 +28,8 @@
 
 /** suffix of backed-up JSON files */
 #define SRPJSON_FILE_BACKUP_SUFFIX ".bck"
+/** suffix of temporary JSON files */
+#define SRPJSON_FILE_TMP_SUFFIX ".tmp"
 
 /** permissions of new directories */
 #define SRPJSON_DIR_PERM 00777

--- a/src/plugins/ds_mongo.c
+++ b/src/plugins/ds_mongo.c
@@ -2942,12 +2942,27 @@ cleanup:
     return err_info;
 }
 
+sr_error_info_t *
+srpds_mongo_store_prepare(const struct lys_module *mod, sr_datastore_t ds, sr_cid_t cid, uint32_t sid,
+        const struct lyd_node *mod_diff, const struct lyd_node *mod_data, void *plg_data)
+{
+    (void) mod;
+    (void) ds;
+    (void) cid;
+    (void) sid;
+    (void) mod_diff;
+    (void) mod_data;
+    (void) plg_data;
+
+    return NULL;
+}
+
 /**
  * @brief Comment for this function can be found in "plugins_datastore.h".
  *
  */
 sr_error_info_t *
-srpds_mongo_store(const struct lys_module *mod, sr_datastore_t ds, sr_cid_t cid, uint32_t sid,
+srpds_mongo_store_commit(const struct lys_module *mod, sr_datastore_t ds, sr_cid_t cid, uint32_t sid,
         const struct lyd_node *mod_diff, const struct lyd_node *mod_data, void *plg_data)
 {
     mongo_data_t mdata;
@@ -3514,7 +3529,8 @@ const struct srplg_ds_s srpds_mongo = {
     .init_cb = srpds_mongo_init,
     .conn_init_cb = srpds_mongo_conn_init,
     .conn_destroy_cb = srpds_mongo_conn_destroy,
-    .store_cb = srpds_mongo_store,
+    .store_prepare_cb = srpds_mongo_store_prepare,
+    .store_commit_cb = srpds_mongo_store_commit,
     .load_cb = srpds_mongo_load,
     .copy_cb = srpds_mongo_copy,
     .candidate_modified_cb = srpds_mongo_candidate_modified,

--- a/src/plugins/ds_redis.c
+++ b/src/plugins/ds_redis.c
@@ -3454,12 +3454,27 @@ cleanup:
     return err_info;
 }
 
+sr_error_info_t *
+srpds_redis_store_prepare(const struct lys_module *mod, sr_datastore_t ds, sr_cid_t cid, uint32_t sid,
+        const struct lyd_node *mod_diff, const struct lyd_node *mod_data, void *plg_data)
+{
+    (void) mod;
+    (void) ds;
+    (void) cid;
+    (void) sid;
+    (void) mod_diff;
+    (void) mod_data;
+    (void) plg_data;
+
+    return NULL;
+}
+
 /**
  * @brief Comment for this function can be found in "plugins_datastore.h".
  *
  */
 sr_error_info_t *
-srpds_redis_store(const struct lys_module *mod, sr_datastore_t ds, sr_cid_t cid, uint32_t sid,
+srpds_redis_store_commit(const struct lys_module *mod, sr_datastore_t ds, sr_cid_t cid, uint32_t sid,
         const struct lyd_node *mod_diff, const struct lyd_node *mod_data, void *plg_data)
 {
     redis_plg_conn_data_t *pdata = (redis_plg_conn_data_t *)plg_data;
@@ -4045,7 +4060,8 @@ const struct srplg_ds_s srpds_redis = {
     .init_cb = srpds_redis_init,
     .conn_init_cb = srpds_redis_conn_init,
     .conn_destroy_cb = srpds_redis_conn_destroy,
-    .store_cb = srpds_redis_store,
+    .store_prepare_cb = srpds_redis_store_prepare,
+    .store_commit_cb = srpds_redis_store_commit,
     .load_cb = srpds_redis_load,
     .copy_cb = srpds_redis_copy,
     .candidate_modified_cb = srpds_redis_candidate_modified,

--- a/src/shm_mod.c
+++ b/src/shm_mod.c
@@ -894,8 +894,13 @@ sr_shmmod_del_module_sess_oper_data(sr_conn_ctx_t *conn, const struct lys_module
         }
 
         /* store the empty data */
-        if ((err_info = oper_ds_handle->plugin->store_cb(ly_mod, SR_DS_OPERATIONAL, cid, sid, mod_diff, NULL,
-                oper_ds_handle->plg_data))) {
+        if ((err_info = oper_ds_handle->plugin->store_prepare_cb(ly_mod, SR_DS_OPERATIONAL, cid, sid, mod_diff,
+                NULL, oper_ds_handle->plg_data))) {
+            goto cleanup;
+        }
+
+        if ((err_info = oper_ds_handle->plugin->store_commit_cb(ly_mod, SR_DS_OPERATIONAL, cid, sid, mod_diff,
+                NULL, oper_ds_handle->plg_data))) {
             goto cleanup;
         }
     }
@@ -1728,7 +1733,11 @@ sr_shmmod_copy_mod(const struct lys_module *ly_mod, const struct sr_ds_handle_s 
     }
 
     /* write data to target */
-    if ((err_info = tds_handle->plugin->store_cb(ly_mod, tds, 0, 0, mod_diff, s_mod_data, tds_handle->plg_data))) {
+    if ((err_info = tds_handle->plugin->store_prepare_cb(ly_mod, tds, 0, 0, mod_diff, s_mod_data, tds_handle->plg_data))) {
+        goto cleanup;
+    }
+
+    if ((err_info = tds_handle->plugin->store_commit_cb(ly_mod, tds, 0, 0, mod_diff, s_mod_data, tds_handle->plg_data))) {
         goto cleanup;
     }
 

--- a/src/sysrepo.c
+++ b/src/sysrepo.c
@@ -4383,13 +4383,18 @@ store:
         goto cleanup;
     }
 
+    /* prepare to store updated datastore before upgrading to WRITE lock */
+    if ((err_info = sr_modinfo_data_store(mod_info, session, shmmod_session_del, 0))) {
+        goto cleanup;
+    }
+
     /* MODULES WRITE LOCK (upgrade) */
     if ((err_info = sr_shmmod_modinfo_rdlock_upgrade(mod_info, sid, timeout_ms, timeout_ms))) {
         goto cleanup;
     }
 
-    /* store updated datastore or remove left over session in Ext SHM if deleting */
-    if ((err_info = sr_modinfo_data_store(mod_info, session, shmmod_session_del))) {
+    /* commit and store updated datastore or remove left over session in Ext SHM if deleting */
+    if ((err_info = sr_modinfo_data_store(mod_info, session, shmmod_session_del, 1))) {
         goto cleanup;
     }
 


### PR DESCRIPTION
modules are WRITE locked before calling `sr_modinfo_data_store()`. This is because the datastore is being replaced with new data, and readers must be blocked until the store operation is complete.

 ### JSON datastore plugin:
Storing large module data into JSON can be expensive. Normally, this requires WRITE module locks to be held as `srpds_json_store()` overwrites the current JSON module data file with new data.

This can be done differently in two steps:
1. Creating a temporary json data file
2. Replacing the current json data file with the temporary file.

Step 1. is a heavy operation, and does not require WRITE module locks. Step 2. is a extremely fast `rename()`, and requires WRITE module locks.

Doing the two-step store, allows reads to almost never have to block.

Similar logic could be implemented for other plugins if feasible.