### PR TITLE
Adding a couple of dir macros

### DIFF
--- a/distro/pkg/rpm/sysrepo.spec
+++ b/distro/pkg/rpm/sysrepo.spec
@@ -106,6 +106,7 @@ rm -rf /dev/shm/srsub_*
 %{_datadir}/yang/modules/sysrepo/*.yang
 %dir %{_datadir}/yang/modules/sysrepo/
 %dir %{_sysconfdir}/sysrepo
+%dir %{_libdir}/sysrepo
 %dir %{_libdir}/sysrepo/plugins
 %attr(0770,root,sysrepo) %{_sysconfdir}/sysrepo
 
@@ -121,6 +122,7 @@ rm -rf /dev/shm/srsub_*
 %{_sysusersdir}/sysrepo-plugind.conf
 %{_bindir}/sysrepo-plugind
 %{_datadir}/man/man8/sysrepo-plugind.8.gz
+%dir %{_libdir}/sysrepo-plugind
 %dir %{_libdir}/sysrepo-plugind/plugins
 
 %files tools


### PR DESCRIPTION
To avoid leaving some directories behind when the package is removed, each directory in the owned path should be explicitly named in the %files section as explained here:

https://docs.fedoraproject.org/en-US/packaging-guidelines/UnownedDirectories/