### PR TITLE
mod_info run_cache reduce timeouts

### DIFF
--- a/src/modinfo.c
+++ b/src/modinfo.c
@@ -4179,7 +4179,9 @@ sr_modinfo_data_store(struct sr_mod_info_s *mod_info, sr_session_ctx_t *session,
                     /* store the changed data in the cache */
                     if ((err_info = sr_conn_run_cache_update_mod(mod_info->conn, mod->ly_mod, mod->shm_mod->run_cache_id,
                             mod_data))) {
-                        goto cleanup;
+                        /* not a fatal error, cache can be updated in a future operation */
+                        sr_errinfo_free(&err_info);
+                        lyd_free_siblings(mod_data);
                     }
 
                     /* mod data spent */


### PR DESCRIPTION
### mod_info run_cache reduce timeouts

    running ds cache lock needs to be held for the entire operation, only
    when reading the running datastore.

    For all other operations, the necessary data can be quickly duplicated
    and the cache unlocked.

    Without this change, there are a couple of problems:

    1. sr_apply_changes() for the running datastore can fail during store
       operation because the cache could not be updated, because another
       thread is concurrently reading the operational datastore, even from
       potentially unrelated modules.
    2. cache is locked even when oper get subscribers are called to
       fetch operational data.

    - added a test for this scenario, and enabled running cache in
      test_multi_connection for increased testing.

###     modinfo ignore cache update fail during store

    A user facing process, such as gnmi, could be reading data and applying
    changes to the running datastore concurrently with multiple threads.

    A WRITE lock is needed to update the run cache, and may not always be
    available.

    "DONE_ONLY" subscribers can no longer be informed of these changes,
    because although sr_apply_changes() failed, the same changes can no
    longer be retried.

    It can also cause inconsistency when multiple modules are being changed,
    and the cache update fails after some modules were already written into,
    and remaining modules are left with previous data.

    To avoid such problems, it's best to ignore non-fatal problems such as
    cache update failures during sr_modinfo_data_store().
