### PR TITLE
read upgr context lock for operational ds only when needed

### DIFF
--- a/src/sysrepo.c
+++ b/src/sysrepo.c
@@ -5111,7 +5111,7 @@ _sr_discard_oper_changes(sr_session_ctx_t *session, const char *module_name, int
     }
 
     /* CONTEXT LOCK */
-    if ((err_info = sr_lycc_lock(session->conn, SR_LOCK_READ_UPGR, 0, __func__))) {
+    if ((err_info = sr_lycc_lock(session->conn, SR_LOCK_READ, 0, __func__))) {
         return sr_api_ret(session, err_info);
     }
 
@@ -5140,15 +5140,26 @@ _sr_discard_oper_changes(sr_session_ctx_t *session, const char *module_name, int
     }
 
     if (data_old.run) {
+        /* CONTEXT READ UPGR LOCK - sm data changed, new context will be created */
+        if ((err_info = sr_lycc_lock(session->conn, SR_LOCK_READ_UPGR, 0, __func__))) {
+            goto cleanup;
+        }
+
+        /* CONTEXT READ UNLOCK to allow upgrade */
+        sr_lycc_unlock(session->conn, SR_LOCK_READ, 0, __func__);
+
         /* MODULES UNLOCK, free modinfo before a new context is printed */
         sr_shmmod_modinfo_unlock(&mod_info);
         sr_modinfo_erase(&mod_info);
         memset(&mod_info, 0, sizeof mod_info);
 
         /* operational schema-mount data were changed, prepare a new context to be able to use them */
-        if ((err_info = sr_schema_mount_ds_data_update(session->conn, &data_old))) {
-            goto cleanup;
-        }
+        err_info = sr_schema_mount_ds_data_update(session->conn, &data_old);
+
+        /* CONTEXT READ_UPGR UNLOCK  */
+        sr_lycc_unlock(session->conn, SR_LOCK_READ_UPGR, 0, __func__);
+
+        return sr_api_ret(NULL, err_info);
     }
 
 cleanup:
@@ -5158,8 +5169,8 @@ cleanup:
     sr_shmmod_modinfo_unlock(&mod_info);
     sr_modinfo_erase(&mod_info);
 
-    /* CONTEXT UNLOCK */
-    sr_lycc_unlock(session->conn, SR_LOCK_READ_UPGR, 0, __func__);
+    /* CONTEXT READ UNLOCK */
+    sr_lycc_unlock(session->conn, SR_LOCK_READ, 0, __func__);
 
     if (cb_err_info) {
         /* return callback error if some was generated */


### PR DESCRIPTION
- discard_oper_changes conditional upgr ctx lock

    _sr_discard_oper_changes() can acquire a READ UPGR context lock if
    needed to update schema mount data in the context.
    A normal READ lock is enough in all other cases.

    A READ UPGR context lock creates a prevents concurrent execution of
    _sr_discard_oper_changes(), and also causes data caches to be flushed.
    Both of these are not good for performance.
- sr_oper_get_subscribe does not need ctx upgr lock
