### PR TITLE
cmake UPDATE specify sysrepo as C project

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 2.8.12...3.28.1)
 
-project(sysrepo)
+project(sysrepo C)
 set(SYSREPO_DESC "YANG-based system repository for all-around configuration management.")
 
 # include custom Modules


### PR DESCRIPTION
I noticed that sysrepo requires a CXX compiler.
Since it is a C based project, only a C compiler is needed.
This updates the CMake config to reflect this.