### PR TITLE
cmake UPDATE use sr_cond_futex only if SYS_futex syscall is available

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -168,7 +168,8 @@ set(NACM_SRMON_DATA_PERM "600" CACHE STRING "NACM modules ietf-netconf-acm and s
 # sr_cond implementation
 if(NOT SR_COND_IMPL)
     check_include_file("linux/futex.h" HAS_FUTEX)
-    if(HAS_FUTEX)
+    check_symbol_exists(SYS_futex "sys/syscall.h" HAS_SYS_FUTEX)
+    if(HAS_FUTEX AND HAS_SYS_FUTEX)
         set(SR_COND_IMPL "sr_cond_futex")
     else()
         set(SR_COND_IMPL "sr_cond_pthread")


### PR DESCRIPTION
This is a follow-up to https://github.com/sysrepo/sysrepo/issues/3346

Checking for the presence of `linux/futex.h` does not guarantee that futexes can be used.
That is why an extra check for `SYS_futex` symbol was added.