### PR TITLE
ly_wrap UPDATE add SR_CTX_COMPILE_OBSOLETE option

### DIFF
--- a/src/ly_wrap.c
+++ b/src/ly_wrap.c
@@ -234,6 +234,10 @@ sr_ly_ctx_new(struct ly_ctx **ly_ctx)
         ctx_opts |= LY_CTX_SET_PRIV_PARSED;
     }
 
+    if (ATOMIC_LOAD_RELAXED(sr_yang_ctx.sr_opts) & SR_CTX_COMPILE_OBSOLETE) {
+        ctx_opts |= LY_CTX_COMPILE_OBSOLETE;
+    }
+
     sr_ly_log_setup();
 
     /* create new context */

--- a/src/sysrepo_types.h
+++ b/src/sysrepo_types.h
@@ -113,8 +113,9 @@ typedef enum {
     SR_CTX_DEFAULT = 0x0,           /**< No special behaviour. */
     SR_CTX_NO_PRINTED = 0x1,        /**< Do not print nor use printed context even if available. Can be used to keep
                                          parsed modules in the context. */
-    SR_CTX_SET_PRIV_PARSED = 0x2    /**< Use LY_CTX_SET_PRIV_PARSED libyang option for the context. Affects only
+    SR_CTX_SET_PRIV_PARSED = 0x2,   /**< Use LY_CTX_SET_PRIV_PARSED libyang option for the context. Affects only
                                          non-printed context. */
+    SR_CTX_COMPILE_OBSOLETE = 0x3   /**< Use LY_CTX_COMPILE_OBSOLETE libyang option for the context. */
 } sr_context_flag_t;
 
 /**


### PR DESCRIPTION
Add an option to compile the context with obsolete nodes.