### PR TITLE
fix: Teardown sequence must be inverse of init sequence

### DIFF
--- a/src/executables/sysrepo-plugind.c
+++ b/src/executables/sysrepo-plugind.c
@@ -628,16 +628,17 @@ main(int argc, char **argv)
     rc = EXIT_SUCCESS;
 
 cleanup:
-    for (i = plugin_count - 1; i >= 0; --i) {
+    for (i = plugin_count; i > 0; --i) {
+        const int idx = i - 1;
         /* plugin cleanup */
-        if (plugins[i].initialized) {
-            plugins[i].cleanup_cb(sess, plugins[i].private_data);
+        if (plugins[idx].initialized) {
+            plugins[idx].cleanup_cb(sess, plugins[idx].private_data);
         }
 
-        if (plugins[i].handle) {
-            dlclose(plugins[i].handle);
+        if (plugins[idx].handle) {
+            dlclose(plugins[idx].handle);
         }
-        free(plugins[i].plugin_name);
+        free(plugins[idx].plugin_name);
     }
     free(plugins);
 

--- a/src/executables/sysrepo-plugind.c
+++ b/src/executables/sysrepo-plugind.c
@@ -628,7 +628,7 @@ main(int argc, char **argv)
     rc = EXIT_SUCCESS;
 
 cleanup:
-    for (i = 0; i < plugin_count; ++i) {
+    for (i = plugin_count - 1; i >= 0; --i) {
         /* plugin cleanup */
         if (plugins[i].initialized) {
             plugins[i].cleanup_cb(sess, plugins[i].private_data);

--- a/src/executables/sysrepo-plugind.c
+++ b/src/executables/sysrepo-plugind.c
@@ -628,17 +628,17 @@ main(int argc, char **argv)
     rc = EXIT_SUCCESS;
 
 cleanup:
-    for (i = plugin_count; i > 0; --i) {
-        const int idx = i - 1;
+    while (plugin_count > 0) {
         /* plugin cleanup */
-        if (plugins[idx].initialized) {
-            plugins[idx].cleanup_cb(sess, plugins[idx].private_data);
+        if (plugins[plugin_count - 1].initialized) {
+            plugins[plugin_count - 1].cleanup_cb(sess, plugins[plugin_count - 1].private_data);
         }
 
-        if (plugins[idx].handle) {
-            dlclose(plugins[idx].handle);
+        if (plugins[plugin_count - 1].handle) {
+            dlclose(plugins[plugin_count - 1].handle);
         }
-        free(plugins[idx].plugin_name);
+        free(plugins[plugin_count - 1].plugin_name);
+        --plugin_count;
     }
     free(plugins);
 


### PR DESCRIPTION
The sysrepo-plugind daemon loads the found plugins in a well-defined order that can be controlled by writing the list `/sysrepo-plugind:sysrepo-plugind/plugin-order/plugin`. That's a nice feature to help control dependencies between plugins. Currently the teardown sequence is the same as the initialization sequence, however, it should be _inverse_ to respect those dependencies.