### PR TITLE
nacm BUGFIX memory leak

### DIFF
--- a/src/utils/nacm.c
+++ b/src/utils/nacm.c
@@ -1826,6 +1826,7 @@ sr_nacm_check_operation(sr_session_ctx_t *session, const struct lyd_node *op)
     }
 
 cleanup:
+    free(denied.rule_name);
     return sr_api_ret(session, err_info);
 }
 


### PR DESCRIPTION
The rule_name string is copied and must be properly freed, otherwise it causes a leak. I triggered it in sysrepo-cpp tests after wrapping sr_nacm_check_operation function in sysrepo-cpp.
LSAN report follows:

```
  ==381000==ERROR: LeakSanitizer: detected memory leaks

  Direct leak of 2 byte(s) in 1 object(s) allocated from:
      #0 0x5d551e1cb56a in strdup (/build/sysrepo-cpp/build-clang-asan/test-session+0x1ae56a) (BuildId: d78ee32ce1fd55641090ef563448cfd2bd45b112)
      #1 0x7606a2a071f5 in sr_nacm_check_op /build/sysrepo/src/utils/nacm.c:1785:36
      #2 0x7606a2a0c796 in sr_nacm_check_operation /build/sysrepo/src/utils/nacm.c:1809:21
      #3 0x7606a382b0b0 in sysrepo::Session::checkNacmOperation(libyang::DataNode const&) const /build/sysrepo-cpp/src/Session.cpp:727:16
      #4 0x5d551e2428fc in DOCTEST_ANON_FUNC_2() /build/sysrepo-cpp/tests/session.cpp:459:9
      #5 0x5d551e2bbc8e in doctest::Context::run() /build/build/prefixes/clang-asan/include/doctest/doctest.h:7007:21
      #6 0x5d551e2c0702 in main /build/build/prefixes/clang-asan/include/doctest/doctest.h:7085:71
      #7 0x7606a2c35487 in __libc_start_call_main /usr/src/debug/glibc/glibc/csu/../sysdeps/nptl/libc_start_call_main.h:58:16
      #8 0x7606a2c3554b in __libc_start_main /usr/src/debug/glibc/glibc/csu/../csu/libc-start.c:360:3
      #9 0x5d551e0de564 in _start (/build/sysrepo-cpp/build-clang-asan/test-session+0xc1564) (BuildId: d78ee32ce1fd55641090ef563448cfd2bd45b112)
```

Fixes: 1382043d ("nacm UPDATE explicit func for op checking")