### PR TITLE
build: read packaging version form CMakeLists.txt

### DIFF
--- a/distro/scripts/make-archive.sh
+++ b/distro/scripts/make-archive.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # create archive from current source using git
 
-VERSION=$(git log --oneline -n1 --grep="^VERSION" | rev | cut -d' ' -f1 | rev)
+VERSION=$(grep \(SYSREPO_M.*_VERSION CMakeLists.txt | sed 'N; N; s/[[:print:]]*[[:blank:]]\([[:digit:]]\+\)[[:print:]]/\1/g; s/\n/./g')
 
 NAMEVER=sysrepo-$VERSION
 ARCHIVE=$NAMEVER.tar.gz


### PR DESCRIPTION
Same as https://github.com/CESNET/libnetconf2/pull/555 and https://github.com/CESNET/libyang/pull/2427 for https://github.com/CESNET/libyang/issues/2423.

Builds package from CMakeLists.txt so you can clone with --depth=1.