### PR TITLE
sr_module_change_subscribe URGE locks for Ext SHM and sr_module_change_subscribe_enable unlock modules sooner

### DIFF
--- a/src/sysrepo.c
+++ b/src/sysrepo.c
@@ -6514,8 +6514,8 @@ sr_module_change_subscribe(sr_session_ctx_t *session, const char *module_name, c
         _sr_subscription_thread_suspend(*subscription);
     }
 
-    /* CHANGE SUB WRITE LOCK - also prevents events from being published */
-    if ((err_info = sr_rwlock(&shm_mod->change_sub[session->ds].lock, SR_SHMEXT_SUB_LOCK_TIMEOUT, SR_LOCK_WRITE,
+    /* CHANGE SUB WRITE URGE LOCK - also prevents events from being published */
+    if ((err_info = sr_rwlock(&shm_mod->change_sub[session->ds].lock, SR_SHMEXT_SUB_LOCK_TIMEOUT, SR_LOCK_WRITE_URGE,
             conn->cid, __func__, NULL, NULL))) {
         goto cleanup;
     }
@@ -6571,8 +6571,8 @@ error2:
     subs_mode = SR_LOCK_NONE;
 
 error1:
-    /* CHANGE SUB WRITE lock - and remove the newly added sub from Ext SHM */
-    if ((tmp_err = sr_rwlock(&shm_mod->change_sub[session->ds].lock, SR_SHMEXT_SUB_LOCK_TIMEOUT, SR_LOCK_WRITE,
+    /* CHANGE SUB WRITE URGE lock - and remove the newly added sub from Ext SHM */
+    if ((tmp_err = sr_rwlock(&shm_mod->change_sub[session->ds].lock, SR_SHMEXT_SUB_LOCK_TIMEOUT, SR_LOCK_WRITE_URGE,
             conn->cid, __func__, NULL, NULL))) {
         sr_errinfo_merge(&err_info, tmp_err);
     }


### PR DESCRIPTION
## sr_module_change_subscribe URGE locks for Ext SHM

in sr_module_change_subscribe(), the change sub Ext SHM lock should be
acquired in a writer preferred manner (WRITE_URGE).

Adding a change subscr holds the WRITE lock for a very short duration.

But, a change_sub READ lock is held for much longer, because the oper
notify diff needs to be determined correctly based on the subscriptions
present.

So, for modules with frequent writes, subscription can fail due to
starvation.

## module_change_subscr_enable unlock modules sooner

in sr_module_change_subscribe_enable(), there is no need to hold on to
module READ locks while the ENABLED event callback is called.

Since the newly added subscription is already in the Ext SHM, if a new
changeset matches its xpath filter, sr_apply_changes() will wait on the
subscription. So, no events are missed by the subscriber.

Also, a WRITE module lock is only needed to actually write the data into
the datastore. At all other times when UPDATE, CHANGE, or DONE events
are notified, we are actually holding a READ_UPGR lock.
