### PR TITLE
tests: Format time_t as long long

### DIFF
--- a/tests/tcommon.c
+++ b/tests/tcommon.c
@@ -50,7 +50,7 @@ _test_log_msg(sr_log_level_t level, const char *message, const char *prefix)
     clock_gettime(CLOCK_REALTIME, &ts);
     ts.tv_sec %= 1000;
     ts.tv_nsec /= 1000;
-    fprintf(stderr, "%03ld.%06ld [%ld][%lu][%s]%s: %s\n", ts.tv_sec, ts.tv_nsec,
+    fprintf(stderr, "%03lld.%06ld [%ld][%lu][%s]%s: %s\n", ts.tv_sec, ts.tv_nsec,
             (long)getpid(), (unsigned long)pthread_self(), severity,
             prefix, message);
 }


### PR DESCRIPTION
time_t can be 64 bits wide on a 32 bit system (see Y2k38 problem). Format time_t as long long instead of long to address this.