### PR TITLE
ds plugins OPTIMIZE pass req xpaths to load_cb

### DIFF
--- a/src/modinfo.c
+++ b/src/modinfo.c
@@ -1376,7 +1376,7 @@ sr_module_oper_data_load(struct sr_mod_info_mod_s *mod, sr_conn_ctx_t *conn, sr_
             }
             /* load push oper data for the session from the datastore plugin if cache was empty */
             if (!mod_data && (err_info = sr_module_file_data_append(mod->ly_mod, mod->ds_handle, SR_DS_OPERATIONAL,
-                    oper_push_dup[i].cid, oper_push_dup[i].sid, NULL, 0, &mod_data))) {
+                    oper_push_dup[i].cid, oper_push_dup[i].sid, mod->xpaths, mod->xpath_count, &mod_data))) {
                 goto cleanup;
             }
         } else {


### PR DESCRIPTION
load_cb can be xpath aware for operational datastore, and fetch only the required data for the datastore plugins that support it.

Implemented support:
1. redis DS plugin supports this for all datastores.
2. mongo ds plugin supports this except for operational datastore.
  - ietf-origin metadata must be explicitly retrieved for each path.
  - this is not implemented yet, so all data will be retrieved.
3. json ds plugin - unimplemented. ignores passed xpaths.

This has the benefit of optimally loading only the requested data, and not constructing the entire module datatree, if only a small part is being read.

Further, it can reduce the amount of time modules remain read locked, when they have large amount of data, and occasional readers of small data.