### PR TITLE
sr_cond OPTIMIZE use FUTEX_PRIVATE_FLAG if local

### DIFF
--- a/src/shm_types.h
+++ b/src/shm_types.h
@@ -25,7 +25,7 @@
 #include "common_types.h"
 #include "sysrepo_types.h"
 
-#define SR_SHM_VER 20   /**< Main, mod, and ext SHM version of their expected content structures. */
+#define SR_SHM_VER 21   /**< Main, mod, and ext SHM version of their expected content structures. */
 #define SR_MAIN_SHM_LOCK "sr_main_lock"     /**< Main SHM file lock name. */
 
 /**

--- a/src/sr_cond/sr_cond_futex.h
+++ b/src/sr_cond/sr_cond_futex.h
@@ -28,7 +28,8 @@
  * @brief Condition variable futex implementation.
  */
 typedef struct {
-    uint32_t futex;             /**< futex used for waiting and signalling idle/ready */
+    uint32_t futex;             /**< futex used for waiting and signalling idle/ready. */
+    int shared;                 /**< Flag whether the futex is process-shared or private. */
 } sr_cond_t;
 
 /**


### PR DESCRIPTION
In the sr_cond_futex implementation, the shared flag is unused.

From the manpage:
> **FUTEX_PRIVATE_FLAG (since Linux 2.6.22)**
  This option bit can be employed with all futex operations.
  It tells the kernel that the futex is process-private and
  not shared with another process (i.e., it is being used for
  synchronization only between threads of the same process).
  This allows the kernel to make some additional performance
  optimizations.
  As a convenience, <linux/futex.h> defines a set of
  constants with the suffix _PRIVATE that are equivalents of
  all of the operations listed below, but with the
  **FUTEX_PRIVATE_FLAG** ORed into the constant value.  Thus,
  there are **FUTEX_WAIT_PRIVATE, FUTEX_WAKE_PRIVATE,** and so
  on.

Also update the SHM version.