### PR TITLE
sr_shmmod_release_locks only if ds locks are held

### DIFF
--- a/src/common_types.h
+++ b/src/common_types.h
@@ -224,6 +224,7 @@ struct sr_session_ctx_s {
         } *first;                   /**< First stored notification buffer node. */
         struct sr_sess_notif_buf_node *last;    /**< Last stored notification buffer node. */
     } notif_buf;                    /**< Notification buffering attributes. */
+    uint32_t ds_locks;              /**< Count of datastore locks held by this session. */
 };
 
 /**


### PR DESCRIPTION
`sr_shmmod_release_locks()` iterates through all the modules (and there can be a lot of them), and acquires a system-wide mutex (ds_lock) and checks whether the current session has locked it.

These locks are only held if `sr_lock()` was called during the lifetime of the session, which happens very rarely.
Most sessions are short-lived, and this makes stopping sessions more expensive than necessary.

So, remember if the session has any ds_locks, and check before calling `sr_shmmod_release_locks()`.

More importantly, context lock needs to be acquired before calling `sr_shmmod_release_locks()`. During events like system restart when all processes are trying to stop, this can cause deadlocks, as context lock readers are at the limit (SR_RWLOCK_READ_LIMIT=16).