### PR TITLE
sysrepoctl check return value of asprintf

### DIFF
--- a/src/executables/sysrepoctl.c
+++ b/src/executables/sysrepoctl.c
@@ -427,7 +427,10 @@ srctl_list_collect(sr_conn_ctx_t *conn, const struct ly_ctx *ly_ctx, struct list
             cur_item->main_mod = strdup(ly_mod->name);
 
             /* name and revision */
-            asprintf(&cur_item->name, " %s", ly_mod->parsed->includes[u].submodule->name);
+            if (asprintf(&cur_item->name, " %s", ly_mod->parsed->includes[u].submodule->name) == -1) {
+                error_print(0, "Memory allocation failed");
+                return SR_ERR_NO_MEMORY;
+            }
             str = ly_mod->parsed->includes[u].submodule->revs ? ly_mod->parsed->includes[u].submodule->revs[0].date : NULL;
             cur_item->revision = str ? strdup(str) : strdup("");
         }


### PR DESCRIPTION
build fails with latest sysrepo version due to compiler warning for unused result being treated as error due to -Werror flag.

/usr/src/packages/BUILD/src/executables/sysrepoctl.c:440:13: error: ignoring return value of 'asprintf' declared with attribute 'warn_unused_result' [-Werror=unused-result] asprintf(&cur_item->name, " %s", ly_mod->parsed->includes[u]
                                    .submodule->name);