### PR TITLE
Implement sysrepo notification daemon (sysrepo-notifd)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -97,6 +97,7 @@ option(ENABLE_DS_REDIS "Enable Redis datastore plugin" OFF)
 option(ENABLE_SYSREPOCTL "Build binary tool 'sysrepoctl'" ON)
 option(ENABLE_SYSREPOCFG "Build binary tool 'sysrepocfg'" ON)
 option(ENABLE_SYSREPO_PLUGIND "Build binary daemon 'sysrepo-plugind'" ON)
+option(ENABLE_SYSREPO_NOTIFD "Build binary daemon 'sysrepo-notifd'" ON)
 option(BUILD_SHARED_LIBS "By default, shared libs are enabled. Turn off for a static build." ON)
 option(INSTALL_SYSCTL_CONF "Install sysctl conf file to allow shared access to SHM files." OFF)
 set(YANG_MODULE_DIR "${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_DATADIR}/yang/modules/sysrepo" CACHE STRING "Directory where to copy the YANG modules to.")
@@ -285,6 +286,12 @@ set(SYSREPOPLUGIND_SRC
     src/executables/srpd_common.c
     src/executables/sysrepo-plugind.c)
 
+set(SYSREPONOTIFD_SRC
+    src/executables/sysrepo-notifd/main.c
+    src/executables/sysrepo-notifd/notifd_config.c
+    src/executables/sysrepo-notifd/notifd_runtime.c
+    src/executables/sysrepo-notifd/notifd_udp.c)
+
 # public headers to check API/ABI on
 set(LIB_MAIN_HEADERS
     src/sysrepo.h
@@ -322,6 +329,8 @@ set(FORMAT_SOURCES
     src/*.h
     src/executables/*.c
     src/executables/*.h*
+    src/executables/sysrepo-notifd/*.c
+    src/executables/sysrepo-notifd/*.h*
     src/plugins/*.c
     src/plugins/*.h*
     src/utils/*
@@ -535,6 +544,12 @@ if(ENABLE_SYSREPO_PLUGIND)
     target_link_libraries(sysrepo-plugind sysrepo)
 endif()
 
+if(ENABLE_SYSREPO_NOTIFD)
+    # sysrepo-notifd daemon
+    add_executable(sysrepo-notifd ${SYSREPONOTIFD_SRC} ${compatsrc})
+    target_link_libraries(sysrepo-notifd sysrepo)
+endif()
+
 # include repository files with highest priority
 include_directories("${PROJECT_SOURCE_DIR}/src")
 include_directories("${PROJECT_SOURCE_DIR}/src/plugins")
@@ -573,6 +588,9 @@ if(LIBSYSTEMD_FOUND)
     set(SR_HAVE_SYSTEMD 1)
     if(ENABLE_SYSREPO_PLUGIND)
         target_link_libraries(sysrepo-plugind ${LIBSYSTEMD_LIBRARIES})
+    endif()
+    if(ENABLE_SYSREPO_NOTIFD)
+        target_link_libraries(sysrepo-notifd ${LIBSYSTEMD_LIBRARIES})
     endif()
     include_directories(${LIBSYSTEMD_INCLUDE_DIRS})
     message(STATUS "systemd system service unit path: ${SYSTEMD_UNIT_DIR}")
@@ -630,6 +648,9 @@ if(ENABLE_SYSREPO_PLUGIND)
     install(TARGETS sysrepo-plugind DESTINATION ${CMAKE_INSTALL_BINDIR})
     install(FILES ${PROJECT_SOURCE_DIR}/src/executables/sysrepo-plugind.8 DESTINATION ${CMAKE_INSTALL_MANDIR}/man8)
     install(DIRECTORY DESTINATION ${SRPD_PLUGINS_PATH})
+endif()
+if(ENABLE_SYSREPO_NOTIFD)
+    install(TARGETS sysrepo-notifd DESTINATION ${CMAKE_INSTALL_BINDIR})
 endif()
 if(SR_HAVE_DLOPEN)
     install(DIRECTORY DESTINATION ${SR_PLUGINS_PATH})

--- a/modules/subscribed_notifications/iana-tls-cipher-suite-algs@2024-03-16.yang
+++ b/modules/subscribed_notifications/iana-tls-cipher-suite-algs@2024-03-16.yang
@@ -1,0 +1,3551 @@
+module iana-tls-cipher-suite-algs {
+  yang-version 1.1;
+  namespace "urn:ietf:params:xml:ns:yang:iana-tls-cipher-suite-algs";
+  prefix tlscsa;
+
+  organization
+    "Internet Assigned Numbers Authority (IANA)";
+
+  contact
+    "Postal: ICANN
+             12025 Waterfront Drive, Suite 300
+             Los Angeles, CA  90094-2536
+             United States of America
+     Tel:    +1 310 301 5800
+     Email:  iana@iana.org";
+
+  description
+    "This module defines enumerations for the Cipher Suite
+     algorithms defined in the 'TLS Cipher Suites' sub-registry
+     of the 'Transport Layer Security (TLS) Parameters' registry
+     maintained by IANA.
+
+     Copyright (c) 2024 IETF Trust and the persons identified as
+     authors of the code. All rights reserved.
+
+     Redistribution and use in source and binary forms, with
+     or without modification, is permitted pursuant to, and
+     subject to the license terms contained in, the Revised
+     BSD License set forth in Section 4.c of the IETF Trust's
+     Legal Provisions Relating to IETF Documents
+     (https://trustee.ietf.org/license-info).
+
+     The initial version of this YANG module is part of RFC FFFF
+     (https://www.rfc-editor.org/info/rfcFFFF); see the RFC
+     itself for full legal notices.
+
+     All versions of this module are published by IANA at
+     https://www.iana.org/assignments/yang-parameters.";
+
+  revision 2024-03-16 {
+    description
+      "This initial version of the module was created using
+       the script defined in RFC FFFF to reflect the contents
+       of the cipher-suite algorithms registry maintained by IANA.";
+    reference
+      "RFC FFFF: YANG Groupings for TLS Clients and TLS Servers";
+  }
+
+  typedef tls-cipher-suite-algorithm {
+    type enumeration {
+      enum TLS_NULL_WITH_NULL_NULL {
+        status deprecated;
+        description
+          "Enumeration for the 'TLS_NULL_WITH_NULL_NULL' algorithm.";
+        reference
+          "RFC 5246:
+             The Transport Layer Security (TLS) Protocol Version
+             1.2";
+      }
+      enum TLS_RSA_WITH_NULL_MD5 {
+        status deprecated;
+        description
+          "Enumeration for the 'TLS_RSA_WITH_NULL_MD5' algorithm.";
+        reference
+          "RFC 5246:
+             The Transport Layer Security (TLS) Protocol Version
+             1.2";
+      }
+      enum TLS_RSA_WITH_NULL_SHA {
+        status deprecated;
+        description
+          "Enumeration for the 'TLS_RSA_WITH_NULL_SHA' algorithm.";
+        reference
+          "RFC 5246:
+             The Transport Layer Security (TLS) Protocol Version
+             1.2";
+      }
+      enum TLS_RSA_EXPORT_WITH_RC4_40_MD5 {
+        status deprecated;
+        description
+          "Enumeration for the 'TLS_RSA_EXPORT_WITH_RC4_40_MD5'
+           algorithm.";
+        reference
+          "RFC 4346:
+             The Transport Layer Security (TLS) Protocol Version 1.1
+           RFC 6347:
+             Datagram Transport Layer Security Version 1.2";
+      }
+      enum TLS_RSA_WITH_RC4_128_MD5 {
+        status deprecated;
+        description
+          "Enumeration for the 'TLS_RSA_WITH_RC4_128_MD5'
+           algorithm.";
+        reference
+          "RFC 5246:
+             The Transport Layer Security (TLS) Protocol Version 1.2
+           RFC 6347:
+             Datagram Transport Layer Security Version 1.2";
+      }
+      enum TLS_RSA_WITH_RC4_128_SHA {
+        status deprecated;
+        description
+          "Enumeration for the 'TLS_RSA_WITH_RC4_128_SHA'
+           algorithm.";
+        reference
+          "RFC 5246:
+             The Transport Layer Security (TLS) Protocol Version 1.2
+           RFC 6347:
+             Datagram Transport Layer Security Version 1.2";
+      }
+      enum TLS_RSA_EXPORT_WITH_RC2_CBC_40_MD5 {
+        status deprecated;
+        description
+          "Enumeration for the 'TLS_RSA_EXPORT_WITH_RC2_CBC_40_MD5'
+           algorithm.";
+        reference
+          "RFC 4346:
+             The Transport Layer Security (TLS) Protocol Version
+             1.1";
+      }
+      enum TLS_RSA_WITH_IDEA_CBC_SHA {
+        status deprecated;
+        description
+          "Enumeration for the 'TLS_RSA_WITH_IDEA_CBC_SHA'
+           algorithm.";
+        reference
+          "RFC 8996:
+             Deprecating TLS 1.0 and TLS 1.1";
+      }
+      enum TLS_RSA_EXPORT_WITH_DES40_CBC_SHA {
+        status deprecated;
+        description
+          "Enumeration for the 'TLS_RSA_EXPORT_WITH_DES40_CBC_SHA'
+           algorithm.";
+        reference
+          "RFC 4346:
+             The Transport Layer Security (TLS) Protocol Version
+             1.1";
+      }
+      enum TLS_RSA_WITH_DES_CBC_SHA {
+        status deprecated;
+        description
+          "Enumeration for the 'TLS_RSA_WITH_DES_CBC_SHA'
+           algorithm.";
+        reference
+          "RFC 8996:
+             Deprecating TLS 1.0 and TLS 1.1";
+      }
+      enum TLS_RSA_WITH_3DES_EDE_CBC_SHA {
+        status deprecated;
+        description
+          "Enumeration for the 'TLS_RSA_WITH_3DES_EDE_CBC_SHA'
+           algorithm.";
+        reference
+          "RFC 5246:
+             The Transport Layer Security (TLS) Protocol Version
+             1.2";
+      }
+      enum TLS_DH_DSS_EXPORT_WITH_DES40_CBC_SHA {
+        status deprecated;
+        description
+          "Enumeration for the 'TLS_DH_DSS_EXPORT_WITH_DES40_CBC_SHA'
+           algorithm.";
+        reference
+          "RFC 4346:
+             The Transport Layer Security (TLS) Protocol Version
+             1.1";
+      }
+      enum TLS_DH_DSS_WITH_DES_CBC_SHA {
+        status deprecated;
+        description
+          "Enumeration for the 'TLS_DH_DSS_WITH_DES_CBC_SHA'
+           algorithm.";
+        reference
+          "RFC 8996:
+             Deprecating TLS 1.0 and TLS 1.1";
+      }
+      enum TLS_DH_DSS_WITH_3DES_EDE_CBC_SHA {
+        status deprecated;
+        description
+          "Enumeration for the 'TLS_DH_DSS_WITH_3DES_EDE_CBC_SHA'
+           algorithm.";
+        reference
+          "RFC 5246:
+             The Transport Layer Security (TLS) Protocol Version
+             1.2";
+      }
+      enum TLS_DH_RSA_EXPORT_WITH_DES40_CBC_SHA {
+        status deprecated;
+        description
+          "Enumeration for the 'TLS_DH_RSA_EXPORT_WITH_DES40_CBC_SHA'
+           algorithm.";
+        reference
+          "RFC 4346:
+             The Transport Layer Security (TLS) Protocol Version
+             1.1";
+      }
+      enum TLS_DH_RSA_WITH_DES_CBC_SHA {
+        status deprecated;
+        description
+          "Enumeration for the 'TLS_DH_RSA_WITH_DES_CBC_SHA'
+           algorithm.";
+        reference
+          "RFC 8996:
+             Deprecating TLS 1.0 and TLS 1.1";
+      }
+      enum TLS_DH_RSA_WITH_3DES_EDE_CBC_SHA {
+        status deprecated;
+        description
+          "Enumeration for the 'TLS_DH_RSA_WITH_3DES_EDE_CBC_SHA'
+           algorithm.";
+        reference
+          "RFC 5246:
+             The Transport Layer Security (TLS) Protocol Version
+             1.2";
+      }
+      enum TLS_DHE_DSS_EXPORT_WITH_DES40_CBC_SHA {
+        status deprecated;
+        description
+          "Enumeration for the
+           'TLS_DHE_DSS_EXPORT_WITH_DES40_CBC_SHA' algorithm.";
+        reference
+          "RFC 4346:
+             The Transport Layer Security (TLS) Protocol Version
+             1.1";
+      }
+      enum TLS_DHE_DSS_WITH_DES_CBC_SHA {
+        status deprecated;
+        description
+          "Enumeration for the 'TLS_DHE_DSS_WITH_DES_CBC_SHA'
+           algorithm.";
+        reference
+          "RFC 8996:
+             Deprecating TLS 1.0 and TLS 1.1";
+      }
+      enum TLS_DHE_DSS_WITH_3DES_EDE_CBC_SHA {
+        status deprecated;
+        description
+          "Enumeration for the 'TLS_DHE_DSS_WITH_3DES_EDE_CBC_SHA'
+           algorithm.";
+        reference
+          "RFC 5246:
+             The Transport Layer Security (TLS) Protocol Version
+             1.2";
+      }
+      enum TLS_DHE_RSA_EXPORT_WITH_DES40_CBC_SHA {
+        status deprecated;
+        description
+          "Enumeration for the
+           'TLS_DHE_RSA_EXPORT_WITH_DES40_CBC_SHA' algorithm.";
+        reference
+          "RFC 4346:
+             The Transport Layer Security (TLS) Protocol Version
+             1.1";
+      }
+      enum TLS_DHE_RSA_WITH_DES_CBC_SHA {
+        status deprecated;
+        description
+          "Enumeration for the 'TLS_DHE_RSA_WITH_DES_CBC_SHA'
+           algorithm.";
+        reference
+          "RFC 8996:
+             Deprecating TLS 1.0 and TLS 1.1";
+      }
+      enum TLS_DHE_RSA_WITH_3DES_EDE_CBC_SHA {
+        status deprecated;
+        description
+          "Enumeration for the 'TLS_DHE_RSA_WITH_3DES_EDE_CBC_SHA'
+           algorithm.";
+        reference
+          "RFC 5246:
+             The Transport Layer Security (TLS) Protocol Version
+             1.2";
+      }
+      enum TLS_DH_anon_EXPORT_WITH_RC4_40_MD5 {
+        status deprecated;
+        description
+          "Enumeration for the 'TLS_DH_anon_EXPORT_WITH_RC4_40_MD5'
+           algorithm.";
+        reference
+          "RFC 4346:
+             The Transport Layer Security (TLS) Protocol Version 1.1
+           RFC 6347:
+             Datagram Transport Layer Security Version 1.2";
+      }
+      enum TLS_DH_anon_WITH_RC4_128_MD5 {
+        status deprecated;
+        description
+          "Enumeration for the 'TLS_DH_anon_WITH_RC4_128_MD5'
+           algorithm.";
+        reference
+          "RFC 5246:
+             The Transport Layer Security (TLS) Protocol Version 1.2
+           RFC 6347:
+             Datagram Transport Layer Security Version 1.2";
+      }
+      enum TLS_DH_anon_EXPORT_WITH_DES40_CBC_SHA {
+        status deprecated;
+        description
+          "Enumeration for the
+           'TLS_DH_anon_EXPORT_WITH_DES40_CBC_SHA' algorithm.";
+        reference
+          "RFC 4346:
+             The Transport Layer Security (TLS) Protocol Version
+             1.1";
+      }
+      enum TLS_DH_anon_WITH_DES_CBC_SHA {
+        status deprecated;
+        description
+          "Enumeration for the 'TLS_DH_anon_WITH_DES_CBC_SHA'
+           algorithm.";
+        reference
+          "RFC 8996:
+             Deprecating TLS 1.0 and TLS 1.1";
+      }
+      enum TLS_DH_anon_WITH_3DES_EDE_CBC_SHA {
+        status deprecated;
+        description
+          "Enumeration for the 'TLS_DH_anon_WITH_3DES_EDE_CBC_SHA'
+           algorithm.";
+        reference
+          "RFC 5246:
+             The Transport Layer Security (TLS) Protocol Version
+             1.2";
+      }
+      enum TLS_KRB5_WITH_DES_CBC_SHA {
+        status deprecated;
+        description
+          "Enumeration for the 'TLS_KRB5_WITH_DES_CBC_SHA'
+           algorithm.";
+        reference
+          "RFC 2712:
+             Addition of Kerberos Cipher Suites to Transport Layer
+             Security (TLS)";
+      }
+      enum TLS_KRB5_WITH_3DES_EDE_CBC_SHA {
+        status deprecated;
+        description
+          "Enumeration for the 'TLS_KRB5_WITH_3DES_EDE_CBC_SHA'
+           algorithm.";
+        reference
+          "RFC 2712:
+             Addition of Kerberos Cipher Suites to Transport Layer
+             Security (TLS)";
+      }
+      enum TLS_KRB5_WITH_RC4_128_SHA {
+        status deprecated;
+        description
+          "Enumeration for the 'TLS_KRB5_WITH_RC4_128_SHA'
+           algorithm.";
+        reference
+          "RFC 2712:
+             Addition of Kerberos Cipher Suites to Transport Layer
+             Security (TLS)
+           RFC 6347:
+             Datagram Transport Layer Security Version 1.2";
+      }
+      enum TLS_KRB5_WITH_IDEA_CBC_SHA {
+        status deprecated;
+        description
+          "Enumeration for the 'TLS_KRB5_WITH_IDEA_CBC_SHA'
+           algorithm.";
+        reference
+          "RFC 2712:
+             Addition of Kerberos Cipher Suites to Transport Layer
+             Security (TLS)";
+      }
+      enum TLS_KRB5_WITH_DES_CBC_MD5 {
+        status deprecated;
+        description
+          "Enumeration for the 'TLS_KRB5_WITH_DES_CBC_MD5'
+           algorithm.";
+        reference
+          "RFC 2712:
+             Addition of Kerberos Cipher Suites to Transport Layer
+             Security (TLS)";
+      }
+      enum TLS_KRB5_WITH_3DES_EDE_CBC_MD5 {
+        status deprecated;
+        description
+          "Enumeration for the 'TLS_KRB5_WITH_3DES_EDE_CBC_MD5'
+           algorithm.";
+        reference
+          "RFC 2712:
+             Addition of Kerberos Cipher Suites to Transport Layer
+             Security (TLS)";
+      }
+      enum TLS_KRB5_WITH_RC4_128_MD5 {
+        status deprecated;
+        description
+          "Enumeration for the 'TLS_KRB5_WITH_RC4_128_MD5'
+           algorithm.";
+        reference
+          "RFC 2712:
+             Addition of Kerberos Cipher Suites to Transport Layer
+             Security (TLS)
+           RFC 6347:
+             Datagram Transport Layer Security Version 1.2";
+      }
+      enum TLS_KRB5_WITH_IDEA_CBC_MD5 {
+        status deprecated;
+        description
+          "Enumeration for the 'TLS_KRB5_WITH_IDEA_CBC_MD5'
+           algorithm.";
+        reference
+          "RFC 2712:
+             Addition of Kerberos Cipher Suites to Transport Layer
+             Security (TLS)";
+      }
+      enum TLS_KRB5_EXPORT_WITH_DES_CBC_40_SHA {
+        status deprecated;
+        description
+          "Enumeration for the 'TLS_KRB5_EXPORT_WITH_DES_CBC_40_SHA'
+           algorithm.";
+        reference
+          "RFC 2712:
+             Addition of Kerberos Cipher Suites to Transport Layer
+             Security (TLS)";
+      }
+      enum TLS_KRB5_EXPORT_WITH_RC2_CBC_40_SHA {
+        status deprecated;
+        description
+          "Enumeration for the 'TLS_KRB5_EXPORT_WITH_RC2_CBC_40_SHA'
+           algorithm.";
+        reference
+          "RFC 2712:
+             Addition of Kerberos Cipher Suites to Transport Layer
+             Security (TLS)";
+      }
+      enum TLS_KRB5_EXPORT_WITH_RC4_40_SHA {
+        status deprecated;
+        description
+          "Enumeration for the 'TLS_KRB5_EXPORT_WITH_RC4_40_SHA'
+           algorithm.";
+        reference
+          "RFC 2712:
+             Addition of Kerberos Cipher Suites to Transport Layer
+             Security (TLS)
+           RFC 6347:
+             Datagram Transport Layer Security Version 1.2";
+      }
+      enum TLS_KRB5_EXPORT_WITH_DES_CBC_40_MD5 {
+        status deprecated;
+        description
+          "Enumeration for the 'TLS_KRB5_EXPORT_WITH_DES_CBC_40_MD5'
+           algorithm.";
+        reference
+          "RFC 2712:
+             Addition of Kerberos Cipher Suites to Transport Layer
+             Security (TLS)";
+      }
+      enum TLS_KRB5_EXPORT_WITH_RC2_CBC_40_MD5 {
+        status deprecated;
+        description
+          "Enumeration for the 'TLS_KRB5_EXPORT_WITH_RC2_CBC_40_MD5'
+           algorithm.";
+        reference
+          "RFC 2712:
+             Addition of Kerberos Cipher Suites to Transport Layer
+             Security (TLS)";
+      }
+      enum TLS_KRB5_EXPORT_WITH_RC4_40_MD5 {
+        status deprecated;
+        description
+          "Enumeration for the 'TLS_KRB5_EXPORT_WITH_RC4_40_MD5'
+           algorithm.";
+        reference
+          "RFC 2712:
+             Addition of Kerberos Cipher Suites to Transport Layer
+             Security (TLS)
+           RFC 6347:
+             Datagram Transport Layer Security Version 1.2";
+      }
+      enum TLS_PSK_WITH_NULL_SHA {
+        status deprecated;
+        description
+          "Enumeration for the 'TLS_PSK_WITH_NULL_SHA' algorithm.";
+        reference
+          "RFC 4785:
+             Pre-Shared Key (PSK) Ciphersuites with NULL Encryption
+             for Transport Layer Security (TLS)";
+      }
+      enum TLS_DHE_PSK_WITH_NULL_SHA {
+        status deprecated;
+        description
+          "Enumeration for the 'TLS_DHE_PSK_WITH_NULL_SHA'
+           algorithm.";
+        reference
+          "RFC 4785:
+             Pre-Shared Key (PSK) Ciphersuites with NULL Encryption
+             for Transport Layer Security (TLS)";
+      }
+      enum TLS_RSA_PSK_WITH_NULL_SHA {
+        status deprecated;
+        description
+          "Enumeration for the 'TLS_RSA_PSK_WITH_NULL_SHA'
+           algorithm.";
+        reference
+          "RFC 4785:
+             Pre-Shared Key (PSK) Ciphersuites with NULL Encryption
+             for Transport Layer Security (TLS)";
+      }
+      enum TLS_RSA_WITH_AES_128_CBC_SHA {
+        status deprecated;
+        description
+          "Enumeration for the 'TLS_RSA_WITH_AES_128_CBC_SHA'
+           algorithm.";
+        reference
+          "RFC 5246:
+             The Transport Layer Security (TLS) Protocol Version
+             1.2";
+      }
+      enum TLS_DH_DSS_WITH_AES_128_CBC_SHA {
+        status deprecated;
+        description
+          "Enumeration for the 'TLS_DH_DSS_WITH_AES_128_CBC_SHA'
+           algorithm.";
+        reference
+          "RFC 5246:
+             The Transport Layer Security (TLS) Protocol Version
+             1.2";
+      }
+      enum TLS_DH_RSA_WITH_AES_128_CBC_SHA {
+        status deprecated;
+        description
+          "Enumeration for the 'TLS_DH_RSA_WITH_AES_128_CBC_SHA'
+           algorithm.";
+        reference
+          "RFC 5246:
+             The Transport Layer Security (TLS) Protocol Version
+             1.2";
+      }
+      enum TLS_DHE_DSS_WITH_AES_128_CBC_SHA {
+        status deprecated;
+        description
+          "Enumeration for the 'TLS_DHE_DSS_WITH_AES_128_CBC_SHA'
+           algorithm.";
+        reference
+          "RFC 5246:
+             The Transport Layer Security (TLS) Protocol Version
+             1.2";
+      }
+      enum TLS_DHE_RSA_WITH_AES_128_CBC_SHA {
+        status deprecated;
+        description
+          "Enumeration for the 'TLS_DHE_RSA_WITH_AES_128_CBC_SHA'
+           algorithm.";
+        reference
+          "RFC 5246:
+             The Transport Layer Security (TLS) Protocol Version
+             1.2";
+      }
+      enum TLS_DH_anon_WITH_AES_128_CBC_SHA {
+        status deprecated;
+        description
+          "Enumeration for the 'TLS_DH_anon_WITH_AES_128_CBC_SHA'
+           algorithm.";
+        reference
+          "RFC 5246:
+             The Transport Layer Security (TLS) Protocol Version
+             1.2";
+      }
+      enum TLS_RSA_WITH_AES_256_CBC_SHA {
+        status deprecated;
+        description
+          "Enumeration for the 'TLS_RSA_WITH_AES_256_CBC_SHA'
+           algorithm.";
+        reference
+          "RFC 5246:
+             The Transport Layer Security (TLS) Protocol Version
+             1.2";
+      }
+      enum TLS_DH_DSS_WITH_AES_256_CBC_SHA {
+        status deprecated;
+        description
+          "Enumeration for the 'TLS_DH_DSS_WITH_AES_256_CBC_SHA'
+           algorithm.";
+        reference
+          "RFC 5246:
+             The Transport Layer Security (TLS) Protocol Version
+             1.2";
+      }
+      enum TLS_DH_RSA_WITH_AES_256_CBC_SHA {
+        status deprecated;
+        description
+          "Enumeration for the 'TLS_DH_RSA_WITH_AES_256_CBC_SHA'
+           algorithm.";
+        reference
+          "RFC 5246:
+             The Transport Layer Security (TLS) Protocol Version
+             1.2";
+      }
+      enum TLS_DHE_DSS_WITH_AES_256_CBC_SHA {
+        status deprecated;
+        description
+          "Enumeration for the 'TLS_DHE_DSS_WITH_AES_256_CBC_SHA'
+           algorithm.";
+        reference
+          "RFC 5246:
+             The Transport Layer Security (TLS) Protocol Version
+             1.2";
+      }
+      enum TLS_DHE_RSA_WITH_AES_256_CBC_SHA {
+        status deprecated;
+        description
+          "Enumeration for the 'TLS_DHE_RSA_WITH_AES_256_CBC_SHA'
+           algorithm.";
+        reference
+          "RFC 5246:
+             The Transport Layer Security (TLS) Protocol Version
+             1.2";
+      }
+      enum TLS_DH_anon_WITH_AES_256_CBC_SHA {
+        status deprecated;
+        description
+          "Enumeration for the 'TLS_DH_anon_WITH_AES_256_CBC_SHA'
+           algorithm.";
+        reference
+          "RFC 5246:
+             The Transport Layer Security (TLS) Protocol Version
+             1.2";
+      }
+      enum TLS_RSA_WITH_NULL_SHA256 {
+        status deprecated;
+        description
+          "Enumeration for the 'TLS_RSA_WITH_NULL_SHA256'
+           algorithm.";
+        reference
+          "RFC 5246:
+             The Transport Layer Security (TLS) Protocol Version
+             1.2";
+      }
+      enum TLS_RSA_WITH_AES_128_CBC_SHA256 {
+        status deprecated;
+        description
+          "Enumeration for the 'TLS_RSA_WITH_AES_128_CBC_SHA256'
+           algorithm.";
+        reference
+          "RFC 5246:
+             The Transport Layer Security (TLS) Protocol Version
+             1.2";
+      }
+      enum TLS_RSA_WITH_AES_256_CBC_SHA256 {
+        status deprecated;
+        description
+          "Enumeration for the 'TLS_RSA_WITH_AES_256_CBC_SHA256'
+           algorithm.";
+        reference
+          "RFC 5246:
+             The Transport Layer Security (TLS) Protocol Version
+             1.2";
+      }
+      enum TLS_DH_DSS_WITH_AES_128_CBC_SHA256 {
+        status deprecated;
+        description
+          "Enumeration for the 'TLS_DH_DSS_WITH_AES_128_CBC_SHA256'
+           algorithm.";
+        reference
+          "RFC 5246:
+             The Transport Layer Security (TLS) Protocol Version
+             1.2";
+      }
+      enum TLS_DH_RSA_WITH_AES_128_CBC_SHA256 {
+        status deprecated;
+        description
+          "Enumeration for the 'TLS_DH_RSA_WITH_AES_128_CBC_SHA256'
+           algorithm.";
+        reference
+          "RFC 5246:
+             The Transport Layer Security (TLS) Protocol Version
+             1.2";
+      }
+      enum TLS_DHE_DSS_WITH_AES_128_CBC_SHA256 {
+        status deprecated;
+        description
+          "Enumeration for the 'TLS_DHE_DSS_WITH_AES_128_CBC_SHA256'
+           algorithm.";
+        reference
+          "RFC 5246:
+             The Transport Layer Security (TLS) Protocol Version
+             1.2";
+      }
+      enum TLS_RSA_WITH_CAMELLIA_128_CBC_SHA {
+        status deprecated;
+        description
+          "Enumeration for the 'TLS_RSA_WITH_CAMELLIA_128_CBC_SHA'
+           algorithm.";
+        reference
+          "RFC 5932:
+             Camellia Cipher Suites for TLS";
+      }
+      enum TLS_DH_DSS_WITH_CAMELLIA_128_CBC_SHA {
+        status deprecated;
+        description
+          "Enumeration for the 'TLS_DH_DSS_WITH_CAMELLIA_128_CBC_SHA'
+           algorithm.";
+        reference
+          "RFC 5932:
+             Camellia Cipher Suites for TLS";
+      }
+      enum TLS_DH_RSA_WITH_CAMELLIA_128_CBC_SHA {
+        status deprecated;
+        description
+          "Enumeration for the 'TLS_DH_RSA_WITH_CAMELLIA_128_CBC_SHA'
+           algorithm.";
+        reference
+          "RFC 5932:
+             Camellia Cipher Suites for TLS";
+      }
+      enum TLS_DHE_DSS_WITH_CAMELLIA_128_CBC_SHA {
+        status deprecated;
+        description
+          "Enumeration for the
+           'TLS_DHE_DSS_WITH_CAMELLIA_128_CBC_SHA' algorithm.";
+        reference
+          "RFC 5932:
+             Camellia Cipher Suites for TLS";
+      }
+      enum TLS_DHE_RSA_WITH_CAMELLIA_128_CBC_SHA {
+        status deprecated;
+        description
+          "Enumeration for the
+           'TLS_DHE_RSA_WITH_CAMELLIA_128_CBC_SHA' algorithm.";
+        reference
+          "RFC 5932:
+             Camellia Cipher Suites for TLS";
+      }
+      enum TLS_DH_anon_WITH_CAMELLIA_128_CBC_SHA {
+        status deprecated;
+        description
+          "Enumeration for the
+           'TLS_DH_anon_WITH_CAMELLIA_128_CBC_SHA' algorithm.";
+        reference
+          "RFC 5932:
+             Camellia Cipher Suites for TLS";
+      }
+      enum TLS_DHE_RSA_WITH_AES_128_CBC_SHA256 {
+        status deprecated;
+        description
+          "Enumeration for the 'TLS_DHE_RSA_WITH_AES_128_CBC_SHA256'
+           algorithm.";
+        reference
+          "RFC 5246:
+             The Transport Layer Security (TLS) Protocol Version
+             1.2";
+      }
+      enum TLS_DH_DSS_WITH_AES_256_CBC_SHA256 {
+        status deprecated;
+        description
+          "Enumeration for the 'TLS_DH_DSS_WITH_AES_256_CBC_SHA256'
+           algorithm.";
+        reference
+          "RFC 5246:
+             The Transport Layer Security (TLS) Protocol Version
+             1.2";
+      }
+      enum TLS_DH_RSA_WITH_AES_256_CBC_SHA256 {
+        status deprecated;
+        description
+          "Enumeration for the 'TLS_DH_RSA_WITH_AES_256_CBC_SHA256'
+           algorithm.";
+        reference
+          "RFC 5246:
+             The Transport Layer Security (TLS) Protocol Version
+             1.2";
+      }
+      enum TLS_DHE_DSS_WITH_AES_256_CBC_SHA256 {
+        status deprecated;
+        description
+          "Enumeration for the 'TLS_DHE_DSS_WITH_AES_256_CBC_SHA256'
+           algorithm.";
+        reference
+          "RFC 5246:
+             The Transport Layer Security (TLS) Protocol Version
+             1.2";
+      }
+      enum TLS_DHE_RSA_WITH_AES_256_CBC_SHA256 {
+        status deprecated;
+        description
+          "Enumeration for the 'TLS_DHE_RSA_WITH_AES_256_CBC_SHA256'
+           algorithm.";
+        reference
+          "RFC 5246:
+             The Transport Layer Security (TLS) Protocol Version
+             1.2";
+      }
+      enum TLS_DH_anon_WITH_AES_128_CBC_SHA256 {
+        status deprecated;
+        description
+          "Enumeration for the 'TLS_DH_anon_WITH_AES_128_CBC_SHA256'
+           algorithm.";
+        reference
+          "RFC 5246:
+             The Transport Layer Security (TLS) Protocol Version
+             1.2";
+      }
+      enum TLS_DH_anon_WITH_AES_256_CBC_SHA256 {
+        status deprecated;
+        description
+          "Enumeration for the 'TLS_DH_anon_WITH_AES_256_CBC_SHA256'
+           algorithm.";
+        reference
+          "RFC 5246:
+             The Transport Layer Security (TLS) Protocol Version
+             1.2";
+      }
+      enum TLS_RSA_WITH_CAMELLIA_256_CBC_SHA {
+        status deprecated;
+        description
+          "Enumeration for the 'TLS_RSA_WITH_CAMELLIA_256_CBC_SHA'
+           algorithm.";
+        reference
+          "RFC 5932:
+             Camellia Cipher Suites for TLS";
+      }
+      enum TLS_DH_DSS_WITH_CAMELLIA_256_CBC_SHA {
+        status deprecated;
+        description
+          "Enumeration for the 'TLS_DH_DSS_WITH_CAMELLIA_256_CBC_SHA'
+           algorithm.";
+        reference
+          "RFC 5932:
+             Camellia Cipher Suites for TLS";
+      }
+      enum TLS_DH_RSA_WITH_CAMELLIA_256_CBC_SHA {
+        status deprecated;
+        description
+          "Enumeration for the 'TLS_DH_RSA_WITH_CAMELLIA_256_CBC_SHA'
+           algorithm.";
+        reference
+          "RFC 5932:
+             Camellia Cipher Suites for TLS";
+      }
+      enum TLS_DHE_DSS_WITH_CAMELLIA_256_CBC_SHA {
+        status deprecated;
+        description
+          "Enumeration for the
+           'TLS_DHE_DSS_WITH_CAMELLIA_256_CBC_SHA' algorithm.";
+        reference
+          "RFC 5932:
+             Camellia Cipher Suites for TLS";
+      }
+      enum TLS_DHE_RSA_WITH_CAMELLIA_256_CBC_SHA {
+        status deprecated;
+        description
+          "Enumeration for the
+           'TLS_DHE_RSA_WITH_CAMELLIA_256_CBC_SHA' algorithm.";
+        reference
+          "RFC 5932:
+             Camellia Cipher Suites for TLS";
+      }
+      enum TLS_DH_anon_WITH_CAMELLIA_256_CBC_SHA {
+        status deprecated;
+        description
+          "Enumeration for the
+           'TLS_DH_anon_WITH_CAMELLIA_256_CBC_SHA' algorithm.";
+        reference
+          "RFC 5932:
+             Camellia Cipher Suites for TLS";
+      }
+      enum TLS_PSK_WITH_RC4_128_SHA {
+        status deprecated;
+        description
+          "Enumeration for the 'TLS_PSK_WITH_RC4_128_SHA'
+           algorithm.";
+        reference
+          "RFC 4279:
+             Pre-Shared Key Ciphersuites for Transport Layer Security
+             (TLS)
+           RFC 6347:
+             Datagram Transport Layer Security Version 1.2";
+      }
+      enum TLS_PSK_WITH_3DES_EDE_CBC_SHA {
+        status deprecated;
+        description
+          "Enumeration for the 'TLS_PSK_WITH_3DES_EDE_CBC_SHA'
+           algorithm.";
+        reference
+          "RFC 4279:
+             Pre-Shared Key Ciphersuites for Transport Layer Security
+             (TLS)";
+      }
+      enum TLS_PSK_WITH_AES_128_CBC_SHA {
+        status deprecated;
+        description
+          "Enumeration for the 'TLS_PSK_WITH_AES_128_CBC_SHA'
+           algorithm.";
+        reference
+          "RFC 4279:
+             Pre-Shared Key Ciphersuites for Transport Layer Security
+             (TLS)";
+      }
+      enum TLS_PSK_WITH_AES_256_CBC_SHA {
+        status deprecated;
+        description
+          "Enumeration for the 'TLS_PSK_WITH_AES_256_CBC_SHA'
+           algorithm.";
+        reference
+          "RFC 4279:
+             Pre-Shared Key Ciphersuites for Transport Layer Security
+             (TLS)";
+      }
+      enum TLS_DHE_PSK_WITH_RC4_128_SHA {
+        status deprecated;
+        description
+          "Enumeration for the 'TLS_DHE_PSK_WITH_RC4_128_SHA'
+           algorithm.";
+        reference
+          "RFC 4279:
+             Pre-Shared Key Ciphersuites for Transport Layer Security
+             (TLS)
+           RFC 6347:
+             Datagram Transport Layer Security Version 1.2";
+      }
+      enum TLS_DHE_PSK_WITH_3DES_EDE_CBC_SHA {
+        status deprecated;
+        description
+          "Enumeration for the 'TLS_DHE_PSK_WITH_3DES_EDE_CBC_SHA'
+           algorithm.";
+        reference
+          "RFC 4279:
+             Pre-Shared Key Ciphersuites for Transport Layer Security
+             (TLS)";
+      }
+      enum TLS_DHE_PSK_WITH_AES_128_CBC_SHA {
+        status deprecated;
+        description
+          "Enumeration for the 'TLS_DHE_PSK_WITH_AES_128_CBC_SHA'
+           algorithm.";
+        reference
+          "RFC 4279:
+             Pre-Shared Key Ciphersuites for Transport Layer Security
+             (TLS)";
+      }
+      enum TLS_DHE_PSK_WITH_AES_256_CBC_SHA {
+        status deprecated;
+        description
+          "Enumeration for the 'TLS_DHE_PSK_WITH_AES_256_CBC_SHA'
+           algorithm.";
+        reference
+          "RFC 4279:
+             Pre-Shared Key Ciphersuites for Transport Layer Security
+             (TLS)";
+      }
+      enum TLS_RSA_PSK_WITH_RC4_128_SHA {
+        status deprecated;
+        description
+          "Enumeration for the 'TLS_RSA_PSK_WITH_RC4_128_SHA'
+           algorithm.";
+        reference
+          "RFC 4279:
+             Pre-Shared Key Ciphersuites for Transport Layer Security
+             (TLS)
+           RFC 6347:
+             Datagram Transport Layer Security Version 1.2";
+      }
+      enum TLS_RSA_PSK_WITH_3DES_EDE_CBC_SHA {
+        status deprecated;
+        description
+          "Enumeration for the 'TLS_RSA_PSK_WITH_3DES_EDE_CBC_SHA'
+           algorithm.";
+        reference
+          "RFC 4279:
+             Pre-Shared Key Ciphersuites for Transport Layer Security
+             (TLS)";
+      }
+      enum TLS_RSA_PSK_WITH_AES_128_CBC_SHA {
+        status deprecated;
+        description
+          "Enumeration for the 'TLS_RSA_PSK_WITH_AES_128_CBC_SHA'
+           algorithm.";
+        reference
+          "RFC 4279:
+             Pre-Shared Key Ciphersuites for Transport Layer Security
+             (TLS)";
+      }
+      enum TLS_RSA_PSK_WITH_AES_256_CBC_SHA {
+        status deprecated;
+        description
+          "Enumeration for the 'TLS_RSA_PSK_WITH_AES_256_CBC_SHA'
+           algorithm.";
+        reference
+          "RFC 4279:
+             Pre-Shared Key Ciphersuites for Transport Layer Security
+             (TLS)";
+      }
+      enum TLS_RSA_WITH_SEED_CBC_SHA {
+        status deprecated;
+        description
+          "Enumeration for the 'TLS_RSA_WITH_SEED_CBC_SHA'
+           algorithm.";
+        reference
+          "RFC 4162:
+             Addition of SEED Cipher Suites to Transport Layer
+             Security (TLS)";
+      }
+      enum TLS_DH_DSS_WITH_SEED_CBC_SHA {
+        status deprecated;
+        description
+          "Enumeration for the 'TLS_DH_DSS_WITH_SEED_CBC_SHA'
+           algorithm.";
+        reference
+          "RFC 4162:
+             Addition of SEED Cipher Suites to Transport Layer
+             Security (TLS)";
+      }
+      enum TLS_DH_RSA_WITH_SEED_CBC_SHA {
+        status deprecated;
+        description
+          "Enumeration for the 'TLS_DH_RSA_WITH_SEED_CBC_SHA'
+           algorithm.";
+        reference
+          "RFC 4162:
+             Addition of SEED Cipher Suites to Transport Layer
+             Security (TLS)";
+      }
+      enum TLS_DHE_DSS_WITH_SEED_CBC_SHA {
+        status deprecated;
+        description
+          "Enumeration for the 'TLS_DHE_DSS_WITH_SEED_CBC_SHA'
+           algorithm.";
+        reference
+          "RFC 4162:
+             Addition of SEED Cipher Suites to Transport Layer
+             Security (TLS)";
+      }
+      enum TLS_DHE_RSA_WITH_SEED_CBC_SHA {
+        status deprecated;
+        description
+          "Enumeration for the 'TLS_DHE_RSA_WITH_SEED_CBC_SHA'
+           algorithm.";
+        reference
+          "RFC 4162:
+             Addition of SEED Cipher Suites to Transport Layer
+             Security (TLS)";
+      }
+      enum TLS_DH_anon_WITH_SEED_CBC_SHA {
+        status deprecated;
+        description
+          "Enumeration for the 'TLS_DH_anon_WITH_SEED_CBC_SHA'
+           algorithm.";
+        reference
+          "RFC 4162:
+             Addition of SEED Cipher Suites to Transport Layer
+             Security (TLS)";
+      }
+      enum TLS_RSA_WITH_AES_128_GCM_SHA256 {
+        status deprecated;
+        description
+          "Enumeration for the 'TLS_RSA_WITH_AES_128_GCM_SHA256'
+           algorithm.";
+        reference
+          "RFC 5288:
+             AES Galois Counter Mode (GCM) Cipher Suites for TLS";
+      }
+      enum TLS_RSA_WITH_AES_256_GCM_SHA384 {
+        status deprecated;
+        description
+          "Enumeration for the 'TLS_RSA_WITH_AES_256_GCM_SHA384'
+           algorithm.";
+        reference
+          "RFC 5288:
+             AES Galois Counter Mode (GCM) Cipher Suites for TLS";
+      }
+      enum TLS_DHE_RSA_WITH_AES_128_GCM_SHA256 {
+        description
+          "Enumeration for the 'TLS_DHE_RSA_WITH_AES_128_GCM_SHA256'
+           algorithm.";
+        reference
+          "RFC 5288:
+             AES Galois Counter Mode (GCM) Cipher Suites for TLS";
+      }
+      enum TLS_DHE_RSA_WITH_AES_256_GCM_SHA384 {
+        description
+          "Enumeration for the 'TLS_DHE_RSA_WITH_AES_256_GCM_SHA384'
+           algorithm.";
+        reference
+          "RFC 5288:
+             AES Galois Counter Mode (GCM) Cipher Suites for TLS";
+      }
+      enum TLS_DH_RSA_WITH_AES_128_GCM_SHA256 {
+        status deprecated;
+        description
+          "Enumeration for the 'TLS_DH_RSA_WITH_AES_128_GCM_SHA256'
+           algorithm.";
+        reference
+          "RFC 5288:
+             AES Galois Counter Mode (GCM) Cipher Suites for TLS";
+      }
+      enum TLS_DH_RSA_WITH_AES_256_GCM_SHA384 {
+        status deprecated;
+        description
+          "Enumeration for the 'TLS_DH_RSA_WITH_AES_256_GCM_SHA384'
+           algorithm.";
+        reference
+          "RFC 5288:
+             AES Galois Counter Mode (GCM) Cipher Suites for TLS";
+      }
+      enum TLS_DHE_DSS_WITH_AES_128_GCM_SHA256 {
+        status deprecated;
+        description
+          "Enumeration for the 'TLS_DHE_DSS_WITH_AES_128_GCM_SHA256'
+           algorithm.";
+        reference
+          "RFC 5288:
+             AES Galois Counter Mode (GCM) Cipher Suites for TLS";
+      }
+      enum TLS_DHE_DSS_WITH_AES_256_GCM_SHA384 {
+        status deprecated;
+        description
+          "Enumeration for the 'TLS_DHE_DSS_WITH_AES_256_GCM_SHA384'
+           algorithm.";
+        reference
+          "RFC 5288:
+             AES Galois Counter Mode (GCM) Cipher Suites for TLS";
+      }
+      enum TLS_DH_DSS_WITH_AES_128_GCM_SHA256 {
+        status deprecated;
+        description
+          "Enumeration for the 'TLS_DH_DSS_WITH_AES_128_GCM_SHA256'
+           algorithm.";
+        reference
+          "RFC 5288:
+             AES Galois Counter Mode (GCM) Cipher Suites for TLS";
+      }
+      enum TLS_DH_DSS_WITH_AES_256_GCM_SHA384 {
+        status deprecated;
+        description
+          "Enumeration for the 'TLS_DH_DSS_WITH_AES_256_GCM_SHA384'
+           algorithm.";
+        reference
+          "RFC 5288:
+             AES Galois Counter Mode (GCM) Cipher Suites for TLS";
+      }
+      enum TLS_DH_anon_WITH_AES_128_GCM_SHA256 {
+        status deprecated;
+        description
+          "Enumeration for the 'TLS_DH_anon_WITH_AES_128_GCM_SHA256'
+           algorithm.";
+        reference
+          "RFC 5288:
+             AES Galois Counter Mode (GCM) Cipher Suites for TLS";
+      }
+      enum TLS_DH_anon_WITH_AES_256_GCM_SHA384 {
+        status deprecated;
+        description
+          "Enumeration for the 'TLS_DH_anon_WITH_AES_256_GCM_SHA384'
+           algorithm.";
+        reference
+          "RFC 5288:
+             AES Galois Counter Mode (GCM) Cipher Suites for TLS";
+      }
+      enum TLS_PSK_WITH_AES_128_GCM_SHA256 {
+        status deprecated;
+        description
+          "Enumeration for the 'TLS_PSK_WITH_AES_128_GCM_SHA256'
+           algorithm.";
+        reference
+          "RFC 5487:
+             Pre-Shared Key Cipher Suites for TLS with SHA-256/384
+             and AES Galois Counter Mode";
+      }
+      enum TLS_PSK_WITH_AES_256_GCM_SHA384 {
+        status deprecated;
+        description
+          "Enumeration for the 'TLS_PSK_WITH_AES_256_GCM_SHA384'
+           algorithm.";
+        reference
+          "RFC 5487:
+             Pre-Shared Key Cipher Suites for TLS with SHA-256/384
+             and AES Galois Counter Mode";
+      }
+      enum TLS_DHE_PSK_WITH_AES_128_GCM_SHA256 {
+        description
+          "Enumeration for the 'TLS_DHE_PSK_WITH_AES_128_GCM_SHA256'
+           algorithm.";
+        reference
+          "RFC 5487:
+             Pre-Shared Key Cipher Suites for TLS with SHA-256/384
+             and AES Galois Counter Mode";
+      }
+      enum TLS_DHE_PSK_WITH_AES_256_GCM_SHA384 {
+        description
+          "Enumeration for the 'TLS_DHE_PSK_WITH_AES_256_GCM_SHA384'
+           algorithm.";
+        reference
+          "RFC 5487:
+             Pre-Shared Key Cipher Suites for TLS with SHA-256/384
+             and AES Galois Counter Mode";
+      }
+      enum TLS_RSA_PSK_WITH_AES_128_GCM_SHA256 {
+        status deprecated;
+        description
+          "Enumeration for the 'TLS_RSA_PSK_WITH_AES_128_GCM_SHA256'
+           algorithm.";
+        reference
+          "RFC 5487:
+             Pre-Shared Key Cipher Suites for TLS with SHA-256/384
+             and AES Galois Counter Mode";
+      }
+      enum TLS_RSA_PSK_WITH_AES_256_GCM_SHA384 {
+        status deprecated;
+        description
+          "Enumeration for the 'TLS_RSA_PSK_WITH_AES_256_GCM_SHA384'
+           algorithm.";
+        reference
+          "RFC 5487:
+             Pre-Shared Key Cipher Suites for TLS with SHA-256/384
+             and AES Galois Counter Mode";
+      }
+      enum TLS_PSK_WITH_AES_128_CBC_SHA256 {
+        status deprecated;
+        description
+          "Enumeration for the 'TLS_PSK_WITH_AES_128_CBC_SHA256'
+           algorithm.";
+        reference
+          "RFC 5487:
+             Pre-Shared Key Cipher Suites for TLS with SHA-256/384
+             and AES Galois Counter Mode";
+      }
+      enum TLS_PSK_WITH_AES_256_CBC_SHA384 {
+        status deprecated;
+        description
+          "Enumeration for the 'TLS_PSK_WITH_AES_256_CBC_SHA384'
+           algorithm.";
+        reference
+          "RFC 5487:
+             Pre-Shared Key Cipher Suites for TLS with SHA-256/384
+             and AES Galois Counter Mode";
+      }
+      enum TLS_PSK_WITH_NULL_SHA256 {
+        status deprecated;
+        description
+          "Enumeration for the 'TLS_PSK_WITH_NULL_SHA256'
+           algorithm.";
+        reference
+          "RFC 5487:
+             Pre-Shared Key Cipher Suites for TLS with SHA-256/384
+             and AES Galois Counter Mode";
+      }
+      enum TLS_PSK_WITH_NULL_SHA384 {
+        status deprecated;
+        description
+          "Enumeration for the 'TLS_PSK_WITH_NULL_SHA384'
+           algorithm.";
+        reference
+          "RFC 5487:
+             Pre-Shared Key Cipher Suites for TLS with SHA-256/384
+             and AES Galois Counter Mode";
+      }
+      enum TLS_DHE_PSK_WITH_AES_128_CBC_SHA256 {
+        status deprecated;
+        description
+          "Enumeration for the 'TLS_DHE_PSK_WITH_AES_128_CBC_SHA256'
+           algorithm.";
+        reference
+          "RFC 5487:
+             Pre-Shared Key Cipher Suites for TLS with SHA-256/384
+             and AES Galois Counter Mode";
+      }
+      enum TLS_DHE_PSK_WITH_AES_256_CBC_SHA384 {
+        status deprecated;
+        description
+          "Enumeration for the 'TLS_DHE_PSK_WITH_AES_256_CBC_SHA384'
+           algorithm.";
+        reference
+          "RFC 5487:
+             Pre-Shared Key Cipher Suites for TLS with SHA-256/384
+             and AES Galois Counter Mode";
+      }
+      enum TLS_DHE_PSK_WITH_NULL_SHA256 {
+        status deprecated;
+        description
+          "Enumeration for the 'TLS_DHE_PSK_WITH_NULL_SHA256'
+           algorithm.";
+        reference
+          "RFC 5487:
+             Pre-Shared Key Cipher Suites for TLS with SHA-256/384
+             and AES Galois Counter Mode";
+      }
+      enum TLS_DHE_PSK_WITH_NULL_SHA384 {
+        status deprecated;
+        description
+          "Enumeration for the 'TLS_DHE_PSK_WITH_NULL_SHA384'
+           algorithm.";
+        reference
+          "RFC 5487:
+             Pre-Shared Key Cipher Suites for TLS with SHA-256/384
+             and AES Galois Counter Mode";
+      }
+      enum TLS_RSA_PSK_WITH_AES_128_CBC_SHA256 {
+        status deprecated;
+        description
+          "Enumeration for the 'TLS_RSA_PSK_WITH_AES_128_CBC_SHA256'
+           algorithm.";
+        reference
+          "RFC 5487:
+             Pre-Shared Key Cipher Suites for TLS with SHA-256/384
+             and AES Galois Counter Mode";
+      }
+      enum TLS_RSA_PSK_WITH_AES_256_CBC_SHA384 {
+        status deprecated;
+        description
+          "Enumeration for the 'TLS_RSA_PSK_WITH_AES_256_CBC_SHA384'
+           algorithm.";
+        reference
+          "RFC 5487:
+             Pre-Shared Key Cipher Suites for TLS with SHA-256/384
+             and AES Galois Counter Mode";
+      }
+      enum TLS_RSA_PSK_WITH_NULL_SHA256 {
+        status deprecated;
+        description
+          "Enumeration for the 'TLS_RSA_PSK_WITH_NULL_SHA256'
+           algorithm.";
+        reference
+          "RFC 5487:
+             Pre-Shared Key Cipher Suites for TLS with SHA-256/384
+             and AES Galois Counter Mode";
+      }
+      enum TLS_RSA_PSK_WITH_NULL_SHA384 {
+        status deprecated;
+        description
+          "Enumeration for the 'TLS_RSA_PSK_WITH_NULL_SHA384'
+           algorithm.";
+        reference
+          "RFC 5487:
+             Pre-Shared Key Cipher Suites for TLS with SHA-256/384
+             and AES Galois Counter Mode";
+      }
+      enum TLS_RSA_WITH_CAMELLIA_128_CBC_SHA256 {
+        status deprecated;
+        description
+          "Enumeration for the 'TLS_RSA_WITH_CAMELLIA_128_CBC_SHA256'
+           algorithm.";
+        reference
+          "RFC 5932:
+             Camellia Cipher Suites for TLS";
+      }
+      enum TLS_DH_DSS_WITH_CAMELLIA_128_CBC_SHA256 {
+        status deprecated;
+        description
+          "Enumeration for the
+           'TLS_DH_DSS_WITH_CAMELLIA_128_CBC_SHA256' algorithm.";
+        reference
+          "RFC 5932:
+             Camellia Cipher Suites for TLS";
+      }
+      enum TLS_DH_RSA_WITH_CAMELLIA_128_CBC_SHA256 {
+        status deprecated;
+        description
+          "Enumeration for the
+           'TLS_DH_RSA_WITH_CAMELLIA_128_CBC_SHA256' algorithm.";
+        reference
+          "RFC 5932:
+             Camellia Cipher Suites for TLS";
+      }
+      enum TLS_DHE_DSS_WITH_CAMELLIA_128_CBC_SHA256 {
+        status deprecated;
+        description
+          "Enumeration for the
+           'TLS_DHE_DSS_WITH_CAMELLIA_128_CBC_SHA256' algorithm.";
+        reference
+          "RFC 5932:
+             Camellia Cipher Suites for TLS";
+      }
+      enum TLS_DHE_RSA_WITH_CAMELLIA_128_CBC_SHA256 {
+        status deprecated;
+        description
+          "Enumeration for the
+           'TLS_DHE_RSA_WITH_CAMELLIA_128_CBC_SHA256' algorithm.";
+        reference
+          "RFC 5932:
+             Camellia Cipher Suites for TLS";
+      }
+      enum TLS_DH_anon_WITH_CAMELLIA_128_CBC_SHA256 {
+        status deprecated;
+        description
+          "Enumeration for the
+           'TLS_DH_anon_WITH_CAMELLIA_128_CBC_SHA256' algorithm.";
+        reference
+          "RFC 5932:
+             Camellia Cipher Suites for TLS";
+      }
+      enum TLS_RSA_WITH_CAMELLIA_256_CBC_SHA256 {
+        status deprecated;
+        description
+          "Enumeration for the 'TLS_RSA_WITH_CAMELLIA_256_CBC_SHA256'
+           algorithm.";
+        reference
+          "RFC 5932:
+             Camellia Cipher Suites for TLS";
+      }
+      enum TLS_DH_DSS_WITH_CAMELLIA_256_CBC_SHA256 {
+        status deprecated;
+        description
+          "Enumeration for the
+           'TLS_DH_DSS_WITH_CAMELLIA_256_CBC_SHA256' algorithm.";
+        reference
+          "RFC 5932:
+             Camellia Cipher Suites for TLS";
+      }
+      enum TLS_DH_RSA_WITH_CAMELLIA_256_CBC_SHA256 {
+        status deprecated;
+        description
+          "Enumeration for the
+           'TLS_DH_RSA_WITH_CAMELLIA_256_CBC_SHA256' algorithm.";
+        reference
+          "RFC 5932:
+             Camellia Cipher Suites for TLS";
+      }
+      enum TLS_DHE_DSS_WITH_CAMELLIA_256_CBC_SHA256 {
+        status deprecated;
+        description
+          "Enumeration for the
+           'TLS_DHE_DSS_WITH_CAMELLIA_256_CBC_SHA256' algorithm.";
+        reference
+          "RFC 5932:
+             Camellia Cipher Suites for TLS";
+      }
+      enum TLS_DHE_RSA_WITH_CAMELLIA_256_CBC_SHA256 {
+        status deprecated;
+        description
+          "Enumeration for the
+           'TLS_DHE_RSA_WITH_CAMELLIA_256_CBC_SHA256' algorithm.";
+        reference
+          "RFC 5932:
+             Camellia Cipher Suites for TLS";
+      }
+      enum TLS_DH_anon_WITH_CAMELLIA_256_CBC_SHA256 {
+        status deprecated;
+        description
+          "Enumeration for the
+           'TLS_DH_anon_WITH_CAMELLIA_256_CBC_SHA256' algorithm.";
+        reference
+          "RFC 5932:
+             Camellia Cipher Suites for TLS";
+      }
+      enum TLS_SM4_GCM_SM3 {
+        status deprecated;
+        description
+          "Enumeration for the 'TLS_SM4_GCM_SM3' algorithm.";
+        reference
+          "RFC 8998:
+             ShangMi (SM) Cipher Suites for TLS 1.3";
+      }
+      enum TLS_SM4_CCM_SM3 {
+        status deprecated;
+        description
+          "Enumeration for the 'TLS_SM4_CCM_SM3' algorithm.";
+        reference
+          "RFC 8998:
+             ShangMi (SM) Cipher Suites for TLS 1.3";
+      }
+      enum TLS_EMPTY_RENEGOTIATION_INFO_SCSV {
+        status deprecated;
+        description
+          "Enumeration for the 'TLS_EMPTY_RENEGOTIATION_INFO_SCSV'
+           algorithm.";
+        reference
+          "RFC 5746:
+             Transport Layer Security (TLS) Renegotiation Indication
+             Extension";
+      }
+      enum TLS_AES_128_GCM_SHA256 {
+        description
+          "Enumeration for the 'TLS_AES_128_GCM_SHA256' algorithm.";
+        reference
+          "RFC 8446:
+             The Transport Layer Security (TLS) Protocol Version
+             1.3";
+      }
+      enum TLS_AES_256_GCM_SHA384 {
+        description
+          "Enumeration for the 'TLS_AES_256_GCM_SHA384' algorithm.";
+        reference
+          "RFC 8446:
+             The Transport Layer Security (TLS) Protocol Version
+             1.3";
+      }
+      enum TLS_CHACHA20_POLY1305_SHA256 {
+        description
+          "Enumeration for the 'TLS_CHACHA20_POLY1305_SHA256'
+           algorithm.";
+        reference
+          "RFC 8446:
+             The Transport Layer Security (TLS) Protocol Version
+             1.3";
+      }
+      enum TLS_AES_128_CCM_SHA256 {
+        description
+          "Enumeration for the 'TLS_AES_128_CCM_SHA256' algorithm.";
+        reference
+          "RFC 8446:
+             The Transport Layer Security (TLS) Protocol Version
+             1.3";
+      }
+      enum TLS_AES_128_CCM_8_SHA256 {
+        status deprecated;
+        description
+          "Enumeration for the 'TLS_AES_128_CCM_8_SHA256'
+           algorithm.";
+        reference
+          "RFC 8446:
+             The Transport Layer Security (TLS) Protocol Version 1.3
+           IESG Action:
+             IESG Action 2018-08-16";
+      }
+      enum TLS_AEGIS_256_SHA512 {
+        status deprecated;
+        description
+          "Enumeration for the 'TLS_AEGIS_256_SHA512' algorithm.";
+        reference
+          "draft-irtf-cfrg-aegis-aead-08:
+             The AEGIS Family of Authenticated Encryption
+             Algorithms";
+      }
+      enum TLS_AEGIS_128L_SHA256 {
+        status deprecated;
+        description
+          "Enumeration for the 'TLS_AEGIS_128L_SHA256' algorithm.";
+        reference
+          "draft-irtf-cfrg-aegis-aead-08:
+             The AEGIS Family of Authenticated Encryption
+             Algorithms";
+      }
+      enum TLS_FALLBACK_SCSV {
+        status deprecated;
+        description
+          "Enumeration for the 'TLS_FALLBACK_SCSV' algorithm.";
+        reference
+          "RFC 7507:
+             TLS Fallback Signaling Cipher Suite Value (SCSV) for
+             Preventing Protocol Downgrade Attacks";
+      }
+      enum TLS_ECDH_ECDSA_WITH_NULL_SHA {
+        status deprecated;
+        description
+          "Enumeration for the 'TLS_ECDH_ECDSA_WITH_NULL_SHA'
+           algorithm.";
+        reference
+          "RFC 8422:
+             Elliptic Curve Cryptography (ECC) Cipher Suites for
+             Transport Layer Security (TLS) Versions 1.2 and
+             Earlier";
+      }
+      enum TLS_ECDH_ECDSA_WITH_RC4_128_SHA {
+        status deprecated;
+        description
+          "Enumeration for the 'TLS_ECDH_ECDSA_WITH_RC4_128_SHA'
+           algorithm.";
+        reference
+          "RFC 8422:
+             Elliptic Curve Cryptography (ECC) Cipher Suites for
+             Transport Layer Security (TLS) Versions 1.2 and Earlier
+           RFC 6347:
+             Datagram Transport Layer Security Version 1.2";
+      }
+      enum TLS_ECDH_ECDSA_WITH_3DES_EDE_CBC_SHA {
+        status deprecated;
+        description
+          "Enumeration for the 'TLS_ECDH_ECDSA_WITH_3DES_EDE_CBC_SHA'
+           algorithm.";
+        reference
+          "RFC 8422:
+             Elliptic Curve Cryptography (ECC) Cipher Suites for
+             Transport Layer Security (TLS) Versions 1.2 and
+             Earlier";
+      }
+      enum TLS_ECDH_ECDSA_WITH_AES_128_CBC_SHA {
+        status deprecated;
+        description
+          "Enumeration for the 'TLS_ECDH_ECDSA_WITH_AES_128_CBC_SHA'
+           algorithm.";
+        reference
+          "RFC 8422:
+             Elliptic Curve Cryptography (ECC) Cipher Suites for
+             Transport Layer Security (TLS) Versions 1.2 and
+             Earlier";
+      }
+      enum TLS_ECDH_ECDSA_WITH_AES_256_CBC_SHA {
+        status deprecated;
+        description
+          "Enumeration for the 'TLS_ECDH_ECDSA_WITH_AES_256_CBC_SHA'
+           algorithm.";
+        reference
+          "RFC 8422:
+             Elliptic Curve Cryptography (ECC) Cipher Suites for
+             Transport Layer Security (TLS) Versions 1.2 and
+             Earlier";
+      }
+      enum TLS_ECDHE_ECDSA_WITH_NULL_SHA {
+        status deprecated;
+        description
+          "Enumeration for the 'TLS_ECDHE_ECDSA_WITH_NULL_SHA'
+           algorithm.";
+        reference
+          "RFC 8422:
+             Elliptic Curve Cryptography (ECC) Cipher Suites for
+             Transport Layer Security (TLS) Versions 1.2 and
+             Earlier";
+      }
+      enum TLS_ECDHE_ECDSA_WITH_RC4_128_SHA {
+        status deprecated;
+        description
+          "Enumeration for the 'TLS_ECDHE_ECDSA_WITH_RC4_128_SHA'
+           algorithm.";
+        reference
+          "RFC 8422:
+             Elliptic Curve Cryptography (ECC) Cipher Suites for
+             Transport Layer Security (TLS) Versions 1.2 and Earlier
+           RFC 6347:
+             Datagram Transport Layer Security Version 1.2";
+      }
+      enum TLS_ECDHE_ECDSA_WITH_3DES_EDE_CBC_SHA {
+        status deprecated;
+        description
+          "Enumeration for the
+           'TLS_ECDHE_ECDSA_WITH_3DES_EDE_CBC_SHA' algorithm.";
+        reference
+          "RFC 8422:
+             Elliptic Curve Cryptography (ECC) Cipher Suites for
+             Transport Layer Security (TLS) Versions 1.2 and
+             Earlier";
+      }
+      enum TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA {
+        status deprecated;
+        description
+          "Enumeration for the 'TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA'
+           algorithm.";
+        reference
+          "RFC 8422:
+             Elliptic Curve Cryptography (ECC) Cipher Suites for
+             Transport Layer Security (TLS) Versions 1.2 and
+             Earlier";
+      }
+      enum TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA {
+        status deprecated;
+        description
+          "Enumeration for the 'TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA'
+           algorithm.";
+        reference
+          "RFC 8422:
+             Elliptic Curve Cryptography (ECC) Cipher Suites for
+             Transport Layer Security (TLS) Versions 1.2 and
+             Earlier";
+      }
+      enum TLS_ECDH_RSA_WITH_NULL_SHA {
+        status deprecated;
+        description
+          "Enumeration for the 'TLS_ECDH_RSA_WITH_NULL_SHA'
+           algorithm.";
+        reference
+          "RFC 8422:
+             Elliptic Curve Cryptography (ECC) Cipher Suites for
+             Transport Layer Security (TLS) Versions 1.2 and
+             Earlier";
+      }
+      enum TLS_ECDH_RSA_WITH_RC4_128_SHA {
+        status deprecated;
+        description
+          "Enumeration for the 'TLS_ECDH_RSA_WITH_RC4_128_SHA'
+           algorithm.";
+        reference
+          "RFC 8422:
+             Elliptic Curve Cryptography (ECC) Cipher Suites for
+             Transport Layer Security (TLS) Versions 1.2 and Earlier
+           RFC 6347:
+             Datagram Transport Layer Security Version 1.2";
+      }
+      enum TLS_ECDH_RSA_WITH_3DES_EDE_CBC_SHA {
+        status deprecated;
+        description
+          "Enumeration for the 'TLS_ECDH_RSA_WITH_3DES_EDE_CBC_SHA'
+           algorithm.";
+        reference
+          "RFC 8422:
+             Elliptic Curve Cryptography (ECC) Cipher Suites for
+             Transport Layer Security (TLS) Versions 1.2 and
+             Earlier";
+      }
+      enum TLS_ECDH_RSA_WITH_AES_128_CBC_SHA {
+        status deprecated;
+        description
+          "Enumeration for the 'TLS_ECDH_RSA_WITH_AES_128_CBC_SHA'
+           algorithm.";
+        reference
+          "RFC 8422:
+             Elliptic Curve Cryptography (ECC) Cipher Suites for
+             Transport Layer Security (TLS) Versions 1.2 and
+             Earlier";
+      }
+      enum TLS_ECDH_RSA_WITH_AES_256_CBC_SHA {
+        status deprecated;
+        description
+          "Enumeration for the 'TLS_ECDH_RSA_WITH_AES_256_CBC_SHA'
+           algorithm.";
+        reference
+          "RFC 8422:
+             Elliptic Curve Cryptography (ECC) Cipher Suites for
+             Transport Layer Security (TLS) Versions 1.2 and
+             Earlier";
+      }
+      enum TLS_ECDHE_RSA_WITH_NULL_SHA {
+        status deprecated;
+        description
+          "Enumeration for the 'TLS_ECDHE_RSA_WITH_NULL_SHA'
+           algorithm.";
+        reference
+          "RFC 8422:
+             Elliptic Curve Cryptography (ECC) Cipher Suites for
+             Transport Layer Security (TLS) Versions 1.2 and
+             Earlier";
+      }
+      enum TLS_ECDHE_RSA_WITH_RC4_128_SHA {
+        status deprecated;
+        description
+          "Enumeration for the 'TLS_ECDHE_RSA_WITH_RC4_128_SHA'
+           algorithm.";
+        reference
+          "RFC 8422:
+             Elliptic Curve Cryptography (ECC) Cipher Suites for
+             Transport Layer Security (TLS) Versions 1.2 and Earlier
+           RFC 6347:
+             Datagram Transport Layer Security Version 1.2";
+      }
+      enum TLS_ECDHE_RSA_WITH_3DES_EDE_CBC_SHA {
+        status deprecated;
+        description
+          "Enumeration for the 'TLS_ECDHE_RSA_WITH_3DES_EDE_CBC_SHA'
+           algorithm.";
+        reference
+          "RFC 8422:
+             Elliptic Curve Cryptography (ECC) Cipher Suites for
+             Transport Layer Security (TLS) Versions 1.2 and
+             Earlier";
+      }
+      enum TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA {
+        status deprecated;
+        description
+          "Enumeration for the 'TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA'
+           algorithm.";
+        reference
+          "RFC 8422:
+             Elliptic Curve Cryptography (ECC) Cipher Suites for
+             Transport Layer Security (TLS) Versions 1.2 and
+             Earlier";
+      }
+      enum TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA {
+        status deprecated;
+        description
+          "Enumeration for the 'TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA'
+           algorithm.";
+        reference
+          "RFC 8422:
+             Elliptic Curve Cryptography (ECC) Cipher Suites for
+             Transport Layer Security (TLS) Versions 1.2 and
+             Earlier";
+      }
+      enum TLS_ECDH_anon_WITH_NULL_SHA {
+        status deprecated;
+        description
+          "Enumeration for the 'TLS_ECDH_anon_WITH_NULL_SHA'
+           algorithm.";
+        reference
+          "RFC 8422:
+             Elliptic Curve Cryptography (ECC) Cipher Suites for
+             Transport Layer Security (TLS) Versions 1.2 and
+             Earlier";
+      }
+      enum TLS_ECDH_anon_WITH_RC4_128_SHA {
+        status deprecated;
+        description
+          "Enumeration for the 'TLS_ECDH_anon_WITH_RC4_128_SHA'
+           algorithm.";
+        reference
+          "RFC 8422:
+             Elliptic Curve Cryptography (ECC) Cipher Suites for
+             Transport Layer Security (TLS) Versions 1.2 and Earlier
+           RFC 6347:
+             Datagram Transport Layer Security Version 1.2";
+      }
+      enum TLS_ECDH_anon_WITH_3DES_EDE_CBC_SHA {
+        status deprecated;
+        description
+          "Enumeration for the 'TLS_ECDH_anon_WITH_3DES_EDE_CBC_SHA'
+           algorithm.";
+        reference
+          "RFC 8422:
+             Elliptic Curve Cryptography (ECC) Cipher Suites for
+             Transport Layer Security (TLS) Versions 1.2 and
+             Earlier";
+      }
+      enum TLS_ECDH_anon_WITH_AES_128_CBC_SHA {
+        status deprecated;
+        description
+          "Enumeration for the 'TLS_ECDH_anon_WITH_AES_128_CBC_SHA'
+           algorithm.";
+        reference
+          "RFC 8422:
+             Elliptic Curve Cryptography (ECC) Cipher Suites for
+             Transport Layer Security (TLS) Versions 1.2 and
+             Earlier";
+      }
+      enum TLS_ECDH_anon_WITH_AES_256_CBC_SHA {
+        status deprecated;
+        description
+          "Enumeration for the 'TLS_ECDH_anon_WITH_AES_256_CBC_SHA'
+           algorithm.";
+        reference
+          "RFC 8422:
+             Elliptic Curve Cryptography (ECC) Cipher Suites for
+             Transport Layer Security (TLS) Versions 1.2 and
+             Earlier";
+      }
+      enum TLS_SRP_SHA_WITH_3DES_EDE_CBC_SHA {
+        status deprecated;
+        description
+          "Enumeration for the 'TLS_SRP_SHA_WITH_3DES_EDE_CBC_SHA'
+           algorithm.";
+        reference
+          "RFC 5054:
+             Using the Secure Remote Password (SRP) Protocol for TLS
+             Authentication";
+      }
+      enum TLS_SRP_SHA_RSA_WITH_3DES_EDE_CBC_SHA {
+        status deprecated;
+        description
+          "Enumeration for the
+           'TLS_SRP_SHA_RSA_WITH_3DES_EDE_CBC_SHA' algorithm.";
+        reference
+          "RFC 5054:
+             Using the Secure Remote Password (SRP) Protocol for TLS
+             Authentication";
+      }
+      enum TLS_SRP_SHA_DSS_WITH_3DES_EDE_CBC_SHA {
+        status deprecated;
+        description
+          "Enumeration for the
+           'TLS_SRP_SHA_DSS_WITH_3DES_EDE_CBC_SHA' algorithm.";
+        reference
+          "RFC 5054:
+             Using the Secure Remote Password (SRP) Protocol for TLS
+             Authentication";
+      }
+      enum TLS_SRP_SHA_WITH_AES_128_CBC_SHA {
+        status deprecated;
+        description
+          "Enumeration for the 'TLS_SRP_SHA_WITH_AES_128_CBC_SHA'
+           algorithm.";
+        reference
+          "RFC 5054:
+             Using the Secure Remote Password (SRP) Protocol for TLS
+             Authentication";
+      }
+      enum TLS_SRP_SHA_RSA_WITH_AES_128_CBC_SHA {
+        status deprecated;
+        description
+          "Enumeration for the 'TLS_SRP_SHA_RSA_WITH_AES_128_CBC_SHA'
+           algorithm.";
+        reference
+          "RFC 5054:
+             Using the Secure Remote Password (SRP) Protocol for TLS
+             Authentication";
+      }
+      enum TLS_SRP_SHA_DSS_WITH_AES_128_CBC_SHA {
+        status deprecated;
+        description
+          "Enumeration for the 'TLS_SRP_SHA_DSS_WITH_AES_128_CBC_SHA'
+           algorithm.";
+        reference
+          "RFC 5054:
+             Using the Secure Remote Password (SRP) Protocol for TLS
+             Authentication";
+      }
+      enum TLS_SRP_SHA_WITH_AES_256_CBC_SHA {
+        status deprecated;
+        description
+          "Enumeration for the 'TLS_SRP_SHA_WITH_AES_256_CBC_SHA'
+           algorithm.";
+        reference
+          "RFC 5054:
+             Using the Secure Remote Password (SRP) Protocol for TLS
+             Authentication";
+      }
+      enum TLS_SRP_SHA_RSA_WITH_AES_256_CBC_SHA {
+        status deprecated;
+        description
+          "Enumeration for the 'TLS_SRP_SHA_RSA_WITH_AES_256_CBC_SHA'
+           algorithm.";
+        reference
+          "RFC 5054:
+             Using the Secure Remote Password (SRP) Protocol for TLS
+             Authentication";
+      }
+      enum TLS_SRP_SHA_DSS_WITH_AES_256_CBC_SHA {
+        status deprecated;
+        description
+          "Enumeration for the 'TLS_SRP_SHA_DSS_WITH_AES_256_CBC_SHA'
+           algorithm.";
+        reference
+          "RFC 5054:
+             Using the Secure Remote Password (SRP) Protocol for TLS
+             Authentication";
+      }
+      enum TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256 {
+        status deprecated;
+        description
+          "Enumeration for the
+           'TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256' algorithm.";
+        reference
+          "RFC 5289:
+             TLS Elliptic Curve Cipher Suites with SHA-256/384 and
+             AES Galois Counter Mode (GCM)";
+      }
+      enum TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA384 {
+        status deprecated;
+        description
+          "Enumeration for the
+           'TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA384' algorithm.";
+        reference
+          "RFC 5289:
+             TLS Elliptic Curve Cipher Suites with SHA-256/384 and
+             AES Galois Counter Mode (GCM)";
+      }
+      enum TLS_ECDH_ECDSA_WITH_AES_128_CBC_SHA256 {
+        status deprecated;
+        description
+          "Enumeration for the
+           'TLS_ECDH_ECDSA_WITH_AES_128_CBC_SHA256' algorithm.";
+        reference
+          "RFC 5289:
+             TLS Elliptic Curve Cipher Suites with SHA-256/384 and
+             AES Galois Counter Mode (GCM)";
+      }
+      enum TLS_ECDH_ECDSA_WITH_AES_256_CBC_SHA384 {
+        status deprecated;
+        description
+          "Enumeration for the
+           'TLS_ECDH_ECDSA_WITH_AES_256_CBC_SHA384' algorithm.";
+        reference
+          "RFC 5289:
+             TLS Elliptic Curve Cipher Suites with SHA-256/384 and
+             AES Galois Counter Mode (GCM)";
+      }
+      enum TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256 {
+        status deprecated;
+        description
+          "Enumeration for the
+           'TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256' algorithm.";
+        reference
+          "RFC 5289:
+             TLS Elliptic Curve Cipher Suites with SHA-256/384 and
+             AES Galois Counter Mode (GCM)";
+      }
+      enum TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA384 {
+        status deprecated;
+        description
+          "Enumeration for the
+           'TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA384' algorithm.";
+        reference
+          "RFC 5289:
+             TLS Elliptic Curve Cipher Suites with SHA-256/384 and
+             AES Galois Counter Mode (GCM)";
+      }
+      enum TLS_ECDH_RSA_WITH_AES_128_CBC_SHA256 {
+        status deprecated;
+        description
+          "Enumeration for the 'TLS_ECDH_RSA_WITH_AES_128_CBC_SHA256'
+           algorithm.";
+        reference
+          "RFC 5289:
+             TLS Elliptic Curve Cipher Suites with SHA-256/384 and
+             AES Galois Counter Mode (GCM)";
+      }
+      enum TLS_ECDH_RSA_WITH_AES_256_CBC_SHA384 {
+        status deprecated;
+        description
+          "Enumeration for the 'TLS_ECDH_RSA_WITH_AES_256_CBC_SHA384'
+           algorithm.";
+        reference
+          "RFC 5289:
+             TLS Elliptic Curve Cipher Suites with SHA-256/384 and
+             AES Galois Counter Mode (GCM)";
+      }
+      enum TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256 {
+        description
+          "Enumeration for the
+           'TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256' algorithm.";
+        reference
+          "RFC 5289:
+             TLS Elliptic Curve Cipher Suites with SHA-256/384 and
+             AES Galois Counter Mode (GCM)";
+      }
+      enum TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384 {
+        description
+          "Enumeration for the
+           'TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384' algorithm.";
+        reference
+          "RFC 5289:
+             TLS Elliptic Curve Cipher Suites with SHA-256/384 and
+             AES Galois Counter Mode (GCM)";
+      }
+      enum TLS_ECDH_ECDSA_WITH_AES_128_GCM_SHA256 {
+        status deprecated;
+        description
+          "Enumeration for the
+           'TLS_ECDH_ECDSA_WITH_AES_128_GCM_SHA256' algorithm.";
+        reference
+          "RFC 5289:
+             TLS Elliptic Curve Cipher Suites with SHA-256/384 and
+             AES Galois Counter Mode (GCM)";
+      }
+      enum TLS_ECDH_ECDSA_WITH_AES_256_GCM_SHA384 {
+        status deprecated;
+        description
+          "Enumeration for the
+           'TLS_ECDH_ECDSA_WITH_AES_256_GCM_SHA384' algorithm.";
+        reference
+          "RFC 5289:
+             TLS Elliptic Curve Cipher Suites with SHA-256/384 and
+             AES Galois Counter Mode (GCM)";
+      }
+      enum TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256 {
+        description
+          "Enumeration for the
+           'TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256' algorithm.";
+        reference
+          "RFC 5289:
+             TLS Elliptic Curve Cipher Suites with SHA-256/384 and
+             AES Galois Counter Mode (GCM)";
+      }
+      enum TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384 {
+        description
+          "Enumeration for the
+           'TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384' algorithm.";
+        reference
+          "RFC 5289:
+             TLS Elliptic Curve Cipher Suites with SHA-256/384 and
+             AES Galois Counter Mode (GCM)";
+      }
+      enum TLS_ECDH_RSA_WITH_AES_128_GCM_SHA256 {
+        status deprecated;
+        description
+          "Enumeration for the 'TLS_ECDH_RSA_WITH_AES_128_GCM_SHA256'
+           algorithm.";
+        reference
+          "RFC 5289:
+             TLS Elliptic Curve Cipher Suites with SHA-256/384 and
+             AES Galois Counter Mode (GCM)";
+      }
+      enum TLS_ECDH_RSA_WITH_AES_256_GCM_SHA384 {
+        status deprecated;
+        description
+          "Enumeration for the 'TLS_ECDH_RSA_WITH_AES_256_GCM_SHA384'
+           algorithm.";
+        reference
+          "RFC 5289:
+             TLS Elliptic Curve Cipher Suites with SHA-256/384 and
+             AES Galois Counter Mode (GCM)";
+      }
+      enum TLS_ECDHE_PSK_WITH_RC4_128_SHA {
+        status deprecated;
+        description
+          "Enumeration for the 'TLS_ECDHE_PSK_WITH_RC4_128_SHA'
+           algorithm.";
+        reference
+          "RFC 5489:
+             ECDHE_PSK Cipher Suites for Transport Layer Security
+             (TLS)
+           RFC 6347:
+             Datagram Transport Layer Security Version 1.2";
+      }
+      enum TLS_ECDHE_PSK_WITH_3DES_EDE_CBC_SHA {
+        status deprecated;
+        description
+          "Enumeration for the 'TLS_ECDHE_PSK_WITH_3DES_EDE_CBC_SHA'
+           algorithm.";
+        reference
+          "RFC 5489:
+             ECDHE_PSK Cipher Suites for Transport Layer Security
+             (TLS)";
+      }
+      enum TLS_ECDHE_PSK_WITH_AES_128_CBC_SHA {
+        status deprecated;
+        description
+          "Enumeration for the 'TLS_ECDHE_PSK_WITH_AES_128_CBC_SHA'
+           algorithm.";
+        reference
+          "RFC 5489:
+             ECDHE_PSK Cipher Suites for Transport Layer Security
+             (TLS)";
+      }
+      enum TLS_ECDHE_PSK_WITH_AES_256_CBC_SHA {
+        status deprecated;
+        description
+          "Enumeration for the 'TLS_ECDHE_PSK_WITH_AES_256_CBC_SHA'
+           algorithm.";
+        reference
+          "RFC 5489:
+             ECDHE_PSK Cipher Suites for Transport Layer Security
+             (TLS)";
+      }
+      enum TLS_ECDHE_PSK_WITH_AES_128_CBC_SHA256 {
+        status deprecated;
+        description
+          "Enumeration for the
+           'TLS_ECDHE_PSK_WITH_AES_128_CBC_SHA256' algorithm.";
+        reference
+          "RFC 5489:
+             ECDHE_PSK Cipher Suites for Transport Layer Security
+             (TLS)";
+      }
+      enum TLS_ECDHE_PSK_WITH_AES_256_CBC_SHA384 {
+        status deprecated;
+        description
+          "Enumeration for the
+           'TLS_ECDHE_PSK_WITH_AES_256_CBC_SHA384' algorithm.";
+        reference
+          "RFC 5489:
+             ECDHE_PSK Cipher Suites for Transport Layer Security
+             (TLS)";
+      }
+      enum TLS_ECDHE_PSK_WITH_NULL_SHA {
+        status deprecated;
+        description
+          "Enumeration for the 'TLS_ECDHE_PSK_WITH_NULL_SHA'
+           algorithm.";
+        reference
+          "RFC 5489:
+             ECDHE_PSK Cipher Suites for Transport Layer Security
+             (TLS)";
+      }
+      enum TLS_ECDHE_PSK_WITH_NULL_SHA256 {
+        status deprecated;
+        description
+          "Enumeration for the 'TLS_ECDHE_PSK_WITH_NULL_SHA256'
+           algorithm.";
+        reference
+          "RFC 5489:
+             ECDHE_PSK Cipher Suites for Transport Layer Security
+             (TLS)";
+      }
+      enum TLS_ECDHE_PSK_WITH_NULL_SHA384 {
+        status deprecated;
+        description
+          "Enumeration for the 'TLS_ECDHE_PSK_WITH_NULL_SHA384'
+           algorithm.";
+        reference
+          "RFC 5489:
+             ECDHE_PSK Cipher Suites for Transport Layer Security
+             (TLS)";
+      }
+      enum TLS_RSA_WITH_ARIA_128_CBC_SHA256 {
+        status deprecated;
+        description
+          "Enumeration for the 'TLS_RSA_WITH_ARIA_128_CBC_SHA256'
+           algorithm.";
+        reference
+          "RFC 6209:
+             Addition of the ARIA Cipher Suites to Transport Layer
+             Security (TLS)";
+      }
+      enum TLS_RSA_WITH_ARIA_256_CBC_SHA384 {
+        status deprecated;
+        description
+          "Enumeration for the 'TLS_RSA_WITH_ARIA_256_CBC_SHA384'
+           algorithm.";
+        reference
+          "RFC 6209:
+             Addition of the ARIA Cipher Suites to Transport Layer
+             Security (TLS)";
+      }
+      enum TLS_DH_DSS_WITH_ARIA_128_CBC_SHA256 {
+        status deprecated;
+        description
+          "Enumeration for the 'TLS_DH_DSS_WITH_ARIA_128_CBC_SHA256'
+           algorithm.";
+        reference
+          "RFC 6209:
+             Addition of the ARIA Cipher Suites to Transport Layer
+             Security (TLS)";
+      }
+      enum TLS_DH_DSS_WITH_ARIA_256_CBC_SHA384 {
+        status deprecated;
+        description
+          "Enumeration for the 'TLS_DH_DSS_WITH_ARIA_256_CBC_SHA384'
+           algorithm.";
+        reference
+          "RFC 6209:
+             Addition of the ARIA Cipher Suites to Transport Layer
+             Security (TLS)";
+      }
+      enum TLS_DH_RSA_WITH_ARIA_128_CBC_SHA256 {
+        status deprecated;
+        description
+          "Enumeration for the 'TLS_DH_RSA_WITH_ARIA_128_CBC_SHA256'
+           algorithm.";
+        reference
+          "RFC 6209:
+             Addition of the ARIA Cipher Suites to Transport Layer
+             Security (TLS)";
+      }
+      enum TLS_DH_RSA_WITH_ARIA_256_CBC_SHA384 {
+        status deprecated;
+        description
+          "Enumeration for the 'TLS_DH_RSA_WITH_ARIA_256_CBC_SHA384'
+           algorithm.";
+        reference
+          "RFC 6209:
+             Addition of the ARIA Cipher Suites to Transport Layer
+             Security (TLS)";
+      }
+      enum TLS_DHE_DSS_WITH_ARIA_128_CBC_SHA256 {
+        status deprecated;
+        description
+          "Enumeration for the 'TLS_DHE_DSS_WITH_ARIA_128_CBC_SHA256'
+           algorithm.";
+        reference
+          "RFC 6209:
+             Addition of the ARIA Cipher Suites to Transport Layer
+             Security (TLS)";
+      }
+      enum TLS_DHE_DSS_WITH_ARIA_256_CBC_SHA384 {
+        status deprecated;
+        description
+          "Enumeration for the 'TLS_DHE_DSS_WITH_ARIA_256_CBC_SHA384'
+           algorithm.";
+        reference
+          "RFC 6209:
+             Addition of the ARIA Cipher Suites to Transport Layer
+             Security (TLS)";
+      }
+      enum TLS_DHE_RSA_WITH_ARIA_128_CBC_SHA256 {
+        status deprecated;
+        description
+          "Enumeration for the 'TLS_DHE_RSA_WITH_ARIA_128_CBC_SHA256'
+           algorithm.";
+        reference
+          "RFC 6209:
+             Addition of the ARIA Cipher Suites to Transport Layer
+             Security (TLS)";
+      }
+      enum TLS_DHE_RSA_WITH_ARIA_256_CBC_SHA384 {
+        status deprecated;
+        description
+          "Enumeration for the 'TLS_DHE_RSA_WITH_ARIA_256_CBC_SHA384'
+           algorithm.";
+        reference
+          "RFC 6209:
+             Addition of the ARIA Cipher Suites to Transport Layer
+             Security (TLS)";
+      }
+      enum TLS_DH_anon_WITH_ARIA_128_CBC_SHA256 {
+        status deprecated;
+        description
+          "Enumeration for the 'TLS_DH_anon_WITH_ARIA_128_CBC_SHA256'
+           algorithm.";
+        reference
+          "RFC 6209:
+             Addition of the ARIA Cipher Suites to Transport Layer
+             Security (TLS)";
+      }
+      enum TLS_DH_anon_WITH_ARIA_256_CBC_SHA384 {
+        status deprecated;
+        description
+          "Enumeration for the 'TLS_DH_anon_WITH_ARIA_256_CBC_SHA384'
+           algorithm.";
+        reference
+          "RFC 6209:
+             Addition of the ARIA Cipher Suites to Transport Layer
+             Security (TLS)";
+      }
+      enum TLS_ECDHE_ECDSA_WITH_ARIA_128_CBC_SHA256 {
+        status deprecated;
+        description
+          "Enumeration for the
+           'TLS_ECDHE_ECDSA_WITH_ARIA_128_CBC_SHA256' algorithm.";
+        reference
+          "RFC 6209:
+             Addition of the ARIA Cipher Suites to Transport Layer
+             Security (TLS)";
+      }
+      enum TLS_ECDHE_ECDSA_WITH_ARIA_256_CBC_SHA384 {
+        status deprecated;
+        description
+          "Enumeration for the
+           'TLS_ECDHE_ECDSA_WITH_ARIA_256_CBC_SHA384' algorithm.";
+        reference
+          "RFC 6209:
+             Addition of the ARIA Cipher Suites to Transport Layer
+             Security (TLS)";
+      }
+      enum TLS_ECDH_ECDSA_WITH_ARIA_128_CBC_SHA256 {
+        status deprecated;
+        description
+          "Enumeration for the
+           'TLS_ECDH_ECDSA_WITH_ARIA_128_CBC_SHA256' algorithm.";
+        reference
+          "RFC 6209:
+             Addition of the ARIA Cipher Suites to Transport Layer
+             Security (TLS)";
+      }
+      enum TLS_ECDH_ECDSA_WITH_ARIA_256_CBC_SHA384 {
+        status deprecated;
+        description
+          "Enumeration for the
+           'TLS_ECDH_ECDSA_WITH_ARIA_256_CBC_SHA384' algorithm.";
+        reference
+          "RFC 6209:
+             Addition of the ARIA Cipher Suites to Transport Layer
+             Security (TLS)";
+      }
+      enum TLS_ECDHE_RSA_WITH_ARIA_128_CBC_SHA256 {
+        status deprecated;
+        description
+          "Enumeration for the
+           'TLS_ECDHE_RSA_WITH_ARIA_128_CBC_SHA256' algorithm.";
+        reference
+          "RFC 6209:
+             Addition of the ARIA Cipher Suites to Transport Layer
+             Security (TLS)";
+      }
+      enum TLS_ECDHE_RSA_WITH_ARIA_256_CBC_SHA384 {
+        status deprecated;
+        description
+          "Enumeration for the
+           'TLS_ECDHE_RSA_WITH_ARIA_256_CBC_SHA384' algorithm.";
+        reference
+          "RFC 6209:
+             Addition of the ARIA Cipher Suites to Transport Layer
+             Security (TLS)";
+      }
+      enum TLS_ECDH_RSA_WITH_ARIA_128_CBC_SHA256 {
+        status deprecated;
+        description
+          "Enumeration for the
+           'TLS_ECDH_RSA_WITH_ARIA_128_CBC_SHA256' algorithm.";
+        reference
+          "RFC 6209:
+             Addition of the ARIA Cipher Suites to Transport Layer
+             Security (TLS)";
+      }
+      enum TLS_ECDH_RSA_WITH_ARIA_256_CBC_SHA384 {
+        status deprecated;
+        description
+          "Enumeration for the
+           'TLS_ECDH_RSA_WITH_ARIA_256_CBC_SHA384' algorithm.";
+        reference
+          "RFC 6209:
+             Addition of the ARIA Cipher Suites to Transport Layer
+             Security (TLS)";
+      }
+      enum TLS_RSA_WITH_ARIA_128_GCM_SHA256 {
+        status deprecated;
+        description
+          "Enumeration for the 'TLS_RSA_WITH_ARIA_128_GCM_SHA256'
+           algorithm.";
+        reference
+          "RFC 6209:
+             Addition of the ARIA Cipher Suites to Transport Layer
+             Security (TLS)";
+      }
+      enum TLS_RSA_WITH_ARIA_256_GCM_SHA384 {
+        status deprecated;
+        description
+          "Enumeration for the 'TLS_RSA_WITH_ARIA_256_GCM_SHA384'
+           algorithm.";
+        reference
+          "RFC 6209:
+             Addition of the ARIA Cipher Suites to Transport Layer
+             Security (TLS)";
+      }
+      enum TLS_DHE_RSA_WITH_ARIA_128_GCM_SHA256 {
+        status deprecated;
+        description
+          "Enumeration for the 'TLS_DHE_RSA_WITH_ARIA_128_GCM_SHA256'
+           algorithm.";
+        reference
+          "RFC 6209:
+             Addition of the ARIA Cipher Suites to Transport Layer
+             Security (TLS)";
+      }
+      enum TLS_DHE_RSA_WITH_ARIA_256_GCM_SHA384 {
+        status deprecated;
+        description
+          "Enumeration for the 'TLS_DHE_RSA_WITH_ARIA_256_GCM_SHA384'
+           algorithm.";
+        reference
+          "RFC 6209:
+             Addition of the ARIA Cipher Suites to Transport Layer
+             Security (TLS)";
+      }
+      enum TLS_DH_RSA_WITH_ARIA_128_GCM_SHA256 {
+        status deprecated;
+        description
+          "Enumeration for the 'TLS_DH_RSA_WITH_ARIA_128_GCM_SHA256'
+           algorithm.";
+        reference
+          "RFC 6209:
+             Addition of the ARIA Cipher Suites to Transport Layer
+             Security (TLS)";
+      }
+      enum TLS_DH_RSA_WITH_ARIA_256_GCM_SHA384 {
+        status deprecated;
+        description
+          "Enumeration for the 'TLS_DH_RSA_WITH_ARIA_256_GCM_SHA384'
+           algorithm.";
+        reference
+          "RFC 6209:
+             Addition of the ARIA Cipher Suites to Transport Layer
+             Security (TLS)";
+      }
+      enum TLS_DHE_DSS_WITH_ARIA_128_GCM_SHA256 {
+        status deprecated;
+        description
+          "Enumeration for the 'TLS_DHE_DSS_WITH_ARIA_128_GCM_SHA256'
+           algorithm.";
+        reference
+          "RFC 6209:
+             Addition of the ARIA Cipher Suites to Transport Layer
+             Security (TLS)";
+      }
+      enum TLS_DHE_DSS_WITH_ARIA_256_GCM_SHA384 {
+        status deprecated;
+        description
+          "Enumeration for the 'TLS_DHE_DSS_WITH_ARIA_256_GCM_SHA384'
+           algorithm.";
+        reference
+          "RFC 6209:
+             Addition of the ARIA Cipher Suites to Transport Layer
+             Security (TLS)";
+      }
+      enum TLS_DH_DSS_WITH_ARIA_128_GCM_SHA256 {
+        status deprecated;
+        description
+          "Enumeration for the 'TLS_DH_DSS_WITH_ARIA_128_GCM_SHA256'
+           algorithm.";
+        reference
+          "RFC 6209:
+             Addition of the ARIA Cipher Suites to Transport Layer
+             Security (TLS)";
+      }
+      enum TLS_DH_DSS_WITH_ARIA_256_GCM_SHA384 {
+        status deprecated;
+        description
+          "Enumeration for the 'TLS_DH_DSS_WITH_ARIA_256_GCM_SHA384'
+           algorithm.";
+        reference
+          "RFC 6209:
+             Addition of the ARIA Cipher Suites to Transport Layer
+             Security (TLS)";
+      }
+      enum TLS_DH_anon_WITH_ARIA_128_GCM_SHA256 {
+        status deprecated;
+        description
+          "Enumeration for the 'TLS_DH_anon_WITH_ARIA_128_GCM_SHA256'
+           algorithm.";
+        reference
+          "RFC 6209:
+             Addition of the ARIA Cipher Suites to Transport Layer
+             Security (TLS)";
+      }
+      enum TLS_DH_anon_WITH_ARIA_256_GCM_SHA384 {
+        status deprecated;
+        description
+          "Enumeration for the 'TLS_DH_anon_WITH_ARIA_256_GCM_SHA384'
+           algorithm.";
+        reference
+          "RFC 6209:
+             Addition of the ARIA Cipher Suites to Transport Layer
+             Security (TLS)";
+      }
+      enum TLS_ECDHE_ECDSA_WITH_ARIA_128_GCM_SHA256 {
+        status deprecated;
+        description
+          "Enumeration for the
+           'TLS_ECDHE_ECDSA_WITH_ARIA_128_GCM_SHA256' algorithm.";
+        reference
+          "RFC 6209:
+             Addition of the ARIA Cipher Suites to Transport Layer
+             Security (TLS)";
+      }
+      enum TLS_ECDHE_ECDSA_WITH_ARIA_256_GCM_SHA384 {
+        status deprecated;
+        description
+          "Enumeration for the
+           'TLS_ECDHE_ECDSA_WITH_ARIA_256_GCM_SHA384' algorithm.";
+        reference
+          "RFC 6209:
+             Addition of the ARIA Cipher Suites to Transport Layer
+             Security (TLS)";
+      }
+      enum TLS_ECDH_ECDSA_WITH_ARIA_128_GCM_SHA256 {
+        status deprecated;
+        description
+          "Enumeration for the
+           'TLS_ECDH_ECDSA_WITH_ARIA_128_GCM_SHA256' algorithm.";
+        reference
+          "RFC 6209:
+             Addition of the ARIA Cipher Suites to Transport Layer
+             Security (TLS)";
+      }
+      enum TLS_ECDH_ECDSA_WITH_ARIA_256_GCM_SHA384 {
+        status deprecated;
+        description
+          "Enumeration for the
+           'TLS_ECDH_ECDSA_WITH_ARIA_256_GCM_SHA384' algorithm.";
+        reference
+          "RFC 6209:
+             Addition of the ARIA Cipher Suites to Transport Layer
+             Security (TLS)";
+      }
+      enum TLS_ECDHE_RSA_WITH_ARIA_128_GCM_SHA256 {
+        status deprecated;
+        description
+          "Enumeration for the
+           'TLS_ECDHE_RSA_WITH_ARIA_128_GCM_SHA256' algorithm.";
+        reference
+          "RFC 6209:
+             Addition of the ARIA Cipher Suites to Transport Layer
+             Security (TLS)";
+      }
+      enum TLS_ECDHE_RSA_WITH_ARIA_256_GCM_SHA384 {
+        status deprecated;
+        description
+          "Enumeration for the
+           'TLS_ECDHE_RSA_WITH_ARIA_256_GCM_SHA384' algorithm.";
+        reference
+          "RFC 6209:
+             Addition of the ARIA Cipher Suites to Transport Layer
+             Security (TLS)";
+      }
+      enum TLS_ECDH_RSA_WITH_ARIA_128_GCM_SHA256 {
+        status deprecated;
+        description
+          "Enumeration for the
+           'TLS_ECDH_RSA_WITH_ARIA_128_GCM_SHA256' algorithm.";
+        reference
+          "RFC 6209:
+             Addition of the ARIA Cipher Suites to Transport Layer
+             Security (TLS)";
+      }
+      enum TLS_ECDH_RSA_WITH_ARIA_256_GCM_SHA384 {
+        status deprecated;
+        description
+          "Enumeration for the
+           'TLS_ECDH_RSA_WITH_ARIA_256_GCM_SHA384' algorithm.";
+        reference
+          "RFC 6209:
+             Addition of the ARIA Cipher Suites to Transport Layer
+             Security (TLS)";
+      }
+      enum TLS_PSK_WITH_ARIA_128_CBC_SHA256 {
+        status deprecated;
+        description
+          "Enumeration for the 'TLS_PSK_WITH_ARIA_128_CBC_SHA256'
+           algorithm.";
+        reference
+          "RFC 6209:
+             Addition of the ARIA Cipher Suites to Transport Layer
+             Security (TLS)";
+      }
+      enum TLS_PSK_WITH_ARIA_256_CBC_SHA384 {
+        status deprecated;
+        description
+          "Enumeration for the 'TLS_PSK_WITH_ARIA_256_CBC_SHA384'
+           algorithm.";
+        reference
+          "RFC 6209:
+             Addition of the ARIA Cipher Suites to Transport Layer
+             Security (TLS)";
+      }
+      enum TLS_DHE_PSK_WITH_ARIA_128_CBC_SHA256 {
+        status deprecated;
+        description
+          "Enumeration for the 'TLS_DHE_PSK_WITH_ARIA_128_CBC_SHA256'
+           algorithm.";
+        reference
+          "RFC 6209:
+             Addition of the ARIA Cipher Suites to Transport Layer
+             Security (TLS)";
+      }
+      enum TLS_DHE_PSK_WITH_ARIA_256_CBC_SHA384 {
+        status deprecated;
+        description
+          "Enumeration for the 'TLS_DHE_PSK_WITH_ARIA_256_CBC_SHA384'
+           algorithm.";
+        reference
+          "RFC 6209:
+             Addition of the ARIA Cipher Suites to Transport Layer
+             Security (TLS)";
+      }
+      enum TLS_RSA_PSK_WITH_ARIA_128_CBC_SHA256 {
+        status deprecated;
+        description
+          "Enumeration for the 'TLS_RSA_PSK_WITH_ARIA_128_CBC_SHA256'
+           algorithm.";
+        reference
+          "RFC 6209:
+             Addition of the ARIA Cipher Suites to Transport Layer
+             Security (TLS)";
+      }
+      enum TLS_RSA_PSK_WITH_ARIA_256_CBC_SHA384 {
+        status deprecated;
+        description
+          "Enumeration for the 'TLS_RSA_PSK_WITH_ARIA_256_CBC_SHA384'
+           algorithm.";
+        reference
+          "RFC 6209:
+             Addition of the ARIA Cipher Suites to Transport Layer
+             Security (TLS)";
+      }
+      enum TLS_PSK_WITH_ARIA_128_GCM_SHA256 {
+        status deprecated;
+        description
+          "Enumeration for the 'TLS_PSK_WITH_ARIA_128_GCM_SHA256'
+           algorithm.";
+        reference
+          "RFC 6209:
+             Addition of the ARIA Cipher Suites to Transport Layer
+             Security (TLS)";
+      }
+      enum TLS_PSK_WITH_ARIA_256_GCM_SHA384 {
+        status deprecated;
+        description
+          "Enumeration for the 'TLS_PSK_WITH_ARIA_256_GCM_SHA384'
+           algorithm.";
+        reference
+          "RFC 6209:
+             Addition of the ARIA Cipher Suites to Transport Layer
+             Security (TLS)";
+      }
+      enum TLS_DHE_PSK_WITH_ARIA_128_GCM_SHA256 {
+        status deprecated;
+        description
+          "Enumeration for the 'TLS_DHE_PSK_WITH_ARIA_128_GCM_SHA256'
+           algorithm.";
+        reference
+          "RFC 6209:
+             Addition of the ARIA Cipher Suites to Transport Layer
+             Security (TLS)";
+      }
+      enum TLS_DHE_PSK_WITH_ARIA_256_GCM_SHA384 {
+        status deprecated;
+        description
+          "Enumeration for the 'TLS_DHE_PSK_WITH_ARIA_256_GCM_SHA384'
+           algorithm.";
+        reference
+          "RFC 6209:
+             Addition of the ARIA Cipher Suites to Transport Layer
+             Security (TLS)";
+      }
+      enum TLS_RSA_PSK_WITH_ARIA_128_GCM_SHA256 {
+        status deprecated;
+        description
+          "Enumeration for the 'TLS_RSA_PSK_WITH_ARIA_128_GCM_SHA256'
+           algorithm.";
+        reference
+          "RFC 6209:
+             Addition of the ARIA Cipher Suites to Transport Layer
+             Security (TLS)";
+      }
+      enum TLS_RSA_PSK_WITH_ARIA_256_GCM_SHA384 {
+        status deprecated;
+        description
+          "Enumeration for the 'TLS_RSA_PSK_WITH_ARIA_256_GCM_SHA384'
+           algorithm.";
+        reference
+          "RFC 6209:
+             Addition of the ARIA Cipher Suites to Transport Layer
+             Security (TLS)";
+      }
+      enum TLS_ECDHE_PSK_WITH_ARIA_128_CBC_SHA256 {
+        status deprecated;
+        description
+          "Enumeration for the
+           'TLS_ECDHE_PSK_WITH_ARIA_128_CBC_SHA256' algorithm.";
+        reference
+          "RFC 6209:
+             Addition of the ARIA Cipher Suites to Transport Layer
+             Security (TLS)";
+      }
+      enum TLS_ECDHE_PSK_WITH_ARIA_256_CBC_SHA384 {
+        status deprecated;
+        description
+          "Enumeration for the
+           'TLS_ECDHE_PSK_WITH_ARIA_256_CBC_SHA384' algorithm.";
+        reference
+          "RFC 6209:
+             Addition of the ARIA Cipher Suites to Transport Layer
+             Security (TLS)";
+      }
+      enum TLS_ECDHE_ECDSA_WITH_CAMELLIA_128_CBC_SHA256 {
+        status deprecated;
+        description
+          "Enumeration for the
+           'TLS_ECDHE_ECDSA_WITH_CAMELLIA_128_CBC_SHA256'
+           algorithm.";
+        reference
+          "RFC 6367:
+             Addition of the Camellia Cipher Suites to Transport
+             Layer Security (TLS)";
+      }
+      enum TLS_ECDHE_ECDSA_WITH_CAMELLIA_256_CBC_SHA384 {
+        status deprecated;
+        description
+          "Enumeration for the
+           'TLS_ECDHE_ECDSA_WITH_CAMELLIA_256_CBC_SHA384'
+           algorithm.";
+        reference
+          "RFC 6367:
+             Addition of the Camellia Cipher Suites to Transport
+             Layer Security (TLS)";
+      }
+      enum TLS_ECDH_ECDSA_WITH_CAMELLIA_128_CBC_SHA256 {
+        status deprecated;
+        description
+          "Enumeration for the
+           'TLS_ECDH_ECDSA_WITH_CAMELLIA_128_CBC_SHA256' algorithm.";
+        reference
+          "RFC 6367:
+             Addition of the Camellia Cipher Suites to Transport
+             Layer Security (TLS)";
+      }
+      enum TLS_ECDH_ECDSA_WITH_CAMELLIA_256_CBC_SHA384 {
+        status deprecated;
+        description
+          "Enumeration for the
+           'TLS_ECDH_ECDSA_WITH_CAMELLIA_256_CBC_SHA384' algorithm.";
+        reference
+          "RFC 6367:
+             Addition of the Camellia Cipher Suites to Transport
+             Layer Security (TLS)";
+      }
+      enum TLS_ECDHE_RSA_WITH_CAMELLIA_128_CBC_SHA256 {
+        status deprecated;
+        description
+          "Enumeration for the
+           'TLS_ECDHE_RSA_WITH_CAMELLIA_128_CBC_SHA256' algorithm.";
+        reference
+          "RFC 6367:
+             Addition of the Camellia Cipher Suites to Transport
+             Layer Security (TLS)";
+      }
+      enum TLS_ECDHE_RSA_WITH_CAMELLIA_256_CBC_SHA384 {
+        status deprecated;
+        description
+          "Enumeration for the
+           'TLS_ECDHE_RSA_WITH_CAMELLIA_256_CBC_SHA384' algorithm.";
+        reference
+          "RFC 6367:
+             Addition of the Camellia Cipher Suites to Transport
+             Layer Security (TLS)";
+      }
+      enum TLS_ECDH_RSA_WITH_CAMELLIA_128_CBC_SHA256 {
+        status deprecated;
+        description
+          "Enumeration for the
+           'TLS_ECDH_RSA_WITH_CAMELLIA_128_CBC_SHA256' algorithm.";
+        reference
+          "RFC 6367:
+             Addition of the Camellia Cipher Suites to Transport
+             Layer Security (TLS)";
+      }
+      enum TLS_ECDH_RSA_WITH_CAMELLIA_256_CBC_SHA384 {
+        status deprecated;
+        description
+          "Enumeration for the
+           'TLS_ECDH_RSA_WITH_CAMELLIA_256_CBC_SHA384' algorithm.";
+        reference
+          "RFC 6367:
+             Addition of the Camellia Cipher Suites to Transport
+             Layer Security (TLS)";
+      }
+      enum TLS_RSA_WITH_CAMELLIA_128_GCM_SHA256 {
+        status deprecated;
+        description
+          "Enumeration for the 'TLS_RSA_WITH_CAMELLIA_128_GCM_SHA256'
+           algorithm.";
+        reference
+          "RFC 6367:
+             Addition of the Camellia Cipher Suites to Transport
+             Layer Security (TLS)";
+      }
+      enum TLS_RSA_WITH_CAMELLIA_256_GCM_SHA384 {
+        status deprecated;
+        description
+          "Enumeration for the 'TLS_RSA_WITH_CAMELLIA_256_GCM_SHA384'
+           algorithm.";
+        reference
+          "RFC 6367:
+             Addition of the Camellia Cipher Suites to Transport
+             Layer Security (TLS)";
+      }
+      enum TLS_DHE_RSA_WITH_CAMELLIA_128_GCM_SHA256 {
+        status deprecated;
+        description
+          "Enumeration for the
+           'TLS_DHE_RSA_WITH_CAMELLIA_128_GCM_SHA256' algorithm.";
+        reference
+          "RFC 6367:
+             Addition of the Camellia Cipher Suites to Transport
+             Layer Security (TLS)";
+      }
+      enum TLS_DHE_RSA_WITH_CAMELLIA_256_GCM_SHA384 {
+        status deprecated;
+        description
+          "Enumeration for the
+           'TLS_DHE_RSA_WITH_CAMELLIA_256_GCM_SHA384' algorithm.";
+        reference
+          "RFC 6367:
+             Addition of the Camellia Cipher Suites to Transport
+             Layer Security (TLS)";
+      }
+      enum TLS_DH_RSA_WITH_CAMELLIA_128_GCM_SHA256 {
+        status deprecated;
+        description
+          "Enumeration for the
+           'TLS_DH_RSA_WITH_CAMELLIA_128_GCM_SHA256' algorithm.";
+        reference
+          "RFC 6367:
+             Addition of the Camellia Cipher Suites to Transport
+             Layer Security (TLS)";
+      }
+      enum TLS_DH_RSA_WITH_CAMELLIA_256_GCM_SHA384 {
+        status deprecated;
+        description
+          "Enumeration for the
+           'TLS_DH_RSA_WITH_CAMELLIA_256_GCM_SHA384' algorithm.";
+        reference
+          "RFC 6367:
+             Addition of the Camellia Cipher Suites to Transport
+             Layer Security (TLS)";
+      }
+      enum TLS_DHE_DSS_WITH_CAMELLIA_128_GCM_SHA256 {
+        status deprecated;
+        description
+          "Enumeration for the
+           'TLS_DHE_DSS_WITH_CAMELLIA_128_GCM_SHA256' algorithm.";
+        reference
+          "RFC 6367:
+             Addition of the Camellia Cipher Suites to Transport
+             Layer Security (TLS)";
+      }
+      enum TLS_DHE_DSS_WITH_CAMELLIA_256_GCM_SHA384 {
+        status deprecated;
+        description
+          "Enumeration for the
+           'TLS_DHE_DSS_WITH_CAMELLIA_256_GCM_SHA384' algorithm.";
+        reference
+          "RFC 6367:
+             Addition of the Camellia Cipher Suites to Transport
+             Layer Security (TLS)";
+      }
+      enum TLS_DH_DSS_WITH_CAMELLIA_128_GCM_SHA256 {
+        status deprecated;
+        description
+          "Enumeration for the
+           'TLS_DH_DSS_WITH_CAMELLIA_128_GCM_SHA256' algorithm.";
+        reference
+          "RFC 6367:
+             Addition of the Camellia Cipher Suites to Transport
+             Layer Security (TLS)";
+      }
+      enum TLS_DH_DSS_WITH_CAMELLIA_256_GCM_SHA384 {
+        status deprecated;
+        description
+          "Enumeration for the
+           'TLS_DH_DSS_WITH_CAMELLIA_256_GCM_SHA384' algorithm.";
+        reference
+          "RFC 6367:
+             Addition of the Camellia Cipher Suites to Transport
+             Layer Security (TLS)";
+      }
+      enum TLS_DH_anon_WITH_CAMELLIA_128_GCM_SHA256 {
+        status deprecated;
+        description
+          "Enumeration for the
+           'TLS_DH_anon_WITH_CAMELLIA_128_GCM_SHA256' algorithm.";
+        reference
+          "RFC 6367:
+             Addition of the Camellia Cipher Suites to Transport
+             Layer Security (TLS)";
+      }
+      enum TLS_DH_anon_WITH_CAMELLIA_256_GCM_SHA384 {
+        status deprecated;
+        description
+          "Enumeration for the
+           'TLS_DH_anon_WITH_CAMELLIA_256_GCM_SHA384' algorithm.";
+        reference
+          "RFC 6367:
+             Addition of the Camellia Cipher Suites to Transport
+             Layer Security (TLS)";
+      }
+      enum TLS_ECDHE_ECDSA_WITH_CAMELLIA_128_GCM_SHA256 {
+        status deprecated;
+        description
+          "Enumeration for the
+           'TLS_ECDHE_ECDSA_WITH_CAMELLIA_128_GCM_SHA256'
+           algorithm.";
+        reference
+          "RFC 6367:
+             Addition of the Camellia Cipher Suites to Transport
+             Layer Security (TLS)";
+      }
+      enum TLS_ECDHE_ECDSA_WITH_CAMELLIA_256_GCM_SHA384 {
+        status deprecated;
+        description
+          "Enumeration for the
+           'TLS_ECDHE_ECDSA_WITH_CAMELLIA_256_GCM_SHA384'
+           algorithm.";
+        reference
+          "RFC 6367:
+             Addition of the Camellia Cipher Suites to Transport
+             Layer Security (TLS)";
+      }
+      enum TLS_ECDH_ECDSA_WITH_CAMELLIA_128_GCM_SHA256 {
+        status deprecated;
+        description
+          "Enumeration for the
+           'TLS_ECDH_ECDSA_WITH_CAMELLIA_128_GCM_SHA256' algorithm.";
+        reference
+          "RFC 6367:
+             Addition of the Camellia Cipher Suites to Transport
+             Layer Security (TLS)";
+      }
+      enum TLS_ECDH_ECDSA_WITH_CAMELLIA_256_GCM_SHA384 {
+        status deprecated;
+        description
+          "Enumeration for the
+           'TLS_ECDH_ECDSA_WITH_CAMELLIA_256_GCM_SHA384' algorithm.";
+        reference
+          "RFC 6367:
+             Addition of the Camellia Cipher Suites to Transport
+             Layer Security (TLS)";
+      }
+      enum TLS_ECDHE_RSA_WITH_CAMELLIA_128_GCM_SHA256 {
+        status deprecated;
+        description
+          "Enumeration for the
+           'TLS_ECDHE_RSA_WITH_CAMELLIA_128_GCM_SHA256' algorithm.";
+        reference
+          "RFC 6367:
+             Addition of the Camellia Cipher Suites to Transport
+             Layer Security (TLS)";
+      }
+      enum TLS_ECDHE_RSA_WITH_CAMELLIA_256_GCM_SHA384 {
+        status deprecated;
+        description
+          "Enumeration for the
+           'TLS_ECDHE_RSA_WITH_CAMELLIA_256_GCM_SHA384' algorithm.";
+        reference
+          "RFC 6367:
+             Addition of the Camellia Cipher Suites to Transport
+             Layer Security (TLS)";
+      }
+      enum TLS_ECDH_RSA_WITH_CAMELLIA_128_GCM_SHA256 {
+        status deprecated;
+        description
+          "Enumeration for the
+           'TLS_ECDH_RSA_WITH_CAMELLIA_128_GCM_SHA256' algorithm.";
+        reference
+          "RFC 6367:
+             Addition of the Camellia Cipher Suites to Transport
+             Layer Security (TLS)";
+      }
+      enum TLS_ECDH_RSA_WITH_CAMELLIA_256_GCM_SHA384 {
+        status deprecated;
+        description
+          "Enumeration for the
+           'TLS_ECDH_RSA_WITH_CAMELLIA_256_GCM_SHA384' algorithm.";
+        reference
+          "RFC 6367:
+             Addition of the Camellia Cipher Suites to Transport
+             Layer Security (TLS)";
+      }
+      enum TLS_PSK_WITH_CAMELLIA_128_GCM_SHA256 {
+        status deprecated;
+        description
+          "Enumeration for the 'TLS_PSK_WITH_CAMELLIA_128_GCM_SHA256'
+           algorithm.";
+        reference
+          "RFC 6367:
+             Addition of the Camellia Cipher Suites to Transport
+             Layer Security (TLS)";
+      }
+      enum TLS_PSK_WITH_CAMELLIA_256_GCM_SHA384 {
+        status deprecated;
+        description
+          "Enumeration for the 'TLS_PSK_WITH_CAMELLIA_256_GCM_SHA384'
+           algorithm.";
+        reference
+          "RFC 6367:
+             Addition of the Camellia Cipher Suites to Transport
+             Layer Security (TLS)";
+      }
+      enum TLS_DHE_PSK_WITH_CAMELLIA_128_GCM_SHA256 {
+        status deprecated;
+        description
+          "Enumeration for the
+           'TLS_DHE_PSK_WITH_CAMELLIA_128_GCM_SHA256' algorithm.";
+        reference
+          "RFC 6367:
+             Addition of the Camellia Cipher Suites to Transport
+             Layer Security (TLS)";
+      }
+      enum TLS_DHE_PSK_WITH_CAMELLIA_256_GCM_SHA384 {
+        status deprecated;
+        description
+          "Enumeration for the
+           'TLS_DHE_PSK_WITH_CAMELLIA_256_GCM_SHA384' algorithm.";
+        reference
+          "RFC 6367:
+             Addition of the Camellia Cipher Suites to Transport
+             Layer Security (TLS)";
+      }
+      enum TLS_RSA_PSK_WITH_CAMELLIA_128_GCM_SHA256 {
+        status deprecated;
+        description
+          "Enumeration for the
+           'TLS_RSA_PSK_WITH_CAMELLIA_128_GCM_SHA256' algorithm.";
+        reference
+          "RFC 6367:
+             Addition of the Camellia Cipher Suites to Transport
+             Layer Security (TLS)";
+      }
+      enum TLS_RSA_PSK_WITH_CAMELLIA_256_GCM_SHA384 {
+        status deprecated;
+        description
+          "Enumeration for the
+           'TLS_RSA_PSK_WITH_CAMELLIA_256_GCM_SHA384' algorithm.";
+        reference
+          "RFC 6367:
+             Addition of the Camellia Cipher Suites to Transport
+             Layer Security (TLS)";
+      }
+      enum TLS_PSK_WITH_CAMELLIA_128_CBC_SHA256 {
+        status deprecated;
+        description
+          "Enumeration for the 'TLS_PSK_WITH_CAMELLIA_128_CBC_SHA256'
+           algorithm.";
+        reference
+          "RFC 6367:
+             Addition of the Camellia Cipher Suites to Transport
+             Layer Security (TLS)";
+      }
+      enum TLS_PSK_WITH_CAMELLIA_256_CBC_SHA384 {
+        status deprecated;
+        description
+          "Enumeration for the 'TLS_PSK_WITH_CAMELLIA_256_CBC_SHA384'
+           algorithm.";
+        reference
+          "RFC 6367:
+             Addition of the Camellia Cipher Suites to Transport
+             Layer Security (TLS)";
+      }
+      enum TLS_DHE_PSK_WITH_CAMELLIA_128_CBC_SHA256 {
+        status deprecated;
+        description
+          "Enumeration for the
+           'TLS_DHE_PSK_WITH_CAMELLIA_128_CBC_SHA256' algorithm.";
+        reference
+          "RFC 6367:
+             Addition of the Camellia Cipher Suites to Transport
+             Layer Security (TLS)";
+      }
+      enum TLS_DHE_PSK_WITH_CAMELLIA_256_CBC_SHA384 {
+        status deprecated;
+        description
+          "Enumeration for the
+           'TLS_DHE_PSK_WITH_CAMELLIA_256_CBC_SHA384' algorithm.";
+        reference
+          "RFC 6367:
+             Addition of the Camellia Cipher Suites to Transport
+             Layer Security (TLS)";
+      }
+      enum TLS_RSA_PSK_WITH_CAMELLIA_128_CBC_SHA256 {
+        status deprecated;
+        description
+          "Enumeration for the
+           'TLS_RSA_PSK_WITH_CAMELLIA_128_CBC_SHA256' algorithm.";
+        reference
+          "RFC 6367:
+             Addition of the Camellia Cipher Suites to Transport
+             Layer Security (TLS)";
+      }
+      enum TLS_RSA_PSK_WITH_CAMELLIA_256_CBC_SHA384 {
+        status deprecated;
+        description
+          "Enumeration for the
+           'TLS_RSA_PSK_WITH_CAMELLIA_256_CBC_SHA384' algorithm.";
+        reference
+          "RFC 6367:
+             Addition of the Camellia Cipher Suites to Transport
+             Layer Security (TLS)";
+      }
+      enum TLS_ECDHE_PSK_WITH_CAMELLIA_128_CBC_SHA256 {
+        status deprecated;
+        description
+          "Enumeration for the
+           'TLS_ECDHE_PSK_WITH_CAMELLIA_128_CBC_SHA256' algorithm.";
+        reference
+          "RFC 6367:
+             Addition of the Camellia Cipher Suites to Transport
+             Layer Security (TLS)";
+      }
+      enum TLS_ECDHE_PSK_WITH_CAMELLIA_256_CBC_SHA384 {
+        status deprecated;
+        description
+          "Enumeration for the
+           'TLS_ECDHE_PSK_WITH_CAMELLIA_256_CBC_SHA384' algorithm.";
+        reference
+          "RFC 6367:
+             Addition of the Camellia Cipher Suites to Transport
+             Layer Security (TLS)";
+      }
+      enum TLS_RSA_WITH_AES_128_CCM {
+        status deprecated;
+        description
+          "Enumeration for the 'TLS_RSA_WITH_AES_128_CCM'
+           algorithm.";
+        reference
+          "RFC 6655:
+             AES-CCM Cipher Suites for Transport Layer Security
+             (TLS)";
+      }
+      enum TLS_RSA_WITH_AES_256_CCM {
+        status deprecated;
+        description
+          "Enumeration for the 'TLS_RSA_WITH_AES_256_CCM'
+           algorithm.";
+        reference
+          "RFC 6655:
+             AES-CCM Cipher Suites for Transport Layer Security
+             (TLS)";
+      }
+      enum TLS_DHE_RSA_WITH_AES_128_CCM {
+        description
+          "Enumeration for the 'TLS_DHE_RSA_WITH_AES_128_CCM'
+           algorithm.";
+        reference
+          "RFC 6655:
+             AES-CCM Cipher Suites for Transport Layer Security
+             (TLS)";
+      }
+      enum TLS_DHE_RSA_WITH_AES_256_CCM {
+        description
+          "Enumeration for the 'TLS_DHE_RSA_WITH_AES_256_CCM'
+           algorithm.";
+        reference
+          "RFC 6655:
+             AES-CCM Cipher Suites for Transport Layer Security
+             (TLS)";
+      }
+      enum TLS_RSA_WITH_AES_128_CCM_8 {
+        status deprecated;
+        description
+          "Enumeration for the 'TLS_RSA_WITH_AES_128_CCM_8'
+           algorithm.";
+        reference
+          "RFC 6655:
+             AES-CCM Cipher Suites for Transport Layer Security
+             (TLS)";
+      }
+      enum TLS_RSA_WITH_AES_256_CCM_8 {
+        status deprecated;
+        description
+          "Enumeration for the 'TLS_RSA_WITH_AES_256_CCM_8'
+           algorithm.";
+        reference
+          "RFC 6655:
+             AES-CCM Cipher Suites for Transport Layer Security
+             (TLS)";
+      }
+      enum TLS_DHE_RSA_WITH_AES_128_CCM_8 {
+        status deprecated;
+        description
+          "Enumeration for the 'TLS_DHE_RSA_WITH_AES_128_CCM_8'
+           algorithm.";
+        reference
+          "RFC 6655:
+             AES-CCM Cipher Suites for Transport Layer Security
+             (TLS)";
+      }
+      enum TLS_DHE_RSA_WITH_AES_256_CCM_8 {
+        status deprecated;
+        description
+          "Enumeration for the 'TLS_DHE_RSA_WITH_AES_256_CCM_8'
+           algorithm.";
+        reference
+          "RFC 6655:
+             AES-CCM Cipher Suites for Transport Layer Security
+             (TLS)";
+      }
+      enum TLS_PSK_WITH_AES_128_CCM {
+        status deprecated;
+        description
+          "Enumeration for the 'TLS_PSK_WITH_AES_128_CCM'
+           algorithm.";
+        reference
+          "RFC 6655:
+             AES-CCM Cipher Suites for Transport Layer Security
+             (TLS)";
+      }
+      enum TLS_PSK_WITH_AES_256_CCM {
+        status deprecated;
+        description
+          "Enumeration for the 'TLS_PSK_WITH_AES_256_CCM'
+           algorithm.";
+        reference
+          "RFC 6655:
+             AES-CCM Cipher Suites for Transport Layer Security
+             (TLS)";
+      }
+      enum TLS_DHE_PSK_WITH_AES_128_CCM {
+        description
+          "Enumeration for the 'TLS_DHE_PSK_WITH_AES_128_CCM'
+           algorithm.";
+        reference
+          "RFC 6655:
+             AES-CCM Cipher Suites for Transport Layer Security
+             (TLS)";
+      }
+      enum TLS_DHE_PSK_WITH_AES_256_CCM {
+        description
+          "Enumeration for the 'TLS_DHE_PSK_WITH_AES_256_CCM'
+           algorithm.";
+        reference
+          "RFC 6655:
+             AES-CCM Cipher Suites for Transport Layer Security
+             (TLS)";
+      }
+      enum TLS_PSK_WITH_AES_128_CCM_8 {
+        status deprecated;
+        description
+          "Enumeration for the 'TLS_PSK_WITH_AES_128_CCM_8'
+           algorithm.";
+        reference
+          "RFC 6655:
+             AES-CCM Cipher Suites for Transport Layer Security
+             (TLS)";
+      }
+      enum TLS_PSK_WITH_AES_256_CCM_8 {
+        status deprecated;
+        description
+          "Enumeration for the 'TLS_PSK_WITH_AES_256_CCM_8'
+           algorithm.";
+        reference
+          "RFC 6655:
+             AES-CCM Cipher Suites for Transport Layer Security
+             (TLS)";
+      }
+      enum TLS_PSK_DHE_WITH_AES_128_CCM_8 {
+        status deprecated;
+        description
+          "Enumeration for the 'TLS_PSK_DHE_WITH_AES_128_CCM_8'
+           algorithm.";
+        reference
+          "RFC 6655:
+             AES-CCM Cipher Suites for Transport Layer Security
+             (TLS)";
+      }
+      enum TLS_PSK_DHE_WITH_AES_256_CCM_8 {
+        status deprecated;
+        description
+          "Enumeration for the 'TLS_PSK_DHE_WITH_AES_256_CCM_8'
+           algorithm.";
+        reference
+          "RFC 6655:
+             AES-CCM Cipher Suites for Transport Layer Security
+             (TLS)";
+      }
+      enum TLS_ECDHE_ECDSA_WITH_AES_128_CCM {
+        status deprecated;
+        description
+          "Enumeration for the 'TLS_ECDHE_ECDSA_WITH_AES_128_CCM'
+           algorithm.";
+        reference
+          "RFC 7251:
+             AES-CCM Elliptic Curve Cryptography (ECC) Cipher Suites
+             for TLS";
+      }
+      enum TLS_ECDHE_ECDSA_WITH_AES_256_CCM {
+        status deprecated;
+        description
+          "Enumeration for the 'TLS_ECDHE_ECDSA_WITH_AES_256_CCM'
+           algorithm.";
+        reference
+          "RFC 7251:
+             AES-CCM Elliptic Curve Cryptography (ECC) Cipher Suites
+             for TLS";
+      }
+      enum TLS_ECDHE_ECDSA_WITH_AES_128_CCM_8 {
+        status deprecated;
+        description
+          "Enumeration for the 'TLS_ECDHE_ECDSA_WITH_AES_128_CCM_8'
+           algorithm.";
+        reference
+          "RFC 7251:
+             AES-CCM Elliptic Curve Cryptography (ECC) Cipher Suites
+             for TLS";
+      }
+      enum TLS_ECDHE_ECDSA_WITH_AES_256_CCM_8 {
+        status deprecated;
+        description
+          "Enumeration for the 'TLS_ECDHE_ECDSA_WITH_AES_256_CCM_8'
+           algorithm.";
+        reference
+          "RFC 7251:
+             AES-CCM Elliptic Curve Cryptography (ECC) Cipher Suites
+             for TLS";
+      }
+      enum TLS_ECCPWD_WITH_AES_128_GCM_SHA256 {
+        status deprecated;
+        description
+          "Enumeration for the 'TLS_ECCPWD_WITH_AES_128_GCM_SHA256'
+           algorithm.";
+        reference
+          "RFC 8492:
+             Secure Password Ciphersuites for Transport Layer
+             Security (TLS)";
+      }
+      enum TLS_ECCPWD_WITH_AES_256_GCM_SHA384 {
+        status deprecated;
+        description
+          "Enumeration for the 'TLS_ECCPWD_WITH_AES_256_GCM_SHA384'
+           algorithm.";
+        reference
+          "RFC 8492:
+             Secure Password Ciphersuites for Transport Layer
+             Security (TLS)";
+      }
+      enum TLS_ECCPWD_WITH_AES_128_CCM_SHA256 {
+        status deprecated;
+        description
+          "Enumeration for the 'TLS_ECCPWD_WITH_AES_128_CCM_SHA256'
+           algorithm.";
+        reference
+          "RFC 8492:
+             Secure Password Ciphersuites for Transport Layer
+             Security (TLS)";
+      }
+      enum TLS_ECCPWD_WITH_AES_256_CCM_SHA384 {
+        status deprecated;
+        description
+          "Enumeration for the 'TLS_ECCPWD_WITH_AES_256_CCM_SHA384'
+           algorithm.";
+        reference
+          "RFC 8492:
+             Secure Password Ciphersuites for Transport Layer
+             Security (TLS)";
+      }
+      enum TLS_SHA256_SHA256 {
+        status deprecated;
+        description
+          "Enumeration for the 'TLS_SHA256_SHA256' algorithm.";
+        reference
+          "RFC 9150:
+             TLS 1.3 Authentication and Integrity-Only Cipher
+             Suites";
+      }
+      enum TLS_SHA384_SHA384 {
+        status deprecated;
+        description
+          "Enumeration for the 'TLS_SHA384_SHA384' algorithm.";
+        reference
+          "RFC 9150:
+             TLS 1.3 Authentication and Integrity-Only Cipher
+             Suites";
+      }
+      enum TLS_GOSTR341112_256_WITH_KUZNYECHIK_CTR_OMAC {
+        status deprecated;
+        description
+          "Enumeration for the
+           'TLS_GOSTR341112_256_WITH_KUZNYECHIK_CTR_OMAC'
+           algorithm.";
+        reference
+          "RFC 9189:
+             GOST Cipher Suites for Transport Layer Security (TLS)
+             Protocol Version 1.2";
+      }
+      enum TLS_GOSTR341112_256_WITH_MAGMA_CTR_OMAC {
+        status deprecated;
+        description
+          "Enumeration for the
+           'TLS_GOSTR341112_256_WITH_MAGMA_CTR_OMAC' algorithm.";
+        reference
+          "RFC 9189:
+             GOST Cipher Suites for Transport Layer Security (TLS)
+             Protocol Version 1.2";
+      }
+      enum TLS_GOSTR341112_256_WITH_28147_CNT_IMIT {
+        status deprecated;
+        description
+          "Enumeration for the
+           'TLS_GOSTR341112_256_WITH_28147_CNT_IMIT' algorithm.";
+        reference
+          "RFC 9189:
+             GOST Cipher Suites for Transport Layer Security (TLS)
+             Protocol Version 1.2";
+      }
+      enum TLS_GOSTR341112_256_WITH_KUZNYECHIK_MGM_L {
+        status deprecated;
+        description
+          "Enumeration for the
+           'TLS_GOSTR341112_256_WITH_KUZNYECHIK_MGM_L' algorithm.";
+        reference
+          "RFC 9367:
+             GOST Cipher Suites for Transport Layer Security (TLS)
+             Protocol Version 1.3";
+      }
+      enum TLS_GOSTR341112_256_WITH_MAGMA_MGM_L {
+        status deprecated;
+        description
+          "Enumeration for the 'TLS_GOSTR341112_256_WITH_MAGMA_MGM_L'
+           algorithm.";
+        reference
+          "RFC 9367:
+             GOST Cipher Suites for Transport Layer Security (TLS)
+             Protocol Version 1.3";
+      }
+      enum TLS_GOSTR341112_256_WITH_KUZNYECHIK_MGM_S {
+        status deprecated;
+        description
+          "Enumeration for the
+           'TLS_GOSTR341112_256_WITH_KUZNYECHIK_MGM_S' algorithm.";
+        reference
+          "RFC 9367:
+             GOST Cipher Suites for Transport Layer Security (TLS)
+             Protocol Version 1.3";
+      }
+      enum TLS_GOSTR341112_256_WITH_MAGMA_MGM_S {
+        status deprecated;
+        description
+          "Enumeration for the 'TLS_GOSTR341112_256_WITH_MAGMA_MGM_S'
+           algorithm.";
+        reference
+          "RFC 9367:
+             GOST Cipher Suites for Transport Layer Security (TLS)
+             Protocol Version 1.3";
+      }
+      enum TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256 {
+        description
+          "Enumeration for the
+           'TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256' algorithm.";
+        reference
+          "RFC 7905:
+             ChaCha20-Poly1305 Cipher Suites for Transport Layer
+             Security (TLS)";
+      }
+      enum TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256 {
+        description
+          "Enumeration for the
+           'TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256'
+           algorithm.";
+        reference
+          "RFC 7905:
+             ChaCha20-Poly1305 Cipher Suites for Transport Layer
+             Security (TLS)";
+      }
+      enum TLS_DHE_RSA_WITH_CHACHA20_POLY1305_SHA256 {
+        description
+          "Enumeration for the
+           'TLS_DHE_RSA_WITH_CHACHA20_POLY1305_SHA256' algorithm.";
+        reference
+          "RFC 7905:
+             ChaCha20-Poly1305 Cipher Suites for Transport Layer
+             Security (TLS)";
+      }
+      enum TLS_PSK_WITH_CHACHA20_POLY1305_SHA256 {
+        status deprecated;
+        description
+          "Enumeration for the
+           'TLS_PSK_WITH_CHACHA20_POLY1305_SHA256' algorithm.";
+        reference
+          "RFC 7905:
+             ChaCha20-Poly1305 Cipher Suites for Transport Layer
+             Security (TLS)";
+      }
+      enum TLS_ECDHE_PSK_WITH_CHACHA20_POLY1305_SHA256 {
+        description
+          "Enumeration for the
+           'TLS_ECDHE_PSK_WITH_CHACHA20_POLY1305_SHA256' algorithm.";
+        reference
+          "RFC 7905:
+             ChaCha20-Poly1305 Cipher Suites for Transport Layer
+             Security (TLS)";
+      }
+      enum TLS_DHE_PSK_WITH_CHACHA20_POLY1305_SHA256 {
+        description
+          "Enumeration for the
+           'TLS_DHE_PSK_WITH_CHACHA20_POLY1305_SHA256' algorithm.";
+        reference
+          "RFC 7905:
+             ChaCha20-Poly1305 Cipher Suites for Transport Layer
+             Security (TLS)";
+      }
+      enum TLS_RSA_PSK_WITH_CHACHA20_POLY1305_SHA256 {
+        status deprecated;
+        description
+          "Enumeration for the
+           'TLS_RSA_PSK_WITH_CHACHA20_POLY1305_SHA256' algorithm.";
+        reference
+          "RFC 7905:
+             ChaCha20-Poly1305 Cipher Suites for Transport Layer
+             Security (TLS)";
+      }
+      enum TLS_ECDHE_PSK_WITH_AES_128_GCM_SHA256 {
+        description
+          "Enumeration for the
+           'TLS_ECDHE_PSK_WITH_AES_128_GCM_SHA256' algorithm.";
+        reference
+          "RFC 8442:
+             ECDHE_PSK with AES-GCM and AES-CCM Cipher Suites for TLS
+             1.2 and DTLS 1.2";
+      }
+      enum TLS_ECDHE_PSK_WITH_AES_256_GCM_SHA384 {
+        description
+          "Enumeration for the
+           'TLS_ECDHE_PSK_WITH_AES_256_GCM_SHA384' algorithm.";
+        reference
+          "RFC 8442:
+             ECDHE_PSK with AES-GCM and AES-CCM Cipher Suites for TLS
+             1.2 and DTLS 1.2";
+      }
+      enum TLS_ECDHE_PSK_WITH_AES_128_CCM_8_SHA256 {
+        status deprecated;
+        description
+          "Enumeration for the
+           'TLS_ECDHE_PSK_WITH_AES_128_CCM_8_SHA256' algorithm.";
+        reference
+          "RFC 8442:
+             ECDHE_PSK with AES-GCM and AES-CCM Cipher Suites for TLS
+             1.2 and DTLS 1.2";
+      }
+      enum TLS_ECDHE_PSK_WITH_AES_128_CCM_SHA256 {
+        description
+          "Enumeration for the
+           'TLS_ECDHE_PSK_WITH_AES_128_CCM_SHA256' algorithm.";
+        reference
+          "RFC 8442:
+             ECDHE_PSK with AES-GCM and AES-CCM Cipher Suites for TLS
+             1.2 and DTLS 1.2";
+      }
+    }
+    description
+      "An enumeration for TLS cipher-suite algorithms.";
+  }
+
+}

--- a/modules/subscribed_notifications/ietf-crypto-types@2024-10-10.yang
+++ b/modules/subscribed_notifications/ietf-crypto-types@2024-10-10.yang
@@ -1,0 +1,1109 @@
+module ietf-crypto-types {
+  yang-version 1.1;
+  namespace "urn:ietf:params:xml:ns:yang:ietf-crypto-types";
+  prefix ct;
+
+  import ietf-yang-types {
+    prefix yang;
+    reference
+      "RFC 6991: Common YANG Data Types";
+  }
+
+  import ietf-netconf-acm {
+    prefix nacm;
+    reference
+      "RFC 8341: Network Configuration Access Control Model";
+  }
+
+  organization
+    "IETF NETCONF (Network Configuration) Working Group";
+
+  contact
+    "WG Web:   https://datatracker.ietf.org/wg/netconf
+     WG List:  NETCONF WG list <mailto:netconf@ietf.org>
+     Author:   Kent Watsen <mailto:kent+ietf@watsen.net>";
+
+  description
+    "This module defines common YANG types for cryptographic
+     applications.
+
+     The key words 'MUST', 'MUST NOT', 'REQUIRED', 'SHALL',
+     'SHALL NOT', 'SHOULD', 'SHOULD NOT', 'RECOMMENDED',
+     'NOT RECOMMENDED', 'MAY', and 'OPTIONAL' in this document
+     are to be interpreted as described in BCP 14 (RFC 2119)
+     (RFC 8174) when, and only when, they appear in all
+     capitals, as shown here.
+
+     Copyright (c) 2024 IETF Trust and the persons identified
+     as authors of the code.  All rights reserved.
+
+     Redistribution and use in source and binary forms, with
+     or without modification, is permitted pursuant to, and
+     subject to the license terms contained in, the Revised
+     BSD License set forth in Section 4.c of the IETF Trust's
+     Legal Provisions Relating to IETF Documents
+     (https://trustee.ietf.org/license-info).
+
+     This version of this YANG module is part of RFC 9640
+     (https://www.rfc-editor.org/info/rfc9640); see the RFC
+     itself for full legal notices.";
+
+  revision 2024-10-10 {
+    description
+      "Initial version.";
+    reference
+      "RFC 9640: YANG Data Types and Groupings for Cryptography";
+  }
+
+  /****************/
+  /*   Features   */
+  /****************/
+
+  feature one-symmetric-key-format {
+    description
+      "Indicates that the server supports the
+       'one-symmetric-key-format' identity.";
+  }
+
+  feature one-asymmetric-key-format {
+    description
+      "Indicates that the server supports the
+       'one-asymmetric-key-format' identity.";
+  }
+
+  feature symmetrically-encrypted-value-format {
+    description
+      "Indicates that the server supports the
+       'symmetrically-encrypted-value-format' identity.";
+  }
+
+  feature asymmetrically-encrypted-value-format {
+    description
+      "Indicates that the server supports the
+       'asymmetrically-encrypted-value-format' identity.";
+  }
+
+  feature cms-enveloped-data-format {
+    description
+      "Indicates that the server supports the
+       'cms-enveloped-data-format' identity.";
+  }
+
+  feature cms-encrypted-data-format {
+    description
+      "Indicates that the server supports the
+       'cms-encrypted-data-format' identity.";
+  }
+
+  feature p10-csr-format {
+    description
+      "Indicates that the server implements support
+       for generating P10-based CSRs, as defined
+       in RFC 2986.";
+    reference
+      "RFC 2986: PKCS #10: Certification Request Syntax
+                 Specification Version 1.7";
+  }
+
+  feature csr-generation {
+    description
+      "Indicates that the server implements the
+       'generate-csr' action.";
+  }
+
+  feature certificate-expiration-notification {
+    description
+      "Indicates that the server implements the
+       'certificate-expiration' notification.";
+  }
+
+  feature cleartext-passwords {
+    description
+      "Indicates that the server supports cleartext
+       passwords.";
+  }
+
+  feature encrypted-passwords {
+    description
+      "Indicates that the server supports password
+       encryption.";
+  }
+
+  feature cleartext-symmetric-keys {
+    description
+      "Indicates that the server supports cleartext
+       symmetric keys.";
+  }
+
+  feature hidden-symmetric-keys {
+    description
+      "Indicates that the server supports hidden keys.";
+  }
+
+  feature encrypted-symmetric-keys {
+    description
+      "Indicates that the server supports encryption
+       of symmetric keys.";
+  }
+
+  feature cleartext-private-keys {
+    description
+      "Indicates that the server supports cleartext
+       private keys.";
+  }
+
+  feature hidden-private-keys {
+    description
+      "Indicates that the server supports hidden keys.";
+  }
+
+  feature encrypted-private-keys {
+    description
+      "Indicates that the server supports encryption
+       of private keys.";
+  }
+
+  /*************************************************/
+  /*   Base Identities for Key Format Structures   */
+  /*************************************************/
+
+  identity symmetric-key-format {
+    description
+      "Base key-format identity for symmetric keys.";
+  }
+
+  identity public-key-format {
+    description
+      "Base key-format identity for public keys.";
+  }
+
+  identity private-key-format {
+    description
+      "Base key-format identity for private keys.";
+  }
+
+  /****************************************************/
+  /*   Identities for Private Key Format Structures   */
+  /****************************************************/
+
+  identity rsa-private-key-format {
+    base private-key-format;
+    description
+      "Indicates that the private key value is encoded as
+       an RSAPrivateKey (from RFC 8017), encoded using ASN.1
+       distinguished encoding rules (DER), as specified in
+       ITU-T X.690.";
+    reference
+      "RFC 8017:
+         PKCS #1: RSA Cryptography Specifications Version 2.2
+       ITU-T X.690:
+         Information technology - ASN.1 encoding rules:
+         Specification of Basic Encoding Rules (BER),
+         Canonical Encoding Rules (CER) and Distinguished
+         Encoding Rules (DER) 02/2021";
+  }
+
+  identity ec-private-key-format {
+    base private-key-format;
+    description
+      "Indicates that the private key value is encoded as
+       an ECPrivateKey (from RFC 5915), encoded using ASN.1
+       distinguished encoding rules (DER), as specified in
+       ITU-T X.690.";
+    reference
+      "RFC 5915:
+         Elliptic Curve Private Key Structure
+       ITU-T X.690:
+         Information technology - ASN.1 encoding rules:
+         Specification of Basic Encoding Rules (BER),
+         Canonical Encoding Rules (CER) and Distinguished
+         Encoding Rules (DER) 02/2021";
+  }
+
+  identity one-asymmetric-key-format {
+    if-feature "one-asymmetric-key-format";
+    base private-key-format;
+    description
+      "Indicates that the private key value is a
+       Cryptographic Message Syntax (CMS) OneAsymmetricKey
+       structure, as defined in RFC 5958, encoded using
+       ASN.1 distinguished encoding rules (DER), as
+       specified in ITU-T X.690.";
+    reference
+      "RFC 5958:
+         Asymmetric Key Packages
+       ITU-T X.690:
+         Information technology - ASN.1 encoding rules:
+         Specification of Basic Encoding Rules (BER),
+         Canonical Encoding Rules (CER) and Distinguished
+         Encoding Rules (DER) 02/2021";
+  }
+
+  /***************************************************/
+  /*   Identities for Public Key Format Structures   */
+  /***************************************************/
+
+  identity ssh-public-key-format {
+    base public-key-format;
+    description
+      "Indicates that the public key value is a Secure Shell (SSH)
+       public key, as specified in RFC 4253, Section 6.6, i.e.:
+
+         string    certificate or public key format
+                   identifier
+         byte[n]   key/certificate data.";
+    reference
+      "RFC 4253: The Secure Shell (SSH) Transport Layer Protocol";
+  }
+
+  identity subject-public-key-info-format {
+    base public-key-format;
+    description
+      "Indicates that the public key value is a SubjectPublicKeyInfo
+       structure, as described in RFC 5280, encoded using ASN.1
+       distinguished encoding rules (DER), as specified in
+       ITU-T X.690.";
+    reference
+      "RFC 5280:
+         Internet X.509 Public Key Infrastructure Certificate
+         and Certificate Revocation List (CRL) Profile
+       ITU-T X.690:
+         Information technology - ASN.1 encoding rules:
+         Specification of Basic Encoding Rules (BER),
+         Canonical Encoding Rules (CER) and Distinguished
+         Encoding Rules (DER) 02/2021";
+  }
+
+  /******************************************************/
+  /*   Identities for Symmetric Key Format Structures   */
+  /******************************************************/
+
+  identity octet-string-key-format {
+    base symmetric-key-format;
+    description
+      "Indicates that the key is encoded as a raw octet string.
+       The length of the octet string MUST be appropriate for
+       the associated algorithm's block size.
+
+       The identity of the associated algorithm is outside the
+       scope of this specification.  This is also true when
+       the octet string has been encrypted.";
+  }
+
+  identity one-symmetric-key-format {
+    if-feature "one-symmetric-key-format";
+    base symmetric-key-format;
+    description
+      "Indicates that the private key value is a CMS
+       OneSymmetricKey structure, as defined in RFC 6031,
+       encoded using ASN.1 distinguished encoding rules
+       (DER), as specified in ITU-T X.690.";
+    reference
+      "RFC 6031:
+         Cryptographic Message Syntax (CMS)
+         Symmetric Key Package Content Type
+       ITU-T X.690:
+         Information technology - ASN.1 encoding rules:
+         Specification of Basic Encoding Rules (BER),
+         Canonical Encoding Rules (CER) and Distinguished
+         Encoding Rules (DER) 02/2021";
+  }
+
+  /*************************************************/
+  /*   Identities for Encrypted Value Structures   */
+  /*************************************************/
+
+  identity encrypted-value-format {
+    description
+      "Base format identity for encrypted values.";
+  }
+
+  identity symmetrically-encrypted-value-format {
+    if-feature "symmetrically-encrypted-value-format";
+    base encrypted-value-format;
+    description
+      "Base format identity for symmetrically encrypted
+       values.";
+  }
+
+  identity asymmetrically-encrypted-value-format {
+    if-feature "asymmetrically-encrypted-value-format";
+    base encrypted-value-format;
+    description
+      "Base format identity for asymmetrically encrypted
+       values.";
+  }
+
+  identity cms-encrypted-data-format {
+    if-feature "cms-encrypted-data-format";
+    base symmetrically-encrypted-value-format;
+    description
+      "Indicates that the encrypted value conforms to
+       the 'encrypted-data-cms' type with the constraint
+       that the 'unprotectedAttrs' value is not set.";
+    reference
+      "RFC 5652:
+         Cryptographic Message Syntax (CMS)
+       ITU-T X.690:
+         Information technology - ASN.1 encoding rules:
+         Specification of Basic Encoding Rules (BER),
+         Canonical Encoding Rules (CER) and Distinguished
+         Encoding Rules (DER) 02/2021";
+  }
+
+  identity cms-enveloped-data-format {
+    if-feature "cms-enveloped-data-format";
+    base asymmetrically-encrypted-value-format;
+    description
+      "Indicates that the encrypted value conforms to the
+       'enveloped-data-cms' type with the following constraints:
+
+       The EnvelopedData structure MUST have exactly one
+       'RecipientInfo'.
+
+       If the asymmetric key supports public key cryptography
+       (e.g., RSA), then the 'RecipientInfo' must be a
+       'KeyTransRecipientInfo' with the 'RecipientIdentifier'
+       using a 'subjectKeyIdentifier' with the value set using
+       'method 1' in RFC 7093 over the recipient's public key.
+
+       Otherwise, if the asymmetric key supports key agreement
+       (e.g., Elliptic Curve Cryptography (ECC)), then the
+       'RecipientInfo' must be a 'KeyAgreeRecipientInfo'.  The
+       'OriginatorIdentifierOrKey' value must use the
+       'OriginatorPublicKey' alternative.  The
+       'UserKeyingMaterial' value must not be present.  There
+       must be exactly one 'RecipientEncryptedKeys' value
+       having the 'KeyAgreeRecipientIdentifier' set to 'rKeyId'
+       with the value set using 'method 1' in RFC 7093 over the
+       recipient's public key.";
+    reference
+      "RFC 5652:
+         Cryptographic Message Syntax (CMS)
+       RFC 7093:
+         Additional Methods for Generating Key
+         Identifiers Values
+       ITU-T X.690:
+         Information technology - ASN.1 encoding rules:
+         Specification of Basic Encoding Rules (BER),
+         Canonical Encoding Rules (CER) and Distinguished
+         Encoding Rules (DER) 02/2021";
+  }
+
+  /*********************************************************/
+  /*   Identities for Certificate Signing Request Formats  */
+  /*********************************************************/
+
+  identity csr-format {
+    description
+      "A base identity for the certificate signing request
+       formats.  Additional derived identities MAY be defined
+       by future efforts.";
+  }
+
+  identity p10-csr-format {
+    if-feature "p10-csr-format";
+    base csr-format;
+    description
+      "Indicates the CertificationRequest structure
+       defined in RFC 2986.";
+    reference
+      "RFC 2986: PKCS #10: Certification Request Syntax
+                 Specification Version 1.7";
+  }
+
+  /***************************************************/
+  /*   Typedefs for ASN.1 structures from RFC 2986   */
+  /***************************************************/
+
+  typedef csr-info {
+    type binary;
+    description
+      "A CertificationRequestInfo structure, as defined in
+       RFC 2986, encoded using ASN.1 distinguished encoding
+       rules (DER), as specified in ITU-T X.690.";
+    reference
+      "RFC 2986:
+         PKCS #10: Certification Request Syntax
+         Specification Version 1.7
+       ITU-T X.690:
+         Information technology - ASN.1 encoding rules:
+         Specification of Basic Encoding Rules (BER),
+         Canonical Encoding Rules (CER) and Distinguished
+         Encoding Rules (DER) 02/2021";
+  }
+
+  typedef p10-csr {
+    type binary;
+    description
+      "A CertificationRequest structure, as specified in
+       RFC 2986, encoded using ASN.1 distinguished encoding
+       rules (DER), as specified in ITU-T X.690.";
+    reference
+      "RFC 2986:
+         PKCS #10: Certification Request Syntax Specification
+         Version 1.7
+       ITU-T X.690:
+         Information technology - ASN.1 encoding rules:
+         Specification of Basic Encoding Rules (BER),
+         Canonical Encoding Rules (CER) and Distinguished
+         Encoding Rules (DER) 02/2021";
+  }
+
+  /***************************************************/
+  /*   Typedefs for ASN.1 structures from RFC 5280   */
+  /***************************************************/
+
+  typedef x509 {
+    type binary;
+    description
+      "A Certificate structure, as specified in RFC 5280,
+       encoded using ASN.1 distinguished encoding rules (DER),
+       as specified in ITU-T X.690.";
+    reference
+      "RFC 5280:
+         Internet X.509 Public Key Infrastructure Certificate
+         and Certificate Revocation List (CRL) Profile
+       ITU-T X.690:
+         Information technology - ASN.1 encoding rules:
+         Specification of Basic Encoding Rules (BER),
+         Canonical Encoding Rules (CER) and Distinguished
+         Encoding Rules (DER) 02/2021";
+  }
+
+  typedef crl {
+    type binary;
+    description
+      "A CertificateList structure, as specified in RFC 5280,
+       encoded using ASN.1 distinguished encoding rules (DER),
+       as specified in ITU-T X.690.";
+    reference
+      "RFC 5280:
+         Internet X.509 Public Key Infrastructure Certificate
+         and Certificate Revocation List (CRL) Profile
+       ITU-T X.690:
+         Information technology - ASN.1 encoding rules:
+         Specification of Basic Encoding Rules (BER),
+         Canonical Encoding Rules (CER) and Distinguished
+         Encoding Rules (DER) 02/2021";
+  }
+
+  /***************************************************/
+  /*   Typedefs for ASN.1 structures from RFC 6960   */
+  /***************************************************/
+
+  typedef oscp-request {
+    type binary;
+    description
+      "A OCSPRequest structure, as specified in RFC 6960,
+       encoded using ASN.1 distinguished encoding rules
+       (DER), as specified in ITU-T X.690.";
+    reference
+      "RFC 6960:
+         X.509 Internet Public Key Infrastructure Online
+         Certificate Status Protocol - OCSP
+       ITU-T X.690:
+         Information technology - ASN.1 encoding rules:
+         Specification of Basic Encoding Rules (BER),
+         Canonical Encoding Rules (CER) and Distinguished
+         Encoding Rules (DER) 02/2021";
+  }
+
+  typedef oscp-response {
+    type binary;
+    description
+      "A OCSPResponse structure, as specified in RFC 6960,
+       encoded using ASN.1 distinguished encoding rules
+       (DER), as specified in ITU-T X.690.";
+    reference
+      "RFC 6960:
+         X.509 Internet Public Key Infrastructure Online
+         Certificate Status Protocol - OCSP
+       ITU-T X.690:
+         Information technology - ASN.1 encoding rules:
+         Specification of Basic Encoding Rules (BER),
+         Canonical Encoding Rules (CER) and Distinguished
+         Encoding Rules (DER) 02/2021";
+  }
+
+  /***********************************************/
+  /*   Typedefs for ASN.1 structures from 5652   */
+  /***********************************************/
+
+  typedef cms {
+    type binary;
+    description
+      "A ContentInfo structure, as specified in RFC 5652,
+       encoded using ASN.1 distinguished encoding rules (DER),
+       as specified in ITU-T X.690.";
+    reference
+      "RFC 5652:
+         Cryptographic Message Syntax (CMS)
+       ITU-T X.690:
+         Information technology - ASN.1 encoding rules:
+         Specification of Basic Encoding Rules (BER),
+         Canonical Encoding Rules (CER) and Distinguished
+         Encoding Rules (DER) 02/2021";
+  }
+
+  typedef data-content-cms {
+    type cms;
+    description
+      "A CMS structure whose top-most content type MUST be the
+       data content type, as described in Section 4 of RFC 5652.";
+    reference
+      "RFC 5652: Cryptographic Message Syntax (CMS)";
+  }
+
+  typedef signed-data-cms {
+    type cms;
+    description
+      "A CMS structure whose top-most content type MUST be the
+       signed-data content type, as described in Section 5 of
+       RFC 5652.";
+    reference
+      "RFC 5652: Cryptographic Message Syntax (CMS)";
+  }
+
+  typedef enveloped-data-cms {
+    type cms;
+    description
+      "A CMS structure whose top-most content type MUST be the
+       enveloped-data content type, as described in Section 6
+       of RFC 5652.";
+    reference
+      "RFC 5652: Cryptographic Message Syntax (CMS)";
+  }
+
+  typedef digested-data-cms {
+    type cms;
+    description
+      "A CMS structure whose top-most content type MUST be the
+       digested-data content type, as described in Section 7
+       of RFC 5652.";
+    reference
+      "RFC 5652: Cryptographic Message Syntax (CMS)";
+  }
+
+  typedef encrypted-data-cms {
+    type cms;
+    description
+      "A CMS structure whose top-most content type MUST be the
+       encrypted-data content type, as described in Section 8
+       of RFC 5652.";
+    reference
+      "RFC 5652: Cryptographic Message Syntax (CMS)";
+  }
+
+  typedef authenticated-data-cms {
+    type cms;
+    description
+      "A CMS structure whose top-most content type MUST be the
+       authenticated-data content type, as described in Section 9
+       of RFC 5652.";
+    reference
+      "RFC 5652: Cryptographic Message Syntax (CMS)";
+  }
+
+  /*********************************************************/
+  /*   Typedefs for ASN.1 structures related to RFC 5280   */
+  /*********************************************************/
+
+  typedef trust-anchor-cert-x509 {
+    type x509;
+    description
+      "A Certificate structure that MUST encode a self-signed
+       root certificate.";
+  }
+
+  typedef end-entity-cert-x509 {
+    type x509;
+    description
+      "A Certificate structure that MUST encode a certificate
+       that is neither self-signed nor has Basic constraint
+       CA true.";
+  }
+
+  /*********************************************************/
+  /*   Typedefs for ASN.1 structures related to RFC 5652   */
+  /*********************************************************/
+
+  typedef trust-anchor-cert-cms {
+    type signed-data-cms;
+    description
+      "A CMS SignedData structure that MUST contain the chain of
+       X.509 certificates needed to authenticate the certificate
+       presented by a client or end entity.
+
+       The CMS MUST contain only a single chain of certificates.
+       The client or end-entity certificate MUST only authenticate
+       to the last intermediate CA certificate listed in the chain.
+
+       In all cases, the chain MUST include a self-signed root
+       certificate.  In the case where the root certificate is
+       itself the issuer of the client or end-entity certificate,
+       only one certificate is present.
+
+       This CMS structure MAY (as applicable where this type is
+       used) also contain suitably fresh (as defined by local
+       policy) revocation objects with which the device can
+       verify the revocation status of the certificates.
+
+       This CMS encodes the degenerate form of the SignedData
+       structure (RFC 5652, Section 5.2) that is commonly used
+       to disseminate X.509 certificates and revocation objects
+       (RFC 5280).";
+    reference
+      "RFC 5280:
+         Internet X.509 Public Key Infrastructure Certificate
+         and Certificate Revocation List (CRL) Profile
+       RFC 5652:
+         Cryptographic Message Syntax (CMS)";
+  }
+
+  typedef end-entity-cert-cms {
+    type signed-data-cms;
+    description
+      "A CMS SignedData structure that MUST contain the end-entity
+       certificate itself and MAY contain any number
+       of intermediate certificates leading up to a trust
+       anchor certificate.  The trust anchor certificate
+       MAY be included as well.
+
+       The CMS MUST contain a single end-entity certificate.
+       The CMS MUST NOT contain any spurious certificates.
+
+       This CMS structure MAY (as applicable where this type is
+       used) also contain suitably fresh (as defined by local
+       policy) revocation objects with which the device can
+       verify the revocation status of the certificates.
+
+       This CMS encodes the degenerate form of the SignedData
+       structure (RFC 5652, Section 5.2) that is commonly
+       used to disseminate X.509 certificates and revocation
+       objects (RFC 5280).";
+
+    reference
+      "RFC 5280:
+         Internet X.509 Public Key Infrastructure Certificate
+         and Certificate Revocation List (CRL) Profile
+       RFC 5652:
+         Cryptographic Message Syntax (CMS)";
+  }
+
+  /*****************/
+  /*   Groupings   */
+  /*****************/
+
+  grouping encrypted-value-grouping {
+    description
+      "A reusable grouping for a value that has been encrypted by
+       a referenced symmetric or asymmetric key.";
+    container encrypted-by {
+      nacm:default-deny-write;
+      description
+        "An empty container enabling a reference to the key that
+         encrypted the value to be augmented in.  The referenced
+         key MUST be a symmetric key or an asymmetric key.
+
+         A symmetric key MUST be referenced via a leaf node called
+         'symmetric-key-ref'.  An asymmetric key MUST be referenced
+         via a leaf node called 'asymmetric-key-ref'.
+
+         The leaf nodes MUST be direct descendants in the data tree
+         and MAY be direct descendants in the schema tree (e.g.,
+         'choice'/'case' statements are allowed but not a
+         container).";
+    }
+    leaf encrypted-value-format {
+      type identityref {
+        base encrypted-value-format;
+      }
+      mandatory true;
+      description
+        "Identifies the format of the 'encrypted-value' leaf.
+
+         If 'encrypted-by' points to a symmetric key, then an
+         identity based on 'symmetrically-encrypted-value-format'
+         MUST be set (e.g., 'cms-encrypted-data-format').
+
+         If 'encrypted-by' points to an asymmetric key, then an
+         identity based on 'asymmetrically-encrypted-value-format'
+         MUST be set (e.g., 'cms-enveloped-data-format').";
+    }
+    leaf encrypted-value {
+      nacm:default-deny-write;
+      type binary;
+      must '../encrypted-by';
+      mandatory true;
+      description
+        "The value, encrypted using the referenced symmetric
+         or asymmetric key.  The value MUST be encoded using
+         the format associated with the 'encrypted-value-format'
+         leaf.";
+    }
+  }
+
+  grouping password-grouping {
+    description
+      "A password used for authenticating to a remote system.
+
+       The 'ianach:crypt-hash' typedef from RFC 7317 should be
+       used instead when needing a password to authenticate a
+       local account.";
+    choice password-type {
+      nacm:default-deny-write;
+      mandatory true;
+      description
+        "Choice between password types.";
+      case cleartext-password {
+        if-feature "cleartext-passwords";
+        leaf cleartext-password {
+          nacm:default-deny-all;
+          type string;
+          description
+            "The cleartext value of the password.";
+        }
+      }
+      case encrypted-password {
+        if-feature "encrypted-passwords";
+        container encrypted-password {
+          description
+            "A container for the encrypted password value.";
+          uses encrypted-value-grouping;
+        }
+      }
+    }
+  }
+
+  grouping symmetric-key-grouping {
+    description
+      "A symmetric key.";
+    leaf key-format {
+      nacm:default-deny-write;
+      type identityref {
+        base symmetric-key-format;
+      }
+      description
+        "Identifies the symmetric key's format.  Implementations
+         SHOULD ensure that the incoming symmetric key value is
+         encoded in the specified format.
+
+         For encrypted keys, the value is the decrypted key's
+         format (i.e., the 'encrypted-value-format' conveys the
+         encrypted key's format).";
+    }
+    choice key-type {
+      nacm:default-deny-write;
+      mandatory true;
+      description
+        "Choice between key types.";
+      case cleartext-symmetric-key {
+        leaf cleartext-symmetric-key {
+          if-feature "cleartext-symmetric-keys";
+          nacm:default-deny-all;
+          type binary;
+          must '../key-format';
+          description
+            "The binary value of the key.  The interpretation of
+             the value is defined by the 'key-format' field.";
+        }
+      }
+      case hidden-symmetric-key {
+        if-feature "hidden-symmetric-keys";
+        leaf hidden-symmetric-key {
+          type empty;
+          must 'not(../key-format)';
+          description
+            "A hidden key is not exportable and not extractable;
+             therefore, it is of type 'empty' as its value is
+             inaccessible via management interfaces.  Though hidden
+             to users, such keys are not hidden to the server and
+             may be referenced by configuration to indicate which
+             key a server should use for a cryptographic operation.
+             How such keys are created is outside the scope of this
+             module.";
+        }
+      }
+      case encrypted-symmetric-key {
+        if-feature "encrypted-symmetric-keys";
+        container encrypted-symmetric-key {
+          must '../key-format';
+          description
+            "A container for the encrypted symmetric key value.
+             The interpretation of the 'encrypted-value' node
+             is via the 'key-format' node";
+          uses encrypted-value-grouping;
+        }
+      }
+    }
+  }
+
+  grouping public-key-grouping {
+    description
+      "A public key.";
+    leaf public-key-format {
+      nacm:default-deny-write;
+      type identityref {
+        base public-key-format;
+      }
+      mandatory true;
+      description
+        "Identifies the public key's format.  Implementations SHOULD
+         ensure that the incoming public key value is encoded in the
+         specified format.";
+    }
+    leaf public-key {
+      nacm:default-deny-write;
+      type binary;
+      mandatory true;
+      description
+        "The binary value of the public key.  The interpretation
+         of the value is defined by the 'public-key-format' field.";
+    }
+  }
+
+  grouping private-key-grouping {
+    description
+      "A private key.";
+    leaf private-key-format {
+      nacm:default-deny-write;
+      type identityref {
+        base private-key-format;
+      }
+      description
+        "Identifies the private key's format.  Implementations SHOULD
+         ensure that the incoming private key value is encoded in the
+         specified format.
+
+         For encrypted keys, the value is the decrypted key's
+         format (i.e., the 'encrypted-value-format' conveys the
+         encrypted key's format).";
+    }
+    choice private-key-type {
+      nacm:default-deny-write;
+      mandatory true;
+      description
+        "Choice between key types.";
+      case cleartext-private-key {
+        if-feature "cleartext-private-keys";
+        leaf cleartext-private-key {
+          nacm:default-deny-all;
+          type binary;
+          must '../private-key-format';
+          description
+            "The value of the binary key.  The key's value is
+             interpreted by the 'private-key-format' field.";
+        }
+      }
+      case hidden-private-key {
+        if-feature "hidden-private-keys";
+        leaf hidden-private-key {
+          type empty;
+          must 'not(../private-key-format)';
+          description
+            "A hidden key.  It is of type 'empty' as its value is
+             inaccessible via management interfaces.  Though hidden
+             to users, such keys are not hidden to the server and
+             may be referenced by configuration to indicate which
+             key a server should use for a cryptographic operation.
+             How such keys are created is outside the scope of this
+             module.";
+        }
+      }
+      case encrypted-private-key {
+        if-feature "encrypted-private-keys";
+        container encrypted-private-key {
+          must '../private-key-format';
+          description
+            "A container for the encrypted asymmetric private key
+             value.  The interpretation of the 'encrypted-value'
+             node is via the 'private-key-format' node";
+          uses encrypted-value-grouping;
+        }
+      }
+    }
+  }
+
+  grouping asymmetric-key-pair-grouping {
+    description
+      "A private key and, optionally, its associated public key.
+       Implementations MUST ensure that the two keys, when both
+       are specified, are a matching pair.";
+    uses public-key-grouping {
+      refine "public-key-format" {
+        mandatory false;
+      }
+      refine "public-key" {
+        mandatory false;
+      }
+    }
+    uses private-key-grouping;
+  }
+
+  grouping certificate-expiration-grouping {
+    description
+      "A notification for when a certificate is about to expire or
+       has already expired.";
+    notification certificate-expiration {
+      if-feature "certificate-expiration-notification";
+      description
+        "A notification indicating that the configured certificate
+         is either about to expire or has already expired.  When to
+         send notifications is an implementation-specific decision,
+         but it is RECOMMENDED that a notification be sent once a
+         month for 3 months, then once a week for four weeks, and
+         then once a day thereafter until the issue is resolved.
+
+         If the certificate's issuer maintains a Certificate
+         Revocation List (CRL), the expiration notification MAY
+         be sent if the CRL is about to expire.";
+      leaf expiration-date {
+        type yang:date-and-time;
+        mandatory true;
+        description
+          "Identifies the expiration date on the certificate.";
+      }
+    }
+  }
+
+  grouping trust-anchor-cert-grouping {
+    description
+      "A trust anchor certificate and a notification for when
+       it is about to expire or has already expired.";
+    leaf cert-data {
+      nacm:default-deny-all;
+      type trust-anchor-cert-cms;
+      description
+        "The binary certificate data for this certificate.";
+    }
+    uses certificate-expiration-grouping;
+  }
+
+  grouping end-entity-cert-grouping {
+    description
+      "An end-entity certificate and a notification for when
+       it is about to expire or has already expired.  Implementations
+       SHOULD assert that, where used, the end-entity certificate
+       contains the expected public key.";
+    leaf cert-data {
+      nacm:default-deny-all;
+      type end-entity-cert-cms;
+      description
+        "The binary certificate data for this certificate.";
+    }
+    uses certificate-expiration-grouping;
+  }
+
+  grouping generate-csr-grouping {
+    description
+      "Defines the 'generate-csr' action.";
+    action generate-csr {
+      if-feature "csr-generation";
+      nacm:default-deny-all;
+      description
+        "Generates a certificate signing request structure for
+         the associated asymmetric key using the passed subject
+         and attribute values.
+
+         This 'action' statement is only available when the
+         associated 'public-key-format' node's value is
+         'subject-public-key-info-format'.";
+      input {
+        leaf csr-format {
+          type identityref {
+            base csr-format;
+          }
+          mandatory true;
+          description
+            "Specifies the format for the returned certificate.";
+        }
+        leaf csr-info {
+          type csr-info;
+          mandatory true;
+          description
+            "A CertificationRequestInfo structure, as defined in
+             RFC 2986.
+
+             Enables the client to provide a fully populated
+             CertificationRequestInfo structure that the server
+             only needs to sign in order to generate the complete
+             CertificationRequest structure to return in the
+             'output'.
+
+             The 'AlgorithmIdentifier' field contained inside
+             the 'SubjectPublicKeyInfo' field MUST be one known
+             to be supported by the device.";
+          reference
+            "RFC 2986:
+               PKCS #10: Certification Request Syntax Specification
+             RFC 9640:
+               YANG Data Types and Groupings for Cryptography";
+        }
+      }
+      output {
+        choice csr-type {
+          mandatory true;
+          description
+            "A choice amongst certificate signing request formats.
+             Additional formats MAY be augmented into this 'choice'
+             statement by future efforts.";
+          case p10-csr {
+            leaf p10-csr {
+              type p10-csr;
+              description
+                "A CertificationRequest, as defined in RFC 2986.";
+            }
+            description
+              "A CertificationRequest, as defined in RFC 2986.";
+            reference
+              "RFC 2986:
+                 PKCS #10: Certification Request Syntax Specification
+               RFC 9640:
+                 YANG Data Types and Groupings for Cryptography";
+          }
+        }
+      }
+    }
+  } // generate-csr-grouping
+
+  grouping asymmetric-key-pair-with-cert-grouping {
+    description
+      "A private/public key pair and an associated certificate.
+       Implementations MUST assert that the certificate contains
+       the matching public key.";
+    uses asymmetric-key-pair-grouping;
+    uses end-entity-cert-grouping;
+    uses generate-csr-grouping;
+  } // asymmetric-key-pair-with-cert-grouping
+
+  grouping asymmetric-key-pair-with-certs-grouping {
+    description
+      "A private/public key pair and a list of associated
+       certificates.  Implementations MUST assert that
+       certificates contain the matching public key.";
+    uses asymmetric-key-pair-grouping;
+    container certificates {
+      nacm:default-deny-write;
+      description
+        "Certificates associated with this asymmetric key.";
+      list certificate {
+        key "name";
+        description
+          "A certificate for this asymmetric key.";
+        leaf name {
+          type string;
+          description
+            "An arbitrary name for the certificate.";
+        }
+        uses end-entity-cert-grouping {
+          refine "cert-data" {
+            mandatory true;
+          }
+        }
+      }
+    }
+    uses generate-csr-grouping;
+  } // asymmetric-key-pair-with-certs-grouping
+
+}

--- a/modules/subscribed_notifications/ietf-keystore@2024-10-10.yang
+++ b/modules/subscribed_notifications/ietf-keystore@2024-10-10.yang
@@ -1,0 +1,407 @@
+module ietf-keystore {
+  yang-version 1.1;
+  namespace "urn:ietf:params:xml:ns:yang:ietf-keystore";
+  prefix ks;
+
+  import ietf-netconf-acm {
+    prefix nacm;
+    reference
+      "RFC 8341: Network Configuration Access Control Model";
+  }
+
+  import ietf-crypto-types {
+    prefix ct;
+    reference
+      "RFC 9640: YANG Data Types and Groupings for Cryptography";
+  }
+
+  organization
+    "IETF NETCONF (Network Configuration) Working Group";
+
+  contact
+    "WG Web:   https://datatracker.ietf.org/wg/netconf
+     WG List:  NETCONF WG list <mailto:netconf@ietf.org>
+     Author:   Kent Watsen <mailto:kent+ietf@watsen.net>";
+
+  description
+    "This module defines a 'keystore' to centralize management
+     of security credentials.
+
+     The key words 'MUST', 'MUST NOT', 'REQUIRED', 'SHALL',
+     'SHALL NOT', 'SHOULD', 'SHOULD NOT', 'RECOMMENDED',
+     'NOT RECOMMENDED', 'MAY', and 'OPTIONAL' in this document
+     are to be interpreted as described in BCP 14 (RFC 2119)
+     (RFC 8174) when, and only when, they appear in all
+     capitals, as shown here.
+
+     Copyright (c) 2024 IETF Trust and the persons identified
+     as authors of the code. All rights reserved.
+
+     Redistribution and use in source and binary forms, with
+     or without modification, is permitted pursuant to, and
+     subject to the license terms contained in, the Revised
+     BSD License set forth in Section 4.c of the IETF Trust's
+     Legal Provisions Relating to IETF Documents
+     (https://trustee.ietf.org/license-info).
+
+     This version of this YANG module is part of RFC 9642
+     (https://www.rfc-editor.org/info/rfc9642); see the RFC
+     itself for full legal notices.";
+
+  revision 2024-10-10 {
+    description
+      "Initial version";
+    reference
+      "RFC 9642: A YANG Data Model for a Keystore";
+  }
+
+  /****************/
+  /*   Features   */
+  /****************/
+
+  feature central-keystore-supported {
+    description
+      "The 'central-keystore-supported' feature indicates that
+       the server supports the central keystore (i.e., fully
+       implements the 'ietf-keystore' module).";
+  }
+
+  feature inline-definitions-supported {
+    description
+      "The 'inline-definitions-supported' feature indicates that
+       the server supports locally defined keys.";
+  }
+
+  feature asymmetric-keys {
+    description
+      "The 'asymmetric-keys' feature indicates that the server
+       implements the /keystore/asymmetric-keys subtree.";
+
+  }
+
+  feature symmetric-keys {
+    description
+      "The 'symmetric-keys' feature indicates that the server
+       implements the /keystore/symmetric-keys subtree.";
+  }
+
+  /****************/
+  /*   Typedefs   */
+  /****************/
+
+  typedef central-symmetric-key-ref {
+    type leafref {
+      path "/ks:keystore/ks:symmetric-keys/ks:symmetric-key"
+         + "/ks:name";
+    }
+    description
+      "This typedef enables modules to easily define a reference
+       to a symmetric key stored in the central keystore.";
+  }
+
+  typedef central-asymmetric-key-ref {
+    type leafref {
+      path "/ks:keystore/ks:asymmetric-keys/ks:asymmetric-key"
+         + "/ks:name";
+    }
+    description
+      "This typedef enables modules to easily define a reference
+       to an asymmetric key stored in the central keystore.";
+  }
+
+  /*****************/
+  /*   Groupings   */
+  /*****************/
+
+  grouping encrypted-by-grouping {
+    description
+      "A grouping that defines a 'choice' statement that can be
+       augmented into the 'encrypted-by' node, present in the
+       'symmetric-key-grouping' and 'asymmetric-key-pair-grouping'
+       groupings defined in RFC 9640, enabling references to keys
+       in the central keystore.";
+    choice encrypted-by {
+      nacm:default-deny-write;
+      mandatory true;
+      description
+        "A choice amongst other symmetric or asymmetric keys.";
+      case central-symmetric-key-ref {
+        if-feature "central-keystore-supported";
+        if-feature "symmetric-keys";
+        leaf symmetric-key-ref {
+          type ks:central-symmetric-key-ref;
+          description
+            "Identifies the symmetric key used to encrypt the
+             associated key.";
+        }
+      }
+      case central-asymmetric-key-ref {
+        if-feature "central-keystore-supported";
+        if-feature "asymmetric-keys";
+        leaf asymmetric-key-ref {
+          type ks:central-asymmetric-key-ref;
+          description
+            "Identifies the asymmetric key whose public key
+             encrypted the associated key.";
+        }
+      }
+    }
+  }
+
+  // *-ref groupings
+
+  grouping central-asymmetric-key-certificate-ref-grouping {
+    description
+      "A grouping for the reference to a certificate associated
+       with an asymmetric key stored in the central keystore.";
+    leaf asymmetric-key {
+      nacm:default-deny-write;
+      if-feature "central-keystore-supported";
+      if-feature "asymmetric-keys";
+      type ks:central-asymmetric-key-ref;
+      must '../certificate';
+      description
+        "A reference to an asymmetric key in the keystore.";
+    }
+    leaf certificate {
+      nacm:default-deny-write;
+      type leafref {
+        path "/ks:keystore/ks:asymmetric-keys/ks:asymmetric-key"
+           + "[ks:name = current()/../asymmetric-key]/"
+           + "ks:certificates/ks:certificate/ks:name";
+      }
+      must '../asymmetric-key';
+      description
+        "A reference to a specific certificate of the
+         asymmetric key in the keystore.";
+    }
+  }
+
+  // inline-or-keystore-* groupings
+
+  grouping inline-or-keystore-symmetric-key-grouping {
+    description
+      "A grouping for the configuration of a symmetric key.  The
+       symmetric key may be defined inline or as a reference to
+       a symmetric key stored in the central keystore.
+
+       Servers that wish to define alternate keystore locations
+       SHOULD augment in custom 'case' statements enabling
+       references to those alternate keystore locations.";
+    choice inline-or-keystore {
+      nacm:default-deny-write;
+      mandatory true;
+      description
+        "A choice between an inlined definition and a definition
+         that exists in the keystore.";
+      case inline {
+        if-feature "inline-definitions-supported";
+        container inline-definition {
+          description
+            "A container to hold the local key definition.";
+          uses ct:symmetric-key-grouping;
+        }
+      }
+      case central-keystore {
+        if-feature "central-keystore-supported";
+        if-feature "symmetric-keys";
+        leaf central-keystore-reference {
+          type ks:central-symmetric-key-ref;
+          description
+            "A reference to a symmetric key that exists in
+             the central keystore.";
+        }
+      }
+    }
+  }
+
+  grouping inline-or-keystore-asymmetric-key-grouping {
+    description
+      "A grouping for the configuration of an asymmetric key.  The
+       asymmetric key may be defined inline or as a reference to
+       an asymmetric key stored in the central keystore.
+
+       Servers that wish to define alternate keystore locations
+       SHOULD augment in custom 'case' statements enabling
+       references to those alternate keystore locations.";
+    choice inline-or-keystore {
+      nacm:default-deny-write;
+      mandatory true;
+      description
+        "A choice between an inlined definition and a definition
+         that exists in the keystore.";
+      case inline {
+        if-feature "inline-definitions-supported";
+        container inline-definition {
+          description
+            "A container to hold the local key definition.";
+          uses ct:asymmetric-key-pair-grouping;
+        }
+      }
+      case central-keystore {
+        if-feature "central-keystore-supported";
+        if-feature "asymmetric-keys";
+        leaf central-keystore-reference {
+          type ks:central-asymmetric-key-ref;
+          description
+            "A reference to an asymmetric key that exists in
+             the central keystore.  The intent is to reference
+             just the asymmetric key without any regard for
+             any certificates that may be associated with it.";
+        }
+      }
+    }
+  }
+
+  grouping inline-or-keystore-asymmetric-key-with-certs-grouping {
+    description
+      "A grouping for the configuration of an asymmetric key and
+       its associated certificates.  The asymmetric key and its
+       associated certificates may be defined inline or as a
+       reference to an asymmetric key (and its associated
+       certificates) in the central keystore.
+
+       Servers that wish to define alternate keystore locations
+       SHOULD augment in custom 'case' statements enabling
+       references to those alternate keystore locations.";
+    choice inline-or-keystore {
+      nacm:default-deny-write;
+      mandatory true;
+      description
+        "A choice between an inlined definition and a definition
+         that exists in the keystore.";
+      case inline {
+        if-feature "inline-definitions-supported";
+        container inline-definition {
+          description
+            "A container to hold the local key definition.";
+          uses ct:asymmetric-key-pair-with-certs-grouping;
+        }
+      }
+      case central-keystore {
+        if-feature "central-keystore-supported";
+        if-feature "asymmetric-keys";
+        leaf central-keystore-reference {
+          type ks:central-asymmetric-key-ref;
+          description
+            "A reference to an asymmetric key (and all of its
+             associated certificates) in the keystore, when
+             this module is implemented.";
+        }
+      }
+    }
+  }
+
+  grouping inline-or-keystore-end-entity-cert-with-key-grouping {
+    description
+      "A grouping for the configuration of an asymmetric key and
+       its associated end-entity certificate.  The asymmetric key
+       and its associated end-entity certificate may be defined
+       inline or as a reference to an asymmetric key (and its
+       associated end-entity certificate) in the central keystore.
+
+       Servers that wish to define alternate keystore locations
+       SHOULD augment in custom 'case' statements enabling
+       references to those alternate keystore locations.";
+    choice inline-or-keystore {
+      nacm:default-deny-write;
+      mandatory true;
+      description
+        "A choice between an inlined definition and a definition
+         that exists in the keystore.";
+      case inline {
+        if-feature "inline-definitions-supported";
+        container inline-definition {
+          description
+            "A container to hold the local key definition.";
+          uses ct:asymmetric-key-pair-with-cert-grouping;
+        }
+      }
+      case central-keystore {
+        if-feature "central-keystore-supported";
+        if-feature "asymmetric-keys";
+        container central-keystore-reference {
+          uses central-asymmetric-key-certificate-ref-grouping;
+          description
+            "A reference to a specific certificate associated with
+             an asymmetric key stored in the central keystore.";
+        }
+      }
+    }
+  }
+
+  // the keystore grouping
+
+  grouping keystore-grouping {
+    description
+      "A grouping definition enables use in other contexts.  If ever
+       done, implementations MUST augment new 'case' statements
+       into the various inline-or-keystore 'choice' statements to
+       supply leafrefs to the model-specific location(s).";
+    container asymmetric-keys {
+      nacm:default-deny-write;
+      if-feature "asymmetric-keys";
+      description
+        "A list of asymmetric keys.";
+      list asymmetric-key {
+        key "name";
+        description
+          "An asymmetric key.";
+        leaf name {
+          type string;
+          description
+            "An arbitrary name for the asymmetric key.";
+        }
+        uses ct:asymmetric-key-pair-with-certs-grouping;
+      }
+    }
+    container symmetric-keys {
+      nacm:default-deny-write;
+      if-feature "symmetric-keys";
+      description
+        "A list of symmetric keys.";
+      list symmetric-key {
+        key "name";
+        description
+          "A symmetric key.";
+        leaf name {
+          type string;
+          description
+            "An arbitrary name for the symmetric key.";
+        }
+        uses ct:symmetric-key-grouping;
+      }
+    }
+  }
+
+  /*********************************/
+  /*   Protocol accessible nodes   */
+  /*********************************/
+
+  container keystore {
+    if-feature "central-keystore-supported";
+    description
+      "A central keystore containing a list of symmetric keys and
+       a list of asymmetric keys.";
+    nacm:default-deny-write;
+    uses keystore-grouping {
+      augment "symmetric-keys/symmetric-key/key-type/encrypted-"
+            + "symmetric-key/encrypted-symmetric-key/encrypted-by" {
+        description
+          "Augments in a choice statement enabling the encrypting
+           key to be any other symmetric or asymmetric key in the
+           central keystore.";
+        uses encrypted-by-grouping;
+      }
+      augment "asymmetric-keys/asymmetric-key/private-key-type/"
+            + "encrypted-private-key/encrypted-private-key/"
+            + "encrypted-by" {
+        description
+          "Augments in a choice statement enabling the encrypting
+           key to be any other symmetric or asymmetric key in the
+           central keystore.";
+        uses encrypted-by-grouping;
+      }
+    }
+  }
+}

--- a/modules/subscribed_notifications/ietf-subscribed-notif-receivers@2024-02-01.yang
+++ b/modules/subscribed_notifications/ietf-subscribed-notif-receivers@2024-02-01.yang
@@ -1,0 +1,110 @@
+module ietf-subscribed-notif-receivers {
+  yang-version 1.1;
+  namespace
+    "urn:ietf:params:xml:ns:yang:ietf-subscribed-notif-receivers";
+  prefix "snr";
+
+  import ietf-subscribed-notifications {
+    prefix sn;
+    reference
+      "RFC 8639: Subscription to YANG Notifications";
+  }
+
+  organization
+    "IETF NETCONF Working Group";
+
+  contact
+    "WG Web:   <http://datatracker.ietf.org/wg/netconf>
+     WG List:  <netconf@ietf.org>
+
+     Authors: Mahesh Jethanandani (mjethanandani at gmail dot com)
+              Kent Watsen (kent plus ietf at watsen dot net)";
+
+  description
+    "This YANG module is implemented by Publishers implementing
+     the 'ietf-subscribed-notifications' module defined in RFC 8639.
+
+     While this module is defined in RFC XXXX, which primarily
+     defines an HTTPS-based transport for notifications, this module
+     is not HTTP-specific.  It is a generic extension that can be
+     used by any 'notif' transport.
+
+     This module defines two 'augment' statements.  One statement
+     augments a 'container' statement called 'receiver-instances'
+     into the top-level 'subscriptions' container.  The other
+     statement, called 'receiver-instance-ref', augments a 'leaf'
+     statement into each 'receiver' that references one of the
+     afore mentioned receiver instances.  This indirection enables
+     multiple configured subscriptions to send notifications to
+     the same receiver instance.
+
+     Copyright (c) 2024 IETF Trust and the persons identified as
+     authors of the code.  All rights reserved.
+     Redistribution and use in source and binary forms, with or
+     without modification, is permitted pursuant to, and subject
+     to the license terms contained in, the Revised BSD
+     License set forth in Section 4.c of the IETF Trust's Legal
+     Provisions Relating to IETF Documents
+     (http://trustee.ietf.org/license-info).
+
+     This version of this YANG module is part of RFC XXXX; see
+     the RFC itself for full legal notices.
+
+     The key words 'MUST', 'MUST NOT', 'REQUIRED', 'SHALL', 'SHALL
+     NOT', 'SHOULD', 'SHOULD NOT', 'RECOMMENDED', 'NOT RECOMMENDED',
+     'MAY', and 'OPTIONAL' in this document are to be interpreted as
+     described in BCP 14 (RFC 2119) (RFC 8174) when, and only when,
+     they appear in all capitals, as shown here.";
+
+  revision "2024-02-01" {
+    description
+      "Initial Version.";
+    reference
+      "RFC XXXX: An HTTPS-based Transport for YANG Notifications.";
+  }
+
+  augment "/sn:subscriptions" {
+    container receiver-instances {
+      description
+        "A container for all instances of receivers.";
+
+      list receiver-instance {
+        key "name";
+
+        leaf name {
+          type string;
+          description
+            "An arbitrary but unique name for this receiver
+             instance.";
+        }
+
+        choice transport-type {
+          mandatory true;
+          description
+            "Choice of different types of transports used to
+             send notifications.  The 'case' statements must
+             be augmented in by other modules.";
+        }
+        description
+          "A list of all receiver instances.";
+      }
+    }
+    description
+      "Augment the subscriptions container to define the
+       transport type.";
+  }
+  augment
+    "/sn:subscriptions/sn:subscription/sn:receivers/sn:receiver" {
+    leaf receiver-instance-ref {
+      type leafref {
+        path "/sn:subscriptions/snr:receiver-instances/" +
+             "snr:receiver-instance/snr:name";
+      }
+      description
+        "Reference to a receiver instance.";
+    }
+    description
+      "Augment the subscriptions container to define an optional
+       reference to a receiver instance.";
+  }
+}

--- a/modules/subscribed_notifications/ietf-tls-client@2024-03-16.yang
+++ b/modules/subscribed_notifications/ietf-tls-client@2024-03-16.yang
@@ -1,0 +1,525 @@
+module ietf-tls-client {
+  yang-version 1.1;
+  namespace "urn:ietf:params:xml:ns:yang:ietf-tls-client";
+  prefix tlsc;
+
+  import ietf-netconf-acm {
+    prefix nacm;
+    reference
+      "RFC 8341: Network Configuration Access Control Model";
+  }
+
+  import ietf-crypto-types {
+    prefix ct;
+    reference
+      "RFC AAAA: YANG Data Types and Groupings for Cryptography";
+  }
+
+  import ietf-truststore {
+    prefix ts;
+    reference
+      "RFC BBBB: A YANG Data Model for a Truststore";
+  }
+
+  import ietf-keystore {
+    prefix ks;
+    reference
+      "RFC CCCC: A YANG Data Model for a Keystore";
+  }
+
+  import ietf-tls-common {
+    prefix tlscmn;
+    reference
+      "RFC FFFF: YANG Groupings for TLS Clients and TLS Servers";
+  }
+
+  organization
+    "IETF NETCONF (Network Configuration) Working Group";
+
+  contact
+    "WG List:  NETCONF WG list <mailto:netconf@ietf.org>
+     WG Web:   https://datatracker.ietf.org/wg/netconf
+     Author:   Kent Watsen <mailto:kent+ietf@watsen.net>
+     Author:   Jeff Hartley <mailto:intensifysecurity@gmail.com>";
+
+  description
+    "This module defines reusable groupings for TLS clients that
+     can be used as a basis for specific TLS client instances.
+
+     Copyright (c) 2024 IETF Trust and the persons identified
+     as authors of the code. All rights reserved.
+
+     Redistribution and use in source and binary forms, with
+     or without modification, is permitted pursuant to, and
+     subject to the license terms contained in, the Revised
+     BSD License set forth in Section 4.c of the IETF Trust's
+     Legal Provisions Relating to IETF Documents
+     (https://trustee.ietf.org/license-info).
+
+     This version of this YANG module is part of RFC FFFF
+     (https://www.rfc-editor.org/info/rfcFFFF); see the RFC
+     itself for full legal notices.
+
+     The key words 'MUST', 'MUST NOT', 'REQUIRED', 'SHALL',
+     'SHALL NOT', 'SHOULD', 'SHOULD NOT', 'RECOMMENDED',
+     'NOT RECOMMENDED', 'MAY', and 'OPTIONAL' in this document
+     are to be interpreted as described in BCP 14 (RFC 2119)
+     (RFC 8174) when, and only when, they appear in all
+     capitals, as shown here.";
+
+  revision 2024-03-16 {
+    description
+      "Initial version";
+    reference
+      "RFC FFFF: YANG Groupings for TLS Clients and TLS Servers";
+  }
+
+  // Features
+
+  feature tls-client-keepalives {
+    description
+      "Per socket TLS keepalive parameters are configurable for
+       TLS clients on the server implementing this feature.";
+  }
+
+  feature client-ident-x509-cert {
+    description
+      "Indicates that the client supports identifying itself
+       using X.509 certificates.";
+    reference
+      "RFC 5280:
+         Internet X.509 Public Key Infrastructure Certificate
+         and Certificate Revocation List (CRL) Profile";
+  }
+
+  feature client-ident-raw-public-key {
+    description
+      "Indicates that the client supports identifying itself
+       using raw public keys.";
+    reference
+      "RFC 7250:
+         Using Raw Public Keys in Transport Layer Security (TLS)
+         and Datagram Transport Layer Security (DTLS)";
+  }
+
+  feature client-ident-tls12-psk {
+    if-feature "tlscmn:tls12";
+    description
+      "Indicates that the client supports identifying itself
+       using TLS-1.2 PSKs (pre-shared or pairwise-symmetric keys).";
+    reference
+      "RFC 4279:
+         Pre-Shared Key Ciphersuites for Transport Layer Security
+         (TLS)";
+  }
+
+  feature client-ident-tls13-epsk {
+    if-feature "tlscmn:tls13";
+    description
+      "Indicates that the client supports identifying itself
+       using TLS-1.3 External PSKs (pre-shared keys).";
+    reference
+      "RFC 8446:
+         The Transport Layer Security (TLS) Protocol Version 1.3";
+  }
+
+  feature server-auth-x509-cert {
+    description
+      "Indicates that the client supports authenticating servers
+       using X.509 certificates.";
+    reference
+      "RFC 5280:
+         Internet X.509 Public Key Infrastructure Certificate
+         and Certificate Revocation List (CRL) Profile";
+  }
+
+  feature server-auth-raw-public-key {
+    description
+      "Indicates that the client supports authenticating servers
+       using raw public keys.";
+    reference
+      "RFC 7250:
+         Using Raw Public Keys in Transport Layer Security (TLS)
+         and Datagram Transport Layer Security (DTLS)";
+  }
+
+  feature server-auth-tls12-psk {
+    description
+      "Indicates that the client supports authenticating servers
+       using PSKs (pre-shared or pairwise-symmetric keys).";
+    reference
+      "RFC 4279:
+         Pre-Shared Key Ciphersuites for Transport Layer Security
+         (TLS)";
+  }
+
+  feature server-auth-tls13-epsk {
+    description
+      "Indicates that the client supports authenticating servers
+       using TLS-1.3 External PSKs (pre-shared keys).";
+    reference
+      "RFC 8446:
+         The Transport Layer Security (TLS) Protocol Version 1.3";
+  }
+
+  // Groupings
+
+  grouping tls-client-grouping {
+    description
+      "A reusable grouping for configuring a TLS client without
+       any consideration for how an underlying TCP session is
+       established.
+
+       Note that this grouping uses fairly typical descendant
+       node names such that a stack of 'uses' statements will
+       have name conflicts.  It is intended that the consuming
+       data model will resolve the issue (e.g., by wrapping
+       the 'uses' statement in a container called
+       'tls-client-parameters').  This model purposely does
+       not do this itself so as to provide maximum flexibility
+       to consuming models.";
+
+    container client-identity {
+      nacm:default-deny-write;
+      presence
+        "Indicates that a TLS-level client identity has been
+         configured.  This statement is present so the mandatory
+         descendant do not imply that this node must be configured.";
+      description
+        "Identity credentials the TLS client MAY present when
+         establishing a connection to a TLS server.  If not
+         configured, then client authentication is presumed to
+         occur in a protocol layer above TLS.  When configured,
+         and requested by the TLS server when establishing a
+         TLS session, these credentials are passed in the
+         Certificate message defined in Section 7.4.2 of
+         RFC 5246 and Section 4.4.2 in RFC 8446.";
+      reference
+        "RFC 5246: The Transport Layer Security (TLS)
+                   Protocol Version 1.2
+         RFC 8446: The Transport Layer Security (TLS)
+                   Protocol Version 1.3
+         RFC CCCC: A YANG Data Model for a Keystore";
+      choice auth-type {
+        mandatory true;
+        description
+          "A choice amongst authentication types, of which one must
+           be enabled (via its associated 'feature') and selected.";
+        case certificate {
+          if-feature "client-ident-x509-cert";
+          container certificate {
+            description
+              "Specifies the client identity using a certificate.";
+            uses
+              "ks:inline-or-keystore-end-entity-cert-with-key-"
+              + "grouping" {
+              refine "inline-or-keystore/inline/inline-definition" {
+                must 'not(public-key-format) or derived-from-or-self'
+                   + '(public-key-format, "ct:subject-public-key-'
+                   + 'info-format")';
+              }
+              refine "inline-or-keystore/central-keystore/"
+                   + "central-keystore-reference/asymmetric-key" {
+                must 'not(deref(.)/../ks:public-key-format) or '
+                   + 'derived-from-or-self(deref(.)/../ks:public-'
+                   + 'key-format, "ct:subject-public-key-info-'
+                   + 'format")';
+              }
+            }
+          }
+        }
+        case raw-public-key {
+          if-feature "client-ident-raw-public-key";
+          container raw-private-key {
+            description
+              "Specifies the client identity using a raw
+               private key.";
+            uses ks:inline-or-keystore-asymmetric-key-grouping {
+              refine "inline-or-keystore/inline/inline-definition" {
+                must 'not(public-key-format) or derived-from-or-self'
+                   + '(public-key-format, "ct:subject-public-key-'
+                   + 'info-format")';
+              }
+              refine "inline-or-keystore/central-keystore/"
+                   + "central-keystore-reference" {
+                must 'not(deref(.)/../ks:public-key-format) or '
+                   + 'derived-from-or-self(deref(.)/../ks:public-'
+                   + 'key-format, "ct:subject-public-key-info-'
+                   + 'format")';
+              }
+            }
+          }
+        }
+        case tls12-psk {
+          if-feature "client-ident-tls12-psk";
+          container tls12-psk {
+            description
+              "Specifies the client identity using a PSK (pre-shared
+               or pairwise-symmetric key).";
+            uses ks:inline-or-keystore-symmetric-key-grouping;
+            leaf id {
+              type string;
+              description
+                "The key 'psk_identity' value used in the TLS
+                 'ClientKeyExchange' message.";
+              reference
+                "RFC 4279: Pre-Shared Key Ciphersuites for
+                           Transport Layer Security (TLS)";
+            }
+          }
+        }
+        case tls13-epsk {
+          if-feature "client-ident-tls13-epsk";
+          container tls13-epsk {
+            description
+              "An External Pre-Shared Key (EPSK) is established
+              or provisioned out-of-band, i.e., not from a TLS
+              connection.  An EPSK is a tuple of (Base Key,
+              External Identity, Hash).  External PSKs MUST NOT
+              be imported for (D)TLS 1.2 or prior versions.  When
+              PSKs are provisioned out of band, the PSK identity
+              and the KDF hash algorithm to be used with the PSK
+              MUST also be provisioned.
+
+              The structure of this container is designed to
+              satisfy the requirements of RFC 8446 Section
+              4.2.11, the recommendations from Section 6 in
+              RFC 9257, and the EPSK input fields detailed in
+              Section 5.1 in RFC 9258.  The base-key is based
+              upon ks:inline-or-keystore-symmetric-key-grouping
+              in order to provide users with flexible and
+              secure storage options.";
+            reference
+              "RFC 8446: The Transport Layer Security (TLS)
+                         Protocol Version 1.3
+               RFC 9257: Guidance for External Pre-Shared Key
+                         (PSK) Usage in TLS
+               RFC 9258: Importing External Pre-Shared Keys
+                         (PSKs) for TLS 1.3";
+            uses ks:inline-or-keystore-symmetric-key-grouping;
+            leaf external-identity {
+              type string;
+              mandatory true;
+              description
+                "As per Section 4.2.11 of RFC 8446, and Section 4.1
+                 of RFC 9257, a sequence of bytes used to identify
+                 an EPSK. A label for a pre-shared key established
+                 externally.";
+              reference
+                "RFC 8446: The Transport Layer Security (TLS)
+                           Protocol Version 1.3
+                 RFC 9257: Guidance for External Pre-Shared Key
+                           (PSK) Usage in TLS";
+            }
+            leaf hash {
+              type tlscmn:epsk-supported-hash;
+              default sha-256;
+              description
+                "As per Section 4.2.11 of RFC 8446, for externally
+                 established PSKs, the Hash algorithm MUST be set
+                 when the PSK is established or default to SHA-256
+                 if no such algorithm is defined.  The server MUST
+                 ensure that it selects a compatible PSK (if any)
+                 and cipher suite.  Each PSK MUST only be used with
+                 a single hash function.";
+              reference
+                "RFC 8446: The Transport Layer Security (TLS)
+                           Protocol Version 1.3";
+            }
+            leaf context {
+              type string;
+              description
+                "Per Section 5.1 of RFC 9258, context MUST include
+                 the context used to determine the EPSK, if
+                 any exists. For example, context may include
+                 information about peer roles or identities
+                 to mitigate Selfie-style reflection attacks.
+                 Since the EPSK is a key derived from an external
+                 protocol or sequence of protocols, context MUST
+                 include a channel binding for the deriving
+                 protocols [RFC5056].  The details of this
+                 binding are protocol specfic and out of scope
+                 for this document.";
+              reference
+                "RFC 9258: Importing External Pre-Shared Keys
+                           (PSKs) for TLS 1.3";
+            }
+            leaf target-protocol {
+              type uint16;
+              description
+                "As per Section 3 of RFC 9258, the protocol
+                 for which a PSK is imported for use.";
+              reference
+                "RFC 9258: Importing External Pre-Shared Keys
+                           (PSKs) for TLS 1.3";
+            }
+            leaf target-kdf {
+              type uint16;
+              description
+                "As per Section 3 of RFC 9258, the KDF for
+                 which a PSK is imported for use.";
+              reference
+                "RFC 9258: Importing External Pre-Shared Keys
+                           (PSKs) for TLS 1.3";
+            }
+          }
+        }
+      }
+    } // container client-identity
+
+    container server-authentication {
+      nacm:default-deny-write;
+      must 'ca-certs or ee-certs or raw-public-keys or tls12-psks
+        or tls13-epsks';
+      description
+        "Specifies how the TLS client can authenticate TLS servers.
+         Any combination of credentials is additive and unordered.
+
+         Note that no configuration is required for PSK (pre-shared
+         or pairwise-symmetric key) based authentication as the key
+         is necessarily the same as configured in the '../client-
+         identity' node.";
+      container ca-certs {
+        if-feature "server-auth-x509-cert";
+        presence
+          "Indicates that CA certificates have been configured.
+           This statement is present so the mandatory descendant
+           nodes do not imply that this node must be configured.";
+        description
+          "A set of certificate authority (CA) certificates used by
+           the TLS client to authenticate TLS server certificates.
+           A server certificate is authenticated if it has a valid
+           chain of trust to a configured CA certificate.";
+        reference
+          "RFC BBBB: A YANG Data Model for a Truststore";
+        uses ts:inline-or-truststore-certs-grouping;
+      }
+      container ee-certs {
+        if-feature "server-auth-x509-cert";
+        presence
+          "Indicates that EE certificates have been configured.
+           This statement is present so the mandatory descendant
+           nodes do not imply that this node must be configured.";
+        description
+          "A set of server certificates (i.e., end entity
+           certificates) used by the TLS client to authenticate
+           certificates presented by TLS servers.  A server
+           certificate is authenticated if it is an exact
+           match to a configured server certificate.";
+        reference
+          "RFC BBBB: A YANG Data Model for a Truststore";
+        uses ts:inline-or-truststore-certs-grouping;
+      }
+      container raw-public-keys {
+        if-feature "server-auth-raw-public-key";
+        presence
+          "Indicates that raw public keys have been configured.
+           This statement is present so the mandatory descendant
+           nodes do not imply that this node must be configured.";
+        description
+          "A set of raw public keys used by the TLS client to
+           authenticate raw public keys presented by the TLS
+           server.  A raw public key is authenticated if it
+           is an exact match to a configured raw public key.";
+        reference
+          "RFC BBBB: A YANG Data Model for a Truststore";
+        uses ts:inline-or-truststore-public-keys-grouping {
+          refine "inline-or-truststore/inline/inline-definition/"
+               + "public-key" {
+            must 'derived-from-or-self(public-key-format,'
+               + ' "ct:subject-public-key-info-format")';
+          }
+          refine "inline-or-truststore/central-truststore/"
+               + "central-truststore-reference" {
+            must 'not(deref(.)/../ts:public-key/ts:public-key-'
+               + 'format[not(derived-from-or-self(., "ct:subject-'
+               + 'public-key-info-format"))])';
+          }
+        }
+      }
+      leaf tls12-psks {
+        if-feature "server-auth-tls12-psk";
+        type empty;
+        description
+          "Indicates that the TLS client can authenticate TLS servers
+           using configured PSKs (pre-shared or pairwise-symmetric
+           keys).
+
+           No configuration is required since the PSK value is the
+           same as PSK value configured in the 'client-identity'
+           node.";
+      }
+      leaf tls13-epsks {
+        if-feature "server-auth-tls13-epsk";
+        type empty;
+        description
+          "Indicates that the TLS client can authenticate TLS servers
+           using configured external PSKs (pre-shared keys).
+
+           No configuration is required since the PSK value is the
+           same as PSK value configured in the 'client-identity'
+           node.";
+      }
+    } // container server-authentication
+
+    container hello-params {
+      nacm:default-deny-write;
+      if-feature "tlscmn:hello-params";
+      uses tlscmn:hello-params-grouping;
+      description
+        "Configurable parameters for the TLS hello message.";
+    } // container hello-params
+    container keepalives {
+      nacm:default-deny-write;
+      if-feature "tls-client-keepalives";
+      description
+        "Configures the keepalive policy for the TLS client.";
+      leaf peer-allowed-to-send {
+        type empty;
+        description
+          "Indicates that the remote TLS server is allowed to send
+           HeartbeatRequest messages, as defined by RFC 6520
+           to this TLS client.";
+        reference
+          "RFC 6520: Transport Layer Security (TLS) and Datagram
+           Transport Layer Security (DTLS) Heartbeat Extension";
+      }
+      container test-peer-aliveness {
+        presence
+          "Indicates that the TLS client proactively tests the
+           aliveness of the remote TLS server.";
+        description
+          "Configures the keep-alive policy to proactively test
+           the aliveness of the TLS server.  An unresponsive
+           TLS server is dropped after approximately max-wait
+           * max-attempts seconds.  The TLS client MUST send
+           HeartbeatRequest messages, as defined by RFC 6520.";
+        reference
+          "RFC 6520: Transport Layer Security (TLS) and Datagram
+           Transport Layer Security (DTLS) Heartbeat Extension";
+        leaf max-wait {
+          type uint16 {
+            range "1..max";
+          }
+          units "seconds";
+          default "30";
+          description
+            "Sets the amount of time in seconds after which if
+             no data has been received from the TLS server, a
+             TLS-level message will be sent to test the
+             aliveness of the TLS server.";
+        }
+        leaf max-attempts {
+          type uint8;
+          default "3";
+          description
+            "Sets the maximum number of sequential keep-alive
+             messages that can fail to obtain a response from
+             the TLS server before assuming the TLS server is
+             no longer alive.";
+        }
+      }
+    }
+  } // grouping tls-client-grouping
+
+}

--- a/modules/subscribed_notifications/ietf-tls-common@2024-10-10.yang
+++ b/modules/subscribed_notifications/ietf-tls-common@2024-10-10.yang
@@ -1,0 +1,314 @@
+module ietf-tls-common {
+  yang-version 1.1;
+  namespace "urn:ietf:params:xml:ns:yang:ietf-tls-common";
+  prefix tlscmn;
+
+  import iana-tls-cipher-suite-algs {
+    prefix tlscsa;
+    reference
+      "RFC 9645: YANG Groupings for TLS Clients and TLS Servers";
+  }
+
+  import ietf-crypto-types {
+    prefix ct;
+    reference
+      "RFC 9640: YANG Data Types and Groupings for Cryptography";
+  }
+
+  import ietf-keystore {
+    prefix ks;
+    reference
+      "RFC 9642: A YANG Data Model for a Keystore";
+  }
+
+  organization
+    "IETF NETCONF (Network Configuration) Working Group";
+
+  contact
+    "WG List:  NETCONF WG list <mailto:netconf@ietf.org>
+     WG Web:   https://datatracker.ietf.org/wg/netconf
+     Author:   Kent Watsen <mailto:kent+ietf@watsen.net>
+     Author:   Jeff Hartley <mailto:intensifysecurity@gmail.com>
+     Author:   Gary Wu <mailto:garywu@cisco.com>";
+
+   description
+    "This module defines common features and groupings for
+     Transport Layer Security (TLS).
+
+     The key words 'MUST', 'MUST NOT', 'REQUIRED', 'SHALL',
+     'SHALL NOT', 'SHOULD', 'SHOULD NOT', 'RECOMMENDED',
+     'NOT RECOMMENDED', 'MAY', and 'OPTIONAL' in this document
+     are to be interpreted as described in BCP 14 (RFC 2119)
+     (RFC 8174) when, and only when, they appear in all
+     capitals, as shown here.
+
+     Copyright (c) 2024 IETF Trust and the persons identified
+     as authors of the code. All rights reserved.
+
+     Redistribution and use in source and binary forms, with
+     or without modification, is permitted pursuant to, and
+     subject to the license terms contained in, the Revised
+     BSD License set forth in Section 4.c of the IETF Trust's
+     Legal Provisions Relating to IETF Documents
+     (https://trustee.ietf.org/license-info).
+
+     This version of this YANG module is part of RFC 9645
+     (https://www.rfc-editor.org/info/rfc9645); see the RFC
+     itself for full legal notices.";
+
+  revision 2024-10-10 {
+    description
+      "Initial version.";
+    reference
+      "RFC 9645: YANG Groupings for TLS Clients and TLS Servers";
+  }
+
+  // Features
+
+  feature tls12 {
+    description
+      "TLS Protocol Version 1.2 is supported. TLS 1.2 is obsolete,
+       and thus it is NOT RECOMMENDED to enable this feature.";
+    reference
+      "RFC 5246: The Transport Layer Security (TLS) Protocol
+                 Version 1.2";
+  }
+
+  feature tls13 {
+    description
+      "TLS Protocol Version 1.3 is supported.";
+    reference
+      "RFC 8446: The Transport Layer Security (TLS)
+                 Protocol Version 1.3";
+  }
+
+  feature hello-params {
+    description
+      "TLS hello message parameters are configurable.";
+  }
+
+  feature algorithm-discovery {
+    description
+      "Indicates that the server implements the
+       'supported-algorithms' container.";
+  }
+
+  feature asymmetric-key-pair-generation {
+    description
+      "Indicates that the server implements the
+       'generate-asymmetric-key-pair' RPC.";
+  }
+
+  // Identities
+
+  identity tls-version-base {
+    description
+      "Base identity used to identify TLS protocol versions.";
+  }
+
+  identity tls12 {
+    if-feature "tls12";
+    base tls-version-base;
+    description
+      "TLS Protocol Version 1.2.";
+    reference
+      "RFC 5246: The Transport Layer Security (TLS) Protocol
+                 Version 1.2";
+  }
+
+  identity tls13 {
+    if-feature "tls13";
+    base tls-version-base;
+    description
+      "TLS Protocol Version 1.3.";
+    reference
+      "RFC 8446: The Transport Layer Security (TLS)
+                 Protocol Version 1.3";
+  }
+
+  // Typedefs
+
+  typedef epsk-supported-hash {
+    type enumeration {
+      enum sha-256 {
+        description
+          "The SHA-256 hash.";
+      }
+      enum sha-384 {
+        description
+          "The SHA-384 hash.";
+      }
+    }
+    description
+      "As per Section 4.2.11 of RFC 8446, the hash algorithm
+       supported by an instance of an External Pre-Shared
+       Key (EPSK).";
+    reference
+      "RFC 8446: The Transport Layer Security (TLS)
+                 Protocol Version 1.3";
+  }
+
+  // Groupings
+
+  grouping hello-params-grouping {
+    description
+      "A reusable grouping for TLS hello message parameters.";
+    reference
+      "RFC 5246: The Transport Layer Security (TLS) Protocol
+                 Version 1.2
+       RFC 8446: The Transport Layer Security (TLS) Protocol
+                 Version 1.3";
+    container tls-versions {
+      description
+        "Parameters limiting which TLS versions, amongst
+         those enabled by 'features', are presented during
+         the TLS handshake.";
+      leaf min {
+        type identityref {
+          base tls-version-base;
+        }
+        description
+          "If not specified, then there is no configured
+           minimum version.";
+      }
+      leaf max {
+        type identityref {
+          base tls-version-base;
+        }
+        description
+          "If not specified, then there is no configured
+           maximum version.";
+      }
+    }
+    container cipher-suites {
+      description
+        "Parameters regarding cipher suites.";
+      leaf-list cipher-suite {
+        type tlscsa:tls-cipher-suite-algorithm;
+        ordered-by user;
+        description
+          "Acceptable cipher suites in order of descending
+           preference.  The configured host key algorithms should
+           be compatible with the algorithm used by the configured
+           private key.  Please see Section 5 of RFC 9645 for
+           valid combinations.
+
+           If this leaf-list is not configured (has zero elements),
+           the acceptable cipher suites are implementation-
+           defined.";
+        reference
+          "RFC 9645: YANG Groupings for TLS Clients and TLS Servers";
+      }
+    }
+  } // hello-params-grouping
+
+  // Protocol-accessible Nodes
+
+  container supported-algorithms {
+    if-feature "algorithm-discovery";
+    config false;
+    description
+      "A container for a list of cipher suite algorithms supported
+       by the server.";
+    leaf-list supported-algorithm {
+      type tlscsa:tls-cipher-suite-algorithm;
+      description
+        "A cipher suite algorithm supported by the server.";
+    }
+  }
+
+  rpc generate-asymmetric-key-pair {
+    if-feature "asymmetric-key-pair-generation";
+    description
+      "Requests the device to generate an 'asymmetric-key-pair'
+       key using the specified key algorithm.";
+    input {
+      leaf algorithm {
+        type tlscsa:tls-cipher-suite-algorithm;
+        mandatory true;
+        description
+          "The cipher suite algorithm that the generated key
+           works with.  Implementations derive the public key
+           algorithm from the cipher suite algorithm.  For
+           example, cipher suite
+           'tls-rsa-with-aes-256-cbc-sha256' maps to the RSA
+           public key.";
+      }
+      leaf num-bits {
+        type uint16;
+        description
+          "Specifies the number of bits to create in the key.
+           For RSA keys, the minimum size is 1024 bits, and
+           the default is 3072 bits.  Generally, 3072 bits is
+           considered sufficient.  DSA keys must be exactly
+           1024 bits as specified by FIPS 186-2.  For
+           elliptical keys, the 'num-bits' value determines
+           the key length of the curve (e.g., 256, 384, or 521),
+           where valid values supported by the server are
+           conveyed via an unspecified mechanism.  For some
+           public algorithms, the keys have a fixed length, and
+           thus the 'num-bits' value is not specified.";
+      }
+      container private-key-encoding {
+        description
+          "Indicates how the private key is to be encoded.";
+        choice private-key-encoding {
+          mandatory true;
+          description
+            "A choice amongst optional private key handling.";
+          case cleartext {
+            if-feature "ct:cleartext-private-keys";
+            leaf cleartext {
+              type empty;
+              description
+                "Indicates that the private key is to be returned
+                 as a cleartext value.";
+            }
+          }
+          case encrypted {
+            if-feature "ct:encrypted-private-keys";
+            container encrypted {
+              description
+                "Indicates that the key is to be encrypted using
+                 the specified symmetric or asymmetric key.";
+              uses ks:encrypted-by-grouping;
+            }
+          }
+          case hidden {
+            if-feature "ct:hidden-private-keys";
+            leaf hidden {
+              type empty;
+              description
+                "Indicates that the private key is to be hidden.
+
+                 Unlike the 'cleartext' and 'encrypt' options, the
+                 key returned is a placeholder for an internally
+                 stored key.  See Section 3 of RFC 9642 ('Support
+                 for Built-In Keys') for information about hidden
+                 keys.";
+            }
+          }
+        }
+      }
+    }
+    output {
+      choice key-or-hidden {
+        case key {
+          uses ct:asymmetric-key-pair-grouping;
+        }
+        case hidden {
+          leaf location {
+            type instance-identifier;
+            description
+              "The location to where a hidden key was created.";
+          }
+        }
+        description
+          "The output can be either a key (for cleartext and
+           encrypted keys) or the location to where the key
+           was created (for hidden keys).";
+      }
+    }
+  } // end generate-asymmetric-key-pair
+
+}

--- a/modules/subscribed_notifications/ietf-truststore@2024-10-10.yang
+++ b/modules/subscribed_notifications/ietf-truststore@2024-10-10.yang
@@ -1,0 +1,390 @@
+module ietf-truststore {
+  yang-version 1.1;
+  namespace "urn:ietf:params:xml:ns:yang:ietf-truststore";
+  prefix ts;
+
+  import ietf-netconf-acm {
+    prefix nacm;
+    reference
+      "RFC 8341: Network Configuration Access Control Model";
+  }
+  import ietf-crypto-types {
+    prefix ct;
+    reference
+      "RFC 9640: YANG Data Types and Groupings for Cryptography";
+  }
+
+  organization
+    "IETF NETCONF (Network Configuration) Working Group";
+  contact
+    "WG Web:   https://datatracker.ietf.org/wg/netconf
+     WG List:  NETCONF WG list <mailto:netconf@ietf.org>
+     Author:   Kent Watsen <kent+ietf@watsen.net>";
+  description
+    "This module defines a 'truststore' to centralize management
+     of trust anchors, including certificates and public keys.
+
+     The key words 'MUST', 'MUST NOT', 'REQUIRED', 'SHALL',
+     'SHALL NOT', 'SHOULD', 'SHOULD NOT', 'RECOMMENDED',
+     'NOT RECOMMENDED', 'MAY', and 'OPTIONAL' in this document
+     are to be interpreted as described in BCP 14 (RFC 2119)
+     (RFC 8174) when, and only when, they appear in all
+     capitals, as shown here.
+
+     Copyright (c) 2024 IETF Trust and the persons identified
+     as authors of the code.  All rights reserved.
+
+     Redistribution and use in source and binary forms, with
+     or without modification, is permitted pursuant to, and
+     subject to the license terms contained in, the Revised
+     BSD License set forth in Section 4.c of the IETF Trust's
+     Legal Provisions Relating to IETF Documents
+     (https://trustee.ietf.org/license-info).
+
+     This version of this YANG module is part of RFC 9641
+     (https://www.rfc-editor.org/info/rfc9641); see the RFC
+     itself for full legal notices.";
+
+  revision 2024-10-10 {
+    description
+      "Initial version.";
+    reference
+      "RFC 9641: A YANG Data Model for a Truststore";
+  }
+
+  /****************/
+  /*   Features   */
+  /****************/
+
+  feature central-truststore-supported {
+    description
+      "The 'central-truststore-supported' feature indicates that
+       the server supports the truststore (i.e., implements the
+       'ietf-truststore' module).";
+  }
+
+  feature inline-definitions-supported {
+    description
+      "The 'inline-definitions-supported' feature indicates that
+       the server supports locally defined trust anchors.";
+  }
+
+  feature certificates {
+    description
+      "The 'certificates' feature indicates that the server
+       implements the /truststore/certificate-bags subtree.";
+  }
+
+  feature public-keys {
+    description
+      "The 'public-keys' feature indicates that the server
+       implements the /truststore/public-key-bags subtree.";
+  }
+
+  /****************/
+  /*   Typedefs   */
+  /****************/
+
+  typedef central-certificate-bag-ref {
+    type leafref {
+      path "/ts:truststore/ts:certificate-bags/"
+         + "ts:certificate-bag/ts:name";
+    }
+    description
+      "This typedef defines a reference to a certificate bag
+       in the central truststore.";
+  }
+
+  typedef central-certificate-ref {
+    type leafref {
+      path "/ts:truststore/ts:certificate-bags/ts:certificate-bag"
+         + "[ts:name = current()/../certificate-bag]/"
+         + "ts:certificate/ts:name";
+    }
+    description
+      "This typedef defines a reference to a specific certificate
+       in a certificate bag in the central truststore.  This typedef
+       requires that there exist a sibling 'leaf' node called
+       'certificate-bag' that SHOULD have the
+       'central-certificate-bag-ref' typedef.";
+  }
+
+  typedef central-public-key-bag-ref {
+    type leafref {
+      path "/ts:truststore/ts:public-key-bags/"
+         + "ts:public-key-bag/ts:name";
+    }
+    description
+      "This typedef defines a reference to a public key bag
+       in the central truststore.";
+  }
+
+  typedef central-public-key-ref {
+    type leafref {
+      path "/ts:truststore/ts:public-key-bags/ts:public-key-bag"
+         + "[ts:name = current()/../public-key-bag]/"
+         + "ts:public-key/ts:name";
+    }
+    description
+      "This typedef defines a reference to a specific public key
+       in a public key bag in the truststore.  This typedef
+       requires that there exist a sibling 'leaf' node called
+       'public-key-bag' SHOULD have the
+       'central-public-key-bag-ref' typedef.";
+  }
+
+  /*****************/
+  /*   Groupings   */
+  /*****************/
+  // *-ref groupings
+
+  grouping central-certificate-ref-grouping {
+    description
+      "Grouping for the reference to a certificate in a
+       certificate-bag in the central truststore.";
+    leaf certificate-bag {
+      nacm:default-deny-write;
+      if-feature "central-truststore-supported";
+      if-feature "certificates";
+      type ts:central-certificate-bag-ref;
+      must '../certificate';
+      description
+        "Reference to a certificate-bag in the truststore.";
+    }
+    leaf certificate {
+      nacm:default-deny-write;
+      if-feature "central-truststore-supported";
+      if-feature "certificates";
+      type ts:central-certificate-ref;
+      must '../certificate-bag';
+      description
+        "Reference to a specific certificate in the
+         referenced certificate-bag.";
+    }
+  }
+
+  grouping central-public-key-ref-grouping {
+    description
+      "Grouping for the reference to a public key in a
+       public-key-bag in the central truststore.";
+    leaf public-key-bag {
+      nacm:default-deny-write;
+      if-feature "central-truststore-supported";
+      if-feature "public-keys";
+      type ts:central-public-key-bag-ref;
+      description
+        "Reference of a public key bag in the truststore, including
+         the certificate to authenticate the TLS client.";
+    }
+    leaf public-key {
+      nacm:default-deny-write;
+      if-feature "central-truststore-supported";
+      if-feature "public-keys";
+      type ts:central-public-key-ref;
+      description
+        "Reference to a specific public key in the
+         referenced public-key-bag.";
+    }
+  }
+
+  // inline-or-truststore-* groupings
+
+  grouping inline-or-truststore-certs-grouping {
+    description
+      "A grouping for the configuration of a list of certificates.
+       The list of certificates may be defined inline or as a
+       reference to a certificate bag in the central truststore.
+
+       Servers that wish to define alternate truststore locations
+       MUST augment in custom 'case' statements, enabling
+       references to those alternate truststore locations.";
+    choice inline-or-truststore {
+      nacm:default-deny-write;
+      mandatory true;
+      description
+        "A choice between an inlined definition and a definition
+         that exists in the truststore.";
+      case inline {
+        if-feature "inline-definitions-supported";
+        container inline-definition {
+          description
+            "A container for locally configured trust anchor
+             certificates.";
+          list certificate {
+            key "name";
+            min-elements 1;
+            description
+              "A trust anchor certificate or chain of certificates.";
+            leaf name {
+              type string;
+              description
+                "An arbitrary name for this certificate.";
+            }
+            uses ct:trust-anchor-cert-grouping {
+              refine "cert-data" {
+                mandatory true;
+              }
+            }
+          }
+        }
+      }
+      case central-truststore {
+        if-feature "central-truststore-supported";
+        if-feature "certificates";
+        leaf central-truststore-reference {
+          type ts:central-certificate-bag-ref;
+          description
+            "A reference to a certificate bag that exists in the
+             central truststore.";
+        }
+      }
+    }
+  }
+
+  grouping inline-or-truststore-public-keys-grouping {
+    description
+      "A grouping that allows the public keys to either be
+       configured locally, within the data model being used, or be a
+       reference to a public key bag stored in the truststore.
+
+       Servers that wish to define alternate truststore locations
+       SHOULD augment in custom 'case' statement, enabling
+       references to those alternate truststore locations.";
+    choice inline-or-truststore {
+      nacm:default-deny-write;
+      mandatory true;
+      description
+        "A choice between an inlined definition and a definition
+         that exists in the truststore.";
+      case inline {
+        if-feature "inline-definitions-supported";
+        container inline-definition {
+          description
+            "A container to hold local public key definitions.";
+          list public-key {
+            key "name";
+            description
+              "A public key definition.";
+            leaf name {
+              type string;
+              description
+                "An arbitrary name for this public key.";
+            }
+            uses ct:public-key-grouping;
+          }
+        }
+      }
+      case central-truststore {
+        if-feature "central-truststore-supported";
+        if-feature "public-keys";
+        leaf central-truststore-reference {
+          type ts:central-public-key-bag-ref;
+          description
+            "A reference to a bag of public keys that exists
+             in the central truststore.";
+        }
+      }
+    }
+  }
+
+  // the truststore grouping
+
+  grouping truststore-grouping {
+    description
+      "A grouping definition that enables use in other contexts.
+       Where used, implementations MUST augment new 'case'
+       statements into the various inline-or-truststore 'choice'
+       statements to supply leafrefs to the model-specific
+       location(s).";
+    container certificate-bags {
+      nacm:default-deny-write;
+      if-feature "certificates";
+      description
+        "A collection of certificate bags.";
+      list certificate-bag {
+        key "name";
+        description
+          "A bag of certificates.  Each bag of certificates should
+           be for a specific purpose.  For instance, one bag could
+           be used to authenticate a specific set of servers, while
+           another could be used to authenticate a specific set of
+           clients.";
+        leaf name {
+          type string;
+          description
+            "An arbitrary name for this bag of certificates.";
+        }
+        leaf description {
+          type string;
+          description
+            "A description for this bag of certificates.  The
+             intended purpose for the bag SHOULD be described.";
+        }
+        list certificate {
+          key "name";
+          description
+            "A trust anchor certificate or chain of certificates.";
+          leaf name {
+            type string;
+            description
+              "An arbitrary name for this certificate.";
+          }
+          uses ct:trust-anchor-cert-grouping {
+            refine "cert-data" {
+              mandatory true;
+            }
+          }
+        }
+      }
+    }
+    container public-key-bags {
+      nacm:default-deny-write;
+      if-feature "public-keys";
+      description
+        "A collection of public key bags.";
+      list public-key-bag {
+        key "name";
+        description
+          "A bag of public keys.  Each bag of keys SHOULD be for
+           a specific purpose.  For instance, one bag could be used
+           to authenticate a specific set of servers, while another
+           could be used to authenticate a specific set of clients.";
+        leaf name {
+          type string;
+          description
+            "An arbitrary name for this bag of public keys.";
+        }
+        leaf description {
+          type string;
+          description
+            "A description for this bag of public keys.  The
+             intended purpose for the bag MUST be described.";
+        }
+        list public-key {
+          key "name";
+          description
+            "A public key.";
+          leaf name {
+            type string;
+            description
+              "An arbitrary name for this public key.";
+          }
+          uses ct:public-key-grouping;
+        }
+      }
+    }
+  }
+
+  /*********************************/
+  /*   Protocol-accessible nodes   */
+  /*********************************/
+
+  container truststore {
+    if-feature "central-truststore-supported";
+    nacm:default-deny-write;
+    description
+      "The truststore contains bags of certificates and
+       public keys.";
+    uses truststore-grouping;
+  }
+}

--- a/modules/subscribed_notifications/ietf-udp-client@2025-05-14.yang
+++ b/modules/subscribed_notifications/ietf-udp-client@2025-05-14.yang
@@ -1,0 +1,104 @@
+module ietf-udp-client {
+  yang-version 1.1;
+  namespace
+    "urn:ietf:params:xml:ns:yang:ietf-udp-client";
+  prefix udpc;
+  import ietf-inet-types {
+    prefix inet;
+    reference
+      "RFC 6991: Common YANG Data Types";
+  }
+
+  organization "IETF NETCONF (Network Configuration) Working Group";
+  contact
+    "WG Web:   <http:/tools.ietf.org/wg/netconf/>
+     WG List:  <mailto:netconf@ietf.org>
+
+     Authors:  Alex Huang Feng
+               <mailto:alex.huang-feng@insa-lyon.fr>
+               Pierre Francois
+               <mailto:pierre.francois@insa-lyon.fr>";
+
+  description
+    "Defines a generic grouping for UDP-based client applications.
+
+    Copyright (c) 2025 IETF Trust and the persons identified as
+    authors of the code.  All rights reserved.
+
+    Redistribution and use in source and binary forms, with or without
+    modification, is permitted pursuant to, and subject to the license
+    terms contained in, the Revised BSD License set forth in Section
+    4.c of the IETF Trust's Legal Provisions Relating to IETF Documents
+    (https://trustee.ietf.org/license-info).
+
+    This version of this YANG module is part of RFC-to-be; see the RFC
+    itself for full legal notices.";
+
+  revision 2025-05-14 {
+    description
+      "Initial revision";
+    reference
+      "RFC-to-be: YANG Groupings for UDP Clients and UDP Servers";
+  }
+
+  feature local-binding {
+    description
+      "Indicates that the UDP client supports configuring local
+       bindings (i.e., the local address and local port number)
+       for UDP clients.";
+  }
+
+  grouping udp-client {
+    description
+      "A reusable grouping for UDP clients.
+
+      Note that this grouping uses fairly typical descendant
+      node names such that a stack of 'uses' statements will
+      have name conflicts.  It is intended that the consuming
+      data model will resolve the issue (e.g., by wrapping
+      the 'uses' statement in a container called
+      'udp-client-parameters').  This model purposely does
+      not do this itself so as to provide maximum flexibility
+      to consuming models.";
+
+    leaf remote-address {
+      type inet:host;
+      mandatory true;
+      description
+        "The IP address or hostname of the remote UDP server.
+        If a domain name is configured, then the name resolution
+        should happen before each datagram is sent, unless a
+        previously resolved address is cached and still valid.
+        If the name resolution results in multiple IP addresses,
+        the IP addresses are tried until a connection has been
+        established or until all IP addresses have failed. ";
+    }
+
+    leaf remote-port {
+      type inet:port-number;
+      description
+        "The port number of the remote UDP server.";
+    }
+
+    leaf local-address {
+      if-feature "local-binding";
+      type inet:ip-address;
+      description
+        "The local IP address to bind to when sending UDP
+        datagrams to the remote server. INADDR_ANY ('0.0.0.0') or
+        INADDR6_ANY ('0:0:0:0:0:0:0:0' a.k.a. '::') may be used
+        so that the client can bind to any IPv4 or IPv6 address.";
+    }
+
+    leaf local-port {
+      if-feature "local-binding";
+      type inet:port-number;
+      default "0";
+      description
+        "The local port number to bind to when sending UDP
+        datagrams to the remote server. The port number '0',
+        which is the default value, indicates that any available
+        local port number may be used.";
+    }
+  }
+}

--- a/modules/subscribed_notifications/ietf-udp-notif-transport@2025-06-04.yang
+++ b/modules/subscribed_notifications/ietf-udp-notif-transport@2025-06-04.yang
@@ -1,0 +1,189 @@
+module ietf-udp-notif-transport {
+  yang-version 1.1;
+  namespace "urn:ietf:params:xml:ns:yang:ietf-udp-notif-transport";
+  prefix unt;
+
+  import ietf-subscribed-notifications {
+    prefix sn;
+    reference
+      "RFC 8639: Subscription to YANG Notifications";
+  }
+  import ietf-subscribed-notif-receivers {
+    prefix snr;
+    reference
+      "draft-ietf-netconf-https-notif: An HTTPS-based Transport
+       for Configured Subscriptions";
+  }
+  import ietf-udp-client {
+    prefix udpc;
+    reference
+      "draft-ietf-netconf-udp-client-server: YANG Grouping for
+       UDP Clients and UDP Servers";
+  }
+  import ietf-tls-client {
+    prefix tlsc;
+    reference
+      "RFC 9645: YANG Groupings for TLS Clients and TLS Servers";
+  }
+
+  organization
+    "IETF NETCONF (Network Configuration) Working Group";
+  contact
+    "WG Web:   <http:/tools.ietf.org/wg/netconf/>
+     WG List:  <mailto:netconf@ietf.org>
+
+     Authors:  Guangying Zheng
+               <mailto:zhengguangying@huawei.com>
+               Tianran Zhou
+               <mailto:zhoutianran@huawei.com>
+               Thomas Graf
+               <mailto:thomas.graf@swisscom.com>
+               Pierre Francois
+               <mailto:pierre.francois@insa-lyon.fr>
+               Alex Huang Feng
+               <mailto:alex.huang-feng@insa-lyon.fr>
+               Paolo Lucente
+               <mailto:paolo@ntt.net>";
+  description
+    "Defines a model for configuring UDP-Notif as a transport
+     for configured subscriptions [RFC8639].
+
+     Copyright (c) 2025 IETF Trust and the persons identified as
+     authors of the code.  All rights reserved.
+
+     Redistribution and use in source and binary forms, with or
+     without modification, is permitted pursuant to, and subject to
+     the license terms contained in, the Revised BSD License set
+     forth in Section 4.c of the IETF Trust's Legal Provisions
+     Relating to IETF Documents
+     (https://trustee.ietf.org/license-info).
+
+     This version of this YANG module is part of RFC XXXX
+     (https://www.rfc-editor.org/info/rfcXXXX); see the RFC itself
+     for full legal notices.
+
+     The key words 'MUST', 'MUST NOT', 'REQUIRED', 'SHALL', 'SHALL
+     NOT', 'SHOULD', 'SHOULD NOT', 'RECOMMENDED', 'NOT RECOMMENDED',
+     'MAY', and 'OPTIONAL' in this document are to be interpreted as
+     described in BCP 14 (RFC 2119) (RFC 8174) when, and only when,
+     they appear in all capitals, as shown here.";
+
+  revision 2025-06-04 {
+    description
+      "Initial revision";
+    reference
+      "RFC XXXX: UDP-based Transport for Configured Subscriptions";
+  }
+
+  /*
+   * FEATURES
+   */
+
+  feature encode-cbor {
+    description
+      "Indicates that CBOR encoding of notification
+       messages is supported.";
+    reference
+      "RFC 9254: CBOR Encoding of Data Modeled with YANG";
+  }
+
+  feature dtls {
+    description
+      "Indicates that DTLS encryption of UDP
+       packets is supported. UDP-Notif mandates that, in
+       unsecured networks, DTLS 1.2 or later MUST be supported,
+       and DTLS 1.3 SHOULD be supported.";
+    reference
+      "RFC6347: Datagram Transport Layer Security Version 1.2,
+       RFC 9147: The Datagram Transport Layer Security (DTLS)
+       Protocol Version 1.3";
+  }
+
+  /*
+   * IDENTITIES
+   */
+
+  identity udp-notif {
+    base sn:transport;
+    base sn:configurable-encoding;
+    description
+      "UDP-Notif is used as transport for notification messages
+        and state change notifications.";
+  }
+
+  identity encode-cbor {
+    base sn:encoding;
+    description
+      "Encode data using CBOR.";
+    reference
+      "RFC 9254: CBOR Encoding of Data Modeled with YANG";
+  }
+
+  identity unsupported-max-segment-size {
+    base sn:establish-subscription-error;
+    base sn:modify-subscription-error;
+    description
+      "Error triggered when the specified value 'max-segment-size'
+       is not supported by the publisher. An implementation may
+       only support a subset of the uint16.";
+    reference
+      "RFC XXXX: UDP-based Transport for Configured Subscriptions";
+  }
+
+  grouping udp-notif-receiver {
+    description
+      "Provides a reusable identification of a UDP-Notif target
+       receiver.";
+    uses udpc:udp-client {
+      refine "remote-port" {
+        mandatory true;
+      }
+    }
+    container dtls {
+      if-feature "dtls";
+      presence "dtls";
+      uses tlsc:tls-client-grouping {
+        // Remove keep-alives for DTLS
+        refine "keepalives" {
+          if-feature "not tlsc:tls-client-keepalives";
+        }
+      }
+      description
+        "Container for configuring DTLS parameters.";
+    }
+    leaf enable-segmentation {
+      type boolean;
+      default "true";
+      description
+        "When disabled, the publisher will not segment UDP-Notif
+        messages. This may cause IP-layer fragmentation when
+        messages are larger than the MTU. IP fragmentation is
+        discouraged (RFC 8085, RFC 8900) and generally unsafe.
+        Disabling is not recommended.";
+    }
+    leaf max-segment-size {
+      type uint16;
+      description
+        "UDP-Notif provides a configurable max-segment-size to
+         control the size of each segment (UDP-Notif header, with
+         options, included).
+         The publisher may trigger an 'unsupported-max-segment-size'
+         error if the publisher does not support the configured
+         value.";
+    }
+  }
+
+  augment "/sn:subscriptions/snr:receiver-instances/"
+        + "snr:receiver-instance/snr:transport-type" {
+    case udp-notif {
+      container udp-notif-receiver {
+        description
+          "The UDP-Notif receiver to send notifications to.";
+        uses udp-notif-receiver;
+      }
+    }
+    description
+      "Augments the transport-type choice to include the 'udp-notif'
+       transport.";
+  }
+}

--- a/src/common.c
+++ b/src/common.c
@@ -3301,7 +3301,7 @@ sr_schema_mount_ds_data_update(sr_conn_ctx_t *conn, struct sr_lycc_ds_data_set_s
 cleanup:
     sr_lycc_clear_data(&cc_info);
     if (destroy_new_ctx) {
-        ly_ctx_destroy(new_ctx);
+        sr_ly_ctx_destroy(new_ctx);
     }
 
     /* CONTEXT DOWNGRADE - leave the unlock to the caller */

--- a/src/context_change.c
+++ b/src/context_change.c
@@ -161,7 +161,7 @@ sr_lycc_lock(sr_conn_ctx_t *conn, sr_lock_mode_t mode, int lydmods_lock, const c
          * so it needs to be done now to avoid context data collision, see ::sr_lycc_store_context() */
         sr_yang_ctx.content_id = 0;
         sr_yang_ctx.sm_data_id = 0;
-        ly_ctx_destroy(sr_yang_ctx.ly_ctx);
+        sr_ly_ctx_destroy(sr_yang_ctx.ly_ctx);
         sr_yang_ctx.ly_ctx = NULL;
 
         /* get the printed context from the SHM if it is supported/available */
@@ -207,7 +207,7 @@ sr_lycc_lock(sr_conn_ctx_t *conn, sr_lock_mode_t mode, int lydmods_lock, const c
     sr_available_conn = conn;
 
 cleanup_unlock:
-    ly_ctx_destroy(new_ctx);
+    sr_ly_ctx_destroy(new_ctx);
     if (err_info) {
         if (remap_mode) {
             /* MOD REMAP UNLOCK */
@@ -1273,7 +1273,7 @@ sr_lycc_store_context(sr_shm_t *shm, struct ly_ctx *ctx)
      * doing it now avoids a context data collision with the new context */
     sr_yang_ctx.content_id = 0;
     sr_yang_ctx.sm_data_id = 0;
-    ly_ctx_destroy(sr_yang_ctx.ly_ctx);
+    sr_ly_ctx_destroy(sr_yang_ctx.ly_ctx);
     sr_yang_ctx.ly_ctx = NULL;
 
 cleanup:

--- a/src/executables/sysrepo-notifd/common.h
+++ b/src/executables/sysrepo-notifd/common.h
@@ -1,0 +1,720 @@
+/**
+ * @file common.h
+ * @author Roman Janota <Roman.Janota@cesnet.cz>
+ * @brief common declarations shared between sysrepo-notifd source files
+ *
+ * @copyright
+ * Copyright (c) 2026 CESNET, z.s.p.o.
+ *
+ * This source code is licensed under BSD 3-Clause License (the "License").
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://opensource.org/licenses/BSD-3-Clause
+ */
+
+#ifndef COMMON_H_
+#define COMMON_H_
+
+#include <stdint.h>
+
+#include "notifd.h"
+#include "sysrepo.h"
+
+#include <libyang/libyang.h>
+
+/**
+ * @brief UDP transport operations (defined in notifd_udp.c).
+ */
+extern const notif_transport_ops_t udp_transport_ops;
+
+/** @brief Bitmask: include the `stream` field in a state-change notification. */
+#define NOTIF_FIELD_STREAM         0x01
+
+/** @brief Bitmask: include the `xpath-filter` field in a state-change notification. */
+#define NOTIF_FIELD_XPATH_FILTER   0x02
+
+/** @brief Bitmask: include the `stop-time` field in a state-change notification. */
+#define NOTIF_FIELD_STOP_TIME      0x04
+
+/** @brief Bitmask: include the `replay-start-time` field in a state-change notification. */
+#define NOTIF_FIELD_REPLAY_START   0x08
+
+/*
+ * ---------------------------------------------------------------------------
+ * Functions from notifd_config.c
+ * ---------------------------------------------------------------------------
+ */
+
+/**
+ * @brief Find a mandatory descendant node of a context node by YANG path.
+ *
+ * If the descendant does not exist, logs an error and returns ::SR_ERR_NOT_FOUND.
+ *
+ * @param[in] ctx_node Ancestor YANG data node to search from.
+ * @param[in] path Schema path expression passed to lyd_find_path.
+ * @param[out] match Found descendant node, or NULL on failure.
+ * @return ::SR_ERR_OK on success, ::SR_ERR_NOT_FOUND if the descendant does not exist.
+ */
+int get_descendant_mandatory(const struct lyd_node *ctx_node, const char *path, struct lyd_node **match);
+
+/**
+ * @brief Find an optional descendant node of a context node by YANG path.
+ *
+ * Suppresses libyang error logging during the search because the node may
+ * legitimately be absent. Does not log errors on failure.
+ *
+ * @param[in] ctx_node Ancestor YANG data node to search from.
+ * @param[in] path Schema path expression passed to lyd_find_path.
+ * @param[out] match Found descendant node, or NULL if not found.
+ */
+void get_descendant_optional(const struct lyd_node *ctx_node, const char *path, struct lyd_node **match);
+
+/**
+ * @brief Convert a subscription state enum value to a human-readable string.
+ *
+ * @param[in] state Subscription state value.
+ * @return Static string "valid", "invalid", "concluded", or "unknown".
+ */
+const char *subscription_state2str(notif_sub_state_t state);
+
+/**
+ * @brief Convert a receiver state enum value to a human-readable string.
+ *
+ * @param[in] state Receiver state value.
+ * @return Static string "active", "suspended", "connecting", "disconnected", or "unknown".
+ */
+const char *receiver_state2str(notif_recv_state_t state);
+
+/**
+ * @brief Find a subscription by its numeric ID.
+ *
+ * @param[in] ctx Daemon context containing the subscription array.
+ * @param[in] sub_id Subscription ID to search for.
+ * @return Pointer to the matching subscription, or NULL if not found.
+ */
+notif_sub_t *subscription_find_by_id(notifd_ctx_t *ctx, uint32_t sub_id);
+
+/**
+ * @brief Find a subscription by an arbitrary YANG node within its subtree.
+ *
+ * Walks up the tree from @p ctx_node to find the ancestor `subscription` list
+ * entry, extracts its `id` leaf, and looks up the corresponding subscription.
+ *
+ * @param[in] notifd_ctx Daemon context.
+ * @param[in] ctx_node Any YANG data node within a subscription subtree.
+ * @return Pointer to the matching subscription, or NULL if not found.
+ */
+notif_sub_t *subscription_find_by_node(notifd_ctx_t *notifd_ctx, const struct lyd_node *ctx_node);
+
+/**
+ * @brief Find a receiver by name within a subscription.
+ *
+ * @param[in] sub Subscription whose receivers to search.
+ * @param[in] name Receiver name to search for.
+ * @return Pointer to the matching receiver, or NULL if not found.
+ */
+notif_receiver_t *receiver_find_by_name(notif_sub_t *sub, const char *name);
+
+/**
+ * @brief Find a receiver by an arbitrary YANG node within its subtree.
+ *
+ * Walks up the tree from @p ctx_node to find the ancestor `receiver` list entry,
+ * extracts its `name`, then finds the parent subscription and looks up the
+ * receiver by name within it.
+ *
+ * @param[in] notifd_ctx Daemon context.
+ * @param[in] ctx_node Any YANG data node within a receiver subtree.
+ * @return Pointer to the matching receiver, or NULL if not found.
+ */
+notif_receiver_t *receiver_find_by_node(notifd_ctx_t *notifd_ctx, const struct lyd_node *ctx_node);
+
+/**
+ * @brief Find a receiver instance by name.
+ *
+ * @param[in] ctx Daemon context containing the receiver-instance array.
+ * @param[in] name Receiver-instance name to search for.
+ * @return Pointer to the matching receiver instance, or NULL if not found.
+ */
+notif_receiver_inst_t *receiver_inst_find_by_name(notifd_ctx_t *ctx, const char *name);
+
+/**
+ * @brief Find a receiver instance by an arbitrary YANG node within its subtree.
+ *
+ * Walks up the tree from @p ctx_node to find the ancestor `receiver-instance`
+ * list entry, extracts its `name`, and looks up the corresponding instance.
+ *
+ * @param[in] notifd_ctx Daemon context.
+ * @param[in] ctx_node Any YANG data node within a receiver-instance subtree.
+ * @return Pointer to the matching receiver instance, or NULL if not found.
+ */
+notif_receiver_inst_t *receiver_inst_find_by_node(notifd_ctx_t *notifd_ctx, const struct lyd_node *ctx_node);
+
+/**
+ * @brief Create a new subscription from a YANG `subscription` list entry.
+ *
+ * Allocates a ::notif_sub_t, adds it to the daemon context's subscription array,
+ * parses all fields, and sets the initial state to VALID. On parse failure,
+ * disconnects receivers and invalidates the subscription.
+ *
+ * @param[in,out] notifd_ctx Daemon context (subscription is added to its array).
+ * @param[in] node The YANG `subscription` list entry node.
+ * @return ::SR_ERR_OK on success, error code on failure.
+ */
+int subscription_create_from_node(notifd_ctx_t *notifd_ctx, const struct lyd_node *node);
+
+/**
+ * @brief Destroy a subscription identified by a YANG node within its subtree.
+ *
+ * If the subscription was valid, sends a `subscription-terminated` notification
+ * to all its receivers before destruction.
+ *
+ * @param[in,out] notifd_ctx Daemon context.
+ * @param[in] node YANG node within the subscription subtree to be deleted.
+ * @return ::SR_ERR_OK on success, ::SR_ERR_NOT_FOUND if the subscription cannot be found.
+ */
+int subscription_destroy_from_node(notifd_ctx_t *notifd_ctx, const struct lyd_node *node);
+
+/**
+ * @brief Create a new receiver within a subscription from a YANG `receiver` node.
+ *
+ * Allocates the receiver, adds it to the subscription's receiver array, parses
+ * it, starts notification dispatch, attempts to connect, and if successful and
+ * the subscription is valid, sends a `subscription-started` notification.
+ *
+ * @param[in,out] notifd_ctx Daemon context.
+ * @param[in,out] sub Parent subscription (receiver is added to its array).
+ * @param[in] node The YANG `receiver` list entry node.
+ * @return ::SR_ERR_OK on success, error code on failure.
+ */
+int receiver_create_from_node(notifd_ctx_t *notifd_ctx, notif_sub_t *sub, const struct lyd_node *node);
+
+/**
+ * @brief Destroy a receiver identified by a YANG node within its subtree.
+ *
+ * If the receiver was active, sends a `subscription-terminated` notification
+ * to it before destruction.
+ *
+ * @param[in,out] notifd_ctx Daemon context.
+ * @param[in,out] sub Parent subscription.
+ * @param[in] node YANG node within the receiver subtree to be deleted.
+ * @return ::SR_ERR_OK on success, ::SR_ERR_NOT_FOUND if the receiver cannot be found.
+ */
+int receiver_destroy_from_node(notifd_ctx_t *notifd_ctx, notif_sub_t *sub, const struct lyd_node *node);
+
+/**
+ * @brief Create a new receiver instance from a YANG `receiver-instance` node.
+ *
+ * Allocates the struct, adds it to the daemon context's array, and parses it
+ * including transport-specific configuration.
+ *
+ * @param[in,out] notifd_ctx Daemon context (instance is added to its array).
+ * @param[in] node The YANG `receiver-instance` list entry node.
+ * @return ::SR_ERR_OK on success, error code on failure.
+ */
+int receiver_instance_create_from_node(notifd_ctx_t *notifd_ctx, const struct lyd_node *node);
+
+/**
+ * @brief Destroy a receiver instance identified by a YANG node within its subtree.
+ *
+ * Frees the instance name, calls the transport's config_destroy, and removes
+ * it from the daemon context's array. Assumes no subscriptions still reference
+ * this instance.
+ *
+ * @param[in,out] notifd_ctx Daemon context.
+ * @param[in] node YANG node within the receiver-instance subtree to be deleted.
+ * @return ::SR_ERR_OK on success, ::SR_ERR_NOT_FOUND if the instance cannot be found.
+ */
+int receiver_instance_destroy_from_node(notifd_ctx_t *notifd_ctx, const struct lyd_node *node);
+
+/**
+ * @brief Handle a change to the `stream` leaf of a subscription.
+ *
+ * On modification, updates the subscription's stream name and marks the
+ * subscription as modified and needing resubscription.
+ *
+ * @param[in,out] sub Subscription being modified.
+ * @param[in] node The YANG `stream` leaf node with the new value.
+ * @param[in] op Sysrepo change operation (only ::SR_OP_MODIFIED is handled).
+ * @return ::SR_ERR_OK on success, ::SR_ERR_NO_MEMORY on allocation failure.
+ */
+int handle_stream(notif_sub_t *sub, const struct lyd_node *node, sr_change_oper_t op);
+
+/**
+ * @brief Handle a change to the `stream-filter-name` leaf of a subscription.
+ *
+ * On create/modify, resolves the filter name to an XPath filter string via
+ * the datastore. On delete, clears the filter reference and XPath filter.
+ * Marks the subscription as modified and needing resubscription.
+ *
+ * @param[in,out] notifd_ctx Daemon context (used to access the sysrepo session).
+ * @param[in,out] sub Subscription being modified.
+ * @param[in] node The YANG `stream-filter-name` leaf node.
+ * @param[in] op Sysrepo change operation.
+ * @return ::SR_ERR_OK on success, error code on failure.
+ */
+int handle_stream_filter_name(notifd_ctx_t *notifd_ctx, notif_sub_t *sub, const struct lyd_node *node, sr_change_oper_t op);
+
+/**
+ * @brief Handle a change to the `stream-subtree-filter` anydata node of a subscription.
+ *
+ * On create/modify, extracts the filter subtree and converts it to an XPath
+ * filter. On delete, clears the XPath filter. Marks the subscription as
+ * modified and needing resubscription.
+ *
+ * @param[in,out] notifd_ctx Daemon context (used for sysrepo session).
+ * @param[in,out] sub Subscription being modified.
+ * @param[in] node The YANG `stream-subtree-filter` anydata node.
+ * @param[in] op Sysrepo change operation.
+ * @return ::SR_ERR_OK on success, error code on failure.
+ */
+int handle_stream_subtree_filter(notifd_ctx_t *notifd_ctx, notif_sub_t *sub, const struct lyd_node *node, sr_change_oper_t op);
+
+/**
+ * @brief Handle a change to the `stream-xpath-filter` leaf of a subscription.
+ *
+ * On create/modify, duplicates the new XPath value. On delete, clears the
+ * XPath filter. Marks the subscription as modified and needing resubscription.
+ *
+ * @param[in,out] sub Subscription being modified.
+ * @param[in] node The YANG `stream-xpath-filter` leaf node.
+ * @param[in] op Sysrepo change operation.
+ * @return ::SR_ERR_OK on success, ::SR_ERR_NO_MEMORY on allocation failure.
+ */
+int handle_stream_xpath_filter(notif_sub_t *sub, const struct lyd_node *node, sr_change_oper_t op);
+
+/**
+ * @brief Handle a change to the `encoding` leaf of a subscription.
+ *
+ * On create/modify, parses the identity-ref into the internal encoding enum.
+ * On delete, resets to ::NOTIF_ENCODING_UNSET. Marks the subscription as
+ * modified but NOT needing resubscription (encoding only affects serialization).
+ *
+ * @param[in,out] sub Subscription being modified.
+ * @param[in] node The YANG `encoding` leaf node.
+ * @param[in] op Sysrepo change operation.
+ * @return ::SR_ERR_OK on success, ::SR_ERR_UNSUPPORTED if the encoding is not supported.
+ */
+int handle_encoding(notif_sub_t *sub, const struct lyd_node *node, sr_change_oper_t op);
+
+/**
+ * @brief Handle a change to the `stop-time` leaf of a subscription.
+ *
+ * On create/modify, parses the date-time string into a timespec. On delete,
+ * zeroes out the stop time. Marks the subscription as modified and needing
+ * resubscription.
+ *
+ * @param[in,out] sub Subscription being modified.
+ * @param[in] node The YANG `stop-time` leaf node.
+ * @param[in] op Sysrepo change operation.
+ * @return ::SR_ERR_OK on success, ::SR_ERR_LY if the date-time string cannot be parsed.
+ */
+int handle_stop_time(notif_sub_t *sub, const struct lyd_node *node, sr_change_oper_t op);
+
+/**
+ * @brief Handle a change to the `configured-replay` leaf of a subscription.
+ *
+ * On create, enables replay and validates that the stream supports it, then
+ * sets the subscription start time to the earliest replay start time. On delete,
+ * disables replay and clears the start time.
+ *
+ * @param[in,out] notifd_ctx Daemon context (used to check replay support).
+ * @param[in,out] sub Subscription being modified.
+ * @param[in] node The YANG `configured-replay` leaf node (type empty).
+ * @param[in] op Sysrepo change operation.
+ * @return ::SR_ERR_OK on success, ::SR_ERR_UNSUPPORTED if the stream does not support replay.
+ */
+int handle_configured_replay(notifd_ctx_t *notifd_ctx, notif_sub_t *sub, const struct lyd_node *node, sr_change_oper_t op);
+
+/**
+ * @brief Handle a change to the `purpose` leaf of a subscription.
+ *
+ * On create/modify, duplicates the new purpose string. On delete, frees it.
+ * Marks the subscription as modified but NOT needing resubscription (purpose
+ * is metadata only).
+ *
+ * @param[in,out] sub Subscription being modified.
+ * @param[in] node The YANG `purpose` leaf node.
+ * @param[in] op Sysrepo change operation.
+ * @return ::SR_ERR_OK on success, ::SR_ERR_NO_MEMORY on allocation failure.
+ */
+int handle_purpose(notif_sub_t *sub, const struct lyd_node *node, sr_change_oper_t op);
+
+/**
+ * @brief Handle a change to the `source-address` leaf of a subscription.
+ *
+ * On create/modify/delete, updates the local address and reconnects ALL
+ * receivers in the subscription (a new source address requires new sockets).
+ * Implements rollback: if reconnecting receiver @c i fails, disconnects all
+ * previously reconnected receivers [0..i-1].
+ *
+ * @param[in,out] notifd_ctx Daemon context (used for receiver reconnection).
+ * @param[in,out] sub Subscription being modified.
+ * @param[in] node The YANG `source-address` leaf node.
+ * @param[in] op Sysrepo change operation.
+ * @return ::SR_ERR_OK on success, error code on failure.
+ */
+int handle_source_address(notifd_ctx_t *notifd_ctx, notif_sub_t *sub, const struct lyd_node *node, sr_change_oper_t op);
+
+/**
+ * @brief Dispatch a configuration change for a receiver instance to its transport.
+ *
+ * If the receiver instance already has its ops set, delegates directly to the
+ * transport's config_change callback. Otherwise, tries to identify the transport
+ * by matching the changed node's name against registered transport container
+ * names, which also sets the instance's ops and type.
+ *
+ * @param[in,out] recv_inst Receiver instance being modified.
+ * @param[in] node Changed YANG data node.
+ * @param[in] op Sysrepo change operation.
+ * @return ::SR_ERR_OK on success, error code from the transport's config_change on failure.
+ */
+int receiver_inst_config_change(notif_receiver_inst_t *recv_inst, const struct lyd_node *node, sr_change_oper_t op);
+
+/**
+ * @brief Handle a change to the `receiver-instance-ref` leaf within a subscription receiver.
+ *
+ * On create/modify, looks up the named receiver instance and reconnects the
+ * receiver to it. On delete, disconnects the receiver.
+ *
+ * @param[in,out] notifd_ctx Daemon context.
+ * @param[in,out] sub Parent subscription.
+ * @param[in] node The YANG `receiver-instance-ref` leaf node.
+ * @param[in] op Sysrepo change operation.
+ * @return ::SR_ERR_OK on success, ::SR_ERR_NOT_FOUND if the receiver or instance cannot be found,
+ *         or error codes from notif_receiver_reconnect.
+ */
+int handle_receiver_instance_ref(notifd_ctx_t *notifd_ctx, notif_sub_t *sub, const struct lyd_node *node, sr_change_oper_t op);
+
+/**
+ * @brief Handle a change to a `stream-filter` entry in the global filters list.
+ *
+ * When a named filter changes, finds all subscriptions that reference it by
+ * name and updates their xpath_filter accordingly. Only marks a subscription
+ * for resubscription if the effective XPath filter actually changed.
+ *
+ * @param[in,out] notifd_ctx Daemon context.
+ * @param[in] node The changed filter node (either `stream-subtree-filter` or `stream-xpath-filter`).
+ * @param[in] is_subtree Non-zero if the changed node is a subtree filter, zero if it is an xpath filter.
+ * @return ::SR_ERR_OK on success, error code on failure.
+ */
+int handle_stream_filter(notifd_ctx_t *notifd_ctx, const struct lyd_node *node, int is_subtree);
+
+/**
+ * @brief Post-processing pass after subscription configuration changes.
+ *
+ * For subscriptions flagged resubscribe: calls subscription_resubscribe; on
+ * success marks VALID, on failure invalidates. For subscriptions flagged
+ * modified or with a modif_err_reason: if VALID, sends `subscription-modified`;
+ * if INVALID, sends `subscription-terminated` with the error reason.
+ * Resets the modified, resubscribe, and modif_err_reason flags.
+ *
+ * @param[in,out] notifd_ctx Daemon context.
+ */
+void process_modified_subscriptions(notifd_ctx_t *notifd_ctx);
+
+/**
+ * @brief Post-processing pass after receiver-instance configuration changes.
+ *
+ * Iterates all receiver instances flagged as modified and reconnects every
+ * receiver across all subscriptions that references each instance. Then
+ * clears the modified flag.
+ *
+ * @param[in,out] notifd_ctx Daemon context.
+ */
+void process_modified_receiver_instances(notifd_ctx_t *notifd_ctx);
+
+/**
+ * @brief Resubscribe all receivers of a subscription to apply parameter changes.
+ *
+ * For each receiver: stops the current notification dispatch, then starts it
+ * again with the updated parameters.
+ *
+ * @param[in] notifd_ctx Daemon context.
+ * @param[in,out] sub Subscription to resubscribe.
+ * @return ::SR_ERR_OK on success, error code from notification_dispatch_start on failure.
+ */
+int subscription_resubscribe(notifd_ctx_t *notifd_ctx, notif_sub_t *sub);
+
+/**
+ * @brief Validate subscription changes during SR_EV_CHANGE (read-only).
+ *
+ * Validates transport identity, encoding, stream existence, subtree filter
+ * convertibility, configured-replay stream support, and temporal constraints
+ * (start/stop time). Does not modify any state.
+ *
+ * @param[in] notifd_ctx Daemon context.
+ * @param[in,out] session Sysrepo change session (error messages may be set on it).
+ * @return ::SR_ERR_OK if all validations pass, error code on validation failure.
+ */
+int sub_change_validate(notifd_ctx_t *notifd_ctx, sr_session_ctx_t *session);
+
+/**
+ * @brief Validate filter changes during SR_EV_CHANGE (read-only).
+ *
+ * Validates that any newly created or modified `stream-subtree-filter` entries
+ * in the global filters list can be converted to XPath. Does not modify any state.
+ *
+ * @param[in] notifd_ctx Daemon context.
+ * @param[in] session Sysrepo change session.
+ * @return ::SR_ERR_OK if all subtree filters are valid, error code on failure.
+ */
+int filter_change_validate(notifd_ctx_t *notifd_ctx, sr_session_ctx_t *session);
+
+/**
+ * @brief Check whether a specific YANG feature is enabled in a given module.
+ *
+ * @param[in] notifd_ctx Daemon context (used to acquire the libyang context).
+ * @param[in] module_name YANG module name to check.
+ * @param[in] feature_name Feature name within the module.
+ * @param[out] enabled Set to 1 if the feature is enabled, 0 otherwise (including if the module is not found).
+ * @return ::SR_ERR_OK on success, ::SR_ERR_INVAL_ARG if any required argument is NULL,
+ *         ::SR_ERR_INTERNAL if the libyang context cannot be acquired.
+ */
+int module_feature_is_enabled(notifd_ctx_t *notifd_ctx, const char *module_name, const char *feature_name, int *enabled);
+
+/**
+ * @brief Tear down the entire daemon context.
+ *
+ * Destroys all subscriptions (stopping dispatch, disconnecting receivers,
+ * freeing all memory) and all receiver instances. Sets the arrays to NULL.
+ * The ::notifd_ctx_t struct itself is NOT freed (caller's responsibility).
+ *
+ * @param[in,out] notifd_ctx Daemon context to destroy. If NULL, returns immediately.
+ */
+void notifd_ctx_destroy(notifd_ctx_t *notifd_ctx);
+
+/*
+ * ---------------------------------------------------------------------------
+ * Functions from notifd_runtime.c
+ * ---------------------------------------------------------------------------
+ */
+
+/**
+ * @brief Compare two timespec values lexicographically.
+ *
+ * @param[in] ts1 First timestamp.
+ * @param[in] ts2 Second timestamp.
+ * @return -1 if @p ts1 < @p ts2, 1 if @p ts1 > @p ts2, 0 if equal.
+ */
+int timespec_cmp(const struct timespec *ts1, const struct timespec *ts2);
+
+/**
+ * @brief Send a `subscription-started` notification to one or all receivers.
+ *
+ * Includes stream, xpath-filter, stop-time, and replay-start-time fields.
+ * Does not skip inactive receivers -- send failures are fatal.
+ *
+ * @param[in] notifd_ctx Daemon context.
+ * @param[in] sub Subscription that has started.
+ * @param[in] receiver Specific receiver, or NULL to broadcast to all receivers of @p sub.
+ * @return ::SR_ERR_OK on success, error code on failure.
+ */
+int subscription_started_notif_send(notifd_ctx_t *notifd_ctx, notif_sub_t *sub, notif_receiver_t *receiver);
+
+/**
+ * @brief Send a `subscription-terminated` notification to one or all receivers.
+ *
+ * Includes only the `id` and `reason` fields. Skips inactive receivers silently.
+ *
+ * @param[in] notifd_ctx Daemon context.
+ * @param[in] sub Subscription being terminated.
+ * @param[in] receiver Specific receiver, or NULL to broadcast to all receivers of @p sub.
+ * @param[in] reason YANG identity-ref reason string (e.g. "ietf-subscribed-notifications:no-such-subscription").
+ * @return ::SR_ERR_OK on success, error code on failure.
+ */
+int subscription_terminated_notif_send(notifd_ctx_t *notifd_ctx, notif_sub_t *sub, notif_receiver_t *receiver, const char *reason);
+
+/**
+ * @brief Send a `subscription-modified` notification to one or all receivers.
+ *
+ * Includes stream, xpath-filter, stop-time, and replay-start-time fields.
+ * Skips inactive receivers silently.
+ *
+ * @param[in] notifd_ctx Daemon context.
+ * @param[in] sub Subscription that was modified.
+ * @param[in] receiver Specific receiver, or NULL to broadcast to all receivers of @p sub.
+ * @return ::SR_ERR_OK on success, error code on failure.
+ */
+int subscription_modified_notif_send(notifd_ctx_t *notifd_ctx, notif_sub_t *sub, notif_receiver_t *receiver);
+
+/**
+ * @brief Send a `subscription-completed` notification to one or all receivers.
+ *
+ * Includes only the `id` field. Skips inactive receivers silently.
+ *
+ * @param[in] notifd_ctx Daemon context.
+ * @param[in] sub Subscription that has completed (reached stop time).
+ * @param[in] receiver Specific receiver, or NULL to broadcast to all receivers of @p sub.
+ * @return ::SR_ERR_OK on success, error code on failure.
+ */
+int subscription_completed_notif_send(notifd_ctx_t *notifd_ctx, notif_sub_t *sub, notif_receiver_t *receiver);
+
+/**
+ * @brief Check whether a receiver currently has an active transport connection.
+ *
+ * NULL-safe: returns 0 for NULL receiver or NULL ops.
+ *
+ * @param[in] receiver Receiver to check.
+ * @return 1 if connected, 0 otherwise.
+ */
+int notif_receiver_is_connected(notif_receiver_t *receiver);
+
+/**
+ * @brief Establish a transport connection for a receiver.
+ *
+ * If already connected or no instance/ops configured, succeeds silently.
+ * Does NOT modify receiver->state; the caller is responsible for updating it.
+ *
+ * @param[in] receiver Receiver to connect.
+ * @return ::SR_ERR_OK on success (or no-op), error code from the transport's connect on failure.
+ */
+int notif_receiver_connect(notif_receiver_t *receiver);
+
+/**
+ * @brief Tear down a receiver's transport connection.
+ *
+ * Calls the transport's disconnect callback which must close resources,
+ * free conn_ctx, and set it to NULL. Does NOT modify receiver->state;
+ * the caller is responsible for updating it.
+ *
+ * @param[in] receiver Receiver to disconnect.
+ */
+void notif_receiver_disconnect(notif_receiver_t *receiver);
+
+/**
+ * @brief Attempt to reconnect a disconnected receiver using exponential backoff.
+ *
+ * On successful reconnection, sends a `subscription-started` notification
+ * (per RFC 8692 Section 2.1.2) and sets the receiver state to ACTIVE.
+ * Delay = NOTIFD_RECV_RECONNECT_BASE_SEC << reconnect_attempts, capped
+ * at NOTIFD_RECV_RECONNECT_MAX_SEC (60s).
+ *
+ * @param[in] notifd_ctx Daemon context.
+ * @param[in] receiver Disconnected receiver to reconnect.
+ * @return ::SR_ERR_OK on success, ::SR_ERR_OPERATION_FAILED if backoff has not
+ *         elapsed or reconnection failed, or other error codes.
+ */
+int notif_receiver_backoff_reconnect(notifd_ctx_t *notifd_ctx, notif_receiver_t *receiver);
+
+/**
+ * @brief Fully reconnect a receiver with the complete lifecycle.
+ *
+ * If currently connected, sends `subscription-terminated` before disconnecting.
+ * Optionally updates the receiver's instance/ops if @p new_inst is provided.
+ * Then connects and sends `subscription-started`. On any error, the receiver
+ * is disconnected and set to DISCONNECTED state.
+ *
+ * @param[in] notifd_ctx Daemon context.
+ * @param[in] sub Parent subscription of the receiver.
+ * @param[in] receiver Receiver to reconnect.
+ * @param[in] new_inst New receiver instance to assign, or NULL to keep the existing instance.
+ * @return ::SR_ERR_OK on success, error code on failure.
+ */
+int notif_receiver_reconnect(notifd_ctx_t *notifd_ctx, notif_sub_t *sub, notif_receiver_t *receiver, notif_receiver_inst_t *new_inst);
+
+/**
+ * @brief Send a single notification to a specific receiver over its transport.
+ *
+ * Enforces protocol ordering: a `subscription-started` must have been delivered
+ * before any other notification type can be sent. If @p timestamp is NULL, the
+ * current time is used.
+ *
+ * @param[in] notifd_ctx Daemon context.
+ * @param[in] receiver Receiver to send to.
+ * @param[in] notif Notification data tree to send.
+ * @param[in] timestamp Event timestamp, or NULL for current time.
+ * @param[in] encoding Encoding format for the notification payload.
+ * @return ::SR_ERR_OK on success, ::SR_ERR_INVAL_ARG if receiver or notif is NULL,
+ *         ::SR_ERR_OPERATION_FAILED if the receiver is not connected or not active,
+ *         ::SR_ERR_UNSUPPORTED if no transport ops available, or other error codes.
+ */
+int notif_receiver_send(notifd_ctx_t *notifd_ctx, notif_receiver_t *receiver, const struct lyd_node *notif,
+        const struct timespec *timestamp, notif_encoding_t encoding);
+
+/**
+ * @brief Start notification dispatch for a receiver via srsn.
+ *
+ * Subscribes to the configured notification stream and adds a file-descriptor-based
+ * dispatch entry. This begins the flow of notifications from sysrepo to the receiver.
+ *
+ * @param[in] notifd_ctx Daemon context (its sr_sess is used as the srsn subscription session).
+ * @param[in] sub Subscription defining the stream, filter, and stop/start times.
+ * @param[in] receiver Receiver whose srsn_data and cb_data will be populated.
+ * @return ::SR_ERR_OK on success, error code on failure.
+ */
+int notification_dispatch_start(notifd_ctx_t *notifd_ctx, notif_sub_t *sub, notif_receiver_t *receiver);
+
+/**
+ * @brief Stop notification dispatch for a receiver.
+ *
+ * Terminates the srsn subscription and cleans up resources. Temporarily drops
+ * the state write lock to allow srsn_terminate() to invoke the notification
+ * callback (which acquires the state read lock).
+ *
+ * @warning The caller MUST hold both state_rwlock (write) AND config_apply_mutex.
+ * The config_apply_mutex prevents another thread from stealing the write-lock
+ * in the unlock/relock window.
+ *
+ * @param[in] notifd_ctx Daemon context (its state_rwlock is temporarily unlocked/relocked).
+ * @param[in] receiver Receiver whose dispatch is being stopped.
+ */
+void notification_dispatch_stop(notifd_ctx_t *notifd_ctx, notif_receiver_t *receiver);
+
+/**
+ * @brief Main notification callback invoked by the srsn dispatch thread.
+ *
+ * Checks subscription validity, handles stop-time expiration (converting
+ * srsn's `subscription-terminated` into `subscription-completed` per RFC 8692),
+ * attempts automatic reconnection of disconnected receivers with backoff,
+ * and delivers the notification. May upgrade from a read lock to a write lock
+ * for stop-time handling or receiver reconnection.
+ *
+ * @param[in] notif The incoming notification data tree.
+ * @param[in] timestamp Event timestamp of the notification.
+ * @param[in] cb_data User data pointer, must be a pointer to ::notif_cb_data_t.
+ */
+void notifd_notification_cb(const struct lyd_node *notif, const struct timespec *timestamp, void *cb_data);
+
+/*
+ * General utility functions
+*/
+
+/**
+ * @brief Acquire a mutex lock with optional timeout and error reporting.
+ *
+ * @param[in] mutex Mutex to lock.
+ * @param[in] timeout_ms Timeout in milliseconds, 0 for blocking.
+ * @param[in] func Calling function name for error reporting.
+ * @return SR_ERR_OK on success, SR_ERR_TIME_OUT on timeout, SR_ERR_INTERNAL on other errors.
+ */
+int notifd_mutex_lock(pthread_mutex_t *mutex, uint32_t timeout_ms, const char *func);
+
+/**
+ * @brief Unlock a mutex lock.
+ *
+ * @param[in] mutex Mutex to unlock.
+ * @param[in] func Calling function name for error reporting.
+ */
+void notifd_mutex_unlock(pthread_mutex_t *mutex, const char *func);
+
+/**
+ * @brief Acquire a read or write lock on a rwlock with optional timeout and error reporting.
+ *
+ * @param[in] lock RW lock to lock.
+ * @param[in] is_write Whether to acquire a write lock (1) or read lock (0).
+ * @param[in] timeout_ms Timeout in milliseconds, 0 for blocking.
+ * @param[in] func Calling function name for error reporting.
+ * @return SR_ERR_OK on success, SR_ERR_TIME_OUT on timeout, SR_ERR_INTERNAL on other errors.
+ */
+int notifd_rwlock_lock(pthread_rwlock_t *lock, int is_write, uint32_t timeout_ms, const char *func);
+
+/**
+ * @brief Unlock a rwlock.
+ *
+ * @param[in] lock RW lock to unlock.
+ * @param[in] func Calling function name for error reporting.
+ */
+void notifd_rwlock_unlock(pthread_rwlock_t *lock, const char *func);
+
+#endif /* COMMON_H_ */

--- a/src/executables/sysrepo-notifd/main.c
+++ b/src/executables/sysrepo-notifd/main.c
@@ -1,0 +1,1488 @@
+/**
+ * @file main.c
+ * @author Roman Janota <Roman.Janota@cesnet.cz>
+ * @brief sysrepo notification daemon
+ *
+ * @copyright
+ * Copyright (c) 2026 CESNET, z.s.p.o.
+ *
+ * This source code is licensed under BSD 3-Clause License (the "License").
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://opensource.org/licenses/BSD-3-Clause
+ */
+
+#define _GNU_SOURCE
+
+#include "compat.h"
+
+#include <assert.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <getopt.h>
+#include <pthread.h>
+#include <signal.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/types.h>
+#include <unistd.h>
+
+#include "../bin_common.h"
+#include "common.h"
+#include "notifd.h"
+#include "utils/subscribed_notifications.h"
+
+#ifdef SR_HAVE_SYSTEMD
+# include <systemd/sd-daemon.h>
+#endif
+
+/* count argument for srsn_oper_data_subscriptions_free when freeing a single subscription */
+#define SRSN_FREE_SINGLE 1
+
+/* protected flag for terminating sysrepo-notifd */
+static volatile sig_atomic_t loop_finish;
+static pthread_mutex_t lock = PTHREAD_MUTEX_INITIALIZER;
+static pthread_cond_t cond = PTHREAD_COND_INITIALIZER;
+
+/*
+ * ---------------------------------------------------------------------------
+ * Daemon infrastructure
+ * ---------------------------------------------------------------------------
+ */
+
+static void
+version_print(void)
+{
+    printf(
+            "sysrepo-notifd - sysrepo notification daemon, compiled with libsysrepo v%s (SO v%s)\n"
+            "\n",
+            SR_VERSION, SR_SOVERSION);
+}
+
+static void
+help_print(void)
+{
+    printf(
+            "Usage:\n"
+            "  sysrepo-notifd [-h] [-v <level>] [-d]\n"
+            "\n"
+            "Options:\n"
+            "  -h, --help           Prints usage help.\n"
+            "  -V, --version        Prints only information about sysrepo version.\n"
+            "  -v, --verbosity <level>\n"
+            "                       Change verbosity to a level (none, error, warning, info, verbose, debug) or\n"
+            "                       number (0, 1, 2, 3, 4, 5).\n"
+            "  -d, --debug          Debug mode - is not daemonized and logs to stderr instead of syslog.\n"
+            "  -p, --pid-file <path>\n"
+            "                       Create a PID file at the specified path with the PID written only once\n"
+            "                       initialization is finished.\n"
+            "  -s, --schema-dir <dir>\n"
+            "                       Set the directory with internal sysrepo YANG modules.\n"
+            "\n");
+}
+
+static void
+signal_handler(int sig)
+{
+    switch (sig) {
+    case SIGINT:
+    case SIGQUIT:
+    case SIGABRT:
+    case SIGTERM:
+    case SIGHUP:
+        pthread_mutex_lock(&lock);
+
+        /* stop the process */
+        if (!loop_finish) {
+            /* first attempt */
+            loop_finish = 1;
+            pthread_cond_signal(&cond);
+        } else {
+            /* second attempt */
+            SRNTF_LOG_ERR("Exiting without a proper cleanup");
+            exit(EXIT_FAILURE);
+        }
+        pthread_mutex_unlock(&lock);
+        break;
+    default:
+        /* unhandled signal */
+        SRNTF_LOG_ERR("Exiting on receiving an unhandled signal");
+        exit(EXIT_FAILURE);
+    }
+}
+
+static void
+handle_signals(void)
+{
+    struct sigaction action;
+    sigset_t block_mask;
+
+    /* set the signal handler */
+    sigfillset(&block_mask);
+    action.sa_handler = signal_handler;
+    action.sa_mask = block_mask;
+    action.sa_flags = 0;
+    sigaction(SIGINT, &action, NULL);
+    sigaction(SIGQUIT, &action, NULL);
+    sigaction(SIGABRT, &action, NULL);
+    sigaction(SIGTERM, &action, NULL);
+    sigaction(SIGHUP, &action, NULL);
+
+    /* ignore */
+    action.sa_handler = SIG_IGN;
+    sigaction(SIGPIPE, &action, NULL);
+    sigaction(SIGTSTP, &action, NULL);
+    sigaction(SIGTTIN, &action, NULL);
+    sigaction(SIGTTOU, &action, NULL);
+}
+
+static void
+daemon_init(int debug, sr_log_level_t log_level)
+{
+    pid_t pid = 0, sid = 0;
+    int fd = -1;
+
+    if (debug) {
+        handle_signals();
+        sr_log_stderr(log_level);
+        return;
+    }
+
+    /* fork off the parent process. */
+    pid = fork();
+    if (pid < 0) {
+        SRNTF_LOG_ERR("fork() failed (%s).", strerror(errno));
+        exit(EXIT_FAILURE);
+    }
+    if (pid > 0) {
+        /* this is the parent process, exit */
+        exit(EXIT_SUCCESS);
+    }
+
+    /* handle signals properly */
+    handle_signals();
+
+    /* create a new session containing a single (new) process group */
+    sid = setsid();
+    if (sid < 0) {
+        SRNTF_LOG_ERR("setsid() failed (%s).", strerror(errno));
+        exit(EXIT_FAILURE);
+    }
+
+    /* change the current working directory. */
+    if ((chdir(SRPD_WORK_DIR)) < 0) {
+        SRNTF_LOG_ERR("chdir() failed (%s).", strerror(errno));
+        exit(EXIT_FAILURE);
+    }
+
+    /* redirect standard files to /dev/null */
+    fd = open("/dev/null", O_RDWR, 0);
+    if (-1 != fd) {
+        dup2(fd, STDIN_FILENO);
+        dup2(fd, STDOUT_FILENO);
+        dup2(fd, STDERR_FILENO);
+        close(fd);
+    }
+
+    /* set verbosity */
+    sr_log_syslog("sysrepo-notifd", log_level);
+}
+
+static int
+create_pidfile(const char *pidfile)
+{
+    int pidfd;
+    char pid[30] = {0};
+    int pid_len;
+
+    pidfd = open(pidfile, O_RDWR | O_CREAT, 0640);
+    if (pidfd < 0) {
+        SRNTF_LOG_ERR("Unable to open the PID file \"%s\" (%s).", pidfile, strerror(errno));
+        return -1;
+    }
+
+    if (lockf(pidfd, F_TLOCK, 0) < 0) {
+        if ((errno == EACCES) || (errno == EAGAIN)) {
+            SRNTF_LOG_ERR("Another instance of the sysrepo-notifd is running.");
+        } else {
+            SRNTF_LOG_ERR("Unable to lock the PID file \"%s\" (%s).", pidfile, strerror(errno));
+        }
+        close(pidfd);
+        return -1;
+    }
+
+    if (ftruncate(pidfd, 0)) {
+        SRNTF_LOG_ERR("Failed to truncate pid file (%s).", strerror(errno));
+        close(pidfd);
+        return -1;
+    }
+
+    snprintf(pid, sizeof(pid), "%ld\n", (long) getpid());
+
+    pid_len = strlen(pid);
+    if (write(pidfd, pid, pid_len) < pid_len) {
+        SRNTF_LOG_ERR("Failed to write PID into pid file (%s).", strerror(errno));
+        close(pidfd);
+        return -1;
+    }
+
+    return pidfd;
+}
+
+int
+notifd_mutex_lock(pthread_mutex_t *mutex, uint32_t timeout_ms, const char *func)
+{
+    struct timespec ts;
+    int r;
+
+    SRNTF_LOG_DBG("%s: attempting to acquire mutex lock with timeout %" PRIu32 " ms.", func, timeout_ms);
+
+    if (timeout_ms > 0) {
+        clock_gettime(CLOCK_REALTIME, &ts);
+        ts.tv_sec += timeout_ms / 1000;
+        ts.tv_nsec += (timeout_ms % 1000) * 1000000;
+        if (ts.tv_nsec >= 1000000000) {
+            ts.tv_sec++;
+            ts.tv_nsec -= 1000000000;
+        }
+    }
+
+    if (timeout_ms > 0) {
+        r = pthread_mutex_timedlock(mutex, &ts);
+    } else {
+        r = pthread_mutex_lock(mutex);
+    }
+
+    if (r == ETIMEDOUT) {
+        SRNTF_LOG_ERR("%s: timed out acquiring mutex lock after %" PRIu32 " ms.", func, timeout_ms);
+        return SR_ERR_TIME_OUT;
+    } else if (r) {
+        SRNTF_LOG_ERR("%s: failed to acquire mutex lock (%s).", func, strerror(r));
+        return SR_ERR_LOCKED;
+    }
+
+    return SR_ERR_OK;
+}
+
+void
+notifd_mutex_unlock(pthread_mutex_t *mutex, const char *func)
+{
+    int r;
+
+    SRNTF_LOG_DBG("%s: releasing lock.", func);
+
+    if ((r = pthread_mutex_unlock(mutex))) {
+        SRNTF_LOG_ERR("%s: failed to unlock mutex (%s).", func, strerror(r));
+    }
+}
+
+int
+notifd_rwlock_lock(pthread_rwlock_t *lock, int is_write, uint32_t timeout_ms, const char *func)
+{
+    struct timespec ts;
+    int r;
+
+    SRNTF_LOG_DBG("%s: attempting to acquire %s rwlock with timeout %" PRIu32 " ms.",
+            func, is_write ? "write" : "read", timeout_ms);
+
+    if (timeout_ms > 0) {
+        clock_gettime(CLOCK_REALTIME, &ts);
+        ts.tv_sec += timeout_ms / 1000;
+        ts.tv_nsec += (timeout_ms % 1000) * 1000000;
+        if (ts.tv_nsec >= 1000000000) {
+            ts.tv_sec++;
+            ts.tv_nsec -= 1000000000;
+        }
+    }
+
+    if (is_write) {
+        if (timeout_ms > 0) {
+            r = pthread_rwlock_timedwrlock(lock, &ts);
+        } else {
+            r = pthread_rwlock_wrlock(lock);
+        }
+    } else {
+        if (timeout_ms > 0) {
+            r = pthread_rwlock_timedrdlock(lock, &ts);
+        } else {
+            r = pthread_rwlock_rdlock(lock);
+        }
+    }
+
+    if (r == ETIMEDOUT) {
+        SRNTF_LOG_ERR("%s: timed out acquiring %s lock after %" PRIu32 " ms.",
+                func, is_write ? "write" : "read", timeout_ms);
+        return SR_ERR_TIME_OUT;
+    } else if (r) {
+        SRNTF_LOG_ERR("%s: failed to acquire %s lock (%s).", func, is_write ? "write" : "read", strerror(r));
+        return SR_ERR_LOCKED;
+    }
+
+    return SR_ERR_OK;
+}
+
+void
+notifd_rwlock_unlock(pthread_rwlock_t *lock, const char *func)
+{
+    int r;
+
+    SRNTF_LOG_DBG("%s: releasing rwlock.", func);
+
+    if ((r = pthread_rwlock_unlock(lock))) {
+        SRNTF_LOG_ERR("%s: failed to unlock rwlock (%s).", func, strerror(r));
+    }
+}
+
+/**
+  * @brief Send subscription-terminated notifications for all active subscriptions and mark them as concluded.
+  *
+  * @param[in] notifd_ctx Notification daemon context.
+  */
+static void
+notifd_graceful_shutdown(notifd_ctx_t *notifd_ctx)
+{
+    LY_ARRAY_COUNT_TYPE i;
+    notif_sub_t *sub;
+    int r;
+
+    /* CONFIG APPLY LOCK - needed because notification_dispatch_stop temporarily drops
+     * state_rwlock while calling srsn_terminate(), and config_apply_mutex prevents
+     * another thread from stealing the write-lock in that window */
+    if ((r = notifd_mutex_lock(&notifd_ctx->config_apply_mutex, NOTIFD_CONTEXT_LOCK_TIMEOUT_MS, __func__))) {
+        SRNTF_LOG_ERR("Failed to acquire config apply lock for graceful shutdown.");
+        return;
+    }
+
+    /* STATE WR LOCK */
+    if (notifd_rwlock_lock(&notifd_ctx->state_rwlock, 1, NOTIFD_CONTEXT_LOCK_TIMEOUT_MS, __func__)) {
+        SRNTF_LOG_ERR("Failed to acquire state lock for graceful shutdown.");
+        notifd_mutex_unlock(&notifd_ctx->config_apply_mutex, __func__);
+        return;
+    }
+
+    LY_ARRAY_FOR(notifd_ctx->subs, i) {
+        sub = notifd_ctx->subs[i];
+        if (sub->state != NOTIF_SUB_STATE_VALID) {
+            continue;
+        }
+
+        subscription_terminated_notif_send(notifd_ctx, sub, NULL,
+                "ietf-subscribed-notifications:no-such-subscription");
+        sub->state = NOTIF_SUB_STATE_CONCLUDED;
+    }
+
+    /* destroy all subscriptions and receiver instances */
+    notifd_ctx_destroy(notifd_ctx);
+
+    /* STATE UNLOCK */
+    notifd_rwlock_unlock(&notifd_ctx->state_rwlock, __func__);
+
+    /* CONFIG APPLY UNLOCK */
+    notifd_mutex_unlock(&notifd_ctx->config_apply_mutex, __func__);
+}
+
+/**
+ * @brief Check that all required YANG modules are installed in sysrepo.
+ *
+ * @param[in] conn Sysrepo connection.
+ * @return SR_ERR_OK if all required modules are present, otherwise an appropriate error code.
+ */
+static int
+check_required_modules(sr_conn_ctx_t *conn)
+{
+    const char *required_modules[] = {
+        "ietf-subscribed-notifications",
+        "ietf-subscribed-notif-receivers",
+        NULL
+    };
+    const struct ly_ctx *ly_ctx = NULL;
+    const struct lys_module *ly_mod;
+    int rc = SR_ERR_OK, i;
+
+    if (!(ly_ctx = sr_acquire_context(conn))) {
+        SRNTF_LOG_ERR("Failed to acquire libyang context");
+        return SR_ERR_INTERNAL;
+    }
+
+    for (i = 0; required_modules[i]; i++) {
+        if (!(ly_mod = ly_ctx_get_module_implemented(ly_ctx, required_modules[i]))) {
+            SRNTF_LOG_ERR("Required YANG module \"%s\" is not installed. "
+                    "Install it before starting the daemon.", required_modules[i]);
+            rc = SR_ERR_NOT_FOUND;
+            goto cleanup;
+        }
+    }
+
+cleanup:
+    sr_release_context(conn);
+    return rc;
+}
+
+/*
+ * =========================================================================
+ * Sysrepo change callbacks
+ * =========================================================================
+ */
+
+/**
+ * @brief Convert sysrepo event to string for logging.
+ *
+ * @param[in] event Sysrepo event.
+ * @return String representation of the event.
+ */
+static const char *
+sr_event2str(sr_event_t event)
+{
+    switch (event) {
+    case SR_EV_UPDATE:
+        return "update";
+    case SR_EV_CHANGE:
+        return "change";
+    case SR_EV_DONE:
+        return "done";
+    case SR_EV_ABORT:
+        return "abort";
+    case SR_EV_ENABLED:
+        return "enabled";
+    case SR_EV_RPC:
+        return "rpc";
+    }
+
+    return "unknown";
+}
+
+static int
+sub_change_create_recv_instances(notifd_ctx_t *notifd_ctx, sr_session_ctx_t *session)
+{
+    int rc = SR_ERR_OK, r, prev_dflt;
+    sr_change_iter_t *iter = NULL;
+    sr_change_oper_t op;
+    const struct lyd_node *node;
+    const char *prev_value, *prev_list, *node_name;
+
+    if ((rc = sr_get_changes_iter(session, "/ietf-subscribed-notifications:subscriptions/receiver-instances/receiver-instance", &iter))) {
+        goto cleanup;
+    }
+    while (!sr_get_change_tree_next(session, iter, &op, &node, &prev_value, &prev_list, &prev_dflt)) {
+        /* process only the relevant nodes */
+        node_name = LYD_NAME(node);
+        SRNTF_LOG_DBG("Current node: %s", node_name);
+        assert(node_name && !strcmp(node_name, "receiver-instance"));
+
+        if (op != SR_OP_CREATED) {
+            continue;
+        }
+
+        r = receiver_instance_create_from_node(notifd_ctx, node);
+        if (r) {
+            rc = r;
+        }
+    }
+
+cleanup:
+    sr_free_change_iter(iter);
+    return rc;
+}
+
+/**
+ * @brief Check whether any ancestor of a diff node has a create or delete operation.
+ *
+ * When an entire subtree is being created (e.g. on SR_EV_ENABLED where the top-level container gets
+ * operation "create"), the XPath predicate [not(@yang:operation)] on list entries fails
+ * to exclude them since the list entries themselves lack the metadata. This function
+ * detects that case by walking up the tree and checking ancestors for create/delete.
+ *
+ * Since all nodes in a given change callback share the same ancestor chain, the result
+ * is the same for every node - it only needs to be called once (on the first node) and cached.
+ *
+ * @param[in] node Diff node to check.
+ * @return 1 if an ancestor has "create" or "delete" operation, 0 otherwise.
+ */
+static int
+node_ancestor_is_created_or_deleted(const struct lyd_node *node)
+{
+    const struct lyd_node *parent;
+    struct lyd_meta *meta;
+    const char *val;
+
+    for (parent = lyd_parent(node); parent; parent = lyd_parent(parent)) {
+        meta = lyd_find_meta(parent->meta, NULL, "yang:operation");
+        if (meta) {
+            val = lyd_get_meta_value(meta);
+            if (val && (!strcmp(val, "create") || !strcmp(val, "delete"))) {
+                return 1;
+            }
+        }
+    }
+
+    return 0;
+}
+
+static int
+sub_change_modify_recv_instances(notifd_ctx_t *notifd_ctx, sr_session_ctx_t *session)
+{
+    int rc = SR_ERR_OK, r, prev_dflt, ancestor_checked = 0, skip_all = 0;
+    sr_change_iter_t *iter = NULL;
+    sr_change_oper_t op;
+    const struct lyd_node *node;
+    const char *prev_value, *prev_list, *node_name;
+    notif_receiver_inst_t *recv_inst;
+
+    if ((rc = sr_get_changes_iter(session, "/ietf-subscribed-notifications:subscriptions/"
+            "receiver-instances/receiver-instance[not(@yang:operation)]//.", &iter))) {
+        goto cleanup;
+    }
+    while (!sr_get_change_tree_next(session, iter, &op, &node, &prev_value, &prev_list, &prev_dflt)) {
+        /* process only the relevant nodes */
+        node_name = LYD_NAME(node);
+        SRNTF_LOG_DBG("Current node: %s", node_name);
+
+        /* check once whether an ancestor has create/delete (result is same for all nodes) */
+        if (!ancestor_checked) {
+            skip_all = node_ancestor_is_created_or_deleted(node);
+            ancestor_checked = 1;
+        }
+        if (skip_all) {
+            continue;
+        }
+
+        /* all these nodes are under the receiver-instance list, so find it */
+        recv_inst = receiver_inst_find_by_node(notifd_ctx, node);
+        assert(recv_inst);
+
+        r = receiver_inst_config_change(recv_inst, node, op);
+
+        if (r) {
+            rc = r;
+        }
+    }
+    sr_free_change_iter(iter);
+    iter = NULL;
+
+    /* after processing all changes to the receiver instances, we can now update the referencing receivers' states */
+    process_modified_receiver_instances(notifd_ctx);
+
+cleanup:
+    sr_free_change_iter(iter);
+    return rc;
+}
+
+static int
+sub_change_process_subscriptions(notifd_ctx_t *notifd_ctx, sr_session_ctx_t *session)
+{
+    int rc = SR_ERR_OK, r, prev_dflt;
+    sr_change_iter_t *iter = NULL;
+    sr_change_oper_t op;
+    const struct lyd_node *node;
+    const char *prev_value, *prev_list;
+
+    if ((rc = sr_get_changes_iter(session, "/ietf-subscribed-notifications:subscriptions/subscription", &iter))) {
+        goto cleanup;
+    }
+    while (!sr_get_change_tree_next(session, iter, &op, &node, &prev_value, &prev_list, &prev_dflt)) {
+        SRNTF_LOG_DBG("Current node: %s", LYD_NAME(node));
+        assert(LYD_NAME(node) && !strcmp(LYD_NAME(node), "subscription"));
+
+        if (op == SR_OP_CREATED) {
+            if ((r = subscription_create_from_node(notifd_ctx, node))) {
+                rc = r;
+            }
+        } else if (op == SR_OP_DELETED) {
+            if ((r = subscription_destroy_from_node(notifd_ctx, node))) {
+                rc = r;
+            }
+        }
+    }
+
+cleanup:
+    sr_free_change_iter(iter);
+    return rc;
+}
+
+static int
+sub_change_modify_subscriptions(notifd_ctx_t *notifd_ctx, sr_session_ctx_t *session)
+{
+    int rc = SR_ERR_OK, r, prev_dflt, ancestor_checked = 0, skip_all = 0;
+    sr_change_iter_t *iter = NULL;
+    sr_change_oper_t op;
+    const struct lyd_node *node;
+    const char *prev_value, *prev_list, *node_name;
+    notif_sub_t *sub;
+
+    if ((rc = sr_get_changes_iter(session, "/ietf-subscribed-notifications:subscriptions/"
+            "subscription[not(@yang:operation)]//.", &iter))) {
+        goto cleanup;
+    }
+    while (!sr_get_change_tree_next(session, iter, &op, &node, &prev_value, &prev_list, &prev_dflt)) {
+        /* process only the relevant nodes */
+        node_name = LYD_NAME(node);
+        SRNTF_LOG_DBG("Current node: %s", node_name);
+
+        /* check once whether an ancestor has create/delete (result is same for all nodes) */
+        if (!ancestor_checked) {
+            skip_all = node_ancestor_is_created_or_deleted(node);
+            ancestor_checked = 1;
+        }
+        if (skip_all) {
+            continue;
+        }
+
+        /* all these nodes are under the subscription list, so find it */
+        sub = subscription_find_by_node(notifd_ctx, node);
+        assert(sub);
+
+        if (!strcmp(node_name, "stream")) {
+            r = handle_stream(sub, node, op);
+        } else if (!strcmp(node_name, "stream-filter-name")) {
+            r = handle_stream_filter_name(notifd_ctx, sub, node, op);
+        } else if (!strcmp(node_name, "stream-subtree-filter")) {
+            r = handle_stream_subtree_filter(notifd_ctx, sub, node, op);
+        } else if (!strcmp(node_name, "stream-xpath-filter")) {
+            r = handle_stream_xpath_filter(sub, node, op);
+        } else if (!strcmp(node_name, "encoding")) {
+            r = handle_encoding(sub, node, op);
+        } else if (!strcmp(node_name, "stop-time")) {
+            r = handle_stop_time(sub, node, op);
+        } else if (!strcmp(node_name, "configured-replay")) {
+            r = handle_configured_replay(notifd_ctx, sub, node, op);
+        } else if (!strcmp(node_name, "purpose")) {
+            r = handle_purpose(sub, node, op);
+        } else if (!strcmp(node_name, "source-address")) {
+            r = handle_source_address(notifd_ctx, sub, node, op);
+        } else {
+            r = 0;
+        }
+        if (r) {
+            rc = r;
+        }
+    }
+    sr_free_change_iter(iter);
+    iter = NULL;
+
+    /* send subscription-modified/subscription-terminated notification for all modified subs */
+    process_modified_subscriptions(notifd_ctx);
+
+cleanup:
+    sr_free_change_iter(iter);
+    return rc;
+}
+
+static int
+sub_change_modify_receivers(notifd_ctx_t *notifd_ctx, sr_session_ctx_t *session)
+{
+    int rc = SR_ERR_OK, r, prev_dflt, ancestor_checked = 0, skip_all = 0;
+    sr_change_iter_t *iter = NULL;
+    sr_change_oper_t op;
+    const struct lyd_node *node;
+    const char *prev_value, *prev_list, *node_name;
+    notif_sub_t *sub;
+
+    if ((rc = sr_get_changes_iter(session, "/ietf-subscribed-notifications:subscriptions/"
+            "subscription[not(@yang:operation)]/receivers//.", &iter))) {
+        goto cleanup;
+    }
+    while (!sr_get_change_tree_next(session, iter, &op, &node, &prev_value, &prev_list, &prev_dflt)) {
+        /* process only the relevant nodes */
+        node_name = LYD_NAME(node);
+        SRNTF_LOG_DBG("Current node: %s", node_name);
+
+        /* check once whether an ancestor has create/delete (result is same for all nodes) */
+        if (!ancestor_checked) {
+            skip_all = node_ancestor_is_created_or_deleted(node);
+            ancestor_checked = 1;
+        }
+        if (skip_all) {
+            continue;
+        }
+
+        /* all these nodes are under the receiver list, so find the subscription */
+        sub = subscription_find_by_node(notifd_ctx, node);
+        assert(sub);
+
+        if (!strcmp(node_name, "receiver")) {
+            if (op == SR_OP_CREATED) {
+                r = receiver_create_from_node(notifd_ctx, sub, node);
+            } else if (op == SR_OP_DELETED) {
+                r = receiver_destroy_from_node(notifd_ctx, sub, node);
+            } else {
+                r = 0;
+            }
+        } else if (!strcmp(node_name, "receiver-instance-ref")) {
+            r = handle_receiver_instance_ref(notifd_ctx, sub, node, op);
+        } else {
+            r = 0;
+        }
+
+        if (r) {
+            rc = r;
+        }
+    }
+    sr_free_change_iter(iter);
+    iter = NULL;
+
+    /* send subscription-modified/subscription-terminated for subs invalidated by receiver changes */
+    process_modified_subscriptions(notifd_ctx);
+
+cleanup:
+    sr_free_change_iter(iter);
+    return rc;
+}
+
+static int
+sub_change_delete_recv_instances(notifd_ctx_t *notifd_ctx, sr_session_ctx_t *session)
+{
+    int rc = SR_ERR_OK, r, prev_dflt;
+    sr_change_iter_t *iter = NULL;
+    sr_change_oper_t op;
+    const struct lyd_node *node;
+    const char *prev_value, *prev_list, *node_name;
+
+    if ((rc = sr_get_changes_iter(session,
+            "/ietf-subscribed-notifications:subscriptions/receiver-instances/receiver-instance", &iter))) {
+        goto cleanup;
+    }
+    while (!sr_get_change_tree_next(session, iter, &op, &node, &prev_value, &prev_list, &prev_dflt)) {
+        /* process only the relevant nodes */
+        node_name = LYD_NAME(node);
+        SRNTF_LOG_DBG("Current node: %s", node_name);
+
+        if (op != SR_OP_DELETED) {
+            continue;
+        }
+
+        if ((r = receiver_instance_destroy_from_node(notifd_ctx, node))) {
+            rc = r;
+        }
+    }
+
+cleanup:
+    sr_free_change_iter(iter);
+    return rc;
+}
+
+static int
+subscribed_notifications_sub_change_cb(sr_session_ctx_t *session, uint32_t sub_id, const char *module_name, const char *xpath,
+        sr_event_t event, uint32_t operation_id, void *private_data)
+{
+    int rc = SR_ERR_OK, r, appl_locked = 0, state_locked = 0;
+    notifd_ctx_t *notifd_ctx = (notifd_ctx_t *)private_data;
+
+    (void)sub_id;
+    (void)xpath;
+
+    assert(module_name && !strcmp(module_name, "ietf-subscribed-notifications"));
+
+    SRNTF_LOG_INF("Subscribed notifications subscription change callback with ID %" PRIu32 " invoked for event \"%s\".",
+            operation_id, sr_event2str(event));
+
+    /* CONFIG APPLY LOCK */
+    if ((rc = notifd_mutex_lock(&notifd_ctx->config_apply_mutex, NOTIFD_CONTEXT_LOCK_TIMEOUT_MS, __func__))) {
+        return rc;
+    }
+    appl_locked = 1;
+
+    if (event == SR_EV_CHANGE) {
+        /* STATE RD LOCK - validation only reads existing subscriptions */
+        if ((rc = notifd_rwlock_lock(&notifd_ctx->state_rwlock, 0, NOTIFD_CONTEXT_LOCK_TIMEOUT_MS, __func__))) {
+            goto cleanup;
+        }
+        state_locked = 1;
+
+        rc = sub_change_validate(notifd_ctx, session);
+
+        goto cleanup;
+    } else if (event == SR_EV_ABORT) {
+        /* nothing to roll back since SR_EV_CHANGE did not modify any state */
+        goto cleanup;
+    }
+
+    /* STATE WR LOCK */
+    if ((rc = notifd_rwlock_lock(&notifd_ctx->state_rwlock, 1, NOTIFD_CONTEXT_LOCK_TIMEOUT_MS, __func__))) {
+        goto cleanup;
+    }
+    state_locked = 1;
+
+    /* Step 1: create receiver instances (so that we can connect to them) */
+    r = sub_change_create_recv_instances(notifd_ctx, session);
+    if (r) {
+        rc = r;
+    }
+
+    /* Step 2: modify receiver instances */
+    r = sub_change_modify_recv_instances(notifd_ctx, session);
+    if (r) {
+        rc = r;
+    }
+
+    /* Step 3: process subscription list changes */
+    r = sub_change_process_subscriptions(notifd_ctx, session);
+    if (r) {
+        rc = r;
+    }
+
+    /* Step 4: modify subscriptions */
+    r = sub_change_modify_subscriptions(notifd_ctx, session);
+    if (r) {
+        rc = r;
+    }
+
+    /* Step 5: add/modify/delete receivers */
+    r = sub_change_modify_receivers(notifd_ctx, session);
+    if (r) {
+        rc = r;
+    }
+
+    /* Step 6: delete receiver instances */
+    r = sub_change_delete_recv_instances(notifd_ctx, session);
+    if (r) {
+        rc = r;
+    }
+
+cleanup:
+    if (state_locked) {
+        /* STATE UNLOCK */
+        notifd_rwlock_unlock(&notifd_ctx->state_rwlock, __func__);
+    }
+    if (appl_locked) {
+        /* CONFIG APPLY UNLOCK */
+        notifd_mutex_unlock(&notifd_ctx->config_apply_mutex, __func__);
+    }
+    return rc;
+}
+
+static int
+subscribed_notifications_filter_change_cb(sr_session_ctx_t *session, uint32_t sub_id, const char *module_name, const char *xpath,
+        sr_event_t event, uint32_t operation_id, void *private_data)
+{
+    int rc = SR_ERR_OK, r, prev_dflt, appl_locked = 0, state_locked = 0, ancestor_checked = 0, skip_all = 0;
+    notifd_ctx_t *notifd_ctx = (notifd_ctx_t *)private_data;
+    sr_change_iter_t *iter = NULL;
+    sr_change_oper_t op;
+    const struct lyd_node *node;
+    const char *prev_value, *prev_list, *node_name;
+
+    (void)sub_id;
+    (void)xpath;
+
+    assert(module_name && !strcmp(module_name, "ietf-subscribed-notifications"));
+
+    SRNTF_LOG_INF("Subscribed notifications filter change callback with ID %" PRIu32 " invoked for event \"%s\".",
+            operation_id, sr_event2str(event));
+
+    /* CONFIG APPLY LOCK */
+    if ((rc = notifd_mutex_lock(&notifd_ctx->config_apply_mutex, NOTIFD_CONTEXT_LOCK_TIMEOUT_MS, __func__))) {
+        return rc;
+    }
+    appl_locked = 1;
+
+    if (event == SR_EV_CHANGE) {
+        rc = filter_change_validate(notifd_ctx, session);
+        goto cleanup;
+    } else if (event == SR_EV_ABORT) {
+        /* nothing to roll back since SR_EV_CHANGE did not modify any state */
+        goto cleanup;
+    }
+
+    /* STATE WR LOCK */
+    if ((rc = notifd_rwlock_lock(&notifd_ctx->state_rwlock, 1, NOTIFD_CONTEXT_LOCK_TIMEOUT_MS, __func__))) {
+        goto cleanup;
+    }
+    state_locked = 1;
+
+    if ((rc = sr_get_changes_iter(session, "/ietf-subscribed-notifications:filters/stream-filter//.", &iter))) {
+        goto cleanup;
+    }
+    while (!sr_get_change_tree_next(session, iter, &op, &node, &prev_value, &prev_list, &prev_dflt)) {
+        /* process only the relevant nodes */
+        node_name = LYD_NAME(node);
+        SRNTF_LOG_DBG("Current node: %s", node_name);
+
+        /* check once whether an ancestor has create/delete (result is same for all nodes) */
+        if (!ancestor_checked) {
+            skip_all = node_ancestor_is_created_or_deleted(node);
+            ancestor_checked = 1;
+        }
+        if (skip_all) {
+            continue;
+        }
+
+        if (!strcmp(node_name, "stream-subtree-filter")) {
+            r = handle_stream_filter(notifd_ctx, node, 1);
+        } else if (!strcmp(node_name, "stream-xpath-filter")) {
+            r = handle_stream_filter(notifd_ctx, node, 0);
+        } else {
+            r = 0;
+        }
+        if (r) {
+            rc = r;
+        }
+    }
+
+    /* send subscription-modified/subscription-terminated notification for affected subs */
+    process_modified_subscriptions(notifd_ctx);
+
+cleanup:
+    if (state_locked) {
+        /* STATE UNLOCK */
+        notifd_rwlock_unlock(&notifd_ctx->state_rwlock, __func__);
+    }
+    if (appl_locked) {
+        /* CONFIG APPLY UNLOCK */
+        notifd_mutex_unlock(&notifd_ctx->config_apply_mutex, __func__);
+    }
+    sr_free_change_iter(iter);
+    return rc;
+}
+
+/*
+ * =========================================================================
+ * Operational data providers
+ * =========================================================================
+ */
+
+static int
+replay_start_time_oper_get(sr_session_ctx_t *UNUSED(session), uint32_t UNUSED(sub_id), const char *UNUSED(module_name),
+        const char *UNUSED(path), const char *UNUSED(request_xpath), uint32_t UNUSED(operation_id),
+        struct lyd_node **parent, void *private_data)
+{
+    int rc = SR_ERR_OK;
+    notifd_ctx_t *notifd_ctx = (notifd_ctx_t *)private_data;
+    notif_sub_t *sub;
+    char *replay_str = NULL;
+
+    /* RD LOCK */
+    if ((rc = notifd_rwlock_lock(&notifd_ctx->state_rwlock, 0, NOTIFD_CONTEXT_LOCK_TIMEOUT_MS, __func__))) {
+        return rc;
+    }
+
+    if (!(sub = subscription_find_by_node(notifd_ctx, *parent))) {
+        SRNTF_LOG_ERR("Failed to find subscription for replay-start-time operational data request.");
+        goto cleanup;
+    }
+
+    if ((sub->replay_start_time.tv_sec == 0) && (sub->replay_start_time.tv_nsec == 0)) {
+        /* if replay start time is 0, it means replay is not configured, so we return empty data */
+        goto cleanup;
+    }
+
+    /* create the replay-start-time node */
+    if (ly_time_ts2str(&sub->replay_start_time, &replay_str)) {
+        rc = SR_ERR_LY;
+        goto cleanup;
+    }
+    if (lyd_new_term(*parent, NULL, "replay-start-time", replay_str, 0, NULL)) {
+        rc = SR_ERR_LY;
+        goto cleanup;
+    }
+
+cleanup:
+    /* UNLOCK */
+    notifd_rwlock_unlock(&notifd_ctx->state_rwlock, __func__);
+    free(replay_str);
+    return rc;
+}
+
+static int
+configured_sub_state_oper_get(sr_session_ctx_t *UNUSED(session), uint32_t UNUSED(sub_id), const char *UNUSED(module_name),
+        const char *path, const char *UNUSED(request_xpath), uint32_t UNUSED(operation_id),
+        struct lyd_node **parent, void *private_data)
+{
+    int rc = SR_ERR_OK;
+    notifd_ctx_t *notifd_ctx = (notifd_ctx_t *)private_data;
+    notif_sub_t *sub;
+
+    /* RD LOCK */
+    if ((rc = notifd_rwlock_lock(&notifd_ctx->state_rwlock, 0, NOTIFD_CONTEXT_LOCK_TIMEOUT_MS, __func__))) {
+        return rc;
+    }
+
+    if (!(sub = subscription_find_by_node(notifd_ctx, *parent))) {
+        SRNTF_LOG_ERR("Failed to find subscription for \"%s\" operational data request.", path);
+        goto cleanup;
+    }
+
+    /* create the configured-subscription-state node */
+    if (lyd_new_term(*parent, NULL, "configured-subscription-state", subscription_state2str(sub->state), 0, NULL)) {
+        rc = SR_ERR_LY;
+        goto cleanup;
+    }
+
+cleanup:
+    /* UNLOCK */
+    notifd_rwlock_unlock(&notifd_ctx->state_rwlock, __func__);
+    return rc;
+}
+
+static int
+sent_event_records_oper_get(sr_session_ctx_t *UNUSED(session), uint32_t UNUSED(sub_id), const char *UNUSED(module_name),
+        const char *path, const char *UNUSED(request_xpath), uint32_t UNUSED(operation_id),
+        struct lyd_node **parent, void *private_data)
+{
+    int rc = SR_ERR_OK;
+    struct lyd_node *name_node = NULL;
+    notifd_ctx_t *notifd_ctx = (notifd_ctx_t *)private_data;
+    notif_sub_t *sub;
+    notif_receiver_t *recv;
+    srsn_state_sub_t *state_sub = NULL;
+    char num_str[11];   /* uint32 max is 4 294 967 295, so 10 chars + null terminator */
+
+    /* RD LOCK */
+    if ((rc = notifd_rwlock_lock(&notifd_ctx->state_rwlock, 0, NOTIFD_CONTEXT_LOCK_TIMEOUT_MS, __func__))) {
+        return rc;
+    }
+
+    if (!(sub = subscription_find_by_node(notifd_ctx, *parent))) {
+        SRNTF_LOG_ERR("Failed to find subscription for \"%s\" operational data request.", path);
+        goto cleanup;
+    }
+
+    if ((rc = get_descendant_mandatory(*parent, "name", &name_node))) {
+        goto cleanup;
+    }
+    if (!(recv = receiver_find_by_name(sub, lyd_get_value(name_node)))) {
+        SRNTF_LOG_ERR("Failed to find receiver for \"%s\" operational data request.", path);
+        rc = SR_ERR_NOT_FOUND;
+        goto cleanup;
+    }
+
+    /* get the oper data from srsn sub */
+    if ((rc = srsn_oper_data_sub(recv->srsn_data.sub_id, &state_sub))) {
+        SRNTF_LOG_ERR("Failed to get subscription state for \"%s\" operational data request.", path);
+        goto cleanup;
+    }
+
+    /* create the sent-event-records node */
+    snprintf(num_str, sizeof(num_str), "%" PRIu32, (uint32_t)state_sub->sent_count);
+    if (lyd_new_term(*parent, NULL, "sent-event-records", num_str, 0, NULL)) {
+        rc = SR_ERR_LY;
+        goto cleanup;
+    }
+
+cleanup:
+    /* UNLOCK */
+    notifd_rwlock_unlock(&notifd_ctx->state_rwlock, __func__);
+    srsn_oper_data_subscriptions_free(state_sub, SRSN_FREE_SINGLE);
+    return rc;
+}
+
+static int
+excluded_event_records_oper_get(sr_session_ctx_t *UNUSED(session), uint32_t UNUSED(sub_id), const char *UNUSED(module_name),
+        const char *path, const char *UNUSED(request_xpath), uint32_t UNUSED(operation_id),
+        struct lyd_node **parent, void *private_data)
+{
+    int rc = SR_ERR_OK;
+    struct lyd_node *name_node = NULL;
+    notifd_ctx_t *notifd_ctx = (notifd_ctx_t *)private_data;
+    notif_sub_t *sub;
+    notif_receiver_t *recv;
+    srsn_state_sub_t *state_sub = NULL;
+    char num_str[11];   /* uint32 max is 4 294 967 295, so 10 chars + null terminator */
+
+    /* RD LOCK */
+    if ((rc = notifd_rwlock_lock(&notifd_ctx->state_rwlock, 0, NOTIFD_CONTEXT_LOCK_TIMEOUT_MS, __func__))) {
+        return rc;
+    }
+
+    if (!(sub = subscription_find_by_node(notifd_ctx, *parent))) {
+        SRNTF_LOG_ERR("Failed to find subscription for \"%s\" operational data request.", path);
+        goto cleanup;
+    }
+
+    if ((rc = get_descendant_mandatory(*parent, "name", &name_node))) {
+        goto cleanup;
+    }
+    if (!(recv = receiver_find_by_name(sub, lyd_get_value(name_node)))) {
+        SRNTF_LOG_ERR("Failed to find receiver for \"%s\" operational data request.", path);
+        rc = SR_ERR_NOT_FOUND;
+        goto cleanup;
+    }
+
+    /* get the oper data from srsn sub */
+    if ((rc = srsn_oper_data_sub(recv->srsn_data.sub_id, &state_sub))) {
+        SRNTF_LOG_ERR("Failed to get subscription state for \"%s\" operational data request.", path);
+        goto cleanup;
+    }
+
+    /* create the excluded-event-records node */
+    snprintf(num_str, sizeof(num_str), "%" PRIu32, (uint32_t)state_sub->excluded_count);
+    if (lyd_new_term(*parent, NULL, "excluded-event-records", num_str, 0, NULL)) {
+        rc = SR_ERR_LY;
+        goto cleanup;
+    }
+
+cleanup:
+    /* UNLOCK */
+    notifd_rwlock_unlock(&notifd_ctx->state_rwlock, __func__);
+    srsn_oper_data_subscriptions_free(state_sub, SRSN_FREE_SINGLE);
+    return rc;
+}
+
+static int
+receiver_state_oper_get(sr_session_ctx_t *UNUSED(session), uint32_t UNUSED(sub_id), const char *UNUSED(module_name),
+        const char *path, const char *UNUSED(request_xpath), uint32_t UNUSED(operation_id),
+        struct lyd_node **parent, void *private_data)
+{
+    int rc = SR_ERR_OK;
+    struct lyd_node *name_node = NULL;
+    notifd_ctx_t *notifd_ctx = (notifd_ctx_t *)private_data;
+    notif_sub_t *sub;
+    notif_receiver_t *recv;
+
+    /* RD LOCK */
+    if ((rc = notifd_rwlock_lock(&notifd_ctx->state_rwlock, 0, NOTIFD_CONTEXT_LOCK_TIMEOUT_MS, __func__))) {
+        return rc;
+    }
+
+    if (!(sub = subscription_find_by_node(notifd_ctx, *parent))) {
+        SRNTF_LOG_ERR("Failed to find subscription for \"%s\" operational data request.", path);
+        goto cleanup;
+    }
+
+    if ((rc = get_descendant_mandatory(*parent, "name", &name_node))) {
+        goto cleanup;
+    }
+    if (!(recv = receiver_find_by_name(sub, lyd_get_value(name_node)))) {
+        SRNTF_LOG_ERR("Failed to find receiver for \"%s\" operational data request.", path);
+        rc = SR_ERR_NOT_FOUND;
+        goto cleanup;
+    }
+
+    /* create the receiver state node */
+    if (lyd_new_term(*parent, NULL, "state", receiver_state2str(recv->state), 0, NULL)) {
+        rc = SR_ERR_LY;
+        goto cleanup;
+    }
+
+cleanup:
+    /* UNLOCK */
+    notifd_rwlock_unlock(&notifd_ctx->state_rwlock, __func__);
+    return rc;
+}
+
+/*
+ * =========================================================================
+ * Operational data registration
+ * =========================================================================
+ */
+
+static int
+register_oper_data_providers(notifd_ctx_t *notifd_ctx, sr_subscription_ctx_t **subscr)
+{
+    int r, replay_enabled = 0;
+    const char *path, *module = "ietf-subscribed-notifications";
+    sr_session_ctx_t *sess = notifd_ctx->sr_sess;
+
+    if ((r = module_feature_is_enabled(notifd_ctx, module, "replay", &replay_enabled))) {
+        return r;
+    }
+
+    /* replay-start-time */
+    if (replay_enabled) {
+        path = "/ietf-subscribed-notifications:subscriptions/subscription/replay-start-time";
+        if ((r = sr_oper_get_subscribe(sess, module, path, replay_start_time_oper_get, notifd_ctx, 0, subscr))) {
+            SRNTF_LOG_ERR("Failed to subscribe for replay-start-time operational data.");
+            return r;
+        }
+    }
+
+    /* configured-subscription-state */
+    path = "/ietf-subscribed-notifications:subscriptions/subscription/configured-subscription-state";
+    if ((r = sr_oper_get_subscribe(sess, module, path, configured_sub_state_oper_get, notifd_ctx, 0, subscr))) {
+        SRNTF_LOG_ERR("Failed to subscribe for configured-subscription-state operational data.");
+        return r;
+    }
+
+    /* sent-event-records */
+    path = "/ietf-subscribed-notifications:subscriptions/subscription/receivers/receiver/sent-event-records";
+    if ((r = sr_oper_get_subscribe(sess, module, path, sent_event_records_oper_get, notifd_ctx, 0, subscr))) {
+        SRNTF_LOG_ERR("Failed to subscribe for sent-event-records operational data.");
+        return r;
+    }
+
+    /* excluded-event-records */
+    path = "/ietf-subscribed-notifications:subscriptions/subscription/receivers/receiver/excluded-event-records";
+    if ((r = sr_oper_get_subscribe(sess, module, path, excluded_event_records_oper_get, notifd_ctx, 0, subscr))) {
+        SRNTF_LOG_ERR("Failed to subscribe for excluded-event-records operational data.");
+        return r;
+    }
+
+    /* receiver state */
+    path = "/ietf-subscribed-notifications:subscriptions/subscription/receivers/receiver/state";
+    if ((r = sr_oper_get_subscribe(sess, module, path, receiver_state_oper_get, notifd_ctx, 0, subscr))) {
+        SRNTF_LOG_ERR("Failed to subscribe for receiver state operational data.");
+        return r;
+    }
+
+    return SR_ERR_OK;
+}
+
+/*
+ * =========================================================================
+ * RPC/Action callbacks
+ * =========================================================================
+ */
+
+int
+receiver_reset_rpc_cb(sr_session_ctx_t *UNUSED(session), uint32_t UNUSED(sub_id), const char *UNUSED(op_path),
+        const struct lyd_node *input, sr_event_t UNUSED(event), uint32_t UNUSED(operation_id),
+        struct lyd_node *output, void *private_data)
+{
+    int rc = SR_ERR_OK, appl_locked = 0, state_locked = 0;
+    notifd_ctx_t *notifd_ctx = (notifd_ctx_t *)private_data;
+    notif_sub_t *sub;
+    notif_receiver_t *recv;
+    struct lyd_node *name_node = NULL;
+    struct timespec ts_now;
+    char *time_str = NULL;
+
+    /* CONFIG APPLY LOCK */
+    if ((rc = notifd_mutex_lock(&notifd_ctx->config_apply_mutex, NOTIFD_CONTEXT_LOCK_TIMEOUT_MS, __func__))) {
+        return rc;
+    }
+    appl_locked = 1;
+
+    /* STATE WR LOCK */
+    if ((rc = notifd_rwlock_lock(&notifd_ctx->state_rwlock, 1, NOTIFD_CONTEXT_LOCK_TIMEOUT_MS, __func__))) {
+        goto cleanup;
+    }
+    state_locked = 1;
+
+    if (!(sub = subscription_find_by_node(notifd_ctx, input))) {
+        SRNTF_LOG_ERR("Failed to find subscription for receiver reset RPC.");
+        goto cleanup;
+    }
+
+    /* find the receiver to reset */
+    if ((rc = get_descendant_mandatory(lyd_parent(input), "name", &name_node))) {
+        goto cleanup;
+    }
+    if (!(recv = receiver_find_by_name(sub, lyd_get_value(name_node)))) {
+        SRNTF_LOG_ERR("Failed to find receiver for receiver reset RPC.");
+        rc = SR_ERR_NOT_FOUND;
+        goto cleanup;
+    }
+
+    /* disconnect the receiver instance */
+    notif_receiver_disconnect(recv);
+
+    /* reset the receiver state to connecting, it will attempt to reconnect once there is a notif to send */
+    recv->state = NOTIF_RECV_STATE_CONNECTING;
+
+    /* reset reconnect backoff */
+    recv->reconnect_attempts = 0;
+    memset(&recv->last_reconnect_attempt, 0, sizeof(recv->last_reconnect_attempt));
+
+    /* create the output - current time as the reset time */
+    clock_gettime(CLOCK_REALTIME, &ts_now);
+    if (ly_time_ts2str(&ts_now, &time_str)) {
+        rc = SR_ERR_LY;
+        goto cleanup;
+    }
+    if (lyd_new_term(output, NULL, "time", time_str, LYD_NEW_VAL_OUTPUT, NULL)) {
+        rc = SR_ERR_LY;
+        goto cleanup;
+    }
+
+cleanup:
+    if (state_locked) {
+        /* STATE UNLOCK */
+        notifd_rwlock_unlock(&notifd_ctx->state_rwlock, __func__);
+    }
+    if (appl_locked) {
+        /* CONFIG APPLY UNLOCK */
+        notifd_mutex_unlock(&notifd_ctx->config_apply_mutex, __func__);
+    }
+    free(time_str);
+    return rc;
+}
+
+/*
+ * =========================================================================
+ * Main
+ * =========================================================================
+ */
+
+int
+main(int argc, char **argv)
+{
+    sr_conn_ctx_t *conn = NULL;
+    sr_log_level_t log_level = SR_LL_ERR;
+    int rc = EXIT_SUCCESS, opt, debug = 0, pidfd = -1;
+    const char *pidfile = NULL;
+    notifd_ctx_t notifd_ctx = {
+        .state_rwlock = PTHREAD_RWLOCK_INITIALIZER,
+        .config_apply_mutex = PTHREAD_MUTEX_INITIALIZER
+    };
+    sr_subscription_ctx_t *sr_subscr = NULL;
+
+    struct option options[] = {
+        {"help",              no_argument,       NULL, 'h'},
+        {"version",           no_argument,       NULL, 'V'},
+        {"verbosity",         required_argument, NULL, 'v'},
+        {"debug",             no_argument,       NULL, 'd'},
+        {"pid-file",          required_argument, NULL, 'p'},
+        {"schema-dir",        required_argument, NULL, 's'},
+        {NULL,                0,                 NULL, 0},
+    };
+
+    /* process options */
+    opterr = 0;
+    while ((opt = getopt_long(argc, argv, "hVv:dp:s:", options, NULL)) != -1) {
+        switch (opt) {
+        case 'h':
+            version_print();
+            help_print();
+            goto cleanup;
+        case 'V':
+            version_print();
+            goto cleanup;
+        case 'v':
+            if (!strcmp(optarg, "none")) {
+                log_level = SR_LL_NONE;
+            } else if (!strcmp(optarg, "error")) {
+                log_level = SR_LL_ERR;
+            } else if (!strcmp(optarg, "warning")) {
+                log_level = SR_LL_WRN;
+            } else if (!strcmp(optarg, "info")) {
+                log_level = SR_LL_INF;
+            } else if (!strcmp(optarg, "debug")) {
+                log_level = SR_LL_DBG;
+            } else if (!strcmp(optarg, "verbose")) {
+                log_level = SR_LL_VRB;
+            } else if ((strlen(optarg) == 1) && (optarg[0] >= '0') && (optarg[0] <= '5')) {
+                log_level = atoi(optarg);
+            } else {
+                SRNTF_LOG_ERR("Invalid verbosity \"%s\"", optarg);
+                rc = EXIT_FAILURE;
+                goto cleanup;
+            }
+            break;
+        case 'd':
+            debug = 1;
+            break;
+        case 'p':
+            pidfile = optarg;
+            break;
+        case 's':
+            if (sr_set_yang_module_dir(optarg)) {
+                SRNTF_LOG_ERR("Failed to set YANG module directory \"%s\"", optarg);
+                rc = EXIT_FAILURE;
+                goto cleanup;
+            }
+            break;
+        default:
+            SRNTF_LOG_ERR("Invalid option or missing argument: -%c", optopt);
+            rc = EXIT_FAILURE;
+            goto cleanup;
+        }
+    }
+
+    /* check for additional argument */
+    if (optind < argc) {
+        SRNTF_LOG_ERR("Unexpected additional argument: %s", argv[optind]);
+        rc = EXIT_FAILURE;
+        goto cleanup;
+    }
+
+    /* daemonize */
+    daemon_init(debug, log_level);
+
+    /* create connection (after we have forked so that our PID is correct) */
+    if (sr_connect(0, &conn)) {
+        SRNTF_LOG_ERR("Failed to connect");
+        rc = EXIT_FAILURE;
+        goto cleanup;
+    }
+
+    /* create session */
+    if (sr_session_start(conn, SR_DS_RUNNING, &notifd_ctx.sr_sess)) {
+        SRNTF_LOG_ERR("Failed to start new session");
+        rc = EXIT_FAILURE;
+        goto cleanup;
+    }
+
+    /* check that all required YANG modules are installed */
+    if (check_required_modules(conn)) {
+        rc = EXIT_FAILURE;
+        goto cleanup;
+    }
+
+    /* init read notification dispatch */
+    if (srsn_read_dispatch_init(conn, notifd_notification_cb)) {
+        SRNTF_LOG_ERR("Failed to initialize notification dispatch");
+        rc = EXIT_FAILURE;
+        goto cleanup;
+    }
+
+    /* subscribe for subscription changes (higher priority) */
+    if (sr_module_change_subscribe(notifd_ctx.sr_sess, "ietf-subscribed-notifications",
+            "/ietf-subscribed-notifications:subscriptions", subscribed_notifications_sub_change_cb,
+            &notifd_ctx, 2, SR_SUBSCR_ENABLED, &sr_subscr)) {
+        SRNTF_LOG_ERR("Failed to subscribe for subscriptions changes");
+        rc = EXIT_FAILURE;
+        goto cleanup;
+    }
+
+    /* subscribe for filter changes */
+    if (sr_module_change_subscribe(notifd_ctx.sr_sess, "ietf-subscribed-notifications",
+            "/ietf-subscribed-notifications:filters", subscribed_notifications_filter_change_cb,
+            &notifd_ctx, 1, SR_SUBSCR_ENABLED, &sr_subscr)) {
+        SRNTF_LOG_ERR("Failed to subscribe for filters changes");
+        rc = EXIT_FAILURE;
+        goto cleanup;
+    }
+
+    /* register operational data provider callbacks */
+    if (register_oper_data_providers(&notifd_ctx, &sr_subscr)) {
+        rc = EXIT_FAILURE;
+        goto cleanup;
+    }
+
+    /* subscribe for 'reset' action */
+    if (sr_rpc_subscribe_tree(notifd_ctx.sr_sess,
+            "/ietf-subscribed-notifications:subscriptions/subscription/receivers/receiver/reset",
+            receiver_reset_rpc_cb, &notifd_ctx, 0, 0, &sr_subscr)) {
+        SRNTF_LOG_ERR("Failed to subscribe for receiver reset action.");
+        rc = EXIT_FAILURE;
+        goto cleanup;
+    }
+
+    /* create and write PID file (atomically, so existence implies readiness) */
+    if (pidfile && ((pidfd = create_pidfile(pidfile)) < 0)) {
+        rc = EXIT_FAILURE;
+        goto cleanup;
+    }
+
+#ifdef SR_HAVE_SYSTEMD
+    /* notify systemd */
+    sd_notify(0, "READY=1");
+#endif
+
+    /* wait for a terminating signal */
+    pthread_mutex_lock(&lock);
+    while (!loop_finish) {
+        pthread_cond_wait(&cond, &lock);
+    }
+    pthread_mutex_unlock(&lock);
+
+    /* gracefully terminate all active subscriptions */
+    notifd_graceful_shutdown(&notifd_ctx);
+
+#ifdef SR_HAVE_SYSTEMD
+    /* notify systemd */
+    sd_notify(0, "STOPPING=1");
+#endif
+
+cleanup:
+    if (pidfd >= 0) {
+        close(pidfd);
+        unlink(pidfile);
+    }
+
+    srsn_read_dispatch_destroy();
+    sr_unsubscribe(sr_subscr);
+    sr_disconnect(conn);
+    return rc;
+}

--- a/src/executables/sysrepo-notifd/notifd.h
+++ b/src/executables/sysrepo-notifd/notifd.h
@@ -1,0 +1,340 @@
+/**
+ * @file notifd.h
+ * @author Roman Janota <Roman.Janota@cesnet.cz>
+ * @brief header of common functions for sysrepo-notifd
+ *
+ * @copyright
+ * Copyright (c) 2026 CESNET, z.s.p.o.
+ *
+ * This source code is licensed under BSD 3-Clause License (the "License").
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://opensource.org/licenses/BSD-3-Clause
+ */
+
+#ifndef NOTIFD_H_
+#define NOTIFD_H_
+
+#include <pthread.h>
+#include <stdint.h>
+#include <time.h>
+
+#include "compat.h"
+#include "sysrepo.h"
+#include "sysrepo_types.h"
+
+/**
+ * @brief Logging macros for sysrepo-notifd.
+ */
+#define SRNTF_LOG_INF(...) SRPLG_LOG_INF("sysrepo-notifd", __VA_ARGS__)
+#define SRNTF_LOG_WRN(...) SRPLG_LOG_WRN("sysrepo-notifd", __VA_ARGS__)
+#define SRNTF_LOG_ERR(...) SRPLG_LOG_ERR("sysrepo-notifd", __VA_ARGS__)
+#define SRNTF_LOG_DBG(...) SRPLG_LOG_DBG("sysrepo-notifd", __VA_ARGS__)
+
+#define ERRMEM SRNTF_LOG_ERR("Memory allocation failed (%s:%d).", __FILE__, __LINE__)
+
+#define CHECK_ERRMEM_GOTO(_ptr, _ret, _label) \
+    do { \
+        if (!(_ptr)) { \
+            _ret = SR_ERR_NO_MEMORY; \
+            ERRMEM; \
+            goto _label; \
+        } \
+    } while (0)
+
+#define CHECK_ERRMEM_RET(_ptr) \
+    do { \
+        if (!(_ptr)) { \
+            ERRMEM; \
+            return SR_ERR_NO_MEMORY; \
+        } \
+    } while (0)
+
+/**
+ * @brief Timeout for acquiring the main context config rwlock, in milliseconds.
+ *
+ * The main context config lock is used to synchronize access to the entire configuration,
+ * so it may be held for longer periods during e.g. connection creation.
+ */
+#define NOTIFD_CONTEXT_LOCK_TIMEOUT_MS 10000
+
+/**
+ * @brief Base delay in seconds for receiver reconnect exponential backoff.
+ */
+#define NOTIFD_RECV_RECONNECT_BASE_SEC 1
+
+/**
+ * @brief Maximum delay in seconds for receiver reconnect exponential backoff.
+ */
+#define NOTIFD_RECV_RECONNECT_MAX_SEC 60
+
+/* forward declarations */
+typedef struct notifd_ctx_s notifd_ctx_t;
+typedef struct notif_sub_s notif_sub_t;
+typedef struct notif_receiver_s notif_receiver_t;
+typedef struct notif_receiver_inst_s notif_receiver_inst_t;
+
+/**
+ * @brief State of a configured subscription.
+ */
+typedef enum {
+    NOTIF_SUB_STATE_INVALID = 0,    /**< subscription parameters are not supportable */
+    NOTIF_SUB_STATE_VALID,          /**< subscription is supportable with current parameters */
+    NOTIF_SUB_STATE_CONCLUDED       /**< subscription has hit stop time, no active/suspended receivers */
+} notif_sub_state_t;
+
+/**
+ * @brief State of a notification receiver within a subscription.
+ */
+typedef enum {
+    NOTIF_RECV_STATE_CONNECTING = 0,    /**< awaiting initial connection and subscription-started delivery */
+    NOTIF_RECV_STATE_DISCONNECTED,      /**< connection attempt failed, not currently reconnecting */
+    NOTIF_RECV_STATE_ACTIVE,            /**< receiver is connected and receiving notifications */
+    NOTIF_RECV_STATE_SUSPENDED          /**< publisher unable to provide notifications (not yet implemented) */
+} notif_recv_state_t;
+
+/**
+ * @brief Notification transport type.
+ */
+typedef enum {
+    NOTIF_TRANSPORT_TYPE_NONE = 0,  /**< no transport configured */
+    NOTIF_TRANSPORT_TYPE_UDP        /**< UDP transport */
+} notif_transport_type_t;
+
+/**
+ * @brief Notification encoding type.
+ */
+typedef enum {
+    NOTIF_ENCODING_UNSET = 0,   /**< not set, left to the underlying transport default */
+    NOTIF_ENCODING_XML,         /**< XML encoding */
+    NOTIF_ENCODING_JSON,        /**< JSON encoding */
+    NOTIF_ENCODING_CBOR         /**< CBOR encoding */
+} notif_encoding_t;
+
+/**
+ * @brief Establish a transport connection for a notification receiver.
+ *
+ * Called when a receiver needs to connect to its configured destination.
+ * On success, must allocate and set @p recv->conn_ctx to a transport-specific
+ * connection context. The caller ensures the receiver is not already connected.
+ *
+ * @param[in] recv Receiver to connect. @p recv->inst and @p recv->ops are set.
+ * @param[in] cfg Transport-specific configuration (from @p recv->inst->transport_config).
+ * @return SR_ERR_OK on success, error code on failure (receiver remains disconnected).
+ */
+typedef int (*notif_transport_connect_cb)(notif_receiver_t *recv, void *cfg);
+
+/**
+ * @brief Tear down a transport connection for a notification receiver.
+ *
+ * Called when a receiver must be disconnected. Must close any transport resources
+ * (sockets, file descriptors, etc.), free @p recv->conn_ctx, and set it to NULL.
+ * The caller ensures the receiver is currently connected.
+ *
+ * @param[in] recv Receiver to disconnect. @p recv->conn_ctx is non-NULL.
+ */
+typedef void (*notif_transport_disconnect_cb)(notif_receiver_t *recv);
+
+/**
+ * @brief Check whether a notification receiver is currently connected.
+ *
+ * @param[in] recv Receiver to check.
+ * @return 1 if connected, 0 otherwise.
+ */
+typedef int (*notif_transport_is_connected_cb)(const notif_receiver_t *recv);
+
+/**
+ * @brief Send a notification over the transport to a receiver.
+ *
+ * Encodes and transmits a single notification using the given encoding.
+ * The caller ensures the receiver is connected before calling.
+ *
+ * @param[in] recv Receiver to send to. @p recv->conn_ctx is non-NULL.
+ * @param[in] cfg Transport-specific configuration (from @p recv->inst->transport_config).
+ * @param[in] notif Notification data tree to send.
+ * @param[in] ts Notification event timestamp.
+ * @param[in] encoding Encoding format for the notification payload.
+ * @return SR_ERR_OK on success, error code on failure.
+ */
+typedef int (*notif_transport_send_cb)(notif_receiver_t *recv, void *cfg, const struct lyd_node *notif,
+        const struct timespec *ts, notif_encoding_t encoding);
+
+/**
+ * @brief Parse transport configuration from a YANG data node.
+ *
+ * Called when a receiver instance is created from the YANG datastore.
+ * Must allocate and fill a transport-specific configuration structure
+ * and return it via @p cfg. The returned pointer is owned by the caller
+ * and will later be freed via ::notif_transport_config_destroy_cb.
+ *
+ * @param[in] node Root YANG node of the transport-specific config container
+ *             (e.g. the "udp-notif-receiver" NP container).
+ * @param[out] cfg Newly allocated transport-specific configuration.
+ * @return SR_ERR_OK on success, error code on failure (*cfg is untouched).
+ */
+typedef int (*notif_transport_config_parse_cb)(const struct lyd_node *node, void **cfg);
+
+/**
+ * @brief Handle an incremental configuration change for a receiver instance.
+ *
+ * Called for each YANG node that was created, modified, or deleted within
+ * a receiver instance. The implementation must update @p inst->transport_config
+ * in place and set @p inst->modified if the change requires receivers to reconnect.
+ *
+ * For the transport NP container itself (e.g. "udp-notif-receiver"), SR_OP_CREATED
+ * means the transport type is being set and the config should be initialized;
+ * SR_OP_DELETED means the transport is being removed and the config should be freed.
+ *
+ * @param[in] inst Receiver instance being modified. @p inst->transport_config may be NULL
+ *             if the transport container has not been created yet.
+ * @param[in] node Changed YANG data node.
+ * @param[in] op Sysrepo change operation (SR_OP_CREATED, SR_OP_MODIFIED, SR_OP_DELETED).
+ * @return SR_ERR_OK on success, error code on failure.
+ */
+typedef int (*notif_transport_config_change_cb)(notif_receiver_inst_t *inst,
+        const struct lyd_node *node, sr_change_oper_t op);
+
+/**
+ * @brief Free a transport-specific configuration structure.
+ *
+ * Called when a receiver instance is being destroyed or when the transport
+ * container is deleted. Must release all memory held by @p cfg.
+ *
+ * @param[in] cfg Transport-specific configuration to free (may be NULL).
+ */
+typedef void (*notif_transport_config_destroy_cb)(void *cfg);
+
+/**
+ * @brief Validate transport configuration for a subscription.
+ *
+ * Called during subscription validation (SR_EV_CHANGE) to check that the transport-specific
+ * configuration under the subscription's receiver instance is valid and
+ * supportable. The @p node is the subscription YANG node (not the transport
+ * config container), allowing cross-validation between subscription parameters
+ * and transport capabilities.
+ *
+ * @param[in] node Subscription YANG data node containing the transport reference.
+ * @return SR_ERR_OK if valid, error code otherwise.
+ */
+typedef int (*notif_transport_config_validate_cb)(const struct lyd_node *node);
+
+/**
+ * @brief Transport operations vtable.
+ *
+ * Each transport type implements this interface, enabling polymorphic
+ * connect/disconnect/send/config operations without switch statements.
+ */
+typedef struct notif_transport_ops_s {
+    const char *name;                                   /**< human-readable transport name (e.g. "UDP") */
+    const char *transport_identity;                     /**< YANG identity value (e.g. "ietf-udp-notif-transport:udp-notif") */
+    const char *config_container_name;                  /**< NP container name under receiver-instance (e.g. "udp-notif-receiver") */
+    notif_transport_type_t type;                        /**< transport type enum value */
+
+    notif_transport_connect_cb connect;                 /**< establish transport connection */
+    notif_transport_disconnect_cb disconnect;           /**< tear down transport connection */
+    notif_transport_is_connected_cb is_connected;       /**< check if transport is connected */
+    notif_transport_send_cb send;                       /**< send a notification */
+
+    notif_transport_config_parse_cb config_parse;       /**< parse config from YANG datastore */
+    notif_transport_config_change_cb config_change;     /**< handle incremental config changes */
+    notif_transport_config_destroy_cb config_destroy;   /**< free transport config */
+    notif_transport_config_validate_cb config_validate; /**< validate transport config */
+} notif_transport_ops_t;
+
+/**
+ * @brief Receiver instance shared by subscriptions.
+ * Corresponds to /ietf-subscribed-notifications:receiver-instances/receiver-instance.
+ *
+ * Holds transport configuration and is referenced by subscription receivers.
+ */
+struct notif_receiver_inst_s {
+    char *name;                             /**< receiver instance name */
+
+    int modified;                           /**< whether the instance was modified and needs reconnect */
+
+    notif_transport_type_t type;            /**< configured transport type */
+    const notif_transport_ops_t *ops;       /**< transport operations vtable */
+    void *transport_config;                 /**< transport-specific configuration (owned by the transport ops) */
+};
+
+/**
+ * @brief Callback data passed to ::srsn_notif_cb().
+ */
+typedef struct notif_cb_data_s {
+    notifd_ctx_t *ctx;          /**< main daemon context */
+    notif_receiver_t *recv;     /**< receiver to send the notification to */
+    notif_encoding_t encoding;  /**< notification encoding to use for sending */
+} notif_cb_data_t;
+
+/**
+ * @brief Receiver within a subscription.
+ * Corresponds to /ietf-subscribed-notifications:subscriptions/subscription/receivers/receiver
+ *
+ * References a receiver instance, which holds the actual transport configuration.
+ */
+struct notif_receiver_s {
+    char *name;                                 /**< receiver name */
+
+    notif_recv_state_t state;                   /**< current receiver state */
+    notif_receiver_inst_t *inst;                /**< resolved reference to the receiver instance */
+
+    const notif_transport_ops_t *ops;           /**< transport operations vtable (copied from inst) */
+    void *conn_ctx;                             /**< transport-specific connection context (owned by the transport ops) */
+
+    struct {
+        sr_subscription_ctx_t *sr_subscr;       /**< sysrepo subscription context */
+        uint32_t sub_id;                        /**< srsn subscription ID */
+        int fd;                                 /**< notification pipe FD from srsn_subscribe */
+    } srsn_data;                                /**< srsn subscription and dispatch data */
+    notif_cb_data_t cb_data;                    /**< callback data for srsn dispatch */
+
+    notif_sub_t *sub;                           /**< back-pointer to the parent subscription */
+    struct timespec last_reconnect_attempt;     /**< time of the last reconnect attempt */
+    uint32_t reconnect_attempts;                /**< number of consecutive failed reconnect attempts */
+
+};
+
+/**
+ * @brief Configured subscription context.
+ * Corresponds to /ietf-subscribed-notifications:subscriptions/subscription
+ */
+struct notif_sub_s {
+    uint32_t id;                        /**< subscription ID */
+
+    notif_sub_state_t state;            /**< subscription state */
+
+    int resubscribe;                    /**< whether the subscription needs to be resubscribed to apply changes */
+    int modified;                       /**< whether the subscription was modified */
+    const char *modif_err_reason;       /**< YANG identity-ref reason the subscription is invalid, used in subscription-terminated */
+
+    char *stream;                       /**< stream name */
+    char *filter_ref;                   /**< optional stream filter name (e.g., XPath or subtree filter) */
+    char *xpath_filter;                 /**< optional XPath filter */
+    notif_encoding_t encoding;          /**< notification encoding */
+    struct timespec stop_time;          /**< optional stop time */
+    int replay;                         /**< whether to replay notifications */
+    struct timespec start_time;         /**< requested replay start time for configured-replay */
+    struct timespec replay_start_time;  /**< actual replay start time returned by srsn_subscribe */
+    char *purpose;                      /**< purpose of the subscription */
+    char *local_address;                /**< local address to send notifications from (NULL means OS default) */
+
+    notif_receiver_t *receivers;        /**< receivers of this subscription (sized-array, see libyang docs) */
+};
+
+/**
+ * @brief Main daemon context.
+ */
+struct notifd_ctx_s {
+    sr_session_ctx_t *sr_sess;              /**< sysrepo session used by the daemon */
+    pthread_rwlock_t state_rwlock;          /**< synchronize access to daemon shared state (subscriptions,
+                                                 receiver instances, and related runtime fields) */
+    pthread_mutex_t config_apply_mutex;     /**< serialize config-apply operations; keeps a single apply
+                                                 transaction active so state_rwlock write-lock ownership
+                                                 cannot be stolen across temporary unlock/relock windows */
+
+    notif_sub_t **subs;                     /**< configured subscriptions (sized-array, see libyang docs) */
+    notif_receiver_inst_t **recv_insts;     /**< configured receiver instances (sized-array, see libyang docs) */
+};
+
+#endif /* NOTIFD_H_ */

--- a/src/executables/sysrepo-notifd/notifd_config.c
+++ b/src/executables/sysrepo-notifd/notifd_config.c
@@ -1,0 +1,1862 @@
+/**
+ * @file notifd_config.c
+ * @author Roman Janota <Roman.Janota@cesnet.cz>
+ * @brief sysrepo notification daemon configuration model and change handling
+ *
+ * @copyright
+ * Copyright (c) 2026 CESNET, z.s.p.o.
+ *
+ * This source code is licensed under BSD 3-Clause License (the "License").
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://opensource.org/licenses/BSD-3-Clause
+ */
+
+#define _GNU_SOURCE
+
+#include "compat.h"
+
+#include <assert.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
+
+#include "common.h"
+#include "notifd.h"
+#include "utils/subscribed_notifications.h"
+
+#include <libyang/libyang.h>
+
+/* forward declarations */
+void receiver_destroy(notifd_ctx_t *notifd_ctx, notif_sub_t *sub, notif_receiver_t *receiver);
+
+/*
+ * ---------------------------------------------------------------------------
+ * Transport registry
+ * ---------------------------------------------------------------------------
+ */
+
+/**
+ * @brief Static registry of all compiled-in transports.
+ *
+ * To add a new transport, define a notif_transport_ops_t in its own source
+ * file and add a pointer to it here.
+ */
+static const notif_transport_ops_t *transport_registry[] = {
+    &udp_transport_ops,
+    NULL
+};
+
+/**
+ * @brief Find a registered transport by its YANG identity value.
+ *
+ * @param[in] identity YANG identity string (e.g. "ietf-udp-notif-transport:udp-notif").
+ * @return Pointer to the matching transport ops, or NULL if not found.
+ */
+const notif_transport_ops_t *
+notif_transport_find_by_identity(const char *identity)
+{
+    int i;
+
+    if (!identity) {
+        return NULL;
+    }
+
+    for (i = 0; transport_registry[i]; i++) {
+        if (!strcmp(transport_registry[i]->transport_identity, identity)) {
+            return transport_registry[i];
+        }
+    }
+
+    return NULL;
+}
+
+/**
+ * @brief Find a registered transport by its NP container name.
+ *
+ * @param[in] container_name NP container node name (e.g. "udp-notif-receiver").
+ * @return Pointer to the matching transport ops, or NULL if not found.
+ */
+const notif_transport_ops_t *
+notif_transport_find_by_container(const char *container_name)
+{
+    int i;
+
+    if (!container_name) {
+        return NULL;
+    }
+
+    for (i = 0; transport_registry[i]; i++) {
+        if (!strcmp(transport_registry[i]->config_container_name, container_name)) {
+            return transport_registry[i];
+        }
+    }
+
+    return NULL;
+}
+
+/*
+ * ---------------------------------------------------------------------------
+ * Helpers
+ * ---------------------------------------------------------------------------
+ */
+
+int
+get_descendant_mandatory(const struct lyd_node *ctx_node, const char *path, struct lyd_node **match)
+{
+    *match = NULL;
+
+    lyd_find_path(ctx_node, path, 0, match);
+
+    if (!*match) {
+        SRNTF_LOG_ERR("Expected descendant \"%s\" of node \"%s\" missing.", path, LYD_NAME(ctx_node));
+        return SR_ERR_NOT_FOUND;
+    }
+    return SR_ERR_OK;
+}
+
+void
+get_descendant_optional(const struct lyd_node *ctx_node, const char *path, struct lyd_node **match)
+{
+    uint32_t ll = 0;
+
+    *match = NULL;
+
+    /* temporarily suppress error logging, since the node may be legitimately missing */
+    ly_temp_log_options(&ll);
+
+    lyd_find_path(ctx_node, path, 0, match);
+
+    /* restore error logging */
+    ly_temp_log_options(NULL);
+}
+
+const char *
+subscription_state2str(notif_sub_state_t state)
+{
+    switch (state) {
+    case NOTIF_SUB_STATE_VALID:
+        return "valid";
+    case NOTIF_SUB_STATE_INVALID:
+        return "invalid";
+    case NOTIF_SUB_STATE_CONCLUDED:
+        return "concluded";
+    default:
+        return "unknown";
+    }
+}
+
+const char *
+receiver_state2str(notif_recv_state_t state)
+{
+    switch (state) {
+    case NOTIF_RECV_STATE_ACTIVE:
+        return "active";
+    case NOTIF_RECV_STATE_SUSPENDED:
+        return "suspended";
+    case NOTIF_RECV_STATE_CONNECTING:
+        return "connecting";
+    case NOTIF_RECV_STATE_DISCONNECTED:
+        return "disconnected";
+    default:
+        return "unknown";
+    }
+}
+
+static int
+notif_encoding_parse(const struct lyd_node *node, notif_encoding_t *encoding)
+{
+    int rc = SR_ERR_OK;
+    const char *value;
+
+    *encoding = NOTIF_ENCODING_UNSET;
+
+    value = ((struct lyd_node_term *)node)->value.ident->name;
+    if (!strcmp(value, "encode-xml")) {
+        *encoding = NOTIF_ENCODING_XML;
+    } else if (!strcmp(value, "encode-json")) {
+        *encoding = NOTIF_ENCODING_JSON;
+    } else if (!strcmp(value, "encode-cbor")) {
+        SRNTF_LOG_ERR("CBOR encoding is not yet supported.");
+        rc = SR_ERR_UNSUPPORTED;
+    } else {
+        SRNTF_LOG_ERR("Unsupported encoding \"%s\".", value);
+        rc = SR_ERR_UNSUPPORTED;
+    }
+
+    return rc;
+}
+
+static int
+stream_filter_xpath_get(sr_session_ctx_t *sess, const char *filter_name, char **xpath_filter)
+{
+    int rc = SR_ERR_OK;
+    struct lyd_node *filter, *tree;
+    char *path = NULL;
+    sr_data_t *data = NULL;
+
+    /* get the filter with this name */
+    if ((asprintf(&path, "/ietf-subscribed-notifications:filters/stream-filter[name=\"%s\"]", filter_name) == -1)) {
+        rc = SR_ERR_NO_MEMORY;
+        ERRMEM;
+        goto cleanup;
+    }
+    if ((rc = sr_get_data(sess, path, 0, 0, 0, &data))) {
+        goto cleanup;
+    }
+    if (!data) {
+        /* filter not set yet, so no filter to apply */
+        goto cleanup;
+    }
+
+    /* data->tree points to filters cont, we go one level down to the filter instance */
+    tree = lyd_child(data->tree);
+
+    /* because it's a choice, only one of the two filter types can be present */
+    get_descendant_optional(tree, "stream-subtree-filter", &filter);
+    if (filter) {
+        /* convert the subtree filter to an xpath filter, subtree is anydata so use lyd_child_any */
+        if ((rc = srsn_filter_subtree2xpath(lyd_child_any(filter), sess, xpath_filter))) {
+            goto cleanup;
+        }
+    }
+
+    get_descendant_optional(tree, "stream-xpath-filter", &filter);
+    if (filter) {
+        /* filter is already an xpath filter, just return the value */
+        *xpath_filter = strdup(lyd_get_value(filter));
+        CHECK_ERRMEM_GOTO(*xpath_filter, rc, cleanup);
+    }
+
+cleanup:
+    free(path);
+    sr_release_data(data);
+    return rc;
+}
+
+/**
+ * @brief Check whether the specified stream supports replay.
+ *
+ * @param[in] notifd_ctx Daemon context.
+ * @param[in] stream Name of the stream to check.
+ * @param[in] xpath_filter Optional stream filter to consider when determining replay support.
+ * @param[out] earliest_replay_start_time If replay is supported,
+ * set to the earliest replay start time across all modules in the stream.
+ * @return ::SR_ERR_OK if replay is supported, ::SR_ERR_UNSUPPORTED if not, or other error code on failure.
+ */
+static int
+stream_supports_replay(notifd_ctx_t *notifd_ctx, const char *stream, const char *xpath_filter,
+        struct timespec *earliest_replay_start_time)
+{
+    int rc = SR_ERR_OK, r, replay_enabled = 0;
+    const struct ly_ctx *ly_ctx;
+    struct ly_set *mod_set = NULL;
+    uint32_t i;
+    const struct lys_module *ly_mod;
+    sr_conn_ctx_t *conn;
+    struct timespec ts = {0};
+
+    if (!earliest_replay_start_time) {
+        return SR_ERR_INVAL_ARG;
+    }
+
+    earliest_replay_start_time->tv_sec = 0;
+    earliest_replay_start_time->tv_nsec = 0;
+
+    conn = sr_session_get_connection(notifd_ctx->sr_sess);
+    ly_ctx = sr_session_acquire_context(notifd_ctx->sr_sess);
+
+    if ((rc = srsn_stream_collect_mods(stream, xpath_filter, ly_ctx, &mod_set))) {
+        goto cleanup;
+    }
+
+    for (i = 0; i < mod_set->count; i++) {
+        ly_mod = mod_set->objs[i];
+
+        /* get earliest replay start time */
+        if ((rc = sr_get_module_replay_support(conn, ly_mod->name, NULL, &r))) {
+            goto cleanup;
+        }
+
+        if (!r) {
+            SRNTF_LOG_WRN("Module \"%s\" in stream \"%s\" does not support replay.", ly_mod->name, stream);
+            continue;
+        }
+
+        if ((rc = sr_get_module_replay_start(conn, ly_mod->name, NULL, NULL, &ts))) {
+            goto cleanup;
+        }
+
+        replay_enabled = 1;
+
+        if (((earliest_replay_start_time->tv_sec == 0) && (earliest_replay_start_time->tv_nsec == 0)) ||
+                ((ts.tv_sec || ts.tv_nsec) &&
+                (timespec_cmp(&ts, earliest_replay_start_time) < 0))) {
+            *earliest_replay_start_time = ts;
+        }
+    }
+
+    if (!replay_enabled) {
+        rc = SR_ERR_UNSUPPORTED;
+    }
+
+cleanup:
+    sr_session_release_context(notifd_ctx->sr_sess);
+    ly_set_free(mod_set, NULL);
+    return rc;
+}
+
+/*
+ * ---------------------------------------------------------------------------
+ * Find functions
+ * ---------------------------------------------------------------------------
+ */
+
+notif_sub_t *
+subscription_find_by_id(notifd_ctx_t *ctx, uint32_t sub_id)
+{
+    LY_ARRAY_COUNT_TYPE i;
+
+    LY_ARRAY_FOR(ctx->subs, i) {
+        if (ctx->subs[i]->id == sub_id) {
+            return ctx->subs[i];
+        }
+    }
+
+    return NULL;
+}
+
+notif_receiver_t *
+receiver_find_by_name(notif_sub_t *sub, const char *name)
+{
+    LY_ARRAY_COUNT_TYPE i;
+
+    LY_ARRAY_FOR(sub->receivers, i) {
+        if (!strcmp(sub->receivers[i].name, name)) {
+            return &sub->receivers[i];
+        }
+    }
+    return NULL;
+}
+
+notif_receiver_inst_t *
+receiver_inst_find_by_name(notifd_ctx_t *ctx, const char *name)
+{
+    LY_ARRAY_COUNT_TYPE i;
+
+    LY_ARRAY_FOR(ctx->recv_insts, i) {
+        if (!strcmp(ctx->recv_insts[i]->name, name)) {
+            return ctx->recv_insts[i];
+        }
+    }
+
+    return NULL;
+}
+
+notif_sub_t *
+subscription_find_by_node(notifd_ctx_t *notifd_ctx, const struct lyd_node *ctx_node)
+{
+    uint32_t sub_id;
+    struct lyd_node *n;
+
+    /* find the ancestor subscription node */
+    while (ctx_node) {
+        if (!strcmp(LYD_NAME(ctx_node), "subscription")) {
+            break;
+        }
+        ctx_node = lyd_parent(ctx_node);
+    }
+    if (!ctx_node) {
+        return NULL;
+    }
+
+    /* get subscription ID */
+    if (get_descendant_mandatory(ctx_node, "id", &n)) {
+        return NULL;
+    }
+    sub_id = (uint32_t)strtoul(lyd_get_value(n), NULL, 10);
+
+    return subscription_find_by_id(notifd_ctx, sub_id);
+}
+
+notif_receiver_t *
+receiver_find_by_node(notifd_ctx_t *notifd_ctx, const struct lyd_node *ctx_node)
+{
+    const char *name;
+    struct lyd_node *n;
+    notif_sub_t *sub;
+
+    /* find the ancestor receiver node */
+    while (ctx_node) {
+        if (!strcmp(LYD_NAME(ctx_node), "receiver")) {
+            break;
+        }
+        ctx_node = lyd_parent(ctx_node);
+    }
+    if (!ctx_node) {
+        return NULL;
+    }
+
+    /* get receiver name */
+    if (get_descendant_mandatory(ctx_node, "name", &n)) {
+        return NULL;
+    }
+    name = lyd_get_value(n);
+
+    /* find the ancestor subscription node */
+    if (!(sub = subscription_find_by_node(notifd_ctx, ctx_node))) {
+        return NULL;
+    }
+
+    return receiver_find_by_name(sub, name);
+}
+
+notif_receiver_inst_t *
+receiver_inst_find_by_node(notifd_ctx_t *notifd_ctx, const struct lyd_node *ctx_node)
+{
+    const char *name;
+    struct lyd_node *n;
+
+    /* find the ancestor receiver-instance node */
+    while (ctx_node) {
+        if (!strcmp(LYD_NAME(ctx_node), "receiver-instance")) {
+            break;
+        }
+        ctx_node = lyd_parent(ctx_node);
+    }
+    if (!ctx_node) {
+        return NULL;
+    }
+
+    /* get receiver-instance name */
+    if (get_descendant_mandatory(ctx_node, "name", &n)) {
+        return NULL;
+    }
+    name = lyd_get_value(n);
+
+    return receiver_inst_find_by_name(notifd_ctx, name);
+}
+
+/*
+ * ---------------------------------------------------------------------------
+ * Subscription field change handlers
+ * ---------------------------------------------------------------------------
+ */
+
+/**
+ * @brief Mark a subscription as invalid, setting the reason if not already set.
+ *
+ * @param[in] sub Subscription to mark as invalid.
+ * @param[in] reason Optional YANG identity-ref reason for invalidity.
+ */
+static void
+sub_invalidate(notif_sub_t *sub, const char *reason)
+{
+    sub->state = NOTIF_SUB_STATE_INVALID;
+    if (!sub->modif_err_reason) {
+        sub->modif_err_reason = reason ? reason : "ietf-subscribed-notifications:insufficient-resources";
+    }
+}
+
+int
+handle_stream(notif_sub_t *sub, const struct lyd_node *node, sr_change_oper_t op)
+{
+    int rc = SR_ERR_OK;
+
+    /* mandatory leaf, cr + del handled by 'subscription', so only handle mod */
+    if (op == SR_OP_MODIFIED) {
+        /* switch to the new value */
+        free(sub->stream);
+        sub->stream = strdup(lyd_get_value(node));
+        if (!sub->stream) {
+            rc = SR_ERR_NO_MEMORY;
+            ERRMEM;
+            goto cleanup;
+        }
+
+        /* mark sub as modified so we know to send subscription-modified notification */
+        sub->modified = 1;
+        sub->resubscribe = 1;
+    }
+
+cleanup:
+    if (rc) {
+        sub_invalidate(sub, NULL);
+    }
+    return rc;
+}
+
+int
+handle_stream_filter_name(notifd_ctx_t *notifd_ctx, notif_sub_t *sub, const struct lyd_node *node, sr_change_oper_t op)
+{
+    int rc = SR_ERR_OK;
+
+    /* optional leaf, need to handle all but move */
+    if ((op == SR_OP_CREATED) || (op == SR_OP_MODIFIED)) {
+        /* free the old filter */
+        free(sub->xpath_filter);
+        sub->xpath_filter = NULL;
+        free(sub->filter_ref);
+        sub->filter_ref = NULL;
+
+        /* dup the referenced filter name */
+        sub->filter_ref = strdup(lyd_get_value(node));
+        CHECK_ERRMEM_GOTO(sub->filter_ref, rc, cleanup);
+
+        /* get the xpath filter from the referenced stream filter */
+        if ((rc = stream_filter_xpath_get(notifd_ctx->sr_sess, sub->filter_ref, &sub->xpath_filter))) {
+            goto cleanup;
+        }
+    } else if (op == SR_OP_DELETED) {
+        /* just reset all filter info */
+        free(sub->filter_ref);
+        sub->filter_ref = NULL;
+        free(sub->xpath_filter);
+        sub->xpath_filter = NULL;
+    }
+
+    if ((op == SR_OP_CREATED) || (op == SR_OP_MODIFIED) || (op == SR_OP_DELETED)) {
+        /* mark sub as modified so we know to send subscription-modified notification */
+        sub->modified = 1;
+        sub->resubscribe = 1;
+    }
+
+cleanup:
+    if (rc) {
+        sub_invalidate(sub, NULL);
+    }
+    return rc;
+}
+
+int
+handle_stream_subtree_filter(notifd_ctx_t *notifd_ctx, notif_sub_t *sub, const struct lyd_node *node, sr_change_oper_t op)
+{
+    int rc = SR_ERR_OK;
+    struct lyd_node *filter;
+
+    /* optional leaf, need to handle all but move */
+    if ((op == SR_OP_CREATED) || (op == SR_OP_MODIFIED)) {
+        /* free the old filter */
+        free(sub->xpath_filter);
+        sub->xpath_filter = NULL;
+
+        /* get the first child of the anydata stream-subtree-filter node, which is the first actual filter sibling */
+        filter = lyd_child_any(node);
+        if (filter) {
+            /* filter exists, convert it to an xpath filter and switch to the new value */
+            if ((rc = srsn_filter_subtree2xpath(filter, notifd_ctx->sr_sess, &sub->xpath_filter))) {
+                goto cleanup;
+            }
+        }
+    } else if (op == SR_OP_DELETED) {
+        free(sub->xpath_filter);
+        sub->xpath_filter = NULL;
+    }
+
+    if ((op == SR_OP_CREATED) || (op == SR_OP_MODIFIED) || (op == SR_OP_DELETED)) {
+        /* mark sub as modified so we know to send subscription-modified notification */
+        sub->modified = 1;
+        sub->resubscribe = 1;
+    }
+
+cleanup:
+    if (rc) {
+        sub_invalidate(sub, NULL);
+    }
+    return rc;
+}
+
+int
+handle_stream_xpath_filter(notif_sub_t *sub, const struct lyd_node *node, sr_change_oper_t op)
+{
+    int rc = SR_ERR_OK;
+
+    /* optional leaf, need to handle all but move */
+    if ((op == SR_OP_CREATED) || (op == SR_OP_MODIFIED)) {
+        /* switch to the new value */
+        free(sub->xpath_filter);
+        sub->xpath_filter = strdup(lyd_get_value(node));
+        if (!sub->xpath_filter) {
+            rc = SR_ERR_NO_MEMORY;
+            ERRMEM;
+            goto cleanup;
+        }
+    } else if (op == SR_OP_DELETED) {
+        free(sub->xpath_filter);
+        sub->xpath_filter = NULL;
+    }
+
+    if ((op == SR_OP_CREATED) || (op == SR_OP_MODIFIED) || (op == SR_OP_DELETED)) {
+        /* mark sub as modified so we know to send subscription-modified notification */
+        sub->modified = 1;
+        sub->resubscribe = 1;
+    }
+
+cleanup:
+    if (rc) {
+        sub_invalidate(sub, NULL);
+    }
+    return rc;
+}
+
+int
+handle_encoding(notif_sub_t *sub, const struct lyd_node *node, sr_change_oper_t op)
+{
+    int rc = SR_ERR_OK;
+
+    /* optional leaf, need to handle all but move */
+    if ((op == SR_OP_CREATED) || (op == SR_OP_MODIFIED)) {
+        /* switch to the new value */
+        if ((rc = notif_encoding_parse(node, &sub->encoding))) {
+            sub->modif_err_reason = "ietf-subscribed-notifications:encoding-unsupported";
+            goto cleanup;
+        }
+    } else if (op == SR_OP_DELETED) {
+        sub->encoding = NOTIF_ENCODING_UNSET;
+    }
+
+    if ((op == SR_OP_CREATED) || (op == SR_OP_MODIFIED) || (op == SR_OP_DELETED)) {
+        /* mark sub as modified so we know to send subscription-modified notification */
+        sub->modified = 1;
+    }
+
+cleanup:
+    if (rc) {
+        sub_invalidate(sub, NULL);
+    }
+    return rc;
+}
+
+int
+handle_stop_time(notif_sub_t *sub, const struct lyd_node *node, sr_change_oper_t op)
+{
+    int rc = SR_ERR_OK;
+
+    /* optional leaf, need to handle all but move */
+    if ((op == SR_OP_CREATED) || (op == SR_OP_MODIFIED)) {
+        /* switch to the new value */
+        if (ly_time_str2ts(lyd_get_value(node), &sub->stop_time)) {
+            rc = SR_ERR_LY;
+            goto cleanup;
+        }
+    } else if (op == SR_OP_DELETED) {
+        /* clear stop time */
+        sub->stop_time.tv_sec = 0;
+        sub->stop_time.tv_nsec = 0;
+    }
+
+    if ((op == SR_OP_CREATED) || (op == SR_OP_MODIFIED) || (op == SR_OP_DELETED)) {
+        /* mark sub as modified so we know to send subscription-modified notification */
+        sub->modified = 1;
+        sub->resubscribe = 1;
+    }
+
+cleanup:
+    if (rc) {
+        sub_invalidate(sub, NULL);
+    }
+    return rc;
+}
+
+int
+handle_configured_replay(notifd_ctx_t *notifd_ctx, notif_sub_t *sub, const struct lyd_node *UNUSED(node), sr_change_oper_t op)
+{
+    int rc = SR_ERR_OK;
+    struct timespec replay_start_time = {0};
+
+    /* optional leaf, type empty, so only handle create and delete */
+    if (op == SR_OP_CREATED) {
+        /* switch to the new value */
+        sub->replay = 1;
+    } else if (op == SR_OP_DELETED) {
+        /* clear replay */
+        sub->replay = 0;
+        sub->start_time.tv_sec = 0;
+        sub->start_time.tv_nsec = 0;
+    }
+
+    if (op == SR_OP_CREATED) {
+        /* we need to check that at least 1 mod in the stream supports replay, otherwise this is an invalid subscription config */
+        if ((rc = stream_supports_replay(notifd_ctx, sub->stream, sub->xpath_filter, &replay_start_time))) {
+            SRNTF_LOG_ERR("Stream \"%s\" does not support replay, cannot enable replay for subscription ID %" PRIu32 ".",
+                    sub->stream, sub->id);
+            sub->modif_err_reason = "ietf-subscribed-notifications:stream-unavailable";
+            goto cleanup;
+        }
+
+        sub->start_time = replay_start_time;
+
+        /* mark sub as modified so we know to send subscription-modified notification + resubscribe to apply replay */
+        sub->modified = 1;
+        sub->resubscribe = 1;
+    }
+
+cleanup:
+    if (rc) {
+        sub_invalidate(sub, NULL);
+    }
+    return rc;
+}
+
+int
+handle_purpose(notif_sub_t *sub, const struct lyd_node *node, sr_change_oper_t op)
+{
+    int rc = SR_ERR_OK;
+
+    /* optional leaf, need to handle all but move */
+    if ((op == SR_OP_CREATED) || (op == SR_OP_MODIFIED)) {
+        /* switch to the new value */
+        free(sub->purpose);
+        sub->purpose = strdup(lyd_get_value(node));
+        if (!sub->purpose) {
+            rc = SR_ERR_NO_MEMORY;
+            ERRMEM;
+            goto cleanup;
+        }
+    } else if (op == SR_OP_DELETED) {
+        /* clear purpose */
+        free(sub->purpose);
+        sub->purpose = NULL;
+    }
+
+    if ((op == SR_OP_CREATED) || (op == SR_OP_MODIFIED) || (op == SR_OP_DELETED)) {
+        /* mark sub as modified so we know to send subscription-modified notification */
+        sub->modified = 1;
+    }
+
+cleanup:
+    if (rc) {
+        sub_invalidate(sub, NULL);
+    }
+    return rc;
+}
+
+int
+handle_source_address(notifd_ctx_t *notifd_ctx, notif_sub_t *sub, const struct lyd_node *node, sr_change_oper_t op)
+{
+    int rc = SR_ERR_OK;
+    notif_receiver_t *receiver;
+    LY_ARRAY_COUNT_TYPE i, j, count;
+
+    /* optional leaf, need to handle all but move */
+    if ((op == SR_OP_CREATED) || (op == SR_OP_MODIFIED)) {
+        /* switch to the new value */
+        free(sub->local_address);
+        sub->local_address = strdup(lyd_get_value(node));
+        if (!sub->local_address) {
+            rc = SR_ERR_NO_MEMORY;
+            ERRMEM;
+            goto cleanup;
+        }
+    } else if (op == SR_OP_DELETED) {
+        /* clear local address */
+        free(sub->local_address);
+        sub->local_address = NULL;
+    }
+
+    if ((op == SR_OP_CREATED) || (op == SR_OP_MODIFIED) || (op == SR_OP_DELETED)) {
+        /* reconnect all the receivers, since we will need to create new sockets with the new local address */
+        count = LY_ARRAY_COUNT(sub->receivers);
+        for (i = 0; i < count; i++) {
+            receiver = &sub->receivers[i];
+            if (!receiver->inst) {
+                /* receiver instance not mandatory */
+                continue;
+            }
+
+            rc = notif_receiver_reconnect(notifd_ctx, sub, receiver, NULL);
+            if (rc) {
+                /* rollback: disconnect previously reconnected receivers so they are in a consistent state */
+                for (j = 0; j < i; j++) {
+                    if (sub->receivers[j].inst && notif_receiver_is_connected(&sub->receivers[j])) {
+                        notif_receiver_disconnect(&sub->receivers[j]);
+                        sub->receivers[j].state = NOTIF_RECV_STATE_DISCONNECTED;
+                    }
+                }
+                goto cleanup;
+            }
+        }
+
+        /* mark sub as modified so we know to send subscription-modified notification */
+        sub->modified = 1;
+    }
+
+cleanup:
+    if (rc) {
+        sub_invalidate(sub, NULL);
+    }
+    return rc;
+}
+
+/*
+ * ---------------------------------------------------------------------------
+ * Receiver-instance config change dispatch
+ * ---------------------------------------------------------------------------
+ */
+
+int
+receiver_inst_config_change(notif_receiver_inst_t *recv_inst, const struct lyd_node *node, sr_change_oper_t op)
+{
+    const char *node_name;
+    const notif_transport_ops_t *ops;
+
+    node_name = LYD_NAME(node);
+
+    if (recv_inst->ops) {
+        return recv_inst->ops->config_change(recv_inst, node, op);
+    }
+
+    ops = notif_transport_find_by_container(node_name);
+    if (ops) {
+        recv_inst->ops = ops;
+        recv_inst->type = ops->type;
+        return ops->config_change(recv_inst, node, op);
+    }
+
+    return SR_ERR_OK;
+}
+
+int
+handle_receiver_instance_ref(notifd_ctx_t *notifd_ctx, notif_sub_t *sub, const struct lyd_node *node, sr_change_oper_t op)
+{
+    int rc = SR_ERR_OK;
+    notif_receiver_t *receiver;
+    notif_receiver_inst_t *new_inst;
+
+    /* get the receiver */
+    if (!(receiver = receiver_find_by_node(notifd_ctx, node))) {
+        SRNTF_LOG_ERR("Failed to find receiver for receiver-instance-ref change.");
+        rc = SR_ERR_NOT_FOUND;
+        goto cleanup;
+    }
+
+    /* optional leaf, need to handle all but move */
+    if ((op == SR_OP_CREATED) || (op == SR_OP_MODIFIED)) {
+        /* get the new instance */
+        new_inst = receiver_inst_find_by_name(notifd_ctx, lyd_get_value(node));
+        if (!new_inst) {
+            SRNTF_LOG_ERR("Receiver instance \"%s\" not found for receiver \"%s\".", lyd_get_value(node), receiver->name);
+            rc = SR_ERR_NOT_FOUND;
+            goto cleanup;
+        }
+    } else if (op == SR_OP_DELETED) {
+        /* the instance ref is being removed */
+        new_inst = NULL;
+    }
+
+    if ((op == SR_OP_CREATED) || (op == SR_OP_MODIFIED) || (op == SR_OP_DELETED)) {
+        if (!new_inst) {
+            /* just disconnect the old instance */
+            notif_receiver_disconnect(receiver);
+            receiver->state = NOTIF_RECV_STATE_DISCONNECTED;
+            receiver->inst = NULL;
+            receiver->ops = NULL;
+        } else {
+            /* disconnect from old and connect to the new instance */
+            rc = notif_receiver_reconnect(notifd_ctx, sub, receiver, new_inst);
+            if (rc) {
+                goto cleanup;
+            }
+        }
+    }
+
+cleanup:
+    if (rc) {
+        sub_invalidate(sub, NULL);
+        sub->modified = 1;
+    }
+    return rc;
+}
+
+/*
+ * ---------------------------------------------------------------------------
+ * Subscription parsing and CRUD
+ * ---------------------------------------------------------------------------
+ */
+
+static int
+subscription_from_node(notifd_ctx_t *notifd_ctx, const struct lyd_node *node, notif_sub_t *sub)
+{
+    int rc = SR_ERR_OK;
+    struct lyd_node *n, *filter;
+    struct ly_set *set = NULL;
+    uint32_t i;
+
+    /* subscription ID */
+    if ((rc = get_descendant_mandatory(node, "id", &n))) {
+        goto cleanup;
+    }
+    sub->id = strtoul(lyd_get_value(n), NULL, 10);
+
+    /* stream */
+    if ((rc = get_descendant_mandatory(node, "stream", &n))) {
+        goto cleanup;
+    }
+    sub->stream = strdup(lyd_get_value(n));
+    CHECK_ERRMEM_GOTO(sub->stream, rc, cleanup);
+
+    /* stream-filter-name */
+    get_descendant_optional(node, "stream-filter-name", &n);
+    if (n) {
+        /* dup the referenced filter name */
+        sub->filter_ref = strdup(lyd_get_value(n));
+        CHECK_ERRMEM_GOTO(sub->filter_ref, rc, cleanup);
+
+        /* get the xpath filter from the referenced stream filter (if any, it's a leafref, not instanceref) */
+        if ((rc = stream_filter_xpath_get(notifd_ctx->sr_sess, sub->filter_ref, &sub->xpath_filter))) {
+            goto cleanup;
+        }
+    }
+
+    /* subtree filter */
+    get_descendant_optional(node, "stream-subtree-filter", &n);
+    if (n) {
+        /* free the old filter */
+        free(sub->xpath_filter);
+        sub->xpath_filter = NULL;
+
+        /* get the first child of the anydata stream-subtree-filter node, which is the first actual filter sibling */
+        filter = lyd_child_any(n);
+        if (filter) {
+            /* filter exists, convert it to an xpath filter and switch to the new value */
+            if ((rc = srsn_filter_subtree2xpath(filter, notifd_ctx->sr_sess, &sub->xpath_filter))) {
+                goto cleanup;
+            }
+        }
+    }
+
+    /* xpath filter */
+    get_descendant_optional(node, "stream-xpath-filter", &n);
+    if (n) {
+        sub->xpath_filter = strdup(lyd_get_value(n));
+        CHECK_ERRMEM_GOTO(sub->xpath_filter, rc, cleanup);
+    }
+
+    /* encoding */
+    get_descendant_optional(node, "encoding", &n);
+    if (n) {
+        if ((rc = notif_encoding_parse(n, &sub->encoding))) {
+            goto cleanup;
+        }
+    }
+
+    /* stop time */
+    get_descendant_optional(node, "stop-time", &n);
+    if (n) {
+        if (ly_time_str2ts(lyd_get_value(n), &sub->stop_time)) {
+            rc = SR_ERR_LY;
+            goto cleanup;
+        }
+    }
+
+    /* transport (mandatory for configured subs, even though it is not mandatory in the model), refine "transport" */
+    if ((rc = get_descendant_mandatory(node, "transport", &n))) {
+        goto cleanup;
+    }
+    if (!notif_transport_find_by_identity(lyd_get_value(n))) {
+        SRNTF_LOG_ERR("Unsupported transport \"%s\".", lyd_get_value(n));
+        rc = SR_ERR_UNSUPPORTED;
+        goto cleanup;
+    }
+
+    /* purpose */
+    get_descendant_optional(node, "purpose", &n);
+    if (n) {
+        sub->purpose = strdup(lyd_get_value(n));
+        CHECK_ERRMEM_GOTO(sub->purpose, rc, cleanup);
+    }
+
+    /* source address */
+    get_descendant_optional(node, "source-address", &n);
+    if (n) {
+        sub->local_address = strdup(lyd_get_value(n));
+        CHECK_ERRMEM_GOTO(sub->local_address, rc, cleanup);
+    }
+
+    /* receivers */
+    if (lyd_find_xpath(node, "receivers/receiver", &set)) {
+        rc = SR_ERR_LY;
+        goto cleanup;
+    }
+    for (i = 0; i < set->count; i++) {
+        if ((rc = receiver_create_from_node(notifd_ctx, sub, set->dnodes[i]))) {
+            goto cleanup;
+        }
+    }
+
+cleanup:
+    ly_set_free(set, NULL);
+    return rc;
+}
+
+/**
+ * @brief Disconnect all receivers of a subscription.
+ *
+ * @param[in] notifd_ctx Daemon context.
+ * @param[in] sub Subscription whose receivers should be disconnected.
+ */
+static void
+subscription_receivers_disconnect(notifd_ctx_t *notifd_ctx, notif_sub_t *sub)
+{
+    notif_receiver_t *receiver;
+
+    LY_ARRAY_FOR(sub->receivers, notif_receiver_t, receiver) {
+        /* disconnect the receiver */
+        notification_dispatch_stop(notifd_ctx, receiver);
+        notif_receiver_disconnect(receiver);
+    }
+}
+
+int
+subscription_create_from_node(notifd_ctx_t *notifd_ctx, const struct lyd_node *node)
+{
+    int rc = SR_ERR_OK;
+    notif_sub_t *sub, **sub_ptr;
+
+    /* create a new sub and add it to the context array */
+    sub = calloc(1, sizeof *sub);
+    CHECK_ERRMEM_RET(sub);
+    LY_ARRAY_NEW_GOTO(LYD_CTX(node), notifd_ctx->subs, sub_ptr, rc, cleanup);
+    *sub_ptr = sub;
+    sub->state = NOTIF_SUB_STATE_VALID;
+
+    /* parse the subscription */
+    if ((rc = subscription_from_node(notifd_ctx, node, sub))) {
+        goto cleanup;
+    }
+
+cleanup:
+    if (rc) {
+        subscription_receivers_disconnect(notifd_ctx, sub);
+        sub_invalidate(sub, NULL);
+    }
+    return rc;
+}
+
+/**
+ * @brief Destroy a subscription, disconnecting all receivers and removing it from the context.
+ *
+ * @param[in] notifd_ctx Daemon context.
+ * @param[in] sub Subscription to destroy.
+ */
+static void
+subscription_destroy(notifd_ctx_t *notifd_ctx, notif_sub_t *sub)
+{
+    LY_ARRAY_COUNT_TYPE i;
+
+    if (!sub) {
+        return;
+    }
+
+    /* free members */
+    free(sub->stream);
+    free(sub->xpath_filter);
+    free(sub->filter_ref);
+    free(sub->purpose);
+    free(sub->local_address);
+    for (i = LY_ARRAY_COUNT(sub->receivers); i > 0; i--) {
+        receiver_destroy(notifd_ctx, sub, &sub->receivers[i - 1]);
+    }
+    LY_ARRAY_FREE(sub->receivers);
+
+    /* replace with the last and decrement array */
+    LY_ARRAY_FOR(notifd_ctx->subs, i) {
+        if (notifd_ctx->subs[i] == sub) {
+            notifd_ctx->subs[i] = notifd_ctx->subs[LY_ARRAY_COUNT(notifd_ctx->subs) - 1];
+            break;
+        }
+    }
+    LY_ARRAY_DECREMENT_FREE(notifd_ctx->subs);
+    free(sub);
+}
+
+int
+subscription_destroy_from_node(notifd_ctx_t *notifd_ctx, const struct lyd_node *node)
+{
+    notif_sub_t *sub;
+
+    /* try to find the sub */
+    if (!(sub = subscription_find_by_node(notifd_ctx, node))) {
+        SRNTF_LOG_ERR("Failed to find subscription \"%s\" for destruction.", lyd_get_value(lyd_child(node)));
+        return SR_ERR_NOT_FOUND;
+    }
+
+    /* if the sub is still valid, send subscription-terminated notification to all receivers */
+    if (sub->state == NOTIF_SUB_STATE_VALID) {
+        subscription_terminated_notif_send(notifd_ctx, sub, NULL, "ietf-subscribed-notifications:no-such-subscription");
+        sub->state = NOTIF_SUB_STATE_CONCLUDED;
+    }
+
+    /* destroy the sub */
+    subscription_destroy(notifd_ctx, sub);
+
+    return SR_ERR_OK;
+}
+
+/*
+ * ---------------------------------------------------------------------------
+ * Receiver parsing and CRUD
+ * ---------------------------------------------------------------------------
+ */
+
+/**
+ * @brief Parse a receiver from a lyd_node into a notif_receiver_t struct.
+ *
+ * @param[in] notifd_ctx Daemon context.
+ * @param[in] node receiver node.
+ * @param[out] receiver Parsed receiver struct.
+ * @return SR_ERR_OK on success, or other error code on failure.
+ */
+static int
+receiver_from_node(notifd_ctx_t *notifd_ctx, const struct lyd_node *node, notif_receiver_t *receiver)
+{
+    int rc = SR_ERR_OK;
+    struct lyd_node *n;
+
+    /* receiver name */
+    if ((rc = get_descendant_mandatory(node, "name", &n))) {
+        goto cleanup;
+    }
+    receiver->name = strdup(lyd_get_value(n));
+    CHECK_ERRMEM_GOTO(receiver->name, rc, cleanup);
+
+    /* recv instance ref */
+    get_descendant_optional(node, "ietf-subscribed-notif-receivers:receiver-instance-ref", &n);
+    if (n) {
+        receiver->inst = receiver_inst_find_by_name(notifd_ctx, lyd_get_value(n));
+        if (!receiver->inst) {
+            SRNTF_LOG_ERR("Receiver instance \"%s\" not found for receiver \"%s\".", lyd_get_value(n), receiver->name);
+            rc = SR_ERR_NOT_FOUND;
+            goto cleanup;
+        }
+        receiver->ops = receiver->inst->ops;
+    }
+
+cleanup:
+    return rc;
+}
+
+int
+receiver_create_from_node(notifd_ctx_t *notifd_ctx, notif_sub_t *sub, const struct lyd_node *node)
+{
+    int rc = SR_ERR_OK, r;
+    notif_receiver_t *receiver;
+
+    /* create a new receiver */
+    LY_ARRAY_NEW_GOTO(LYD_CTX(node), sub->receivers, receiver, rc, cleanup);
+    receiver->srsn_data.fd = -1;
+    receiver->sub = sub;
+
+    /* parse it */
+    if ((rc = receiver_from_node(notifd_ctx, node, receiver))) {
+        goto cleanup;
+    }
+
+    /* start dispatch so this receiver can receive notifications */
+    if ((rc = notification_dispatch_start(notifd_ctx, sub, receiver))) {
+        goto cleanup;
+    }
+
+    /* connect the receiver and send subscription-started */
+    receiver->state = NOTIF_RECV_STATE_CONNECTING;
+    r = notif_receiver_connect(receiver);
+
+    if (!r && (sub->state == NOTIF_SUB_STATE_VALID)) {
+        r = subscription_started_notif_send(notifd_ctx, sub, receiver);
+        if (!r) {
+            /* successfully sent, receiver is now active */
+            receiver->state = NOTIF_RECV_STATE_ACTIVE;
+        } else {
+            /* on failure, receiver is now disconnected */
+            notif_receiver_disconnect(receiver);
+            receiver->state = NOTIF_RECV_STATE_DISCONNECTED;
+        }
+    }
+
+cleanup:
+    return rc;
+}
+
+void
+receiver_destroy(notifd_ctx_t *notifd_ctx, notif_sub_t *sub, notif_receiver_t *receiver)
+{
+    if (!sub || !receiver) {
+        return;
+    }
+
+    /* stop dispatch for this receiver */
+    notification_dispatch_stop(notifd_ctx, receiver);
+
+    /* disconnect the receiver */
+    notif_receiver_disconnect(receiver);
+
+    /* free members */
+    free(receiver->name);
+    receiver->inst = NULL;
+
+    /* replace with the last and decrement array */
+    *receiver = sub->receivers[LY_ARRAY_COUNT(sub->receivers) - 1];
+    LY_ARRAY_DECREMENT_FREE(sub->receivers);
+}
+
+int
+receiver_destroy_from_node(notifd_ctx_t *notifd_ctx, notif_sub_t *sub, const struct lyd_node *node)
+{
+    int rc = SR_ERR_OK;
+    notif_receiver_t *receiver;
+
+    /* find the receiver */
+    if (!(receiver = receiver_find_by_node(notifd_ctx, node))) {
+        SRNTF_LOG_ERR("Receiver with name \"%s\" not found for deletion.", lyd_get_value(lyd_child(node)));
+        rc = SR_ERR_NOT_FOUND;
+        goto cleanup;
+    }
+
+    /* if the receiver is active, send subscription-terminated to it */
+    if (receiver->state == NOTIF_RECV_STATE_ACTIVE) {
+        subscription_terminated_notif_send(notifd_ctx, sub, receiver, "ietf-subscribed-notifications:no-such-subscription");
+    }
+
+    /* destroy the receiver */
+    receiver_destroy(notifd_ctx, sub, receiver);
+
+cleanup:
+    return rc;
+}
+
+/*
+ * ---------------------------------------------------------------------------
+ * Receiver-instance parsing and CRUD
+ * ---------------------------------------------------------------------------
+ */
+
+static int
+receiver_instance_from_node(const struct lyd_node *node, notif_receiver_inst_t *recv_inst)
+{
+    int rc = SR_ERR_OK;
+    struct lyd_node *n;
+    struct lyd_node *child;
+    const notif_transport_ops_t *ops;
+
+    /* receiver instance name */
+    if ((rc = get_descendant_mandatory(node, "name", &n))) {
+        goto cleanup;
+    }
+    recv_inst->name = strdup(lyd_get_value(n));
+    CHECK_ERRMEM_GOTO(recv_inst->name, rc, cleanup);
+
+    /* find the transport config container by iterating children */
+    LY_LIST_FOR(lyd_child(node), child) {
+        ops = notif_transport_find_by_container(LYD_NAME(child));
+        if (ops) {
+            recv_inst->type = ops->type;
+            recv_inst->ops = ops;
+
+            if ((rc = ops->config_parse(child, &recv_inst->transport_config))) {
+                goto cleanup;
+            }
+            break;
+        }
+    }
+
+cleanup:
+    return rc;
+}
+
+int
+receiver_instance_create_from_node(notifd_ctx_t *notifd_ctx, const struct lyd_node *node)
+{
+    int rc = SR_ERR_OK;
+    notif_receiver_inst_t *recv_inst, **recv_inst_ptr;
+
+    /* create a new receiver instance and add it to the context array */
+    LY_ARRAY_NEW_GOTO(LYD_CTX(node), notifd_ctx->recv_insts, recv_inst_ptr, rc, cleanup);
+    recv_inst = calloc(1, sizeof *recv_inst);
+    CHECK_ERRMEM_GOTO(recv_inst, rc, cleanup);
+    *recv_inst_ptr = recv_inst;
+
+    /* parse the receiver instance */
+    if ((rc = receiver_instance_from_node(node, recv_inst))) {
+        goto cleanup;
+    }
+
+cleanup:
+    return rc;
+}
+
+static void
+receiver_instance_destroy(notifd_ctx_t *notifd_ctx, notif_receiver_inst_t *recv_inst)
+{
+    LY_ARRAY_COUNT_TYPE i;
+
+    if (!recv_inst) {
+        return;
+    }
+
+    /* free members */
+    free(recv_inst->name);
+    if (recv_inst->ops && recv_inst->transport_config) {
+        recv_inst->ops->config_destroy(recv_inst->transport_config);
+        recv_inst->transport_config = NULL;
+    }
+    recv_inst->ops = NULL;
+
+    /* replace with the last and decrement array */
+    LY_ARRAY_FOR(notifd_ctx->recv_insts, i) {
+        if (notifd_ctx->recv_insts[i] == recv_inst) {
+            notifd_ctx->recv_insts[i] = notifd_ctx->recv_insts[LY_ARRAY_COUNT(notifd_ctx->recv_insts) - 1];
+            break;
+        }
+    }
+    LY_ARRAY_DECREMENT_FREE(notifd_ctx->recv_insts);
+    free(recv_inst);
+}
+
+int
+receiver_instance_destroy_from_node(notifd_ctx_t *notifd_ctx, const struct lyd_node *node)
+{
+    notif_receiver_inst_t *recv_inst;
+
+    /* find the receiver instance */
+    if (!(recv_inst = receiver_inst_find_by_node(notifd_ctx, node))) {
+        SRNTF_LOG_ERR("Receiver instance with name \"%s\" not found for deletion.", lyd_get_value(lyd_child(node)));
+        return SR_ERR_NOT_FOUND;
+    }
+
+    /* destroy the receiver instance, no need to lock as no subs can point to it anymore */
+    receiver_instance_destroy(notifd_ctx, recv_inst);
+    return SR_ERR_OK;
+}
+
+/*
+ * ---------------------------------------------------------------------------
+ * Post-processing after config changes
+ * ---------------------------------------------------------------------------
+ */
+
+int
+subscription_resubscribe(notifd_ctx_t *notifd_ctx, notif_sub_t *sub)
+{
+    int rc = SR_ERR_OK;
+    notif_receiver_t *receiver;
+
+    LY_ARRAY_FOR(sub->receivers, notif_receiver_t, receiver) {
+        /* stop the dispatch, which will unsubscribe from sysrepo and stop all timers */
+        notification_dispatch_stop(notifd_ctx, receiver);
+
+        /* start the dispatch again with the new params, which will resubscribe to sysrepo and restart timers */
+        if ((rc = notification_dispatch_start(notifd_ctx, sub, receiver))) {
+            goto cleanup;
+        }
+    }
+
+ cleanup:
+    return rc;
+}
+
+void
+process_modified_subscriptions(notifd_ctx_t *notifd_ctx)
+{
+    int r;
+    notif_sub_t **sub;
+
+    /* go through all subs and send subscription-modified for those that are modified */
+    LY_ARRAY_FOR(notifd_ctx->subs, notif_sub_t *, sub) {
+        if ((*sub)->resubscribe) {
+            r = subscription_resubscribe(notifd_ctx, *sub);
+            if (!r) {
+                (*sub)->state = NOTIF_SUB_STATE_VALID;
+            } else {
+                sub_invalidate(*sub, NULL);
+            }
+
+            (*sub)->resubscribe = 0;
+        }
+
+        if ((*sub)->modified || (*sub)->modif_err_reason) {
+            if ((*sub)->state == NOTIF_SUB_STATE_VALID) {
+                /* valid modification => subscription-modified */
+                subscription_modified_notif_send(notifd_ctx, *sub, NULL);
+            } else if ((*sub)->state == NOTIF_SUB_STATE_INVALID) {
+                /* invalid modification => subscription-terminated */
+                subscription_terminated_notif_send(notifd_ctx, *sub, NULL, (*sub)->modif_err_reason);
+            }
+
+            /* reset modified flag and error reason */
+            (*sub)->modified = 0;
+            (*sub)->modif_err_reason = NULL;
+        }
+    }
+}
+
+void
+process_modified_receiver_instances(notifd_ctx_t *notifd_ctx)
+{
+    notif_receiver_inst_t **recv_inst;
+    notif_sub_t **sub;
+    notif_receiver_t *receiver;
+
+    /* go through all receiver instances and reconnect those that are modified */
+    LY_ARRAY_FOR(notifd_ctx->recv_insts, notif_receiver_inst_t *, recv_inst) {
+        if (!(*recv_inst)->modified) {
+            /* if not modified, skip */
+            continue;
+        }
+
+        /* reconnect all referencing receivers */
+        LY_ARRAY_FOR(notifd_ctx->subs, notif_sub_t *, sub) {
+            LY_ARRAY_FOR((*sub)->receivers, notif_receiver_t, receiver) {
+                if (receiver->inst == *recv_inst) {
+                    notif_receiver_reconnect(notifd_ctx, *sub, receiver, NULL);
+                }
+            }
+        }
+
+        /* reset modified flag */
+        (*recv_inst)->modified = 0;
+    }
+}
+
+/*
+ * ---------------------------------------------------------------------------
+ * Filter change handler (used by filter_change_cb)
+ * ---------------------------------------------------------------------------
+ */
+
+int
+handle_stream_filter(notifd_ctx_t *notifd_ctx, const struct lyd_node *node, int is_subtree)
+{
+    int rc = SR_ERR_OK, r;
+    const char *filter_inst_name = NULL;
+    notif_sub_t **sub;
+    struct lyd_node *filter_inst_name_node;
+    char *new_filter = NULL;
+
+    /* get the key of the filter instance list, by which the subs reference this filter */
+    if ((rc = get_descendant_mandatory(lyd_parent(node), "name", &filter_inst_name_node))) {
+        return rc;
+    }
+    filter_inst_name = lyd_get_value(filter_inst_name_node);
+
+    /* find the sub(s) that reference this filter and update their xpath_filter */
+    LY_ARRAY_FOR(notifd_ctx->subs, notif_sub_t *, sub) {
+        r = 0;
+        if ((*sub)->filter_ref && !strcmp((*sub)->filter_ref, filter_inst_name)) {
+            /* match */
+            if (is_subtree) {
+                /* subtree filter reference, convert to xpath, subtree is anydata, so use lyd_child_any() to get it */
+                if ((r = srsn_filter_subtree2xpath(lyd_child_any(node), notifd_ctx->sr_sess, &new_filter))) {
+                    (*sub)->modif_err_reason = "ietf-subscribed-notifications:filter-unsupported";
+                    rc = r;
+                }
+            } else {
+                /* xpath filter reference, just dup the value */
+                new_filter = strdup(lyd_get_value(node));
+                if (!new_filter) {
+                    r = rc = SR_ERR_NO_MEMORY;
+                    (*sub)->modif_err_reason = "ietf-subscribed-notifications:insufficient-resources";
+                }
+            }
+
+            if (r) {
+                /* we failed to convert the filter, err reason was set */
+                continue;
+            }
+
+            if ((!new_filter && (*sub)->xpath_filter) || (new_filter && !(*sub)->xpath_filter) ||
+                    (new_filter && (*sub)->xpath_filter && strcmp(new_filter, (*sub)->xpath_filter))) {
+                /* the filter was actually modified, update it and mark the sub for resubscription */
+                free((*sub)->xpath_filter);
+                (*sub)->xpath_filter = new_filter;
+                (*sub)->modified = 1;
+                (*sub)->resubscribe = 1;
+            } else {
+                /* the filter was not actually modified, just free the new filter if it was created */
+                free(new_filter);
+            }
+            new_filter = NULL;
+        }
+    }
+
+    return rc;
+}
+
+/*
+ * ---------------------------------------------------------------------------
+ * SR_EV_CHANGE validation (read-only checks, no state modification)
+ * ---------------------------------------------------------------------------
+ */
+
+static int
+sub_change_validate_encoding(const struct lyd_node *node)
+{
+    const char *value;
+
+    value = ((struct lyd_node_term *)node)->value.ident->name;
+    if (!strcmp(value, "encode-xml") || !strcmp(value, "encode-json")) {
+        return SR_ERR_OK;
+    } else if (!strcmp(value, "encode-cbor")) {
+        SRNTF_LOG_ERR("CBOR encoding is not yet supported.");
+        return SR_ERR_UNSUPPORTED;
+    } else {
+        SRNTF_LOG_ERR("Unsupported encoding \"%s\".", value);
+        return SR_ERR_UNSUPPORTED;
+    }
+}
+
+static int
+sub_change_validate_stream(notifd_ctx_t *notifd_ctx, const char *stream, const char *xpath_filter)
+{
+    int rc = SR_ERR_OK;
+    const struct ly_ctx *ly_ctx;
+    struct ly_set *mod_set = NULL;
+
+    ly_ctx = sr_session_acquire_context(notifd_ctx->sr_sess);
+    if ((rc = srsn_stream_collect_mods(stream, xpath_filter, ly_ctx, &mod_set))) {
+        if (rc == SR_ERR_NOT_FOUND) {
+            SRNTF_LOG_ERR("Stream \"%s\" does not match any implemented YANG module.", stream);
+        }
+        goto cleanup;
+    }
+
+cleanup:
+    sr_session_release_context(notifd_ctx->sr_sess);
+    ly_set_free(mod_set, NULL);
+    return rc;
+}
+
+static int
+sub_change_validate_temporal(sr_session_ctx_t *session, const struct timespec *stop_time,
+        const struct timespec *start_time)
+{
+    struct timespec cur_ts;
+
+    clock_gettime(CLOCK_REALTIME, &cur_ts);
+
+    if (start_time && (timespec_cmp(&cur_ts, start_time) < 0)) {
+        sr_session_set_error_message(session, "Specified \"start-time\" is in the future.");
+        return SR_ERR_INVAL_ARG;
+    } else if (!start_time && stop_time && (timespec_cmp(&cur_ts, stop_time) > 0)) {
+        sr_session_set_error_message(session, "Specified \"stop-time\" is in the past.");
+        return SR_ERR_INVAL_ARG;
+    } else if (start_time && stop_time && (timespec_cmp(start_time, stop_time) > 0)) {
+        sr_session_set_error_message(session, "Specified \"stop-time\" is earlier than \"start-time\".");
+        return SR_ERR_INVAL_ARG;
+    }
+
+    return SR_ERR_OK;
+}
+
+static int
+sub_change_validate_subtree_filter(sr_session_ctx_t *session, const struct lyd_node *subtree_filter)
+{
+    int rc = SR_ERR_OK;
+    char *xpath_filter = NULL;
+    struct lyd_node *filter;
+
+    filter = lyd_child_any(subtree_filter);
+    if (!filter) {
+        goto cleanup;
+    }
+
+    if ((rc = srsn_filter_subtree2xpath(filter, session, &xpath_filter))) {
+        SRNTF_LOG_ERR("Failed to convert subtree filter to XPath.");
+        goto cleanup;
+    }
+
+cleanup:
+    free(xpath_filter);
+    return rc;
+}
+
+int
+sub_change_validate(notifd_ctx_t *notifd_ctx, sr_session_ctx_t *session)
+{
+    int rc = SR_ERR_OK, r, prev_dflt;
+    sr_change_iter_t *iter = NULL;
+    sr_change_oper_t op;
+    const struct lyd_node *node;
+    const char *prev_value, *prev_list, *node_name;
+    struct lyd_node *n;
+    const char *stream, *xpath_filter;
+    struct timespec stop_time, start_time;
+    notif_sub_t *sub;
+
+    /* validate created subscriptions */
+    if ((rc = sr_get_changes_iter(session, "/ietf-subscribed-notifications:subscriptions/subscription", &iter))) {
+        goto cleanup;
+    }
+    while (!sr_get_change_tree_next(session, iter, &op, &node, &prev_value, &prev_list, &prev_dflt)) {
+        assert(LYD_NAME(node) && !strcmp(LYD_NAME(node), "subscription"));
+
+        if (op != SR_OP_CREATED) {
+            continue;
+        }
+
+        /* transport - validate against registered transports */
+        if (!lyd_find_path(node, "transport", 0, &n)) {
+            const notif_transport_ops_t *ops;
+
+            ops = notif_transport_find_by_identity(lyd_get_value(n));
+            if (!ops) {
+                SRNTF_LOG_ERR("Unsupported transport \"%s\".", lyd_get_value(n));
+                rc = SR_ERR_UNSUPPORTED;
+                goto cleanup;
+            }
+            if (ops->config_validate && (r = ops->config_validate(node))) {
+                rc = r;
+                goto cleanup;
+            }
+        }
+
+        /* encoding */
+        if (!lyd_find_path(node, "encoding", 0, &n)) {
+            if ((r = sub_change_validate_encoding(n))) {
+                rc = r;
+                goto cleanup;
+            }
+        }
+
+        /* stream must map to an existing module */
+        stream = NULL;
+        xpath_filter = NULL;
+        if (!lyd_find_path(node, "stream", 0, &n)) {
+            stream = lyd_get_value(n);
+        }
+        if (!lyd_find_path(node, "stream-xpath-filter", 0, &n)) {
+            xpath_filter = lyd_get_value(n);
+        }
+        if (stream) {
+            if ((r = sub_change_validate_stream(notifd_ctx, stream, xpath_filter))) {
+                rc = r;
+                goto cleanup;
+            }
+        }
+
+        /* subtree filter must be convertible to XPath */
+        if (!lyd_find_path(node, "stream-subtree-filter", 0, &n)) {
+            if ((r = sub_change_validate_subtree_filter(session, n))) {
+                rc = r;
+                goto cleanup;
+            }
+        }
+
+        /* temporal constraints */
+        stop_time.tv_sec = 0;
+        stop_time.tv_nsec = 0;
+        start_time.tv_sec = 0;
+        start_time.tv_nsec = 0;
+
+        if (!lyd_find_path(node, "stop-time", 0, &n)) {
+            if (ly_time_str2ts(lyd_get_value(n), &stop_time)) {
+                rc = SR_ERR_LY;
+                goto cleanup;
+            }
+        }
+
+        if (!lyd_find_path(node, "configured-replay", 0, &n)) {
+            /* replay requested, check that the stream supports it */
+            if (stream) {
+                if ((r = stream_supports_replay(notifd_ctx, stream, xpath_filter, &start_time))) {
+                    SRNTF_LOG_ERR("Stream \"%s\" does not support replay.", stream);
+                    rc = r;
+                    goto cleanup;
+                }
+            }
+        }
+
+        /* validate temporal constraints with the parsed values */
+        if (stop_time.tv_sec || stop_time.tv_nsec || start_time.tv_sec || start_time.tv_nsec) {
+            if ((r = sub_change_validate_temporal(session,
+                    (stop_time.tv_sec || stop_time.tv_nsec) ? &stop_time : NULL,
+                    (start_time.tv_sec || start_time.tv_nsec) ? &start_time : NULL))) {
+                rc = r;
+                goto cleanup;
+            }
+        }
+    }
+    sr_free_change_iter(iter);
+    iter = NULL;
+
+    /* validate modified subscription fields */
+    if ((rc = sr_get_changes_iter(session, "/ietf-subscribed-notifications:subscriptions/"
+            "subscription[not(@yang:operation)]//.", &iter))) {
+        goto cleanup;
+    }
+    while (!sr_get_change_tree_next(session, iter, &op, &node, &prev_value, &prev_list, &prev_dflt)) {
+        if ((op != SR_OP_CREATED) && (op != SR_OP_MODIFIED)) {
+            continue;
+        }
+
+        node_name = LYD_NAME(node);
+
+        if (!strcmp(node_name, "stream")) {
+            /* stream changed - validate new stream exists */
+            if ((r = sub_change_validate_stream(notifd_ctx, lyd_get_value(node), NULL))) {
+                rc = r;
+                goto cleanup;
+            }
+
+            /* if configured-replay is set on the existing sub, also check replay support for new stream */
+            sub = subscription_find_by_node(notifd_ctx, node);
+            if (sub && sub->replay) {
+                if ((r = stream_supports_replay(notifd_ctx, lyd_get_value(node), sub->xpath_filter,
+                        &start_time))) {
+                    SRNTF_LOG_ERR("Stream \"%s\" does not support replay.", lyd_get_value(node));
+                    rc = r;
+                    goto cleanup;
+                }
+            }
+        } else if (!strcmp(node_name, "encoding")) {
+            if ((r = sub_change_validate_encoding(node))) {
+                rc = r;
+                goto cleanup;
+            }
+        } else if (!strcmp(node_name, "stream-subtree-filter")) {
+            if ((r = sub_change_validate_subtree_filter(session, node))) {
+                rc = r;
+                goto cleanup;
+            }
+        } else if (!strcmp(node_name, "stop-time")) {
+            if (ly_time_str2ts(lyd_get_value(node), &stop_time)) {
+                rc = SR_ERR_LY;
+                goto cleanup;
+            }
+
+            /* check stop-time is not in the past */
+            sub = subscription_find_by_node(notifd_ctx, node);
+            start_time.tv_sec = 0;
+            start_time.tv_nsec = 0;
+            if (sub && (sub->start_time.tv_sec || sub->start_time.tv_nsec)) {
+                start_time = sub->start_time;
+            }
+
+            if ((r = sub_change_validate_temporal(session, &stop_time,
+                    (start_time.tv_sec || start_time.tv_nsec) ? &start_time : NULL))) {
+                rc = r;
+                goto cleanup;
+            }
+        } else if (!strcmp(node_name, "configured-replay")) {
+            /* replay being enabled on existing sub, check stream supports it */
+            sub = subscription_find_by_node(notifd_ctx, node);
+            if (sub && sub->stream) {
+                if ((r = stream_supports_replay(notifd_ctx, sub->stream, sub->xpath_filter,
+                        &start_time))) {
+                    SRNTF_LOG_ERR("Stream \"%s\" does not support replay.", sub->stream);
+                    rc = r;
+                    goto cleanup;
+                }
+            }
+        }
+    }
+    sr_free_change_iter(iter);
+    iter = NULL;
+
+cleanup:
+    sr_free_change_iter(iter);
+    return rc;
+}
+
+int
+filter_change_validate(notifd_ctx_t *notifd_ctx, sr_session_ctx_t *session)
+{
+    int rc = SR_ERR_OK, r, prev_dflt;
+    sr_change_iter_t *iter = NULL;
+    sr_change_oper_t op;
+    const struct lyd_node *node;
+    const char *prev_value, *prev_list, *node_name;
+
+    (void)notifd_ctx;
+
+    if ((rc = sr_get_changes_iter(session, "/ietf-subscribed-notifications:filters/stream-filter//.", &iter))) {
+        goto cleanup;
+    }
+    while (!sr_get_change_tree_next(session, iter, &op, &node, &prev_value, &prev_list, &prev_dflt)) {
+        if ((op != SR_OP_CREATED) && (op != SR_OP_MODIFIED)) {
+            continue;
+        }
+
+        node_name = LYD_NAME(node);
+
+        if (!strcmp(node_name, "stream-subtree-filter")) {
+            if ((r = sub_change_validate_subtree_filter(session, node))) {
+                rc = r;
+                goto cleanup;
+            }
+        }
+    }
+
+cleanup:
+    sr_free_change_iter(iter);
+    return rc;
+}
+
+/*
+ * ---------------------------------------------------------------------------
+ * Feature check
+ * ---------------------------------------------------------------------------
+ */
+
+int
+module_feature_is_enabled(notifd_ctx_t *notifd_ctx, const char *module_name, const char *feature_name, int *enabled)
+{
+    int rc = SR_ERR_OK;
+    LY_ERR lyrc;
+    const struct ly_ctx *ly_ctx = NULL;
+    const struct lys_module *ly_mod;
+
+    if (!notifd_ctx || !module_name || !feature_name || !enabled) {
+        return SR_ERR_INVAL_ARG;
+    }
+
+    *enabled = 0;
+
+    ly_ctx = sr_session_acquire_context(notifd_ctx->sr_sess);
+    if (!ly_ctx) {
+        return SR_ERR_INTERNAL;
+    }
+
+    ly_mod = ly_ctx_get_module_implemented(ly_ctx, module_name);
+    if (!ly_mod) {
+        SRNTF_LOG_WRN("Implemented module \"%s\" was not found while checking feature \"%s\".", module_name,
+                feature_name);
+        goto cleanup;
+    }
+
+    lyrc = lys_feature_value(ly_mod, feature_name);
+    if (lyrc == LY_SUCCESS) {
+        *enabled = 1;
+    } else if ((lyrc != LY_ENOT) && (lyrc != LY_ENOTFOUND)) {
+        SRNTF_LOG_ERR("Failed to evaluate feature \"%s\" in module \"%s\".", feature_name, module_name);
+        rc = SR_ERR_INTERNAL;
+        goto cleanup;
+    }
+
+cleanup:
+    sr_session_release_context(notifd_ctx->sr_sess);
+    return rc;
+}
+
+void
+notifd_ctx_destroy(notifd_ctx_t *notifd_ctx)
+{
+    LY_ARRAY_COUNT_TYPE i;
+
+    if (!notifd_ctx) {
+        return;
+    }
+
+    /* destroy all subscriptions (includes stopping dispatch, disconnecting receivers, freeing memory) */
+    for (i = LY_ARRAY_COUNT(notifd_ctx->subs); i > 0; i--) {
+        subscription_destroy(notifd_ctx, notifd_ctx->subs[i - 1]);
+    }
+    notifd_ctx->subs = NULL;
+
+    /* destroy all receiver instances */
+    for (i = LY_ARRAY_COUNT(notifd_ctx->recv_insts); i > 0; i--) {
+        receiver_instance_destroy(notifd_ctx, notifd_ctx->recv_insts[i - 1]);
+    }
+    notifd_ctx->recv_insts = NULL;
+}

--- a/src/executables/sysrepo-notifd/notifd_runtime.c
+++ b/src/executables/sysrepo-notifd/notifd_runtime.c
@@ -1,0 +1,758 @@
+/**
+ * @file notifd_runtime.c
+ * @author Roman Janota <Roman.Janota@cesnet.cz>
+ * @brief sysrepo notification daemon runtime: notification delivery, receiver connections, and dispatch
+ *
+ * @copyright
+ * Copyright (c) 2026 CESNET, z.s.p.o.
+ *
+ * This source code is licensed under BSD 3-Clause License (the "License").
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://opensource.org/licenses/BSD-3-Clause
+ */
+
+#define _GNU_SOURCE
+
+#include "compat.h"
+
+#include <assert.h>
+#include <inttypes.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
+#include <unistd.h>
+
+#include "common.h"
+#include "notifd.h"
+#include "utils/subscribed_notifications.h"
+
+#include <libyang/libyang.h>
+
+/*
+ * ---------------------------------------------------------------------------
+ * Helpers
+ * ---------------------------------------------------------------------------
+ */
+
+int
+timespec_cmp(const struct timespec *ts1, const struct timespec *ts2)
+{
+    if (ts1->tv_sec < ts2->tv_sec) {
+        return -1;
+    }
+    if (ts1->tv_sec > ts2->tv_sec) {
+        return 1;
+    }
+    if (ts1->tv_nsec < ts2->tv_nsec) {
+        return -1;
+    }
+    if (ts1->tv_nsec > ts2->tv_nsec) {
+        return 1;
+    }
+    return 0;
+}
+
+/*
+ * ---------------------------------------------------------------------------
+ * Notification construction (state-change notifications per RFC 8692)
+ * ---------------------------------------------------------------------------
+ */
+
+static int
+subscription_state_change_notif_new(const struct ly_ctx *ly_ctx, notif_sub_t *sub,
+        const char *notif_path, uint32_t fields, const char *reason, struct lyd_node **notif)
+{
+    int rc = SR_ERR_OK;
+    struct lyd_node *tree = NULL;
+    char *id_str = NULL, *stop_time_str = NULL, *start_time_str = NULL;
+    struct timespec *start_time, *stop_time;
+
+    *notif = NULL;
+
+    /* create the notification */
+    if (lyd_new_path(NULL, ly_ctx, notif_path, NULL, 0, &tree)) {
+        rc = SR_ERR_LY;
+        goto cleanup;
+    }
+
+    /* id */
+    if (asprintf(&id_str, "%" PRIu32, sub->id) == -1) {
+        rc = SR_ERR_NO_MEMORY;
+        goto cleanup;
+    }
+    if (lyd_new_path(tree, ly_ctx, "id", id_str, 0, NULL)) {
+        rc = SR_ERR_LY;
+        goto cleanup;
+    }
+
+    /* stream */
+    if (fields & NOTIF_FIELD_STREAM) {
+        if (lyd_new_path(tree, ly_ctx, "stream", sub->stream, 0, NULL)) {
+            rc = SR_ERR_LY;
+            goto cleanup;
+        }
+    }
+
+    /* xpath filter */
+    if ((fields & NOTIF_FIELD_XPATH_FILTER) && sub->xpath_filter) {
+        if (lyd_new_path(tree, ly_ctx, "stream-xpath-filter", sub->xpath_filter, 0, NULL)) {
+            rc = SR_ERR_LY;
+            goto cleanup;
+        }
+    }
+
+    /* stop time */
+    if (fields & NOTIF_FIELD_STOP_TIME) {
+        stop_time = (sub->stop_time.tv_sec || sub->stop_time.tv_nsec) ? &sub->stop_time : NULL;
+        if (stop_time) {
+            if (ly_time_ts2str(stop_time, &stop_time_str)) {
+                rc = SR_ERR_LY;
+                goto cleanup;
+            }
+
+            if (lyd_new_path(tree, ly_ctx, "stop-time", stop_time_str, 0, NULL)) {
+                rc = SR_ERR_LY;
+                goto cleanup;
+            }
+        }
+    }
+
+    /* replay start time */
+    if (fields & NOTIF_FIELD_REPLAY_START) {
+        start_time = (sub->replay_start_time.tv_sec || sub->replay_start_time.tv_nsec) ?
+                &sub->replay_start_time : NULL;
+        if (start_time) {
+            if (ly_time_ts2str(start_time, &start_time_str)) {
+                rc = SR_ERR_LY;
+                goto cleanup;
+            }
+            if (lyd_new_path(tree, ly_ctx, "replay-start-time", start_time_str, 0, NULL)) {
+                rc = SR_ERR_LY;
+                goto cleanup;
+            }
+        }
+    }
+
+    /* reason */
+    if (reason) {
+        if (lyd_new_path(tree, ly_ctx, "reason", reason, 0, NULL)) {
+            rc = SR_ERR_LY;
+            goto cleanup;
+        }
+    }
+
+    *notif = tree;
+    tree = NULL;
+
+cleanup:
+    lyd_free_tree(tree);
+    free(id_str);
+    free(stop_time_str);
+    free(start_time_str);
+    return rc;
+}
+
+static int
+subscription_started_notif_new(const struct ly_ctx *ly_ctx, notif_sub_t *sub, struct lyd_node **notif)
+{
+    return subscription_state_change_notif_new(ly_ctx, sub,
+            "/ietf-subscribed-notifications:subscription-started",
+            NOTIF_FIELD_STREAM | NOTIF_FIELD_XPATH_FILTER | NOTIF_FIELD_STOP_TIME | NOTIF_FIELD_REPLAY_START,
+            NULL, notif);
+}
+
+static int
+subscription_terminated_notif_new(const struct ly_ctx *ly_ctx, notif_sub_t *sub, const char *reason,
+        struct lyd_node **notif)
+{
+    return subscription_state_change_notif_new(ly_ctx, sub,
+            "/ietf-subscribed-notifications:subscription-terminated", 0, reason, notif);
+}
+
+#if 0 /* not currently used, but may be needed in the future */
+
+static int
+subscription_modified_notif_new(const struct ly_ctx *ly_ctx, notif_sub_t *sub, struct lyd_node **notif)
+{
+    return subscription_state_change_notif_new(ly_ctx, sub,
+            "/ietf-subscribed-notifications:subscription-modified",
+            NOTIF_FIELD_STREAM | NOTIF_FIELD_XPATH_FILTER | NOTIF_FIELD_STOP_TIME | NOTIF_FIELD_REPLAY_START,
+            NULL, notif);
+}
+
+static int
+subscription_completed_notif_new(const struct ly_ctx *ly_ctx, notif_sub_t *sub, struct lyd_node **notif)
+{
+    return subscription_state_change_notif_new(ly_ctx, sub,
+            "/ietf-subscribed-notifications:subscription-completed", 0, NULL, notif);
+}
+
+#endif /* 0 */
+
+/*
+ * ---------------------------------------------------------------------------
+ * Notification sending (to one or all receivers of a subscription)
+ * ---------------------------------------------------------------------------
+ */
+
+static int
+subscription_state_change_notif_send(notifd_ctx_t *notifd_ctx, notif_sub_t *sub,
+        notif_receiver_t *receiver, const char *notif_path, uint32_t fields,
+        const char *reason, const char *notif_name, int skip_inactive)
+{
+    int rc = SR_ERR_OK, r;
+    const struct ly_ctx *ly_ctx;
+    struct lyd_node *notif = NULL;
+    LY_ARRAY_COUNT_TYPE i, start, end;
+
+    if (!sub) {
+        return SR_ERR_INVAL_ARG;
+    }
+
+    ly_ctx = sr_session_acquire_context(notifd_ctx->sr_sess);
+
+    if ((rc = subscription_state_change_notif_new(ly_ctx, sub, notif_path, fields, reason, &notif))) {
+        goto cleanup;
+    }
+
+    if (receiver) {
+        start = receiver - sub->receivers;
+        end = start + 1;
+    } else {
+        start = 0;
+        end = LY_ARRAY_COUNT(sub->receivers);
+    }
+
+    for (i = start; i < end; i++) {
+        if (skip_inactive && (sub->receivers[i].state != NOTIF_RECV_STATE_ACTIVE)) {
+            continue;
+        }
+        r = notif_receiver_send(notifd_ctx, &sub->receivers[i], notif, NULL, sub->encoding);
+        if (r) {
+            if (skip_inactive) {
+                SRNTF_LOG_WRN("Failed to send %s to receiver \"%s\" (sub %" PRIu32 ").",
+                        notif_name, sub->receivers[i].name, sub->id);
+            } else {
+                rc = r;
+                goto cleanup;
+            }
+        }
+    }
+
+cleanup:
+    lyd_free_all(notif);
+    sr_session_release_context(notifd_ctx->sr_sess);
+    return rc;
+}
+
+int
+subscription_started_notif_send(notifd_ctx_t *notifd_ctx, notif_sub_t *sub, notif_receiver_t *receiver)
+{
+    return subscription_state_change_notif_send(notifd_ctx, sub, receiver,
+            "/ietf-subscribed-notifications:subscription-started",
+            NOTIF_FIELD_STREAM | NOTIF_FIELD_XPATH_FILTER | NOTIF_FIELD_STOP_TIME | NOTIF_FIELD_REPLAY_START,
+            NULL, "subscription-started", 0);
+}
+
+int
+subscription_terminated_notif_send(notifd_ctx_t *notifd_ctx, notif_sub_t *sub,
+        notif_receiver_t *receiver, const char *reason)
+{
+    return subscription_state_change_notif_send(notifd_ctx, sub, receiver,
+            "/ietf-subscribed-notifications:subscription-terminated", 0,
+            reason, "subscription-terminated", 1);
+}
+
+int
+subscription_modified_notif_send(notifd_ctx_t *notifd_ctx, notif_sub_t *sub, notif_receiver_t *receiver)
+{
+    return subscription_state_change_notif_send(notifd_ctx, sub, receiver,
+            "/ietf-subscribed-notifications:subscription-modified",
+            NOTIF_FIELD_STREAM | NOTIF_FIELD_XPATH_FILTER | NOTIF_FIELD_STOP_TIME | NOTIF_FIELD_REPLAY_START,
+            NULL, "subscription-modified", 1);
+}
+
+int
+subscription_completed_notif_send(notifd_ctx_t *notifd_ctx, notif_sub_t *sub, notif_receiver_t *receiver)
+{
+    return subscription_state_change_notif_send(notifd_ctx, sub, receiver,
+            "/ietf-subscribed-notifications:subscription-completed", 0,
+            NULL, "subscription-completed", 1);
+}
+
+/*
+ * ---------------------------------------------------------------------------
+ * Receiver connection management
+ * ---------------------------------------------------------------------------
+ */
+
+int
+notif_receiver_is_connected(notif_receiver_t *receiver)
+{
+    if (!receiver || !receiver->ops) {
+        return 0;
+    }
+
+    return receiver->ops->is_connected(receiver);
+}
+
+int
+notif_receiver_connect(notif_receiver_t *receiver)
+{
+    int rc = SR_ERR_OK;
+
+    if (!receiver->inst || !receiver->ops) {
+        return SR_ERR_OK;
+    }
+
+    if (notif_receiver_is_connected(receiver)) {
+        return SR_ERR_OK;
+    }
+
+    rc = receiver->ops->connect(receiver, receiver->inst->transport_config);
+    if (rc) {
+        SRNTF_LOG_ERR("Failed to connect receiver \"%s\" via %s.", receiver->name, receiver->ops->name);
+    }
+
+    return rc;
+}
+
+void
+notif_receiver_disconnect(notif_receiver_t *receiver)
+{
+    if (!notif_receiver_is_connected(receiver)) {
+        return;
+    }
+    if (!receiver->inst || !receiver->ops) {
+        return;
+    }
+
+    receiver->ops->disconnect(receiver);
+}
+
+int
+notif_receiver_backoff_reconnect(notifd_ctx_t *notifd_ctx, notif_receiver_t *receiver)
+{
+    int rc = SR_ERR_OK;
+    struct timespec now;
+    uint32_t backoff_sec, shift;
+    time_t elapsed;
+    const struct ly_ctx *ly_ctx;
+    struct lyd_node *start_notif = NULL;
+
+    if (notif_receiver_is_connected(receiver)) {
+        return SR_ERR_OK;
+    }
+
+    if (!receiver->inst) {
+        return SR_ERR_OK;
+    }
+
+    /* calculate exponential backoff delay */
+    shift = receiver->reconnect_attempts;
+    if (shift > 30) {
+        shift = 30;
+    }
+    backoff_sec = NOTIFD_RECV_RECONNECT_BASE_SEC << shift;
+    if ((backoff_sec > NOTIFD_RECV_RECONNECT_MAX_SEC) || (backoff_sec < NOTIFD_RECV_RECONNECT_BASE_SEC)) {
+        backoff_sec = NOTIFD_RECV_RECONNECT_MAX_SEC;
+    }
+
+    /* check if enough time has passed since last reconnect attempt */
+    clock_gettime(COMPAT_CLOCK_ID, &now);
+    if (receiver->last_reconnect_attempt.tv_sec || receiver->last_reconnect_attempt.tv_nsec) {
+        elapsed = now.tv_sec - receiver->last_reconnect_attempt.tv_sec;
+        if (elapsed < (time_t)backoff_sec) {
+            SRNTF_LOG_WRN("Receiver \"%s\" reconnect backoff not elapsed (%lds < %ds).",
+                    receiver->name, (long)elapsed, (int)backoff_sec);
+            return SR_ERR_OPERATION_FAILED;
+        }
+    }
+
+    /* try to reconnect */
+    receiver->last_reconnect_attempt = now;
+    rc = notif_receiver_connect(receiver);
+    if (rc) {
+        receiver->reconnect_attempts++;
+        SRNTF_LOG_WRN("Failed to reconnect receiver \"%s\" (attempt %" PRIu32 ").",
+                receiver->name, receiver->reconnect_attempts);
+        return rc;
+    }
+
+    /* reconnection succeeded */
+    SRNTF_LOG_INF("Successfully reconnected receiver \"%s\".", receiver->name);
+    receiver->reconnect_attempts = 0;
+
+    /* send subscription-started after reconnecting as per RFC 8692 Section 2.1.2 */
+    ly_ctx = sr_session_acquire_context(notifd_ctx->sr_sess);
+    rc = subscription_started_notif_new(ly_ctx, receiver->sub, &start_notif);
+    if (rc) {
+        SRNTF_LOG_ERR("Failed to create subscription-started notification for receiver \"%s\".",
+                receiver->name);
+        sr_session_release_context(notifd_ctx->sr_sess);
+        goto disconnect;
+    }
+
+    /* send the notification directly via transport */
+    if (receiver->ops) {
+        rc = receiver->ops->send(receiver, receiver->inst->transport_config, start_notif, &now, receiver->cb_data.encoding);
+    } else {
+        SRNTF_LOG_ERR("No transport ops for receiver \"%s\".", receiver->name);
+        rc = SR_ERR_UNSUPPORTED;
+    }
+    lyd_free_all(start_notif);
+    sr_session_release_context(notifd_ctx->sr_sess);
+    if (rc) {
+        SRNTF_LOG_ERR("Failed to send notification to receiver \"%s\".", receiver->name);
+        goto disconnect;
+    }
+
+    receiver->state = NOTIF_RECV_STATE_ACTIVE;
+
+    return SR_ERR_OK;
+
+disconnect:
+    notif_receiver_disconnect(receiver);
+    receiver->state = NOTIF_RECV_STATE_DISCONNECTED;
+    return rc;
+}
+
+int
+notif_receiver_send(notifd_ctx_t *UNUSED(notifd_ctx), notif_receiver_t *receiver, const struct lyd_node *notif,
+        const struct timespec *timestamp, notif_encoding_t encoding)
+{
+    int rc = SR_ERR_OK;
+    struct timespec ts = {0};
+    int is_sub_started;
+    char *notif_path = NULL;
+
+    if (!receiver || !notif) {
+        SRNTF_LOG_ERR("Invalid arguments to send notification.");
+        return SR_ERR_INVAL_ARG;
+    }
+
+    if (!receiver->inst) {
+        /* quietly ignore sending to receivers without an instance, since instance is not mandatory */
+        return SR_ERR_OK;
+    }
+
+    notif_path = lyd_path(notif, LYD_PATH_STD, NULL, 0);
+    if (!notif_path) {
+        SRNTF_LOG_ERR("Failed to get path of notification to send.");
+        return SR_ERR_LY;
+    }
+
+    is_sub_started = !strcmp(LYD_NAME(notif), "subscription-started");
+
+    if (!notif_receiver_is_connected(receiver)) {
+        SRNTF_LOG_WRN("Receiver \"%s\" is not connected, cannot send notification \"%s\".",
+                receiver->name, notif_path);
+        rc = SR_ERR_OPERATION_FAILED;
+        goto cleanup;
+    }
+
+    if ((receiver->state != NOTIF_RECV_STATE_ACTIVE) && !is_sub_started) {
+        SRNTF_LOG_ERR("Cannot send notification \"%s\" to receiver \"%s\" before sending subscription-started.",
+                notif_path, receiver->name);
+        rc = SR_ERR_OPERATION_FAILED;
+        goto cleanup;
+    }
+
+    if (!timestamp) {
+        /* get the current time */
+        clock_gettime(COMPAT_CLOCK_ID, &ts);
+    } else {
+        /* use the provided timestamp */
+        ts = *timestamp;
+    }
+
+    SRNTF_LOG_INF("Sending notification \"%s\" to receiver \"%s\" over %s.", notif_path, receiver->name,
+            receiver->ops ? receiver->ops->name : "unknown");
+
+    if (receiver->ops) {
+        rc = receiver->ops->send(receiver, receiver->inst->transport_config, notif, &ts, encoding);
+    } else {
+        SRNTF_LOG_ERR("No transport ops for receiver \"%s\".", receiver->name);
+        rc = SR_ERR_UNSUPPORTED;
+    }
+    if (rc) {
+        goto cleanup;
+    }
+
+cleanup:
+    free(notif_path);
+    return rc;
+}
+
+int
+notif_receiver_reconnect(notifd_ctx_t *notifd_ctx, notif_sub_t *sub, notif_receiver_t *receiver, notif_receiver_inst_t *new_inst)
+{
+    int rc = SR_ERR_OK;
+    struct lyd_node *term_notif = NULL, *start_notif = NULL;
+    const struct ly_ctx *ly_ctx;
+
+    ly_ctx = sr_session_acquire_context(notifd_ctx->sr_sess);
+
+    if (notif_receiver_is_connected(receiver)) {
+        /* create and send subscription-terminated notification before disconnecting */
+        if ((rc = subscription_terminated_notif_new(ly_ctx, sub,
+                "ietf-subscribed-notifications:no-such-subscription", &term_notif))) {
+            goto cleanup;
+        }
+        if ((rc = notif_receiver_send(notifd_ctx, receiver, term_notif, NULL, sub->encoding))) {
+            goto cleanup;
+        }
+
+        /* disconnect the receiver */
+        notif_receiver_disconnect(receiver);
+        receiver->state = NOTIF_RECV_STATE_DISCONNECTED;
+    }
+
+    if (new_inst) {
+        /* update to the new instance */
+        receiver->inst = new_inst;
+        receiver->ops = new_inst->ops;
+    }
+
+    /* connect the receiver */
+    if ((rc = notif_receiver_connect(receiver))) {
+        goto cleanup;
+    }
+
+    /* create and send subscription-started notification after reconnecting */
+    if ((rc = subscription_started_notif_new(ly_ctx, sub, &start_notif))) {
+        goto cleanup;
+    }
+    if ((rc = notif_receiver_send(notifd_ctx, receiver, start_notif, NULL, sub->encoding))) {
+        goto cleanup;
+    }
+    receiver->state = NOTIF_RECV_STATE_ACTIVE;
+    receiver->reconnect_attempts = 0;
+    memset(&receiver->last_reconnect_attempt, 0, sizeof receiver->last_reconnect_attempt);
+
+cleanup:
+    if (rc) {
+        /* disconnect the receiver */
+        notif_receiver_disconnect(receiver);
+        receiver->state = NOTIF_RECV_STATE_DISCONNECTED;
+
+        /* set reconnect timestamp so automatic backoff respects this attempt */
+        clock_gettime(COMPAT_CLOCK_ID, &receiver->last_reconnect_attempt);
+    }
+    lyd_free_all(term_notif);
+    lyd_free_all(start_notif);
+    sr_session_release_context(notifd_ctx->sr_sess);
+    return rc;
+}
+
+/*
+ * ---------------------------------------------------------------------------
+ * Notification dispatch (srsn integration)
+ * ---------------------------------------------------------------------------
+ */
+
+int
+notification_dispatch_start(notifd_ctx_t *notifd_ctx, notif_sub_t *sub, notif_receiver_t *receiver)
+{
+    int rc = SR_ERR_OK;
+    struct timespec *stop_time, *start_time;
+
+    stop_time = (sub->stop_time.tv_sec || sub->stop_time.tv_nsec) ? &sub->stop_time : NULL;
+    start_time = (sub->start_time.tv_sec || sub->start_time.tv_nsec) ? &sub->start_time : NULL;
+
+    /* subscribe for notifications */
+    if ((rc = srsn_subscribe(notifd_ctx->sr_sess, sub->stream, sub->xpath_filter, stop_time, start_time, 0,
+            &receiver->srsn_data.sr_subscr, &sub->replay_start_time, &receiver->srsn_data.fd, &receiver->srsn_data.sub_id))) {
+        SRNTF_LOG_ERR("Failed to subscribe for notifications for subscription ID %" PRIu32 " and receiver \"%s\".",
+                sub->id, receiver->name);
+        sub->modif_err_reason = "ietf-subscribed-notifications:insufficient-resources";
+        goto cleanup;
+    }
+
+    /* set up notif cb data */
+    receiver->cb_data.ctx = notifd_ctx;
+    receiver->cb_data.recv = receiver;
+    receiver->cb_data.encoding = sub->encoding;
+
+    /* add notification dispatch, set notifd_ctx and sub as user data - the pointer itself won't be
+     * modified (stored as ** in notifd_ctx), but its content might be, so the callback will need to lock */
+    if ((rc = srsn_read_dispatch_add(receiver->srsn_data.fd, &receiver->cb_data))) {
+        SRNTF_LOG_ERR("Failed to add notification dispatch for subscription ID %" PRIu32 " and receiver \"%s\".",
+                sub->id, receiver->name);
+        sub->modif_err_reason = "ietf-subscribed-notifications:insufficient-resources";
+        goto cleanup;
+    }
+
+cleanup:
+    if (rc) {
+        /* unsubscribe */
+        sr_unsubscribe(receiver->srsn_data.sr_subscr);
+        receiver->srsn_data.sr_subscr = NULL;
+        if (receiver->srsn_data.fd != -1) {
+            close(receiver->srsn_data.fd);
+            receiver->srsn_data.fd = -1;
+        }
+    }
+    return rc;
+}
+
+void
+notification_dispatch_stop(notifd_ctx_t *notifd_ctx, notif_receiver_t *receiver)
+{
+    /* UNLOCK state lock, srsn_terminate will call notif cb, which will try to acquire the state lock to send
+     * any remaining notifs. Nobody can steal our WR lock here, because the caller MUST hold config_apply_mutex,
+     * which prevents another thread from acquiring the state WR lock in this window */
+    notifd_rwlock_unlock(&notifd_ctx->state_rwlock, __func__);
+
+    if (receiver->srsn_data.sub_id) {
+        srsn_terminate(receiver->srsn_data.sub_id, NULL);
+        receiver->srsn_data.sub_id = 0;
+    }
+
+    /* WR LOCK, reacquire to finish updating the config before checking retval of srsn_terminate */
+    if (notifd_rwlock_lock(&notifd_ctx->state_rwlock, 1, NOTIFD_CONTEXT_LOCK_TIMEOUT_MS, __func__)) {
+        SRNTF_LOG_ERR("Internal error: failed to acquire state lock to stop notification dispatch for receiver \"%s\".",
+                receiver->name);
+        return;
+    }
+
+    if (receiver->srsn_data.sr_subscr) {
+        sr_unsubscribe(receiver->srsn_data.sr_subscr);
+        receiver->srsn_data.sr_subscr = NULL;
+    }
+    if (receiver->srsn_data.fd != -1) {
+        close(receiver->srsn_data.fd);
+        receiver->srsn_data.fd = -1;
+    }
+}
+
+/*
+ * ---------------------------------------------------------------------------
+ * Main notification callback (called by srsn dispatch thread)
+ * ---------------------------------------------------------------------------
+ */
+
+void
+notifd_notification_cb(const struct lyd_node *notif, const struct timespec *timestamp, void *cb_data)
+{
+    notif_cb_data_t *data = (notif_cb_data_t *)cb_data;
+    notifd_ctx_t *notifd_ctx;
+    notif_receiver_t *receiver;
+    notif_encoding_t encoding;
+    notif_sub_t *sub;
+    struct timespec now;
+    uint32_t sub_id;
+    LY_ARRAY_COUNT_TYPE i;
+
+    assert(data);
+    notifd_ctx = data->ctx;
+    receiver = data->recv;
+    encoding = data->encoding;
+    assert(notifd_ctx && receiver);
+
+    /* STATE RD LOCK */
+    if (notifd_rwlock_lock(&notifd_ctx->state_rwlock, 0, NOTIFD_CONTEXT_LOCK_TIMEOUT_MS, __func__)) {
+        return;
+    }
+
+    sub = receiver->sub;
+    if (sub->state != NOTIF_SUB_STATE_VALID) {
+        /* only send notifications for valid subscriptions */
+        goto unlock;
+    }
+
+    /* save ID before any lock upgrade, as sub may be freed by another thread */
+    sub_id = sub->id;
+
+    /*
+     * Stop time reached - srsn generates subscription-terminated internally,
+     * but per RFC 8692/YANG model, subscription-completed should be sent instead.
+     * Need write lock for the state transition.
+     */
+    if (!strcmp(LYD_NAME(notif), "subscription-terminated")) {
+        clock_gettime(CLOCK_REALTIME, &now);
+        if ((sub->stop_time.tv_sec || sub->stop_time.tv_nsec) &&
+                (timespec_cmp(&sub->stop_time, &now) <= 0)) {
+            /* STATE UNLOCK */
+            notifd_rwlock_unlock(&notifd_ctx->state_rwlock, __func__);
+
+            /* STATE WR LOCK */
+            if (notifd_rwlock_lock(&notifd_ctx->state_rwlock, 1, NOTIFD_CONTEXT_LOCK_TIMEOUT_MS, __func__)) {
+                SRNTF_LOG_ERR("Internal error: failed to acquire state lock to handle subscription stop time.");
+                return;
+            }
+
+            /* revalidate: subscription may have been deleted during lock upgrade */
+            sub = subscription_find_by_id(notifd_ctx, sub_id);
+            if (!sub) {
+                goto unlock;
+            }
+
+            if (sub->state != NOTIF_SUB_STATE_CONCLUDED) {
+                sub->state = NOTIF_SUB_STATE_CONCLUDED;
+                subscription_completed_notif_send(notifd_ctx, sub, NULL);
+            }
+
+            goto unlock;
+        }
+    }
+
+    /* if the receiver is not active, try to reconnect if possible, otherwise skip sending the notification */
+    if (receiver->state != NOTIF_RECV_STATE_ACTIVE) {
+        if (!notif_receiver_is_connected(receiver) &&
+                ((receiver->state == NOTIF_RECV_STATE_DISCONNECTED) ||
+                (receiver->state == NOTIF_RECV_STATE_CONNECTING))) {
+            /* need write lock to reconnect and update state */
+            /* STATE UNLOCK */
+            notifd_rwlock_unlock(&notifd_ctx->state_rwlock, __func__);
+
+            /* STATE WR LOCK */
+            if (notifd_rwlock_lock(&notifd_ctx->state_rwlock, 1, NOTIFD_CONTEXT_LOCK_TIMEOUT_MS, __func__)) {
+                SRNTF_LOG_ERR("Internal error: failed to acquire state lock to handle receiver reconnection.");
+                return;
+            }
+
+            /* revalidate: subscription may have been deleted during lock upgrade */
+            sub = subscription_find_by_id(notifd_ctx, sub_id);
+            if (!sub || (sub->state != NOTIF_SUB_STATE_VALID)) {
+                goto unlock;
+            }
+
+            /* re-find the receiver as it may have been moved in the array */
+            receiver = NULL;
+            LY_ARRAY_FOR(sub->receivers, i) {
+                if (&sub->receivers[i].cb_data == data) {
+                    receiver = &sub->receivers[i];
+                    break;
+                }
+            }
+            if (!receiver) {
+                goto unlock;
+            }
+
+            /* recheck after reacquiring write lock */
+            if ((receiver->state != NOTIF_RECV_STATE_ACTIVE) && !notif_receiver_is_connected(receiver) &&
+                    ((receiver->state == NOTIF_RECV_STATE_DISCONNECTED) ||
+                    (receiver->state == NOTIF_RECV_STATE_CONNECTING))) {
+                /* try to reconnect with exponential backoff */
+                notif_receiver_backoff_reconnect(notifd_ctx, receiver);
+            }
+
+            /* on success, state is now ACTIVE and subscription-started was sent */
+            if (receiver->state != NOTIF_RECV_STATE_ACTIVE) {
+                goto unlock;
+            }
+        } else {
+            goto unlock;
+        }
+    }
+
+    /* send the notification */
+    notif_receiver_send(notifd_ctx, receiver, notif, timestamp, encoding);
+
+unlock:
+    /* STATE UNLOCK */
+    notifd_rwlock_unlock(&notifd_ctx->state_rwlock, __func__);
+}

--- a/src/executables/sysrepo-notifd/notifd_udp.c
+++ b/src/executables/sysrepo-notifd/notifd_udp.c
@@ -1,0 +1,833 @@
+/**
+ * @file notifd_udp.c
+ * @author Roman Janota <Roman.Janota@cesnet.cz>
+ * @brief sysrepo notification daemon UDP transport implementation
+ *
+ * @copyright
+ * Copyright (c) 2026 CESNET, z.s.p.o.
+ *
+ * This source code is licensed under BSD 3-Clause License (the "License").
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://opensource.org/licenses/BSD-3-Clause
+ */
+
+#define _GNU_SOURCE
+
+#include <arpa/inet.h>
+#include <assert.h>
+#include <errno.h>
+#include <inttypes.h>
+#include <netdb.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/socket.h>
+#include <sys/types.h>
+#include <unistd.h>
+
+#include "common.h"
+#include "compat.h"
+#include "notifd.h"
+
+#include <libyang/libyang.h>
+
+/** UDP-Notif protocol version */
+#define UDP_NOTIF_VERSION 1
+
+/** UDP-Notif fixed header size in bytes (without options) */
+#define UDP_NOTIF_HDR_SIZE 12
+
+/** UDP-Notif segmentation option size in bytes */
+#define UDP_NOTIF_SEG_OPT_SIZE 4
+
+/** UDP-Notif segmentation option type */
+#define UDP_NOTIF_OPT_SEGMENTATION 1
+
+/** S-flag: no segmentation present */
+#define UDP_NOTIF_SFLAG_NONE 0
+
+/** S-flag: segmentation present */
+#define UDP_NOTIF_SFLAG_SEG  1
+
+/** Default max segment size if not configured (conservative value for typical MTU) */
+#define UDP_NOTIF_DEFAULT_MAX_SEGMENT_SIZE 1400
+
+/**
+ * @brief UDP notification receiver configuration.
+ *
+ * Corresponds to /ietf-subscribed-notifications:receiver-instances/receiver-instance/ietf-udp-notif-transport:udp-notif-receiver
+ */
+typedef struct udp_notif_receiver_s {
+    char *remote_address;       /**< destination address (hostname or IP) */
+    uint16_t remote_port;       /**< destination UDP port */
+
+    int enable_segmentation;    /**< whether payload segmentation is enabled */
+    uint16_t max_segment_size;  /**< maximum segment size in bytes */
+
+    ATOMIC_T message_id;        /**< monotonically increasing message ID, starts at 1 */
+    uint32_t publisher_id;      /**< message publisher ID, identifies this publisher instance */
+} udp_notif_receiver_t;
+
+/**
+ * @brief UDP transport connection context for a notification receiver.
+ */
+typedef struct {
+    int sockfd;     /**< connected UDP socket file descriptor, -1 if not connected */
+} udp_conn_ctx_t;
+
+/*
+ * ---------------------------------------------------------------------------
+ * UDP-Notif protocol helpers
+ * ---------------------------------------------------------------------------
+ */
+
+/**
+ * @brief UDP-Notif media types (MT field values when S-flag is 0).
+ */
+typedef enum {
+    UDP_NOTIF_MT_RESERVED = 0,  /**< reserved, must not be used */
+    UDP_NOTIF_MT_JSON = 1,      /**< application/yang-data+json */
+    UDP_NOTIF_MT_XML = 2,       /**< application/yang-data+xml */
+    UDP_NOTIF_MT_CBOR = 3       /**< application/yang-data+cbor */
+} udp_notif_media_type_t;
+
+/**
+ * @brief Convert notification encoding to UDP-Notif media type.
+ *
+ * @param[in] encoding Notification encoding.
+ * @return UDP-Notif media type value.
+ */
+static udp_notif_media_type_t
+encoding_to_media_type(notif_encoding_t encoding)
+{
+    switch (encoding) {
+    case NOTIF_ENCODING_XML:
+        return UDP_NOTIF_MT_XML;
+    case NOTIF_ENCODING_JSON:
+        return UDP_NOTIF_MT_JSON;
+    case NOTIF_ENCODING_CBOR:
+        return UDP_NOTIF_MT_CBOR;
+    case NOTIF_ENCODING_UNSET:
+    default:
+        /* default to JSON if not set */
+        return UDP_NOTIF_MT_JSON;
+    }
+}
+
+/**
+ * @brief Build the fixed UDP-Notif message header.
+ *
+ * Header format (12 bytes):
+ *   - Ver (3 bits) + S-flag (1 bit) + MT (4 bits) = 1 byte
+ *   - Header Length (8 bits) = 1 byte
+ *   - Message Length (16 bits) = 2 bytes
+ *   - Message Publisher ID (32 bits) = 4 bytes
+ *   - Message ID (32 bits) = 4 bytes
+ *
+ * @param[out] hdr Buffer to write header to (must be at least UDP_NOTIF_HDR_SIZE bytes).
+ * @param[in] media_type Media type (MT field).
+ * @param[in] header_len Total header length including options.
+ * @param[in] message_len Total message length (header + payload).
+ * @param[in] publisher_id Message Publisher ID.
+ * @param[in] message_id Message ID.
+ */
+static void
+udp_notif_hdr_build(uint8_t *hdr, udp_notif_media_type_t media_type, uint8_t header_len,
+        uint16_t message_len, uint32_t publisher_id, uint32_t message_id)
+{
+    /* Ver (3 bits) | S-flag (1 bit) | MT (4 bits) */
+    hdr[0] = ((UDP_NOTIF_VERSION & 0x07) << 5) | (UDP_NOTIF_SFLAG_NONE << 4) | (media_type & 0x0F);
+
+    /* Header Length */
+    hdr[1] = header_len;
+
+    /* Message Length (network byte order) */
+    hdr[2] = (message_len >> 8) & 0xFF;
+    hdr[3] = message_len & 0xFF;
+
+    /* Message Publisher ID (network byte order) */
+    hdr[4] = (publisher_id >> 24) & 0xFF;
+    hdr[5] = (publisher_id >> 16) & 0xFF;
+    hdr[6] = (publisher_id >> 8) & 0xFF;
+    hdr[7] = publisher_id & 0xFF;
+
+    /* Message ID (network byte order) */
+    hdr[8] = (message_id >> 24) & 0xFF;
+    hdr[9] = (message_id >> 16) & 0xFF;
+    hdr[10] = (message_id >> 8) & 0xFF;
+    hdr[11] = message_id & 0xFF;
+}
+
+/**
+ * @brief Build the segmentation option.
+ *
+ * Option format (4 bytes):
+ *   - Type (8 bits) = 1 byte
+ *   - Length (8 bits) = 1 byte
+ *   - Segment Number (15 bits) + L flag (1 bit) = 2 bytes
+ *
+ * @param[out] opt Buffer to write option to (must be at least UDP_NOTIF_SEG_OPT_SIZE bytes).
+ * @param[in] segment_num Segment number (0-based).
+ * @param[in] is_last Whether this is the last segment.
+ */
+static void
+udp_notif_seg_opt_build(uint8_t *opt, uint16_t segment_num, int is_last)
+{
+    uint16_t seg_field;
+
+    /* Type */
+    opt[0] = UDP_NOTIF_OPT_SEGMENTATION;
+
+    /* Length (total TLV length) */
+    opt[1] = UDP_NOTIF_SEG_OPT_SIZE;
+
+    /* Segment Number (15 bits) | L flag (1 bit) */
+    seg_field = ((segment_num & 0x7FFF) << 1) | (is_last ? 1 : 0);
+    opt[2] = (seg_field >> 8) & 0xFF;
+    opt[3] = seg_field & 0xFF;
+}
+
+/**
+ * @brief Encode a notification to the specified format.
+ *
+ * @param[in] notif Notification data tree.
+ * @param[in] encoding Encoding format.
+ * @param[out] data Encoded data (caller must free).
+ * @param[out] data_len Length of encoded data.
+ * @return SR_ERR_OK on success, error code on failure.
+ */
+static int
+notif_encode(const struct lyd_node *notif, notif_encoding_t encoding, char **data, size_t *data_len)
+{
+    LYD_FORMAT format;
+    uint32_t print_flags = LYD_PRINT_SHRINK;
+
+    *data = NULL;
+    *data_len = 0;
+
+    switch (encoding) {
+    case NOTIF_ENCODING_XML:
+        format = LYD_XML;
+        break;
+    case NOTIF_ENCODING_JSON:
+    case NOTIF_ENCODING_UNSET:
+        format = LYD_JSON;
+        break;
+    case NOTIF_ENCODING_CBOR:
+        /* TODO: CBOR encoding not yet supported */
+        SRNTF_LOG_ERR("CBOR encoding is not yet implemented.");
+        return SR_ERR_UNSUPPORTED;
+    default:
+        SRNTF_LOG_ERR("Unknown encoding type %d.", encoding);
+        return SR_ERR_INVAL_ARG;
+    }
+
+    if (lyd_print_mem(data, notif, format, print_flags)) {
+        SRNTF_LOG_ERR("Failed to encode notification.");
+        return SR_ERR_LY;
+    }
+
+    *data_len = strlen(*data);
+    return SR_ERR_OK;
+}
+
+/**
+ * @brief Send a single UDP-Notif segment.
+ *
+ * @param[in] recv Notification receiver.
+ * @param[in] buf Buffer containing the complete segment (header + options + payload).
+ * @param[in] len Length of buffer.
+ * @return SR_ERR_OK on success, error code on failure.
+ */
+static int
+udp_notif_segment_send(notif_receiver_t *recv, const uint8_t *buf, size_t len)
+{
+    udp_conn_ctx_t *conn;
+    ssize_t sent;
+
+    assert(recv && recv->ops && (recv->ops->type == NOTIF_TRANSPORT_TYPE_UDP) && recv->conn_ctx);
+
+    conn = (udp_conn_ctx_t *)recv->conn_ctx;
+    assert(conn->sockfd >= 0);
+
+    sent = send(conn->sockfd, buf, len, 0);
+    if (sent < 0) {
+        SRNTF_LOG_ERR("Failed to send UDP-Notif message to receiver \"%s\": %s.", recv->name, strerror(errno));
+        return SR_ERR_SYS;
+    }
+
+    if ((size_t)sent != len) {
+        SRNTF_LOG_ERR("Incomplete UDP-Notif send to receiver \"%s\": sent %zd of %zu bytes.", recv->name, sent, len);
+        return SR_ERR_SYS;
+    }
+
+    return SR_ERR_OK;
+}
+
+/**
+ * @brief Send a notification without segmentation.
+ *
+ * @param[in] recv Notification receiver.
+ * @param[in] udp_recv UDP receiver instance.
+ * @param[in] media_type Media type for the message.
+ * @param[in] payload Encoded notification payload.
+ * @param[in] payload_len Length of payload.
+ * @param[in] message_id Message ID to use.
+ * @return SR_ERR_OK on success, error code on failure.
+ */
+static int
+udp_notif_send_unsegmented(notif_receiver_t *recv, udp_notif_receiver_t *udp_recv, udp_notif_media_type_t media_type,
+        const char *payload, size_t payload_len, uint32_t message_id)
+{
+    int rc;
+    uint8_t *buf = NULL;
+    size_t buf_len;
+    uint8_t header_len = UDP_NOTIF_HDR_SIZE;
+    uint16_t message_len;
+
+    buf_len = header_len + payload_len;
+    message_len = (uint16_t)buf_len;
+
+    buf = malloc(buf_len);
+    CHECK_ERRMEM_RET(buf);
+
+    /* build header */
+    udp_notif_hdr_build(buf, media_type, header_len, message_len,
+            udp_recv->publisher_id, message_id);
+
+    /* copy payload */
+    memcpy(buf + header_len, payload, payload_len);
+
+    /* send */
+    rc = udp_notif_segment_send(recv, buf, buf_len);
+
+    free(buf);
+    return rc;
+}
+
+/**
+ * @brief Send a notification with segmentation.
+ *
+ * @param[in] recv Notification receiver.
+ * @param[in] udp_recv UDP receiver instance.
+ * @param[in] media_type Media type for the message.
+ * @param[in] payload Encoded notification payload.
+ * @param[in] payload_len Length of payload.
+ * @param[in] message_id Message ID to use.
+ * @param[in] max_segment_size Maximum segment size.
+ * @return SR_ERR_OK on success, error code on failure.
+ */
+static int
+udp_notif_send_segmented(notif_receiver_t *recv, udp_notif_receiver_t *udp_recv, udp_notif_media_type_t media_type,
+        const char *payload, size_t payload_len, uint32_t message_id, uint16_t max_segment_size)
+{
+    int rc = SR_ERR_OK;
+    uint8_t *buf = NULL;
+    size_t buf_len;
+    uint8_t header_len = UDP_NOTIF_HDR_SIZE + UDP_NOTIF_SEG_OPT_SIZE;
+    size_t max_payload_per_segment;
+    size_t offset = 0;
+    uint16_t segment_num = 0;
+    size_t chunk_len;
+    int is_last;
+
+    /* calculate max payload per segment */
+    if (max_segment_size <= header_len) {
+        SRNTF_LOG_ERR("max-segment-size too small to fit header.");
+        return SR_ERR_INVAL_ARG;
+    }
+    max_payload_per_segment = max_segment_size - header_len;
+
+    /* allocate buffer for one segment */
+    buf_len = max_segment_size;
+    buf = malloc(buf_len);
+    CHECK_ERRMEM_RET(buf);
+
+    /* send segments */
+    while (offset < payload_len) {
+        /* calculate chunk size */
+        chunk_len = payload_len - offset;
+        if (chunk_len > max_payload_per_segment) {
+            chunk_len = max_payload_per_segment;
+        }
+
+        is_last = (offset + chunk_len >= payload_len);
+
+        /* build header */
+        udp_notif_hdr_build(buf, media_type, header_len,
+                (uint16_t)(header_len + chunk_len),
+                udp_recv->publisher_id, message_id);
+
+        /* build segmentation option (must be first option) */
+        udp_notif_seg_opt_build(buf + UDP_NOTIF_HDR_SIZE, segment_num, is_last);
+
+        /* copy payload chunk */
+        memcpy(buf + header_len, payload + offset, chunk_len);
+
+        /* send segment */
+        rc = udp_notif_segment_send(recv, buf, header_len + chunk_len);
+        if (rc != SR_ERR_OK) {
+            goto cleanup;
+        }
+
+        offset += chunk_len;
+        segment_num++;
+
+        /* check for segment number overflow (15-bit field) */
+        if (segment_num > 0x7FFF) {
+            SRNTF_LOG_ERR("Message requires too many segments (max 32768).");
+            rc = SR_ERR_INTERNAL;
+            goto cleanup;
+        }
+    }
+
+cleanup:
+    free(buf);
+    return rc;
+}
+
+/*
+ * ---------------------------------------------------------------------------
+ * UDP socket helpers
+ * ---------------------------------------------------------------------------
+ */
+
+static int
+udp_notif_local_addr_prepare(const char *local_address, struct sockaddr_storage *local_addr,
+        socklen_t *local_addr_len)
+{
+    struct sockaddr_in *addr4;
+    struct sockaddr_in6 *addr6;
+
+    if (!local_address || !local_addr || !local_addr_len) {
+        return SR_ERR_INVAL_ARG;
+    }
+
+    memset(local_addr, 0, sizeof(*local_addr));
+
+    if (inet_pton(AF_INET6, local_address, &((struct sockaddr_in6 *)local_addr)->sin6_addr) == 1) {
+        /* IPv6 */
+        addr6 = (struct sockaddr_in6 *)local_addr;
+        addr6->sin6_family = AF_INET6;
+        addr6->sin6_port = htons(0);
+        *local_addr_len = sizeof(struct sockaddr_in6);
+    } else if (inet_pton(AF_INET, local_address, &((struct sockaddr_in *)local_addr)->sin_addr) == 1) {
+        /* IPv4 */
+        addr4 = (struct sockaddr_in *)local_addr;
+        addr4->sin_family = AF_INET;
+        addr4->sin_port = htons(0);
+        *local_addr_len = sizeof(struct sockaddr_in);
+    } else {
+        SRNTF_LOG_ERR("Invalid source address \"%s\".", local_address);
+        return SR_ERR_INVAL_ARG;
+    }
+
+    return SR_ERR_OK;
+}
+
+/**
+ * @brief Try to create and connect one UDP socket for a resolved destination.
+ *
+ * @param[in] rp Resolved destination address candidate.
+ * @param[in] local_address Local source address string, if configured.
+ * @param[in] local_addr Parsed local source address, if configured.
+ * @param[in] local_addr_len Parsed local source address length.
+ * @return Connected socket fd on success, -1 on failure.
+ */
+static int
+udp_notif_connect_try_one(const struct addrinfo *rp, const char *local_address,
+        const struct sockaddr_storage *local_addr, socklen_t local_addr_len)
+{
+    int sockfd;
+
+    if (!rp) {
+        return -1;
+    }
+
+    sockfd = socket(rp->ai_family, rp->ai_socktype, rp->ai_protocol);
+    if (sockfd < 0) {
+        return -1;
+    }
+
+    /* bind to local address */
+    if (local_address) {
+        if (bind(sockfd, (const struct sockaddr *)local_addr, local_addr_len) < 0) {
+            SRNTF_LOG_ERR("Failed to bind UDP socket to local address \"%s\": %s.",
+                    local_address, strerror(errno));
+            close(sockfd);
+            return -1;
+        }
+    }
+
+    /* connect() on a UDP socket allows using send() instead of sendto() (simplicity),
+     * enables receiving ICMP errors (error-handling) and is faster (route caching) */
+    if (connect(sockfd, rp->ai_addr, rp->ai_addrlen) < 0) {
+        close(sockfd);
+        return -1;
+    }
+
+    return sockfd;
+}
+
+/*
+ * ---------------------------------------------------------------------------
+ * Transport ops callbacks
+ * ---------------------------------------------------------------------------
+ */
+
+static int
+udp_transport_connect_cb(notif_receiver_t *recv, void *cfg)
+{
+    int rc = SR_ERR_OK, sockfd = -1, r;
+    udp_notif_receiver_t *udp_recv = (udp_notif_receiver_t *)cfg;
+    udp_conn_ctx_t *conn;
+    struct addrinfo hints, *res = NULL, *rp;
+    char port_str[6];
+    struct sockaddr_storage local_addr;
+    socklen_t local_addr_len = 0;
+
+    if (!udp_recv || !udp_recv->remote_address) {
+        return SR_ERR_INVAL_ARG;
+    }
+
+    assert(!recv->ops || ((recv->ops->type == NOTIF_TRANSPORT_TYPE_UDP) && !recv->conn_ctx));
+
+    if (recv->sub && recv->sub->local_address) {
+        rc = udp_notif_local_addr_prepare(recv->sub->local_address, &local_addr, &local_addr_len);
+        if (rc != SR_ERR_OK) {
+            return rc;
+        }
+    }
+
+    snprintf(port_str, sizeof(port_str), "%" PRIu16, udp_recv->remote_port);
+
+    /* resolve destination address */
+    memset(&hints, 0, sizeof(hints));
+    hints.ai_family = AF_UNSPEC;
+    hints.ai_socktype = SOCK_DGRAM;
+    hints.ai_flags = 0;
+    hints.ai_protocol = IPPROTO_UDP;
+
+    r = getaddrinfo(udp_recv->remote_address, port_str, &hints, &res);
+    if (r) {
+        SRNTF_LOG_ERR("Failed to resolve address \"%s\": %s.", udp_recv->remote_address, gai_strerror(r));
+        rc = SR_ERR_SYS;
+        goto cleanup;
+    }
+
+    /* try each resolved address until one succeeds */
+    for (rp = res; rp; rp = rp->ai_next) {
+        if (recv->sub && recv->sub->local_address && (rp->ai_family != local_addr.ss_family)) {
+            continue;
+        }
+
+        sockfd = udp_notif_connect_try_one(rp, recv->sub ? recv->sub->local_address : NULL,
+                &local_addr, local_addr_len);
+        if (sockfd >= 0) {
+            break;
+        }
+    }
+
+    if (sockfd < 0) {
+        SRNTF_LOG_ERR("Failed to connect to \"%s:%s\": %s.", udp_recv->remote_address, port_str, strerror(errno));
+        rc = SR_ERR_SYS;
+        goto cleanup;
+    }
+
+    conn = calloc(1, sizeof *conn);
+    if (!conn) {
+        ERRMEM;
+        close(sockfd);
+        rc = SR_ERR_NO_MEMORY;
+        goto cleanup;
+    }
+    conn->sockfd = sockfd;
+    recv->conn_ctx = conn;
+
+    SRNTF_LOG_INF("Connected UDP-Notif receiver to %s:%s on socket %d.", udp_recv->remote_address, port_str, sockfd);
+
+    /* initialize message ID to 1 as per spec (starts at 1 with first message) */
+    if (udp_recv->message_id == 0) {
+        ATOMIC_STORE_RELAXED(udp_recv->message_id, 1);
+    }
+
+    /* TODO: publisher_id should be configured or generated uniquely per publisher instance */
+    if (udp_recv->publisher_id == 0) {
+        udp_recv->publisher_id = (uint32_t)getpid();
+    }
+
+cleanup:
+    freeaddrinfo(res);
+    return rc;
+}
+
+static void
+udp_transport_disconnect_cb(notif_receiver_t *recv)
+{
+    udp_conn_ctx_t *conn;
+
+    if (!recv || !recv->conn_ctx) {
+        return;
+    }
+
+    conn = (udp_conn_ctx_t *)recv->conn_ctx;
+    assert(conn->sockfd >= 0);
+    close(conn->sockfd);
+    free(conn);
+    recv->conn_ctx = NULL;
+}
+
+static int
+udp_transport_is_connected_cb(const notif_receiver_t *recv)
+{
+    udp_conn_ctx_t *conn;
+
+    if (!recv || !recv->conn_ctx) {
+        return 0;
+    }
+
+    conn = (udp_conn_ctx_t *)recv->conn_ctx;
+    return conn->sockfd >= 0 ? 1 : 0;
+}
+
+static int
+udp_transport_send_cb(notif_receiver_t *recv, void *cfg,
+        const struct lyd_node *notif, const struct timespec *timestamp, notif_encoding_t encoding)
+{
+    int rc;
+    char *payload = NULL;
+    size_t payload_len;
+    udp_notif_media_type_t media_type;
+    uint32_t message_id;
+    uint16_t max_segment_size;
+    size_t total_msg_len;
+    udp_notif_receiver_t *udp_recv = (udp_notif_receiver_t *)cfg;
+    udp_conn_ctx_t *conn;
+
+    (void)timestamp;
+
+    if (!recv || !udp_recv || !notif) {
+        return SR_ERR_INVAL_ARG;
+    }
+
+    if (!recv->conn_ctx) {
+        SRNTF_LOG_ERR("UDP-Notif receiver is not connected.");
+        return SR_ERR_OPERATION_FAILED;
+    }
+
+    conn = (udp_conn_ctx_t *)recv->conn_ctx;
+    if (conn->sockfd < 0) {
+        SRNTF_LOG_ERR("UDP-Notif receiver is not connected.");
+        return SR_ERR_OPERATION_FAILED;
+    }
+
+    /* encode the notification */
+    rc = notif_encode(notif, encoding, &payload, &payload_len);
+    if (rc != SR_ERR_OK) {
+        goto cleanup;
+    }
+
+    /* get media type */
+    media_type = encoding_to_media_type(encoding);
+
+    /* get current message ID and increment for next message atomically */
+    message_id = ATOMIC_ADD_RELAXED(udp_recv->message_id, 1);
+
+    /* determine max segment size */
+    max_segment_size = udp_recv->max_segment_size;
+    if (max_segment_size == 0) {
+        max_segment_size = UDP_NOTIF_DEFAULT_MAX_SEGMENT_SIZE;
+    }
+
+    /* calculate total message length (header + payload) */
+    total_msg_len = UDP_NOTIF_HDR_SIZE + payload_len;
+
+    /* check if segmentation is needed */
+    if (total_msg_len <= max_segment_size) {
+        /* message fits in one segment, no segmentation needed */
+        rc = udp_notif_send_unsegmented(recv, udp_recv, media_type, payload, payload_len, message_id);
+    } else if (udp_recv->enable_segmentation) {
+        /* message too large, use segmentation */
+        rc = udp_notif_send_segmented(recv, udp_recv, media_type, payload, payload_len, message_id, max_segment_size);
+    } else {
+        /* message too large but segmentation disabled */
+        SRNTF_LOG_ERR("Notification message too large (%zu bytes) and segmentation is disabled.",
+                payload_len);
+        rc = SR_ERR_INVAL_ARG;
+        goto cleanup;
+    }
+
+cleanup:
+    free(payload);
+    return rc;
+}
+
+/*
+ * ---------------------------------------------------------------------------
+ * Config parse / change / destroy / validate callbacks
+ * ---------------------------------------------------------------------------
+ */
+
+static int
+udp_notif_receiver_from_node(const struct lyd_node *node, udp_notif_receiver_t *udp_recv)
+{
+    int rc = SR_ERR_OK;
+    struct lyd_node *n;
+
+    memset(udp_recv, 0, sizeof *udp_recv);
+
+    if ((rc = get_descendant_mandatory(node, "remote-address", &n))) {
+        goto cleanup;
+    }
+    udp_recv->remote_address = strdup(lyd_get_value(n));
+    CHECK_ERRMEM_GOTO(udp_recv->remote_address, rc, cleanup);
+
+    if ((rc = get_descendant_mandatory(node, "remote-port", &n))) {
+        goto cleanup;
+    }
+    udp_recv->remote_port = (uint16_t)strtoul(lyd_get_value(n), NULL, 10);
+
+    get_descendant_optional(node, "enable-segmentation", &n);
+    if (n) {
+        udp_recv->enable_segmentation = ((struct lyd_node_term *)n)->value.boolean;
+    }
+
+    get_descendant_optional(node, "max-segment-size", &n);
+    if (n) {
+        udp_recv->max_segment_size = (uint16_t)strtoul(lyd_get_value(n), NULL, 10);
+    }
+
+    ATOMIC_STORE_RELAXED(udp_recv->message_id, 1);
+
+cleanup:
+    return rc;
+}
+
+static int
+udp_transport_config_parse_cb(const struct lyd_node *node, void **cfg)
+{
+    int rc = SR_ERR_OK;
+    udp_notif_receiver_t *udp_recv;
+
+    udp_recv = calloc(1, sizeof *udp_recv);
+    CHECK_ERRMEM_RET(udp_recv);
+
+    if ((rc = udp_notif_receiver_from_node(node, udp_recv))) {
+        free(udp_recv);
+        return rc;
+    }
+
+    *cfg = udp_recv;
+    return SR_ERR_OK;
+}
+
+static void
+udp_notif_receiver_destroy(udp_notif_receiver_t *udp_recv)
+{
+    if (!udp_recv) {
+        return;
+    }
+
+    free(udp_recv->remote_address);
+}
+
+static void
+udp_transport_config_destroy_cb(void *cfg)
+{
+    udp_notif_receiver_t *udp_recv = (udp_notif_receiver_t *)cfg;
+
+    udp_notif_receiver_destroy(udp_recv);
+    free(udp_recv);
+}
+
+static int
+udp_transport_config_change_cb(notif_receiver_inst_t *inst, const struct lyd_node *node, sr_change_oper_t op)
+{
+    int rc = SR_ERR_OK;
+    const char *node_name;
+    udp_notif_receiver_t *udp_recv = NULL;
+
+    node_name = LYD_NAME(node);
+
+    if (!strcmp(node_name, "udp-notif-receiver")) {
+        if (op == SR_OP_CREATED) {
+            inst->type = NOTIF_TRANSPORT_TYPE_UDP;
+            inst->modified = 1;
+            if (!inst->transport_config) {
+                udp_recv = calloc(1, sizeof *udp_recv);
+                CHECK_ERRMEM_GOTO(udp_recv, rc, cleanup);
+                ATOMIC_STORE_RELAXED(udp_recv->message_id, 1);
+                inst->transport_config = udp_recv;
+            }
+        } else if (op == SR_OP_DELETED) {
+            inst->type = NOTIF_TRANSPORT_TYPE_NONE;
+            inst->modified = 1;
+            if (inst->transport_config) {
+                udp_transport_config_destroy_cb(inst->transport_config);
+                inst->transport_config = NULL;
+            }
+        }
+    } else if (!strcmp(node_name, "remote-address")) {
+        if (op == SR_OP_MODIFIED) {
+            udp_recv = (udp_notif_receiver_t *)inst->transport_config;
+            free(udp_recv->remote_address);
+            udp_recv->remote_address = strdup(lyd_get_value(node));
+            CHECK_ERRMEM_GOTO(udp_recv->remote_address, rc, cleanup);
+            inst->modified = 1;
+        }
+    } else if (!strcmp(node_name, "remote-port")) {
+        if (op == SR_OP_MODIFIED) {
+            udp_recv = (udp_notif_receiver_t *)inst->transport_config;
+            udp_recv->remote_port = (uint16_t)strtoul(lyd_get_value(node), NULL, 10);
+            inst->modified = 1;
+        }
+    } else if (!strcmp(node_name, "enable-segmentation")) {
+        if ((op == SR_OP_CREATED) || (op == SR_OP_MODIFIED)) {
+            udp_recv = (udp_notif_receiver_t *)inst->transport_config;
+            udp_recv->enable_segmentation = ((struct lyd_node_term *)node)->value.boolean;
+        } else if (op == SR_OP_DELETED) {
+            udp_recv = (udp_notif_receiver_t *)inst->transport_config;
+            udp_recv->enable_segmentation = 0;
+        }
+    } else if (!strcmp(node_name, "max-segment-size")) {
+        if ((op == SR_OP_CREATED) || (op == SR_OP_MODIFIED)) {
+            udp_recv = (udp_notif_receiver_t *)inst->transport_config;
+            udp_recv->max_segment_size = (uint16_t)strtoul(lyd_get_value(node), NULL, 10);
+        } else if (op == SR_OP_DELETED) {
+            udp_recv = (udp_notif_receiver_t *)inst->transport_config;
+            udp_recv->max_segment_size = 0;
+        }
+    }
+
+cleanup:
+    return rc;
+}
+
+static int
+udp_transport_config_validate_cb(const struct lyd_node *UNUSED(node))
+{
+    return SR_ERR_OK;
+}
+
+/*
+ * ---------------------------------------------------------------------------
+ * UDP transport ops vtable definition
+ * ---------------------------------------------------------------------------
+ */
+
+const notif_transport_ops_t udp_transport_ops = {
+    .name = "UDP",
+    .transport_identity = "ietf-udp-notif-transport:udp-notif",
+    .config_container_name = "udp-notif-receiver",
+    .type = NOTIF_TRANSPORT_TYPE_UDP,
+    .connect = udp_transport_connect_cb,
+    .disconnect = udp_transport_disconnect_cb,
+    .is_connected = udp_transport_is_connected_cb,
+    .send = udp_transport_send_cb,
+    .config_parse = udp_transport_config_parse_cb,
+    .config_change = udp_transport_config_change_cb,
+    .config_destroy = udp_transport_config_destroy_cb,
+    .config_validate = udp_transport_config_validate_cb,
+};

--- a/src/ly_wrap.c
+++ b/src/ly_wrap.c
@@ -306,6 +306,16 @@ cleanup:
     return err_info;
 }
 
+void
+sr_ly_ctx_destroy(struct ly_ctx *ly_ctx)
+{
+    sr_ly_log_setup();
+
+    ly_ctx_destroy(ly_ctx);
+
+    sr_ly_log_revert();
+}
+
 sr_error_info_t *
 sr_lys_parse(struct ly_ctx *ctx, const char *data, const char *path, LYS_INFORMAT format, const char **features,
         struct lys_module **ly_mod)

--- a/src/ly_wrap.h
+++ b/src/ly_wrap.h
@@ -34,6 +34,13 @@
 sr_error_info_t *sr_ly_ctx_new(struct ly_ctx **ly_ctx);
 
 /**
+ * @brief Destroy a libyang context.
+ *
+ * @param[in] ly_ctx Context to destroy.
+ */
+void sr_ly_ctx_destroy(struct ly_ctx *ly_ctx);
+
+/**
  * @brief Parse a YANG module.
  *
  * @param[in] ctx Context to use.

--- a/src/lyd_mods.c
+++ b/src/lyd_mods.c
@@ -1523,7 +1523,7 @@ sr_lydmods_update_replay_support_module(const struct lys_module *ly_mod, struct 
         }
 
         /* use earliest stored notification timestamp or use current time */
-        if ((err_info = ntf_handle->plugin->earliest_get_cb(ly_mod, &ts))) {
+        if ((err_info = ntf_handle->plugin->earliest_get_cb(ly_mod, NULL, &ts))) {
             return err_info;
         }
         if (SR_TS_IS_ZERO(ts)) {

--- a/src/plugins/ntf_json.c
+++ b/src/plugins/ntf_json.c
@@ -367,37 +367,131 @@ cleanup:
     return err_info;
 }
 
+/**
+ * @brief Ensure that JSON notification directory exists.
+ *
+ * @param[out] dir_path Optional directory path.
+ * @return err_info, NULL on success.
+ */
+static sr_error_info_t *
+srpntf_ensure_dir(char **dir_path)
+{
+    sr_error_info_t *err_info = NULL;
+    int r;
+    char *path = NULL;
+
+    /* notif dir */
+    if ((err_info = srpjson_get_notif_dir(srpntf_name, &path))) {
+        goto cleanup;
+    }
+    if (((r = access(path, F_OK)) == -1) && (errno != ENOENT)) {
+        srplg_log_errinfo(&err_info, srpntf_name, NULL, SR_ERR_SYS, "Access on \"%s\" failed (%s).", path, strerror(errno));
+        goto cleanup;
+    }
+    if (r && (err_info = srpjson_mkpath(srpntf_name, path, SRPJSON_DIR_PERM))) {
+        goto cleanup;
+    }
+
+    if (dir_path) {
+        *dir_path = path;
+        path = NULL;
+    }
+
+cleanup:
+    free(path);
+    return err_info;
+}
+
+/**
+ * @brief Get path to a module replay file.
+ *
+ * @param[in] mod_name Module name.
+ * @param[out] path Generated file path.
+ * @return err_info, NULL on success.
+ */
+static sr_error_info_t *
+srpntf_get_replay_path(const char *mod_name, char **path)
+{
+    sr_error_info_t *err_info = NULL;
+    char *dir_path = NULL;
+    int r;
+
+    if ((err_info = srpjson_get_notif_dir(srpntf_name, &dir_path))) {
+        return err_info;
+    }
+
+    r = asprintf(path, "%s/%s.replay", dir_path, mod_name);
+    free(dir_path);
+    if (r == -1) {
+        srplg_log_errinfo(&err_info, srpntf_name, NULL, SR_ERR_NO_MEMORY, "Memory allocation failed.");
+    }
+    return err_info;
+}
+
 static sr_error_info_t *
 srpntf_json_enable(const struct lys_module *mod)
 {
     sr_error_info_t *err_info = NULL;
-    int r;
-    char *dir_path = NULL;
+    char *path = NULL;
+    int fd = -1;
+    struct timespec ts;
 
-    (void)mod;
-
-    /* notif dir */
-    if ((err_info = srpjson_get_notif_dir(srpntf_name, &dir_path))) {
+    /* ensure notif directory exists */
+    if ((err_info = srpntf_ensure_dir(NULL))) {
         goto cleanup;
     }
-    if (((r = access(dir_path, F_OK)) == -1) && (errno != ENOENT)) {
-        srplg_log_errinfo(&err_info, srpntf_name, NULL, SR_ERR_SYS, "Access on \"%s\" failed (%s).", dir_path, strerror(errno));
+
+    if ((err_info = srpntf_get_replay_path(mod->name, &path))) {
         goto cleanup;
     }
-    if (r && (err_info = srpjson_mkpath(srpntf_name, dir_path, SRPJSON_DIR_PERM))) {
+
+    /* create the replay file only if it does not exist yet */
+    fd = srpjson_open(srpntf_name, path, O_WRONLY | O_CREAT | O_EXCL, SRPJSON_NOTIF_PERM);
+    if (fd == -1) {
+        if (errno == EEXIST) {
+            /* already enabled, nothing to do */
+            goto cleanup;
+        }
+        err_info = srpjson_open_error(srpntf_name, path);
+        goto cleanup;
+    }
+
+    SRPLG_LOG_INF(srpntf_name, "Replay file \"%s\" created.", strrchr(path, '/') + 1);
+
+    /* write the current real time */
+    clock_gettime(CLOCK_REALTIME, &ts);
+    if (write(fd, &ts, sizeof ts) != (ssize_t) sizeof ts) {
+        srplg_log_errinfo(&err_info, srpntf_name, NULL, SR_ERR_SYS, "Writing replay time failed (%s).", strerror(errno));
+        goto cleanup;
+    }
+
+    if (fsync(fd) == -1) {
+        srplg_log_errinfo(&err_info, srpntf_name, NULL, SR_ERR_SYS, "Fsync failed (%s).", strerror(errno));
         goto cleanup;
     }
 
 cleanup:
-    free(dir_path);
+    if (fd > -1) {
+        close(fd);
+    }
+    free(path);
     return err_info;
 }
 
 static sr_error_info_t *
 srpntf_json_disable(const struct lys_module *mod)
 {
+    sr_error_info_t *err_info = NULL;
+    char *path = NULL;
+
     (void)mod;
 
+    if ((err_info = srpntf_get_replay_path(mod->name, &path))) {
+        return err_info;
+    }
+
+    unlink(path);
+    free(path);
     return NULL;
 }
 
@@ -601,18 +695,20 @@ cleanup:
 }
 
 static sr_error_info_t *
-srpntf_json_earliest_get(const struct lys_module *mod, struct timespec *ts)
+srpntf_json_earliest_get(const struct lys_module *mod, const struct timespec *after, struct timespec *ts)
 {
     sr_error_info_t *err_info = NULL;
     int fd = -1;
     time_t file_from, file_to;
 
     /* create directory in case does not exist */
-    if ((err_info = srpntf_json_enable(mod))) {
+    if ((err_info = srpntf_ensure_dir(NULL))) {
         goto cleanup;
     }
 
-    if ((err_info = srpntf_find_file(mod->name, 1, 0, &file_from, &file_to))) {
+    /* find the earliest file possibly containing notification after 'after' */
+    if ((err_info = srpntf_find_file(mod->name,
+            (after && (after->tv_sec || after->tv_nsec)) ? after->tv_sec : 1, 0, &file_from, &file_to))) {
         goto cleanup;
     }
     if (!file_from) {
@@ -621,17 +717,87 @@ srpntf_json_earliest_get(const struct lys_module *mod, struct timespec *ts)
         goto cleanup;
     }
 
-    /* open the file */
-    if ((err_info = srpntf_open_file(mod->name, file_from, file_to, O_RDONLY, &fd))) {
+    while (file_from && file_to) {
+        /* open the file */
+        if ((err_info = srpntf_open_file(mod->name, file_from, file_to, O_RDONLY, &fd))) {
+            goto cleanup;
+        }
+
+        /* read timestamps and skip notifications until one after 'after' is found */
+        while (1) {
+            if ((err_info = srpntf_read_ts(fd, ts))) {
+                goto cleanup;
+            }
+            if (!ts->tv_sec) {
+                /* EOF, no more notifications in this file */
+                break;
+            }
+            if (!after || (!after->tv_sec && !after->tv_nsec) || (srpjson_time_cmp(ts, after) >= 0)) {
+                /* found a notification after 'after', or no filter */
+                goto cleanup;
+            }
+
+            /* skip the notification data */
+            if ((err_info = srpntf_skip_notif(fd))) {
+                goto cleanup;
+            }
+        }
+
+        /* close this file and try next */
+        close(fd);
+        fd = -1;
+
+        /* find next notification file */
+        if ((err_info = srpntf_find_file(mod->name, file_from, file_to, &file_from, &file_to))) {
+            goto cleanup;
+        }
+    }
+
+    /* no notification found after 'after' */
+    memset(ts, 0, sizeof *ts);
+
+cleanup:
+    if (fd > -1) {
+        close(fd);
+    }
+    return err_info;
+}
+
+static sr_error_info_t *
+srpntf_json_replay_start_get(const struct lys_module *mod, struct timespec *ts)
+{
+    sr_error_info_t *err_info = NULL;
+    char *path = NULL;
+    int fd = -1;
+    ssize_t r;
+
+    /* create directory in case does not exist */
+    if ((err_info = srpntf_ensure_dir(NULL))) {
         goto cleanup;
     }
 
-    /* read first notif timestamp */
-    if ((err_info = srpntf_read_ts(fd, ts))) {
+    if ((err_info = srpntf_get_replay_path(mod->name, &path))) {
         goto cleanup;
     }
-    if (!ts->tv_sec) {
-        srplg_log_errinfo(&err_info, srpntf_name, NULL, SR_ERR_INTERNAL, "Unexpected notification file EOF.");
+
+    fd = open(path, O_RDONLY);
+    if (fd == -1) {
+        if (errno == ENOENT) {
+            /* replay was never enabled */
+            memset(ts, 0, sizeof *ts);
+            goto cleanup;
+        }
+        srplg_log_errinfo(&err_info, srpntf_name, NULL, SR_ERR_SYS, "Opening \"%s\" failed (%s).", path, strerror(errno));
+        goto cleanup;
+    }
+
+    /* read replay timestamp */
+    r = read(fd, ts, sizeof *ts);
+    if (r == -1) {
+        srplg_log_errinfo(&err_info, srpntf_name, NULL, SR_ERR_SYS, "Reading \"%s\" failed (%s).", path, strerror(errno));
+        goto cleanup;
+    } else if (r != (ssize_t) sizeof *ts) {
+        srplg_log_errinfo(&err_info, srpntf_name, NULL, SR_ERR_INTERNAL, "Unexpected replay file size.");
         goto cleanup;
     }
 
@@ -639,6 +805,7 @@ cleanup:
     if (fd > -1) {
         close(fd);
     }
+    free(path);
     return err_info;
 }
 
@@ -828,6 +995,12 @@ srpntf_json_destroy(const struct lys_module *mod)
     }
 
 cleanup:
+    /* remove replay file */
+    if (!srpntf_get_replay_path(mod->name, &path)) {
+        unlink(path);
+        free(path);
+    }
+
     srplg_errinfo_free(&err_info);
 }
 
@@ -838,6 +1011,7 @@ const struct srplg_ntf_s srpntf_json = {
     .store_cb = srpntf_json_store,
     .replay_next_cb = srpntf_json_replay_next,
     .earliest_get_cb = srpntf_json_earliest_get,
+    .replay_start_get_cb = srpntf_json_replay_start_get,
     .access_set_cb = srpntf_json_access_set,
     .access_get_cb = srpntf_json_access_get,
     .access_check_cb = srpntf_json_access_check,

--- a/src/plugins_notification.h
+++ b/src/plugins_notification.h
@@ -40,7 +40,7 @@ extern "C" {
 /**
  * @brief Notification plugin API version
  */
-#define SRPLG_NTF_API_VERSION 4
+#define SRPLG_NTF_API_VERSION 5
 
 /**
  * @brief Initialize notification storage for a specific module.
@@ -98,11 +98,27 @@ typedef sr_error_info_t *(*srntf_replay_next)(const struct lys_module *mod, cons
  * Is called even before ::srntf_enable().
  *
  * @param[in] mod Specific module.
+ * @param[in] after Optional, get the earliest notification stored at or after this time.
  * @param[out] ts Timestamp of the earliest notification, zeroed if there are none.
  * @return NULL on success;
  * @return Sysrepo error info on error.
  */
-typedef sr_error_info_t *(*srntf_earliest_get)(const struct lys_module *mod, struct timespec *ts);
+typedef sr_error_info_t *(*srntf_earliest_get)(const struct lys_module *mod, const struct timespec *after,
+        struct timespec *ts);
+
+/**
+ * @brief Get the timestamp when replay was enabled for the module.
+ *
+ * This timestamp corresponds to the creation time of the replay log and is used
+ * to populate `replay-log-creation-time` in ietf-subscribed-notifications.
+ * Is called even before ::srntf_enable().
+ *
+ * @param[in] mod Specific module.
+ * @param[out] ts Timestamp when replay was enabled, zeroed if replay was never enabled.
+ * @return NULL on success;
+ * @return Sysrepo error info on error.
+ */
+typedef sr_error_info_t *(*srntf_replay_start_get)(const struct lys_module *mod, struct timespec *ts);
 
 /**
  * @brief Set access permissions for notification data of a module.
@@ -157,6 +173,7 @@ struct srplg_ntf_s {
     srntf_store store_cb;           /**< store a notification for replay */
     srntf_replay_next replay_next_cb;   /**< replay next notification in order */
     srntf_earliest_get earliest_get_cb; /**< get the timestamp of the earliest stored notification */
+    srntf_replay_start_get replay_start_get_cb; /**< get the timestamp when replay was enabled */
     srntf_access_set access_set_cb; /**< callback for setting access rights for notification data */
     srntf_access_get access_get_cb; /**< callback got getting access rights for notification data */
     srntf_access_check access_check_cb; /**< callback for checking user access to notificaion data */

--- a/src/sysrepo.c
+++ b/src/sysrepo.c
@@ -166,7 +166,7 @@ sr_conn_free(sr_conn_ctx_t *conn)
         /* destroy lyctx */
         sr_yang_ctx.content_id = 0;
         sr_yang_ctx.sm_data_id = 0;
-        ly_ctx_destroy(sr_yang_ctx.ly_ctx);
+        sr_ly_ctx_destroy(sr_yang_ctx.ly_ctx);
         sr_yang_ctx.ly_ctx = NULL;
 
         /* destroy shm */
@@ -1691,7 +1691,7 @@ cleanup:
     }
 
     sr_lycc_clear_data(&cc_info);
-    ly_ctx_destroy(new_ctx);
+    sr_ly_ctx_destroy(new_ctx);
     free(mod_name);
 
     /* CONTEXT UNLOCK */
@@ -1977,7 +1977,7 @@ sr_remove_modules(sr_conn_ctx_t *conn, const char **module_names, int force)
 cleanup:
     sr_lycc_clear_data(&cc_info);
     lyd_free_siblings(sr_del_mods);
-    ly_ctx_destroy(new_ctx);
+    sr_ly_ctx_destroy(new_ctx);
 
     /* CONTEXT UNLOCK */
     sr_lycc_unlock(conn, ctx_mode, 1, __func__);
@@ -2209,7 +2209,7 @@ sr_update_modules(sr_conn_ctx_t *conn, const char **schema_paths, const char *se
 
 cleanup:
     sr_lycc_clear_data(&cc_info);
-    ly_ctx_destroy(new_ctx);
+    sr_ly_ctx_destroy(new_ctx);
 
     /* CONTEXT UNLOCK */
     sr_lycc_unlock(conn, ctx_mode, 1, __func__);
@@ -2268,19 +2268,30 @@ cleanup:
     return sr_api_ret(NULL, err_info);
 }
 
-API int
-sr_get_module_replay_support(sr_conn_ctx_t *conn, const char *module_name, struct timespec *earliest_notif, int *enabled)
+/**
+ * @brief Get module replay details.
+ *
+ * @param[in] conn Connection to use.
+ * @param[in] module_name Module name to get the details for.
+ * @param[in] after Optional, get the earliest stored notification exactly at or after this time.
+ * @param[out] earliest_notif Optional timestamp of the earliest stored notification (at or after @p after),
+ * zeroed if none are stored. Can be set even if replay is disabled when it was enabled in the past.
+ * @param[out] replay_start Optional timestamp when replay was enabled, zeroed if replay is currently disabled.
+ * @param[out] enabled Optional whether replay is currently enabled for this module.
+ * @return err_info, NULL on success.
+ */
+static sr_error_info_t *
+sr_get_module_replay_info(sr_conn_ctx_t *conn, const char *module_name, const struct timespec *after,
+        struct timespec *earliest_notif, struct timespec *replay_start, int *enabled)
 {
     sr_error_info_t *err_info = NULL;
     sr_mod_t *shm_mod;
     const struct lys_module *ly_mod;
     const struct sr_ntf_handle_s *ntf_handle;
 
-    SR_CHECK_ARG_APIRET(!conn || !module_name || !enabled, NULL, err_info);
-
     /* CONTEXT LOCK */
     if ((err_info = sr_lycc_lock(conn, SR_LOCK_READ, 0, __func__))) {
-        return sr_api_ret(NULL, err_info);
+        return err_info;
     }
 
     /* try to find this module */
@@ -2291,20 +2302,33 @@ sr_get_module_replay_support(sr_conn_ctx_t *conn, const char *module_name, struc
     }
 
     /* read replay support */
-    *enabled = shm_mod->replay_supp;
+    if (enabled) {
+        *enabled = shm_mod->replay_supp;
+    }
+
+    if (!earliest_notif && !replay_start) {
+        /* nothing more to read */
+        goto cleanup;
+    }
+
+    /* find LY module */
+    ly_mod = ly_ctx_get_module_implemented(sr_yang_ctx.ly_ctx, module_name);
+    assert(ly_mod);
+
+    /* find NTF plugin handle */
+    if ((err_info = sr_ntf_handle_find(sr_yang_ctx.mod_shm.addr + shm_mod->plugins[SR_MOD_DS_NOTIF], conn, &ntf_handle))) {
+        goto cleanup;
+    }
 
     if (earliest_notif) {
-        /* find LY module */
-        ly_mod = ly_ctx_get_module_implemented(sr_yang_ctx.ly_ctx, module_name);
-        assert(ly_mod);
-
-        /* find NTF plugin handle */
-        if ((err_info = sr_ntf_handle_find(sr_yang_ctx.mod_shm.addr + shm_mod->plugins[SR_MOD_DS_NOTIF], conn, &ntf_handle))) {
+        /* get earliest notif timestamp (optionally @p after the given time) */
+        if ((err_info = ntf_handle->plugin->earliest_get_cb(ly_mod, after, earliest_notif))) {
             goto cleanup;
         }
-
-        /* get earliest notif timestamp */
-        if ((err_info = ntf_handle->plugin->earliest_get_cb(ly_mod, earliest_notif))) {
+    }
+    if (replay_start) {
+        /* get replay start timestamp */
+        if ((err_info = ntf_handle->plugin->replay_start_get_cb(ly_mod, replay_start))) {
             goto cleanup;
         }
     }
@@ -2313,6 +2337,30 @@ cleanup:
     /* CONTEXT UNLOCK */
     sr_lycc_unlock(conn, SR_LOCK_READ, 0, __func__);
 
+    return err_info;
+}
+
+API int
+sr_get_module_replay_support(sr_conn_ctx_t *conn, const char *module_name, struct timespec *earliest_notif,
+        int *enabled)
+{
+    sr_error_info_t *err_info = NULL;
+
+    SR_CHECK_ARG_APIRET(!conn || !module_name || !enabled, NULL, err_info);
+
+    err_info = sr_get_module_replay_info(conn, module_name, NULL, earliest_notif, NULL, enabled);
+    return sr_api_ret(NULL, err_info);
+}
+
+API int
+sr_get_module_replay_start(sr_conn_ctx_t *conn, const char *module_name, const struct timespec *after,
+        struct timespec *earliest_notif, struct timespec *replay_start)
+{
+    sr_error_info_t *err_info = NULL;
+
+    SR_CHECK_ARG_APIRET(!conn || !module_name || (!earliest_notif && !replay_start), NULL, err_info);
+
+    err_info = sr_get_module_replay_info(conn, module_name, after, earliest_notif, replay_start, NULL);
     return sr_api_ret(NULL, err_info);
 }
 
@@ -2750,7 +2798,7 @@ sr_change_module_feature(sr_conn_ctx_t *conn, const char *module_name, const cha
 cleanup:
     free(features);
     sr_lycc_clear_data(&cc_info);
-    ly_ctx_destroy(new_ctx);
+    sr_ly_ctx_destroy(new_ctx);
 
     /* CONTEXT UNLOCK */
     sr_lycc_unlock(conn, ctx_mode, 1, __func__);

--- a/src/sysrepo.h
+++ b/src/sysrepo.h
@@ -715,6 +715,20 @@ int sr_get_module_replay_support(sr_conn_ctx_t *conn, const char *module_name, s
         int *enabled);
 
 /**
+ * @brief Learn replay details of a module.
+ *
+ * @param[in] conn Connection to use.
+ * @param[in] module_name Name of the module to check.
+ * @param[in] after Optional, get the earliest stored notification exactly at or after this time.
+ * @param[out] earliest_notif Optional timestamp of the earliest stored notification (at or after @p after),
+ * zeroed if none are stored. Can be set even if replay is disabled when it was enabled in the past.
+ * @param[out] replay_start Optional timestamp when replay was enabled, zeroed if replay is currently disabled.
+ * @return Error code (::SR_ERR_OK on success).
+ */
+int sr_get_module_replay_start(sr_conn_ctx_t *conn, const char *module_name, const struct timespec *after,
+        struct timespec *earliest_notif, struct timespec *replay_start);
+
+/**
  * @brief Change module permissions.
  *
  * @param[in] conn Connection to use.

--- a/src/utils/sn_common.c
+++ b/src/utils/sn_common.c
@@ -1543,8 +1543,8 @@ srsn_sn_sr_subscribe(sr_session_ctx_t *sess, struct srsn_sub *sub, int sub_no_th
     const sr_error_info_t *tmp_err;
     const struct ly_ctx *ly_ctx;
     const struct lys_module *ly_mod;
-    int rc = SR_ERR_OK, enabled;
-    struct timespec ts;
+    int rc = SR_ERR_OK;
+    struct timespec earliest_notif, rpl_start;
     struct ly_set *mod_set = NULL;
     uint32_t idx;
 
@@ -1568,16 +1568,21 @@ srsn_sn_sr_subscribe(sr_session_ctx_t *sess, struct srsn_sub *sub, int sub_no_th
     for (idx = 0; idx < mod_set->count; ++idx) {
         ly_mod = mod_set->objs[idx];
 
-        /* learn earliest stored notif */
-        if ((rc = sr_get_module_replay_support(sr_session_get_connection(sess), ly_mod->name, &ts, &enabled))) {
+        /* learn replay start time */
+        if ((rc = sr_get_module_replay_start(sr_session_get_connection(sess), ly_mod->name, &sub->start_time, &earliest_notif, &rpl_start))) {
             sr_session_get_error(sess, &tmp_err);
             sr_errinfo_new(&err_info, tmp_err->err[0].err_code, "%s", tmp_err->err[0].message);
             goto error;
         }
 
-        /* update the earliest stored notif */
-        if (!replay_start->tv_sec || (ts.tv_sec && (sr_time_cmp(replay_start, &ts) > 0))) {
-            *replay_start = ts;
+        /* update the earliest replay start time, if:
+         * 1) the module's replay is enabled, there is a notif stored after sub->start_time (time from which
+         *    the user wants to receive notifications) and the replay was enabled prior to storing the earliest notif,
+         * 2) the found notification is earlier than the current one (find minimum). */
+        if (rpl_start.tv_sec && earliest_notif.tv_sec && (sr_time_cmp(&rpl_start, &earliest_notif) <= 0)) {
+            if (!replay_start->tv_sec || (sr_time_cmp(replay_start, &rpl_start) > 0)) {
+                *replay_start = rpl_start;
+            }
         }
 
         /* subscribe to the module */
@@ -1591,12 +1596,6 @@ srsn_sn_sr_subscribe(sr_session_ctx_t *sess, struct srsn_sub *sub, int sub_no_th
 
         /* add new sub ID */
         sub->sr_sub_ids[idx] = sr_subscription_get_last_sub_id(sub->sr_sub);
-    }
-
-    if (sub->start_time.tv_sec && (sr_time_cmp(replay_start, &sub->start_time) <= 0)) {
-        /* there are earlier stored notifications
-         * TODO not accurate, the earliest stored notification is often not when the replay has actually been enabled */
-        memset(replay_start, 0, sizeof *replay_start);
     }
 
     goto cleanup;

--- a/src/utils/subscribed_notifications.c
+++ b/src/utils/subscribed_notifications.c
@@ -809,7 +809,7 @@ srsn_oper_data_streams_cb(sr_session_ctx_t *session, uint32_t UNUSED(sub_id), co
     uint32_t idx = 0;
     char *buf;
     int enabled, rc;
-    struct timespec earliest_notif;
+    struct timespec replay_start;
 
     /* context locked while the callback is executing */
     conn = sr_session_get_connection(session);
@@ -850,7 +850,7 @@ srsn_oper_data_streams_cb(sr_session_ctx_t *session, uint32_t UNUSED(sub_id), co
         }
 
         /* learn whether replay is supported */
-        if (sr_get_module_replay_support(conn, ly_mod->name, &earliest_notif, &enabled)) {
+        if (sr_get_module_replay_support(conn, ly_mod->name, NULL, &enabled)) {
             SR_ERRINFO_INT(&err_info);
             goto cleanup;
         }
@@ -858,7 +858,11 @@ srsn_oper_data_streams_cb(sr_session_ctx_t *session, uint32_t UNUSED(sub_id), co
             if ((err_info = sr_lyd_new_term(stream, NULL, "replay-support", NULL))) {
                 goto cleanup;
             }
-            ly_time_ts2str(&earliest_notif, &buf);
+            if ((rc = sr_get_module_replay_start(conn, ly_mod->name, NULL, NULL, &replay_start))) {
+                SR_ERRINFO_INT(&err_info);
+                goto cleanup;
+            }
+            ly_time_ts2str(&replay_start, &buf);
             if ((err_info = sr_lyd_new_term(stream, NULL, "replay-log-creation-time", buf))) {
                 free(buf);
                 goto cleanup;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -57,7 +57,7 @@ if(ENABLE_TESTS)
     # lists of all the tests
     set(tests test_modules test_context_change test_validation test_edit test_candidate test_oper_pull test_oper_push
         test_lock test_apply_changes test_copy_config test_rpc_action test_notif test_get test_privcand test_process
-        test_multi_connection test_nacm test_rotation test_sub_notif test_plugin test_rwlock)
+        test_multi_connection test_nacm test_rotation test_sub_notif test_plugin test_rwlock test_notifd)
 
     foreach(test_name IN LISTS tests)
         # link srobj to get the number of DS plugins available

--- a/tests/test_notifd.c
+++ b/tests/test_notifd.c
@@ -1,0 +1,3213 @@
+/**
+ * @file test_notifd.c
+ * @author Roman Janota <Roman.Janota@cesnet.cz>
+ * @brief tests for sysrepo-notifd daemon and UDP notification transport
+ *
+ * @copyright
+ * Copyright (c) 2026 CESNET, z.s.p.o.
+ *
+ * This source code is licensed under BSD 3-Clause License (the "License").
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://opensource.org/licenses/BSD-3-Clause
+ */
+
+#define _GNU_SOURCE
+
+#include <arpa/inet.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <netinet/in.h>
+#include <poll.h>
+#include <pthread.h>
+#include <setjmp.h>
+#include <signal.h>
+#include <stdarg.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/socket.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <sys/wait.h>
+#include <time.h>
+#include <unistd.h>
+
+#include <cmocka.h>
+#include <libyang/libyang.h>
+
+#include "common.h"
+#include "sysrepo.h"
+#include "tests/tcommon.h"
+
+/** Path to sysrepo-notifd executable */
+#define NOTIFD_PATH SR_BINARY_DIR "/sysrepo-notifd"
+
+/** Path to sysrepoctl executable */
+#define SYSREPOCTL_PATH SR_BINARY_DIR "/sysrepoctl"
+
+/** Directory containing YANG modules */
+#define SCHEMA_DIR TESTS_SRC_DIR "/../modules"
+
+/** Directory containing subscribed_notifications YANG modules */
+#define SN_YANG_DIR TESTS_SRC_DIR "/../modules/subscribed_notifications"
+
+/** UDP port for testing */
+#define TEST_UDP_PORT 47950
+
+/** UDP-Notif protocol constants */
+#define UDP_NOTIF_VERSION 1
+#define UDP_NOTIF_HDR_SIZE 12
+#define UDP_NOTIF_SEG_OPT_SIZE 4
+#define UDP_MAX_SIZE 65535
+
+/** UDP-Notif media types */
+#define UDP_NOTIF_MT_JSON 1
+#define UDP_NOTIF_MT_XML 2
+
+/** Maximum time to wait for notification (milliseconds) */
+#define NOTIF_TIMEOUT_MS 3000
+
+/** Maximum number of segments to track for reassembly */
+#define MAX_PENDING_MESSAGES 16
+
+/** Maximum number of segments per message */
+#define MAX_SEGMENTS_PER_MESSAGE 256
+
+/** Timeout for segment reassembly in seconds */
+#define SEGMENT_REASSEMBLY_TIMEOUT 30
+
+/** Short timeout for draining notifications (milliseconds) */
+#define DRAIN_TIMEOUT_MS 200
+
+/** Long timeout for operations that may take a while (milliseconds) */
+#define LONG_TIMEOUT_MS 10000
+
+/** Poll interval for operational counter polling (milliseconds) */
+#define COUNTER_POLL_MS 50
+
+/** Total timeout for operational counter polling (milliseconds) */
+#define COUNTER_WAIT_MS 5000
+
+/**
+ * @brief Segment buffer for message reassembly.
+ */
+typedef struct {
+    uint8_t *data;              /**< segment payload data */
+    size_t len;                 /**< segment payload length */
+    int received;               /**< whether segment was received */
+} segment_buffer_t;
+
+/**
+ * @brief Pending message for reassembly.
+ */
+typedef struct {
+    uint32_t publisher_id;      /**< publisher ID */
+    uint32_t message_id;        /**< message ID */
+    uint8_t media_type;         /**< media type from first segment */
+    segment_buffer_t *segments; /**< array of segment buffers */
+    uint16_t total_segments;    /**< total number of segments (0 if unknown) */
+    uint16_t received_count;    /**< number of received segments */
+    time_t first_received;      /**< timestamp of first segment */
+    int active;                 /**< whether this slot is in use */
+} pending_message_t;
+
+/** Pending messages for reassembly */
+static pending_message_t pending_messages[MAX_PENDING_MESSAGES];
+
+/**
+ * @brief Test state structure.
+ */
+struct state {
+    sr_conn_ctx_t *conn;            /**< sysrepo connection */
+    sr_session_ctx_t *sess;         /**< sysrepo session */
+    const struct ly_ctx *ly_ctx;    /**< libyang context */
+    pid_t notifd_pid;               /**< PID of sysrepo-notifd process */
+    int udp_sockfd;                 /**< UDP socket for receiving notifications */
+    uint16_t udp_port;              /**< UDP port used for test */
+};
+
+/**
+ * @brief Parsed UDP-Notif header.
+ */
+typedef struct {
+    uint8_t version;
+    uint8_t s_flag;
+    uint8_t media_type;
+    uint8_t header_len;
+    uint16_t message_len;
+    uint32_t publisher_id;
+    uint32_t message_id;
+    int has_segmentation;
+    uint16_t segment_num;
+    int is_last_segment;
+} udp_notif_header_t;
+
+/**
+ * @brief Parse UDP-Notif header from received data.
+ *
+ * @param[in] data Received UDP data.
+ * @param[in] data_len Length of received data.
+ * @param[out] header Parsed header structure.
+ * @return 0 on success, -1 on error.
+ */
+static int
+parse_udp_notif_header(const uint8_t *data, size_t data_len, udp_notif_header_t *header)
+{
+    if (data_len < UDP_NOTIF_HDR_SIZE) {
+        return -1;
+    }
+
+    header->version = (data[0] >> 5) & 0x07;
+    header->s_flag = (data[0] >> 4) & 0x01;
+    header->media_type = data[0] & 0x0F;
+    header->header_len = data[1];
+    header->message_len = ((uint16_t)data[2] << 8) | data[3];
+    header->publisher_id = ((uint32_t)data[4] << 24) | ((uint32_t)data[5] << 16) |
+            ((uint32_t)data[6] << 8) | data[7];
+    header->message_id = ((uint32_t)data[8] << 24) | ((uint32_t)data[9] << 16) |
+            ((uint32_t)data[10] << 8) | data[11];
+
+    header->has_segmentation = 0;
+    if (header->header_len > UDP_NOTIF_HDR_SIZE) {
+        size_t opt_offset = UDP_NOTIF_HDR_SIZE;
+
+        while (opt_offset + 2 <= header->header_len) {
+            uint8_t opt_type = data[opt_offset];
+            uint8_t opt_len = data[opt_offset + 1];
+
+            if ((opt_type == 1) && (opt_len == UDP_NOTIF_SEG_OPT_SIZE)) {
+                header->has_segmentation = 1;
+                uint16_t seg_field = ((uint16_t)data[opt_offset + 2] << 8) | data[opt_offset + 3];
+
+                header->segment_num = (seg_field >> 1) & 0x7FFF;
+                header->is_last_segment = seg_field & 0x01;
+            }
+            opt_offset += opt_len;
+        }
+    }
+
+    return 0;
+}
+
+/**
+ * @brief Poll a socket for available data with timeout.
+ *
+ * @param[in] sockfd Socket FD to poll.
+ * @param[in] timeout_ms Timeout in milliseconds.
+ * @return 1 if data available, 0 on timeout, -1 on error.
+ */
+static int
+poll_for_data(int sockfd, int timeout_ms)
+{
+    struct pollfd pfd;
+
+    pfd.fd = sockfd;
+    pfd.events = POLLIN;
+
+    return poll(&pfd, 1, timeout_ms);
+}
+
+/**
+ * @brief Find or create a pending message slot for reassembly.
+ *
+ * @param[in] publisher_id Publisher ID.
+ * @param[in] message_id Message ID.
+ * @param[in] media_type Media type.
+ * @return Pending message slot or NULL on error.
+ */
+static pending_message_t *
+find_or_create_pending(uint32_t publisher_id, uint32_t message_id, uint8_t media_type)
+{
+    pending_message_t *oldest = NULL;
+    time_t oldest_time = 0;
+    time_t now = time(NULL);
+    int i, j;
+
+    /* first, look for existing entry */
+    for (i = 0; i < MAX_PENDING_MESSAGES; i++) {
+        if (pending_messages[i].active &&
+                (pending_messages[i].publisher_id == publisher_id) &&
+                (pending_messages[i].message_id == message_id)) {
+            return &pending_messages[i];
+        }
+
+        /* track oldest for potential eviction */
+        if (pending_messages[i].active) {
+            if (!oldest || (pending_messages[i].first_received < oldest_time)) {
+                oldest = &pending_messages[i];
+                oldest_time = pending_messages[i].first_received;
+            }
+        }
+    }
+
+    /* look for empty slot */
+    for (i = 0; i < MAX_PENDING_MESSAGES; i++) {
+        if (!pending_messages[i].active) {
+            pending_messages[i].active = 1;
+            pending_messages[i].publisher_id = publisher_id;
+            pending_messages[i].message_id = message_id;
+            pending_messages[i].media_type = media_type;
+            pending_messages[i].segments = calloc(MAX_SEGMENTS_PER_MESSAGE, sizeof(segment_buffer_t));
+            pending_messages[i].total_segments = 0;
+            pending_messages[i].received_count = 0;
+            pending_messages[i].first_received = now;
+            return &pending_messages[i];
+        }
+    }
+
+    /* evict oldest if timed out */
+    if (oldest && (now - oldest->first_received > SEGMENT_REASSEMBLY_TIMEOUT)) {
+        TLOG_WRN("Evicting timed-out pending message (pub_id=%u, msg_id=%u)",
+                oldest->publisher_id, oldest->message_id);
+
+        /* free old segments */
+        for (j = 0; j < MAX_SEGMENTS_PER_MESSAGE; j++) {
+            free(oldest->segments[j].data);
+        }
+        free(oldest->segments);
+
+        oldest->active = 1;
+        oldest->publisher_id = publisher_id;
+        oldest->message_id = message_id;
+        oldest->media_type = media_type;
+        oldest->segments = calloc(MAX_SEGMENTS_PER_MESSAGE, sizeof(segment_buffer_t));
+        oldest->total_segments = 0;
+        oldest->received_count = 0;
+        oldest->first_received = now;
+        return oldest;
+    }
+
+    TLOG_ERR("No space for pending message reassembly");
+    return NULL;
+}
+
+/**
+ * @brief Free a pending message slot.
+ *
+ * @param[in] pending Pending message to free.
+ */
+static void
+free_pending_message(pending_message_t *pending)
+{
+    int i;
+
+    if (!pending || !pending->active) {
+        return;
+    }
+
+    for (i = 0; i < MAX_SEGMENTS_PER_MESSAGE; i++) {
+        free(pending->segments[i].data);
+        pending->segments[i].data = NULL;
+        pending->segments[i].len = 0;
+        pending->segments[i].received = 0;
+    }
+    free(pending->segments);
+    pending->segments = NULL;
+    pending->active = 0;
+}
+
+/**
+ * @brief Add a segment to pending message.
+ *
+ * @param[in] pending Pending message.
+ * @param[in] segment_num Segment number.
+ * @param[in] is_last Whether this is the last segment.
+ * @param[in] payload Segment payload data.
+ * @param[in] payload_len Segment payload length.
+ * @param[out] total_len Total reassembled length (if complete).
+ * @return Reassembled payload if complete, NULL otherwise (caller must free).
+ */
+static char *
+add_segment(pending_message_t *pending, uint16_t segment_num, int is_last,
+        const uint8_t *payload, size_t payload_len, size_t *total_len)
+{
+    char *reassembled = NULL;
+    uint16_t i;
+    size_t offset;
+
+    if (segment_num >= MAX_SEGMENTS_PER_MESSAGE) {
+        TLOG_ERR("Segment number %d exceeds maximum", segment_num);
+        return NULL;
+    }
+
+    /* store segment */
+    if (!pending->segments[segment_num].received) {
+        pending->segments[segment_num].data = malloc(payload_len);
+        if (!pending->segments[segment_num].data) {
+            TLOG_ERR("Memory allocation failed");
+            return NULL;
+        }
+        memcpy(pending->segments[segment_num].data, payload, payload_len);
+        pending->segments[segment_num].len = payload_len;
+        pending->segments[segment_num].received = 1;
+        pending->received_count++;
+    }
+
+    /* update total segments count if this is the last segment */
+    if (is_last) {
+        pending->total_segments = segment_num + 1;
+    }
+
+    /* check if all segments received */
+    if ((pending->total_segments > 0) && (pending->received_count == pending->total_segments)) {
+        /* reassemble */
+        *total_len = 0;
+        for (i = 0; i < pending->total_segments; i++) {
+            if (!pending->segments[i].received) {
+                TLOG_ERR("Missing segment %d during reassembly", i);
+                return NULL;
+            }
+            *total_len += pending->segments[i].len;
+        }
+
+        reassembled = malloc(*total_len + 1);
+        if (!reassembled) {
+            TLOG_ERR("Memory allocation failed for reassembly");
+            return NULL;
+        }
+
+        offset = 0;
+        for (i = 0; i < pending->total_segments; i++) {
+            memcpy(reassembled + offset, pending->segments[i].data, pending->segments[i].len);
+            offset += pending->segments[i].len;
+        }
+        reassembled[*total_len] = '\0';
+
+        return reassembled;
+    }
+
+    return NULL;
+}
+
+/**
+ * @brief Create UDP socket for receiving notifications.
+ *
+ * @param[in] port Port to listen on.
+ * @return Socket FD on success, -1 on error.
+ */
+static int
+create_udp_receiver_socket(uint16_t port)
+{
+    int sockfd;
+    struct sockaddr_in addr;
+    int opt = 1;
+
+    sockfd = socket(AF_INET, SOCK_DGRAM, 0);
+    if (sockfd < 0) {
+        return -1;
+    }
+
+    setsockopt(sockfd, SOL_SOCKET, SO_REUSEADDR, &opt, sizeof(opt));
+
+    memset(&addr, 0, sizeof(addr));
+    addr.sin_family = AF_INET;
+    addr.sin_port = htons(port);
+    addr.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
+
+    if (bind(sockfd, (struct sockaddr *)&addr, sizeof(addr)) < 0) {
+        close(sockfd);
+        return -1;
+    }
+
+    return sockfd;
+}
+
+/**
+ * @brief Receive and parse a notification from UDP socket.
+ *
+ * Handles both unsegmented and segmented UDP-Notif messages.
+ * For segmented messages, waits for all segments and reassembles them.
+ *
+ * @param[in] sockfd UDP socket FD.
+ * @param[in] ly_ctx libyang context for parsing.
+ * @param[in] timeout_ms Timeout in milliseconds for waiting for data.
+ * @param[out] notif Parsed notification (caller must free).
+ * @param[out] header Optional parsed header (can be NULL).
+ * @return 0 on success, 1 on timeout, -1 on error.
+ */
+static int
+receive_notification_ext(int sockfd, const struct ly_ctx *ly_ctx, int timeout_ms,
+        struct lyd_node **notif, udp_notif_header_t *header, char *src_addr, size_t src_addr_len)
+{
+    uint8_t buffer[UDP_MAX_SIZE];
+    ssize_t recv_len;
+    udp_notif_header_t hdr;
+    const uint8_t *payload;
+    size_t payload_len, reassembled_len;
+    struct ly_in *in = NULL;
+    LYD_FORMAT format;
+    pending_message_t *pending;
+    char *reassembled = NULL;
+    char *payload_str = NULL;
+    struct sockaddr_storage src_sockaddr;
+    socklen_t src_sockaddr_len;
+    const void *src_ptr;
+    int family;
+    int r;
+    int rc = -1;
+
+    *notif = NULL;
+    if (src_addr && src_addr_len) {
+        src_addr[0] = '\0';
+    }
+
+receive_next:
+    memset(&src_sockaddr, 0, sizeof(src_sockaddr));
+    src_sockaddr_len = sizeof(src_sockaddr);
+
+    /* poll for data with explicit timeout */
+    r = poll_for_data(sockfd, timeout_ms);
+    if (r < 0) {
+        TLOG_ERR("poll() failed: %s", strerror(errno));
+        return -1;
+    }
+    if (r == 0) {
+        TLOG_WRN("Timeout waiting for notification");
+        return 1;
+    }
+
+    recv_len = recvfrom(sockfd, buffer, sizeof(buffer), 0, (struct sockaddr *)&src_sockaddr, &src_sockaddr_len);
+    if (recv_len < 0) {
+        TLOG_ERR("recvfrom() failed: %s", strerror(errno));
+        return -1;
+    }
+
+    if (src_addr && src_addr_len) {
+        src_ptr = NULL;
+        family = ((struct sockaddr *)&src_sockaddr)->sa_family;
+        if (family == AF_INET) {
+            src_ptr = &((struct sockaddr_in *)&src_sockaddr)->sin_addr;
+        } else if (family == AF_INET6) {
+            src_ptr = &((struct sockaddr_in6 *)&src_sockaddr)->sin6_addr;
+        }
+
+        if (src_ptr && !inet_ntop(family, src_ptr, src_addr, src_addr_len)) {
+            src_addr[0] = '\0';
+        }
+    }
+
+    if (parse_udp_notif_header(buffer, recv_len, &hdr)) {
+        TLOG_ERR("Failed to parse UDP-Notif header");
+        return -1;
+    }
+
+    if (header) {
+        *header = hdr;
+    }
+
+    if (hdr.version != UDP_NOTIF_VERSION) {
+        TLOG_ERR("Invalid UDP-Notif version: %d", hdr.version);
+        return -1;
+    }
+
+    payload = buffer + hdr.header_len;
+    payload_len = recv_len - hdr.header_len;
+
+    /* handle segmentation */
+    if (hdr.has_segmentation) {
+        TLOG_INF("Received segment %d%s for message %u",
+                hdr.segment_num, hdr.is_last_segment ? " (last)" : "", hdr.message_id);
+
+        pending = find_or_create_pending(hdr.publisher_id, hdr.message_id, hdr.media_type);
+        if (!pending) {
+            TLOG_ERR("Failed to create pending message for reassembly");
+            return -1;
+        }
+
+        reassembled = add_segment(pending, hdr.segment_num, hdr.is_last_segment,
+                payload, payload_len, &reassembled_len);
+
+        if (!reassembled) {
+            /* not complete yet, wait for more segments */
+            goto receive_next;
+        }
+
+        TLOG_INF("Message reassembly complete: %zu bytes from %d segments",
+                reassembled_len, pending->total_segments);
+
+        /* use reassembled payload */
+        payload_str = reassembled;
+        payload_len = reassembled_len;
+
+        /* update header with info from the pending message */
+        hdr.media_type = pending->media_type;
+
+        /* free the pending message slot */
+        free_pending_message(pending);
+    } else {
+        /* non-segmented message, copy payload to null-terminated string */
+        if (payload_len == 0) {
+            TLOG_ERR("Empty payload");
+            return -1;
+        }
+
+        payload_str = malloc(payload_len + 1);
+        if (!payload_str) {
+            TLOG_ERR("Memory allocation failed");
+            return -1;
+        }
+        memcpy(payload_str, payload, payload_len);
+        payload_str[payload_len] = '\0';
+    }
+
+    switch (hdr.media_type) {
+    case UDP_NOTIF_MT_JSON:
+        format = LYD_JSON;
+        break;
+    case UDP_NOTIF_MT_XML:
+        format = LYD_XML;
+        break;
+    default:
+        TLOG_ERR("Unsupported media type: %d", hdr.media_type);
+        goto cleanup;
+    }
+
+    if (ly_in_new_memory(payload_str, &in)) {
+        TLOG_ERR("Failed to create libyang input");
+        goto cleanup;
+    }
+
+    if (lyd_parse_op(ly_ctx, NULL, in, format, LYD_TYPE_NOTIF_YANG, 0, NULL, notif)) {
+        TLOG_ERR("Failed to parse notification: %s", ly_err_last(ly_ctx)->msg);
+        ly_in_free(in, 0);
+        goto cleanup;
+    }
+
+    ly_in_free(in, 0);
+    rc = 0;
+
+cleanup:
+    free(payload_str);
+    return rc;
+}
+
+static int
+receive_notification(int sockfd, const struct ly_ctx *ly_ctx, struct lyd_node **notif,
+        udp_notif_header_t *header)
+{
+    return receive_notification_ext(sockfd, ly_ctx, NOTIF_TIMEOUT_MS, notif, header, NULL, 0);
+}
+
+/**
+ * @brief Receive notification with custom timeout.
+ */
+static int
+receive_notification_timeout(int sockfd, const struct ly_ctx *ly_ctx, int timeout_ms,
+        struct lyd_node **notif, udp_notif_header_t *header)
+{
+    return receive_notification_ext(sockfd, ly_ctx, timeout_ms, notif, header, NULL, 0);
+}
+
+/**
+ * @brief Wait for a specific notification by path.
+ *
+ * Reads notifications from the socket until one with the expected path is found or timeout occurs.
+ *
+ * @param[in] sockfd UDP socket FD.
+ * @param[in] ly_ctx libyang context for parsing.
+ * @param[in] timeout_ms Timeout in milliseconds per receive attempt.
+ * @param[in] expected_path Expected notification path.
+ * @param[out] notif Parsed notification (caller must free).
+ * @param[out] header Optional parsed header (can be NULL).
+ * @return 0 on success, -1 on error or timeout.
+ */
+static int
+receive_specific_notification_ext(int sockfd, const struct ly_ctx *ly_ctx, int timeout_ms,
+        const char *expected_path, struct lyd_node **notif, udp_notif_header_t *header,
+        char *src_addr, size_t src_addr_len)
+{
+    udp_notif_header_t hdr;
+    struct lyd_node *received_notif = NULL;
+    int r;
+    char *notif_path = NULL;
+    char recv_src_addr[INET6_ADDRSTRLEN] = {0};
+
+    while (1) {
+        r = receive_notification_ext(sockfd, ly_ctx, timeout_ms, &received_notif, &hdr, recv_src_addr, sizeof(recv_src_addr));
+        if (r < 0) {
+            return -1;
+        }
+
+        if (!received_notif) {
+            continue;
+        }
+
+        notif_path = lyd_path(received_notif, LYD_PATH_STD, NULL, 0);
+        r = strcmp(notif_path, expected_path);
+        free(notif_path);
+        if (!r) {
+            *notif = received_notif;
+            if (header) {
+                *header = hdr;
+            }
+            if (src_addr && src_addr_len) {
+                strncpy(src_addr, recv_src_addr, src_addr_len - 1);
+                src_addr[src_addr_len - 1] = '\0';
+            }
+            return 0;
+        }
+
+        /* not the expected notification, free and keep waiting */
+        lyd_free_all(received_notif);
+    }
+}
+
+static int
+receive_specific_notification(int sockfd, const struct ly_ctx *ly_ctx, const char *expected_path,
+        struct lyd_node **notif, udp_notif_header_t *header)
+{
+    return receive_specific_notification_ext(sockfd, ly_ctx, NOTIF_TIMEOUT_MS, expected_path, notif, header, NULL, 0);
+}
+
+/**
+ * @brief Wait for a specific notification with custom timeout.
+ */
+static int
+receive_specific_notification_timeout(int sockfd, const struct ly_ctx *ly_ctx, int timeout_ms,
+        const char *expected_path, struct lyd_node **notif, udp_notif_header_t *header)
+{
+    return receive_specific_notification_ext(sockfd, ly_ctx, timeout_ms, expected_path, notif, header, NULL, 0);
+}
+
+static int
+can_bind_local_ipv4(const char *address)
+{
+    int sockfd;
+    struct sockaddr_in addr;
+    int rc;
+
+    sockfd = socket(AF_INET, SOCK_DGRAM, 0);
+    if (sockfd < 0) {
+        return 0;
+    }
+
+    memset(&addr, 0, sizeof(addr));
+    addr.sin_family = AF_INET;
+    addr.sin_port = htons(0);
+    if (inet_pton(AF_INET, address, &addr.sin_addr) != 1) {
+        close(sockfd);
+        return 0;
+    }
+
+    rc = bind(sockfd, (struct sockaddr *)&addr, sizeof(addr));
+    close(sockfd);
+    if (rc) {
+        return 0;
+    }
+
+    return 1;
+}
+
+static int
+find_alternate_loopback_ipv4(const char *current_address, char *alternate_address, size_t alternate_address_len)
+{
+    int i;
+    char candidate[INET_ADDRSTRLEN];
+
+    if (!alternate_address || (alternate_address_len < INET_ADDRSTRLEN)) {
+        return 0;
+    }
+
+    for (i = 2; i <= 254; i++) {
+        snprintf(candidate, sizeof(candidate), "127.0.0.%d", i);
+        if (current_address && !strcmp(candidate, current_address)) {
+            continue;
+        }
+        if (can_bind_local_ipv4(candidate)) {
+            strcpy(alternate_address, candidate);
+            return 1;
+        }
+    }
+
+    return 0;
+}
+
+/**
+ * @brief Drain all pending notifications from the socket.
+ *
+ * Reads and discards all notifications until no more data is available.
+ * Uses poll() with a short timeout for robustness on slow machines.
+ *
+ * @param[in] sockfd UDP socket FD.
+ */
+static void
+drain_notifications(int sockfd)
+{
+    uint8_t buffer[UDP_MAX_SIZE];
+    ssize_t recv_len;
+    int count;
+    int poll_ret;
+
+    count = 0;
+
+    /* read and discard all pending notifications */
+    while (1) {
+        poll_ret = poll_for_data(sockfd, DRAIN_TIMEOUT_MS);
+        if (poll_ret <= 0) {
+            break;
+        }
+
+        recv_len = recv(sockfd, buffer, sizeof(buffer), 0);
+        if (recv_len <= 0) {
+            break;
+        }
+        count++;
+    }
+
+    if (count > 0) {
+        TLOG_INF("Drained %d pending notification(s)", count);
+    }
+}
+
+/**
+ * @brief Install required YANG modules for testing.
+ *
+ * @param[in] conn Sysrepo connection.
+ * @return 0 on success, non-zero on failure.
+ */
+static int
+install_test_modules(sr_conn_ctx_t *conn)
+{
+    const char *schema_paths[] = {
+        SN_YANG_DIR "/ietf-interfaces@2018-02-20.yang",
+        SN_YANG_DIR "/iana-if-type@2014-05-08.yang",
+        SN_YANG_DIR "/ietf-ip@2018-02-22.yang",
+        SN_YANG_DIR "/ietf-network-instance@2019-01-21.yang",
+        SN_YANG_DIR "/ietf-restconf@2017-01-26.yang",
+        SN_YANG_DIR "/ietf-subscribed-notifications@2019-09-09.yang",
+        SN_YANG_DIR "/ietf-subscribed-notif-receivers@2024-02-01.yang",
+        SN_YANG_DIR "/ietf-crypto-types@2024-10-10.yang",
+        SN_YANG_DIR "/iana-tls-cipher-suite-algs@2024-03-16.yang",
+        SN_YANG_DIR "/ietf-keystore@2024-10-10.yang",
+        SN_YANG_DIR "/ietf-truststore@2024-10-10.yang",
+        SN_YANG_DIR "/ietf-tls-common@2024-10-10.yang",
+        SN_YANG_DIR "/ietf-tls-client@2024-03-16.yang",
+        SN_YANG_DIR "/ietf-udp-client@2025-05-14.yang",
+        SN_YANG_DIR "/ietf-udp-notif-transport@2025-06-04.yang",
+        TESTS_SRC_DIR "/files/test.yang",
+        NULL
+    };
+    const char *sub_ntf_feats[] = {"configured", "xpath", "replay", "subtree", NULL};
+    const char **features[] = {
+        NULL, NULL, NULL, NULL, NULL,  /* interfaces, iana-if-type, ip, network-instance, restconf */
+        sub_ntf_feats,                 /* ietf-subscribed-notifications */
+        NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL,  /* other modules */
+        NULL                           /* test.yang */
+    };
+
+    return sr_install_modules(conn, schema_paths, SN_YANG_DIR, features);
+}
+
+/**
+ * @brief Remove test YANG modules.
+ *
+ * @param[in] conn Sysrepo connection.
+ * @return 0 on success, non-zero on failure.
+ */
+static int
+remove_test_modules(sr_conn_ctx_t *conn)
+{
+    const char *module_names[] = {
+        "test",
+        "ietf-udp-notif-transport",
+        "ietf-udp-client",
+        "ietf-tls-client",
+        "ietf-tls-common",
+        "ietf-truststore",
+        "ietf-keystore",
+        "iana-tls-cipher-suite-algs",
+        "ietf-crypto-types",
+        "ietf-subscribed-notif-receivers",
+        "ietf-subscribed-notifications",
+        "ietf-restconf",
+        "ietf-network-instance",
+        "ietf-ip",
+        "iana-if-type",
+        "ietf-interfaces",
+        NULL
+    };
+
+    return sr_remove_modules(conn, module_names, 0);
+}
+
+/**
+ * @brief Start sysrepo-notifd daemon.
+ *
+ * @param[out] pid PID of started daemon.
+ * @return 0 on success, -1 on failure.
+ */
+static int
+start_notifd(pid_t *pid)
+{
+    pid_t child_pid;
+    int pipefd[2];
+    struct pollfd pfd;
+    int i, status, ret;
+    char c;
+
+    /* create pipe with CLOEXEC so exec() automatically closes the write end */
+    if (pipe2(pipefd, O_CLOEXEC) < 0) {
+        return -1;
+    }
+
+    child_pid = fork();
+    if (child_pid < 0) {
+        close(pipefd[0]);
+        close(pipefd[1]);
+        return -1;
+    }
+
+    if (child_pid == 0) {
+        /* child process - close read end, keep write end for failure signaling */
+        close(pipefd[0]);
+
+        execlp(NOTIFD_PATH, "sysrepo-notifd", "-d", "-v", "info", "-s", SCHEMA_DIR, (char *)NULL);
+
+        /* exec failed - signal parent by writing to pipe before exiting */
+        c = 1;
+        write(pipefd[1], &c, 1);
+        _exit(1);
+    }
+
+    /* parent - close write end so only the child holds it */
+    close(pipefd[1]);
+
+    /*
+     * Poll the read end:
+     * - POLLIN means child wrote to pipe → exec failed
+     * - POLLHUP means child's write end closed → exec succeeded (CLOEXEC kicked in)
+     * - timeout means something unexpected
+     */
+    pfd.fd = pipefd[0];
+    pfd.events = POLLIN;
+    ret = poll(&pfd, 1, 3000);
+
+    close(pipefd[0]);
+
+    if (ret < 0) {
+        TLOG_ERR("poll() failed while waiting for daemon exec: %s", strerror(errno));
+        kill(child_pid, SIGKILL);
+        waitpid(child_pid, NULL, 0);
+        return -1;
+    }
+
+    if (ret == 0) {
+        TLOG_ERR("Timeout waiting for sysrepo-notifd exec");
+        kill(child_pid, SIGKILL);
+        waitpid(child_pid, NULL, 0);
+        return -1;
+    }
+
+    if (pfd.revents & POLLIN) {
+        /* exec failed - child wrote error byte before _exit() */
+        waitpid(child_pid, &status, 0);
+        TLOG_ERR("sysrepo-notifd exec failed with status %d", status);
+        return -1;
+    }
+
+    /* POLLHUP - exec succeeded, daemon binary is now running */
+
+    /* brief crash detection: if it dies within 200ms, report error */
+    for (i = 0; i < 10; i++) {
+        usleep(20000);
+        if (waitpid(child_pid, &status, WNOHANG) != 0) {
+            TLOG_ERR("sysrepo-notifd exited prematurely with status %d", status);
+            return -1;
+        }
+    }
+
+    *pid = child_pid;
+    return 0;
+}
+
+/**
+ * @brief Stop sysrepo-notifd daemon.
+ *
+ * @param[in] pid PID of daemon to stop.
+ */
+static void
+stop_notifd(pid_t pid)
+{
+    int status;
+
+    if (pid > 0) {
+        kill(pid, SIGTERM);
+        waitpid(pid, &status, 0);
+    }
+}
+
+/**
+ * @brief Set common subscription fields (stream, transport, receiver-instance-ref).
+ *
+ * @param[in] sess Sysrepo session.
+ * @param[in] sub_id Subscription ID.
+ * @param[in] stream Stream name.
+ * @param[in] recv_inst_name Receiver instance name to reference.
+ * @return 0 on success, error code on failure.
+ */
+static int
+_set_sub_common(sr_session_ctx_t *sess, uint32_t sub_id, const char *stream,
+        const char *recv_inst_name)
+{
+    int rc;
+    char path[512];
+
+    snprintf(path, sizeof(path),
+            "/ietf-subscribed-notifications:subscriptions/subscription[id='%u']/stream", sub_id);
+    rc = sr_set_item_str(sess, path, stream, NULL, 0);
+    if (rc) {
+        return rc;
+    }
+
+    snprintf(path, sizeof(path),
+            "/ietf-subscribed-notifications:subscriptions/subscription[id='%u']/transport", sub_id);
+    rc = sr_set_item_str(sess, path, "ietf-udp-notif-transport:udp-notif", NULL, 0);
+    if (rc) {
+        return rc;
+    }
+
+    snprintf(path, sizeof(path),
+            "/ietf-subscribed-notifications:subscriptions/subscription[id='%u']"
+            "/receivers/receiver[name='recv1']/ietf-subscribed-notif-receivers:receiver-instance-ref", sub_id);
+    rc = sr_set_item_str(sess, path, recv_inst_name, NULL, 0);
+    if (rc) {
+        return rc;
+    }
+
+    return SR_ERR_OK;
+}
+
+/**
+ * @brief Create a configured subscription via sysrepo edit.
+ *
+ * @param[in] sess Sysrepo session.
+ * @param[in] sub_id Subscription ID.
+ * @param[in] stream Stream name.
+ * @param[in] filter Optional XPath filter.
+ * @param[in] recv_inst_name Receiver instance name to reference.
+ * @return 0 on success, error code on failure.
+ */
+static int
+create_subscription(sr_session_ctx_t *sess, uint32_t sub_id, const char *stream,
+        const char *filter, const char *recv_inst_name)
+{
+    int rc;
+    char path[512];
+
+    rc = _set_sub_common(sess, sub_id, stream, recv_inst_name);
+    if (rc) {
+        return rc;
+    }
+
+    if (filter) {
+        snprintf(path, sizeof(path),
+                "/ietf-subscribed-notifications:subscriptions/subscription[id='%u']/stream-xpath-filter", sub_id);
+        rc = sr_set_item_str(sess, path, filter, NULL, 0);
+        if (rc) {
+            return rc;
+        }
+    }
+
+    return SR_ERR_OK;
+}
+
+/**
+ * @brief Create a configured subscription with subtree filter via sysrepo edit.
+ *
+ * @param[in] sess Sysrepo session.
+ * @param[in] sub_id Subscription ID.
+ * @param[in] stream Stream name.
+ * @param[in] subtree_filter_xml Subtree filter in XML format.
+ * @param[in] recv_inst_name Receiver instance name to reference.
+ * @return 0 on success, error code on failure.
+ */
+static int
+create_subscription_subtree(sr_session_ctx_t *sess, uint32_t sub_id, const char *stream,
+        const char *subtree_filter_xml, const char *recv_inst_name)
+{
+    int rc;
+    char path[512];
+    sr_val_t val;
+
+    rc = _set_sub_common(sess, sub_id, stream, recv_inst_name);
+    if (rc) {
+        return rc;
+    }
+
+    if (subtree_filter_xml) {
+        memset(&val, 0, sizeof(val));
+        val.type = SR_ANYDATA_T;
+        val.data.anydata_val = (char *)subtree_filter_xml;
+
+        snprintf(path, sizeof(path),
+                "/ietf-subscribed-notifications:subscriptions/subscription[id='%u']/stream-subtree-filter", sub_id);
+        rc = sr_set_item(sess, path, &val, 0);
+        if (rc) {
+            return rc;
+        }
+    }
+
+    return SR_ERR_OK;
+}
+
+/**
+ * @brief Create a UDP receiver instance via sysrepo edit.
+ *
+ * @param[in] sess Sysrepo session.
+ * @param[in] name Receiver instance name.
+ * @param[in] address Remote address.
+ * @param[in] port Remote port.
+ * @return 0 on success, error code on failure.
+ */
+static int
+create_receiver_instance(sr_session_ctx_t *sess, const char *name, const char *address, uint16_t port)
+{
+    int rc;
+    char path[512], port_str[16];
+
+    snprintf(port_str, sizeof(port_str), "%u", port);
+
+    snprintf(path, sizeof(path),
+            "/ietf-subscribed-notifications:subscriptions"
+            "/ietf-subscribed-notif-receivers:receiver-instances"
+            "/receiver-instance[name='%s']"
+            "/ietf-udp-notif-transport:udp-notif-receiver/remote-address", name);
+    rc = sr_set_item_str(sess, path, address, NULL, 0);
+    if (rc) {
+        return rc;
+    }
+
+    snprintf(path, sizeof(path),
+            "/ietf-subscribed-notifications:subscriptions"
+            "/ietf-subscribed-notif-receivers:receiver-instances"
+            "/receiver-instance[name='%s']"
+            "/ietf-udp-notif-transport:udp-notif-receiver/remote-port", name);
+    rc = sr_set_item_str(sess, path, port_str, NULL, 0);
+    if (rc) {
+        return rc;
+    }
+
+    return SR_ERR_OK;
+}
+
+/**
+ * @brief Delete a configured subscription.
+ *
+ * @param[in] sess Sysrepo session.
+ * @param[in] sub_id Subscription ID.
+ * @return 0 on success, error code on failure.
+ */
+static int
+delete_subscription(sr_session_ctx_t *sess, uint32_t sub_id)
+{
+    char path[256];
+
+    snprintf(path, sizeof(path),
+            "/ietf-subscribed-notifications:subscriptions/subscription[id='%u']", sub_id);
+    return sr_delete_item(sess, path, 0);
+}
+
+/**
+ * @brief Delete a receiver instance.
+ *
+ * @param[in] sess Sysrepo session.
+ * @param[in] name Receiver instance name.
+ * @return 0 on success, error code on failure.
+ */
+static int
+delete_receiver_instance(sr_session_ctx_t *sess, const char *name)
+{
+    char path[256];
+
+    snprintf(path, sizeof(path),
+            "/ietf-subscribed-notifications:subscriptions"
+            "/ietf-subscribed-notif-receivers:receiver-instances"
+            "/receiver-instance[name='%s']", name);
+    return sr_delete_item(sess, path, 0);
+}
+
+/**
+ * @brief Create a named XPath stream filter.
+ *
+ * @param[in] sess Sysrepo session.
+ * @param[in] filter_name Name of the filter.
+ * @param[in] xpath_filter XPath filter expression.
+ * @return 0 on success, error code on failure.
+ */
+static int
+create_xpath_stream_filter(sr_session_ctx_t *sess, const char *filter_name, const char *xpath_filter)
+{
+    int rc;
+    char path[512];
+
+    snprintf(path, sizeof(path),
+            "/ietf-subscribed-notifications:filters/stream-filter[name='%s']/stream-xpath-filter",
+            filter_name);
+    rc = sr_set_item_str(sess, path, xpath_filter, NULL, 0);
+
+    return rc;
+}
+
+/**
+ * @brief Create a named subtree stream filter.
+ *
+ * @param[in] sess Sysrepo session.
+ * @param[in] filter_name Name of the filter.
+ * @param[in] subtree_filter_xml Subtree filter in XML format.
+ * @return 0 on success, error code on failure.
+ */
+static int
+create_subtree_stream_filter(sr_session_ctx_t *sess, const char *filter_name, const char *subtree_filter_xml)
+{
+    int rc;
+    char path[512];
+    sr_val_t val;
+
+    memset(&val, 0, sizeof(val));
+    val.type = SR_ANYDATA_T;
+    val.data.anydata_val = (char *)subtree_filter_xml;
+
+    snprintf(path, sizeof(path),
+            "/ietf-subscribed-notifications:filters/stream-filter[name='%s']/stream-subtree-filter",
+            filter_name);
+    rc = sr_set_item(sess, path, &val, 0);
+
+    return rc;
+}
+
+/**
+ * @brief Delete a named stream filter.
+ *
+ * @param[in] sess Sysrepo session.
+ * @param[in] filter_name Name of the filter.
+ * @return 0 on success, error code on failure.
+ */
+static int
+delete_stream_filter(sr_session_ctx_t *sess, const char *filter_name)
+{
+    char path[256];
+
+    snprintf(path, sizeof(path),
+            "/ietf-subscribed-notifications:filters/stream-filter[name='%s']", filter_name);
+    return sr_delete_item(sess, path, 0);
+}
+
+/**
+ * @brief Create a subscription with a filter name reference.
+ *
+ * @param[in] sess Sysrepo session.
+ * @param[in] sub_id Subscription ID.
+ * @param[in] stream Stream name.
+ * @param[in] filter_name Name of the filter to reference.
+ * @param[in] recv_inst_name Receiver instance name to reference.
+ * @return 0 on success, error code on failure.
+ */
+static int
+create_subscription_filter_ref(sr_session_ctx_t *sess, uint32_t sub_id, const char *stream,
+        const char *filter_name, const char *recv_inst_name)
+{
+    int rc;
+    char path[512];
+
+    rc = _set_sub_common(sess, sub_id, stream, recv_inst_name);
+    if (rc) {
+        return rc;
+    }
+
+    snprintf(path, sizeof(path),
+            "/ietf-subscribed-notifications:subscriptions/subscription[id='%u']/stream-filter-name", sub_id);
+    rc = sr_set_item_str(sess, path, filter_name, NULL, 0);
+    if (rc) {
+        return rc;
+    }
+
+    return SR_ERR_OK;
+}
+
+/**
+ * @brief Setup function - install modules, start daemon, create socket.
+ */
+static int
+setup(void **state)
+{
+    struct state *st;
+    int rc;
+
+    st = calloc(1, sizeof *st);
+    if (!st) {
+        return 1;
+    }
+    *state = st;
+
+    /* connect to sysrepo */
+    rc = sr_connect(0, &st->conn);
+    if (rc) {
+        TLOG_ERR("sr_connect failed: %s", sr_strerror(rc));
+        return 1;
+    }
+
+    /* install test modules */
+    rc = install_test_modules(st->conn);
+    if (rc && (rc != SR_ERR_EXISTS)) {
+        TLOG_ERR("install_test_modules failed: %s", sr_strerror(rc));
+        return 1;
+    }
+
+    /* get libyang context */
+    st->ly_ctx = sr_acquire_context(st->conn);
+
+    /* start session */
+    rc = sr_session_start(st->conn, SR_DS_RUNNING, &st->sess);
+    if (rc) {
+        TLOG_ERR("sr_session_start failed: %s", sr_strerror(rc));
+        return 1;
+    }
+
+    /* find available port */
+    st->udp_port = TEST_UDP_PORT;
+
+    /* create UDP receiver socket */
+    st->udp_sockfd = create_udp_receiver_socket(st->udp_port);
+    if (st->udp_sockfd < 0) {
+        TLOG_ERR("Failed to create UDP socket");
+        return 1;
+    }
+
+    /* start sysrepo-notifd */
+    if (start_notifd(&st->notifd_pid)) {
+        TLOG_ERR("Failed to start sysrepo-notifd");
+        return 1;
+    }
+
+    return 0;
+}
+
+/**
+ * @brief Teardown function - stop daemon, cleanup.
+ */
+static int
+teardown(void **state)
+{
+    struct state *st = *state;
+    int ret = 0, i;
+
+    /* stop sysrepo-notifd */
+    stop_notifd(st->notifd_pid);
+
+    /* close UDP socket */
+    if (st->udp_sockfd >= 0) {
+        close(st->udp_sockfd);
+    }
+
+    /* cleanup pending messages */
+    for (i = 0; i < MAX_PENDING_MESSAGES; i++) {
+        free_pending_message(&pending_messages[i]);
+    }
+
+    /* release context */
+    if (st->ly_ctx) {
+        sr_release_context(st->conn);
+    }
+
+    /* remove test modules */
+    if (st->conn) {
+        ret = remove_test_modules(st->conn);
+        sr_disconnect(st->conn);
+    }
+
+    free(st);
+    return ret;
+}
+
+/**
+ * @brief Clear any existing subscriptions and unread notifications before each test to ensure a clean state.
+ */
+static int
+clear_subs_notifs(void **state)
+{
+    struct state *st = *state;
+
+    sr_delete_item(st->sess, "/ietf-subscribed-notifications:subscriptions", 0);
+    sr_apply_changes(st->sess, 0);
+
+    /* drain any remaining notifications */
+    drain_notifications(st->udp_sockfd);
+    return 0;
+}
+
+/**
+ * @brief Create a receiver instance and subscription, then apply changes.
+ *
+ * @param[in] sess Sysrepo session.
+ * @param[in] port UDP port for the receiver.
+ * @param[in] sub_id Subscription ID.
+ * @param[in] stream Stream name.
+ * @param[in] xpath_filter Optional XPath filter (can be NULL).
+ */
+static void
+setup_sub(sr_session_ctx_t *sess, uint16_t port, uint32_t sub_id,
+        const char *stream, const char *xpath_filter)
+{
+    int ret;
+
+    ret = create_receiver_instance(sess, "test-recv", "127.0.0.1", port);
+    assert_int_equal(ret, SR_ERR_OK);
+    ret = create_subscription(sess, sub_id, stream, xpath_filter, "test-recv");
+    assert_int_equal(ret, SR_ERR_OK);
+    ret = sr_apply_changes(sess, 0);
+    assert_int_equal(ret, SR_ERR_OK);
+}
+
+/**
+ * @brief Create a receiver instance and subscription with subtree filter, then apply changes.
+ *
+ * @param[in] sess Sysrepo session.
+ * @param[in] port UDP port for the receiver.
+ * @param[in] sub_id Subscription ID.
+ * @param[in] stream Stream name.
+ * @param[in] subtree_filter_xml Subtree filter in XML format.
+ */
+static void
+setup_sub_subtree(sr_session_ctx_t *sess, uint16_t port, uint32_t sub_id,
+        const char *stream, const char *subtree_filter_xml)
+{
+    int ret;
+
+    ret = create_receiver_instance(sess, "test-recv", "127.0.0.1", port);
+    assert_int_equal(ret, SR_ERR_OK);
+    ret = create_subscription_subtree(sess, sub_id, stream, subtree_filter_xml, "test-recv");
+    assert_int_equal(ret, SR_ERR_OK);
+    ret = sr_apply_changes(sess, 0);
+    assert_int_equal(ret, SR_ERR_OK);
+}
+
+/**
+ * @brief Create a receiver instance, XPath stream filter, and filter-ref subscription, then apply changes.
+ *
+ * @param[in] sess Sysrepo session.
+ * @param[in] port UDP port for the receiver.
+ * @param[in] sub_id Subscription ID.
+ * @param[in] stream Stream name.
+ * @param[in] filter_name Name of the XPath stream filter.
+ * @param[in] xpath_filter XPath filter expression.
+ */
+static void
+setup_sub_filter_ref(sr_session_ctx_t *sess, uint16_t port, uint32_t sub_id,
+        const char *stream, const char *filter_name, const char *xpath_filter)
+{
+    int ret;
+
+    ret = create_receiver_instance(sess, "test-recv", "127.0.0.1", port);
+    assert_int_equal(ret, SR_ERR_OK);
+    ret = create_xpath_stream_filter(sess, filter_name, xpath_filter);
+    assert_int_equal(ret, SR_ERR_OK);
+    ret = create_subscription_filter_ref(sess, sub_id, stream, filter_name, "test-recv");
+    assert_int_equal(ret, SR_ERR_OK);
+    ret = sr_apply_changes(sess, 0);
+    assert_int_equal(ret, SR_ERR_OK);
+}
+
+/**
+ * @brief Delete a subscription and its receiver instance, then apply changes.
+ *
+ * @param[in] sess Sysrepo session.
+ * @param[in] sub_id Subscription ID.
+ */
+static void
+cleanup_sub(sr_session_ctx_t *sess, uint32_t sub_id)
+{
+    delete_subscription(sess, sub_id);
+    delete_receiver_instance(sess, "test-recv");
+    sr_apply_changes(sess, 0);
+}
+
+/**
+ * @brief Read a single operational data leaf value.
+ *
+ * Switches to operational datastore, reads the leaf at the given XPath,
+ * and switches back to running datastore. Caller must free the returned string.
+ *
+ * @param[in] sess Sysrepo session.
+ * @param[in] xpath XPath of the leaf to read.
+ * @return Newly allocated string with the leaf value, or NULL on error.
+ */
+static char *
+get_oper_leaf_str(sr_session_ctx_t *sess, const char *xpath)
+{
+    sr_data_t *data = NULL;
+    struct lyd_node *node = NULL;
+    char *value = NULL;
+    int ret;
+
+    ret = sr_session_switch_ds(sess, SR_DS_OPERATIONAL);
+    assert_int_equal(ret, SR_ERR_OK);
+
+    ret = sr_get_data(sess, xpath, 0, 0, 0, &data);
+    assert_int_equal(ret, SR_ERR_OK);
+    assert_non_null(data);
+    assert_non_null(data->tree);
+
+    assert_int_equal(lyd_find_path(data->tree, xpath, 0, &node), LY_SUCCESS);
+    assert_non_null(node);
+    value = strdup(lyd_get_value(node));
+
+    sr_release_data(data);
+
+    ret = sr_session_switch_ds(sess, SR_DS_RUNNING);
+    assert_int_equal(ret, SR_ERR_OK);
+
+    return value;
+}
+
+/**
+ * @brief Read an operational counter value without asserting.
+ *
+ * Similar to get_oper_leaf_str but returns the value as a uint64_t
+ * and returns an error code instead of asserting on failure.
+ *
+ * @param[in] sess Sysrepo session.
+ * @param[in] xpath XPath of the leaf to read.
+ * @param[out] counter Parsed counter value.
+ * @return 0 on success, -1 on error.
+ */
+static int
+get_oper_counter(sr_session_ctx_t *sess, const char *xpath, uint64_t *counter)
+{
+    sr_data_t *data = NULL;
+    struct lyd_node *node = NULL;
+    char *value = NULL;
+    int ret;
+
+    ret = sr_session_switch_ds(sess, SR_DS_OPERATIONAL);
+    if (ret) {
+        return -1;
+    }
+
+    ret = sr_get_data(sess, xpath, 0, 0, 0, &data);
+    if (ret || !data || !data->tree) {
+        if (data) {
+            sr_release_data(data);
+        }
+        sr_session_switch_ds(sess, SR_DS_RUNNING);
+        return -1;
+    }
+
+    if (lyd_find_path(data->tree, xpath, 0, &node) || !node) {
+        sr_release_data(data);
+        sr_session_switch_ds(sess, SR_DS_RUNNING);
+        return -1;
+    }
+
+    value = strdup(lyd_get_value(node));
+    *counter = strtoull(value, NULL, 10);
+    free(value);
+
+    sr_release_data(data);
+
+    ret = sr_session_switch_ds(sess, SR_DS_RUNNING);
+    if (ret) {
+        return -1;
+    }
+
+    return 0;
+}
+
+/**
+ * @brief Wait for excluded-event-records to increment above a baseline.
+ *
+ * Polls the operational datastore counter in a loop until it exceeds
+ * the baseline value or the timeout expires. Used instead of waiting
+ * for a socket timeout to prove that a notification was filtered.
+ *
+ * @param[in] sess Sysrepo session.
+ * @param[in] sub_id Subscription ID.
+ * @param[in] baseline Baseline counter value.
+ * @param[in] timeout_ms Total timeout in milliseconds.
+ * @return 0 if counter incremented, -1 on timeout.
+ */
+static int
+wait_for_excluded_records_increment(sr_session_ctx_t *sess, uint32_t sub_id,
+        uint64_t baseline, int timeout_ms)
+{
+    char xpath[512];
+    uint64_t current;
+    int elapsed_ms = 0;
+    int ret;
+
+    snprintf(xpath, sizeof(xpath),
+            "/ietf-subscribed-notifications:subscriptions/subscription[id='%u']"
+            "/receivers/receiver[name='recv1']/excluded-event-records", sub_id);
+
+    while (elapsed_ms < timeout_ms) {
+        usleep(COUNTER_POLL_MS * 1000);
+        elapsed_ms += COUNTER_POLL_MS;
+
+        ret = get_oper_counter(sess, xpath, &current);
+        if (ret) {
+            continue;
+        }
+
+        if (current > baseline) {
+            return 0;
+        }
+    }
+
+    return -1;
+}
+
+/* ========== TESTS ========== */
+
+/**
+ * @brief Test: Create subscription and receive subscription-started notification.
+ */
+static void
+test_subscription_started(void **state)
+{
+    struct state *st = *state;
+    struct lyd_node *notif = NULL;
+    udp_notif_header_t header;
+    int ret;
+
+    TLOG_INF("Creating receiver instance and subscription...");
+
+    setup_sub(st->sess, st->udp_port, 1, "NETCONF", NULL);
+
+    TLOG_INF("Waiting for subscription-started notification...");
+
+    /* receive notification */
+    ret = receive_notification(st->udp_sockfd, st->ly_ctx, &notif, &header);
+    assert_int_equal(ret, 0);
+    assert_non_null(notif);
+
+    /* verify it's a subscription-started notification */
+    assert_string_equal(notif->schema->name, "subscription-started");
+
+    /* verify header fields */
+    assert_int_equal(header.version, UDP_NOTIF_VERSION);
+    assert_int_equal(header.s_flag, 0);
+    assert_true(header.media_type == UDP_NOTIF_MT_JSON || header.media_type == UDP_NOTIF_MT_XML);
+
+    TLOG_INF("Received subscription-started notification successfully");
+
+    lyd_free_all(notif);
+
+    cleanup_sub(st->sess, 1);
+}
+
+/**
+ * @brief Test: Delete subscription and receive subscription-terminated notification.
+ */
+static void
+test_subscription_terminated(void **state)
+{
+    struct state *st = *state;
+    struct lyd_node *notif = NULL;
+    int ret;
+
+    TLOG_INF("Creating receiver instance and subscription...");
+
+    setup_sub(st->sess, st->udp_port, 2, "NETCONF", NULL);
+
+    /* receive subscription-started notification first */
+    ret = receive_notification(st->udp_sockfd, st->ly_ctx, &notif, NULL);
+    assert_int_equal(ret, 0);
+    lyd_free_all(notif);
+    notif = NULL;
+
+    TLOG_INF("Deleting subscription...");
+
+    /* delete subscription */
+    ret = delete_subscription(st->sess, 2);
+    assert_int_equal(ret, SR_ERR_OK);
+    ret = sr_apply_changes(st->sess, 0);
+    assert_int_equal(ret, SR_ERR_OK);
+
+    TLOG_INF("Waiting for subscription-terminated notification...");
+
+    /* receive notification */
+    ret = receive_specific_notification(st->udp_sockfd, st->ly_ctx,
+            "/ietf-subscribed-notifications:subscription-terminated", &notif, NULL);
+    assert_int_equal(ret, 0);
+    assert_non_null(notif);
+
+    TLOG_INF("Received subscription-terminated notification successfully");
+
+    lyd_free_all(notif);
+
+    delete_receiver_instance(st->sess, "test-recv");
+    sr_apply_changes(st->sess, 0);
+}
+
+/**
+ * @brief Test: Modify subscription filter and receive subscription-modified notification.
+ */
+static void
+test_subscription_modified(void **state)
+{
+    struct state *st = *state;
+    struct lyd_node *notif = NULL;
+    char path[512];
+    int ret;
+
+    TLOG_INF("Creating receiver instance and subscription...");
+
+    setup_sub(st->sess, st->udp_port, 3, "NETCONF", "/ietf-netconf-notifications:*");
+
+    TLOG_INF("Modifying subscription filter...");
+
+    /* modify the filter */
+    snprintf(path, sizeof(path),
+            "/ietf-subscribed-notifications:subscriptions/subscription[id='3']/stream-xpath-filter");
+    ret = sr_set_item_str(st->sess, path, "/ietf-netconf-notifications:netconf-config-change", NULL, 0);
+    assert_int_equal(ret, SR_ERR_OK);
+    ret = sr_apply_changes(st->sess, 0);
+    assert_int_equal(ret, SR_ERR_OK);
+
+    TLOG_INF("Waiting for subscription-modified notification...");
+
+    /* receive notification */
+    ret = receive_specific_notification(st->udp_sockfd, st->ly_ctx,
+            "/ietf-subscribed-notifications:subscription-modified", &notif, NULL);
+    assert_int_equal(ret, 0);
+    assert_non_null(notif);
+
+    TLOG_INF("Received subscription-modified notification successfully");
+
+    lyd_free_all(notif);
+
+    cleanup_sub(st->sess, 3);
+}
+
+/**
+ * @brief Test: Multiple subscriptions to the same receiver.
+ */
+static void
+test_multiple_subscriptions(void **state)
+{
+    struct state *st = *state;
+    struct lyd_node *notif = NULL;
+    int ret, i;
+    int started_count = 0;
+
+    TLOG_INF("Creating receiver instance and multiple subscriptions...");
+
+    /* create receiver */
+    ret = create_receiver_instance(st->sess, "test-recv", "127.0.0.1", st->udp_port);
+    assert_int_equal(ret, SR_ERR_OK);
+
+    /* create 3 subscriptions */
+    for (i = 1; i <= 3; i++) {
+        ret = create_subscription(st->sess, 10 + i, "NETCONF", NULL, "test-recv");
+        assert_int_equal(ret, SR_ERR_OK);
+    }
+
+    ret = sr_apply_changes(st->sess, 0);
+    assert_int_equal(ret, SR_ERR_OK);
+
+    TLOG_INF("Waiting for subscription-started notifications...");
+
+    /* receive all subscription-started notifications */
+    for (i = 0; i < 3; i++) {
+        ret = receive_notification(st->udp_sockfd, st->ly_ctx, &notif, NULL);
+        assert_int_equal(ret, 0);
+        assert_non_null(notif);
+        if (strcmp(notif->schema->name, "subscription-started") == 0) {
+            started_count++;
+        }
+        lyd_free_all(notif);
+        notif = NULL;
+    }
+
+    assert_int_equal(started_count, 3);
+    TLOG_INF("Received %d subscription-started notifications", started_count);
+
+    /* cleanup */
+    for (i = 1; i <= 3; i++) {
+        delete_subscription(st->sess, 10 + i);
+    }
+    delete_receiver_instance(st->sess, "test-recv");
+    sr_apply_changes(st->sess, 0);
+}
+
+/**
+ * @brief Test: netconf-config-change notification through configured subscription.
+ */
+static void
+test_config_change_notification(void **state)
+{
+    struct state *st = *state;
+    struct lyd_node *notif = NULL;
+    int ret;
+
+    TLOG_INF("Creating subscription for netconf-config-change...");
+
+    setup_sub(st->sess, st->udp_port, 20, "NETCONF",
+            "/ietf-netconf-notifications:netconf-config-change");
+
+    TLOG_INF("Making configuration change to trigger notification...");
+
+    /* make a configuration change */
+    ret = sr_set_item_str(st->sess, "/test:test-leaf", "67", NULL, 0);
+    assert_int_equal(ret, SR_ERR_OK);
+    ret = sr_apply_changes(st->sess, 0);
+    assert_int_equal(ret, SR_ERR_OK);
+
+    TLOG_INF("Waiting for netconf-config-change notification...");
+
+    /* try to receive config-change notification */
+    ret = receive_specific_notification(st->udp_sockfd, st->ly_ctx,
+            "/ietf-netconf-notifications:netconf-config-change", &notif, NULL);
+    assert_int_equal(ret, 0);
+    assert_non_null(notif);
+
+    TLOG_INF("Received netconf-config-change notification successfully");
+
+    /* cleanup */
+    lyd_free_all(notif);
+    sr_delete_item(st->sess, "/test:test-leaf", 0);
+    cleanup_sub(st->sess, 20);
+}
+
+/**
+ * @brief Test: UDP-Notif header validation.
+ */
+static void
+test_udp_notif_header(void **state)
+{
+    struct state *st = *state;
+    struct lyd_node *notif = NULL;
+    udp_notif_header_t header;
+    int ret;
+
+    TLOG_INF("Creating subscription to test UDP-Notif header...");
+
+    setup_sub(st->sess, st->udp_port, 30, "NETCONF", NULL);
+
+    /* receive notification and check header */
+    ret = receive_notification(st->udp_sockfd, st->ly_ctx, &notif, &header);
+    assert_int_equal(ret, 0);
+    assert_non_null(notif);
+
+    /* verify UDP-Notif header fields */
+    assert_int_equal(header.version, UDP_NOTIF_VERSION);
+
+    /* standard space */
+    assert_int_equal(header.s_flag, 0);
+    assert_true(header.media_type == UDP_NOTIF_MT_JSON || header.media_type == UDP_NOTIF_MT_XML);
+
+    /* no options */
+    assert_int_equal(header.header_len, UDP_NOTIF_HDR_SIZE);
+    assert_true(header.message_len > UDP_NOTIF_HDR_SIZE);
+    assert_true(header.publisher_id > 0);
+    assert_true(header.message_id > 0);
+
+    TLOG_INF("UDP-Notif header validated: version=%d, MT=%d, pub_id=%u, msg_id=%u",
+            header.version, header.media_type, header.publisher_id, header.message_id);
+
+    lyd_free_all(notif);
+
+    cleanup_sub(st->sess, 30);
+}
+
+/**
+ * @brief Test: Message ID incrementing.
+ */
+static void
+test_message_id_increment(void **state)
+{
+    struct state *st = *state;
+    struct lyd_node *notif = NULL;
+    udp_notif_header_t header1, header2;
+    int ret;
+
+    TLOG_INF("Testing message ID incrementing...");
+
+    setup_sub(st->sess, st->udp_port, 40, "NETCONF", NULL);
+
+    /* receive first notification */
+    ret = receive_notification(st->udp_sockfd, st->ly_ctx, &notif, &header1);
+    assert_int_equal(ret, 0);
+    lyd_free_all(notif);
+    notif = NULL;
+
+    /* delete and re-create to generate another notification */
+    delete_subscription(st->sess, 40);
+    sr_apply_changes(st->sess, 0);
+
+    /* receive second notification (subscription-terminated) */
+    ret = receive_notification(st->udp_sockfd, st->ly_ctx, &notif, &header2);
+    assert_int_equal(ret, 0);
+    lyd_free_all(notif);
+    notif = NULL;
+
+    /* message ID should have incremented */
+    assert_true(header2.message_id > header1.message_id);
+    TLOG_INF("Message ID incremented from %u to %u", header1.message_id, header2.message_id);
+
+    /* cleanup */
+    delete_receiver_instance(st->sess, "test-recv");
+    sr_apply_changes(st->sess, 0);
+}
+
+/**
+ * @brief Test: XPath filter that matches notifications.
+ *
+ * Creates a subscription with an XPath filter that matches netconf-config-change
+ * notifications and verifies that matching notifications are received.
+ */
+static void
+test_xpath_filter_match(void **state)
+{
+    struct state *st = *state;
+    struct lyd_node *notif = NULL;
+    int ret;
+
+    TLOG_INF("Testing XPath filter that matches notifications...");
+
+    setup_sub(st->sess, st->udp_port, 50, "NETCONF",
+            "/ietf-netconf-notifications:netconf-config-change");
+
+    TLOG_INF("Making configuration change to trigger notification...");
+
+    /* make a configuration change - this should produce a netconf-config-change notification */
+    ret = sr_set_item_str(st->sess, "/test:test-leaf", "42", NULL, 0);
+    assert_int_equal(ret, SR_ERR_OK);
+    ret = sr_apply_changes(st->sess, 0);
+    assert_int_equal(ret, SR_ERR_OK);
+
+    TLOG_INF("Waiting for netconf-config-change notification (should match filter)...");
+
+    /* the XPath filter should match and we should receive the notification */
+    ret = receive_specific_notification(st->udp_sockfd, st->ly_ctx,
+            "/ietf-netconf-notifications:netconf-config-change", &notif, NULL);
+    assert_int_equal(ret, 0);
+    assert_non_null(notif);
+
+    TLOG_INF("Received netconf-config-change notification - XPath filter matched successfully");
+
+    lyd_free_all(notif);
+
+    sr_delete_item(st->sess, "/test:test-leaf", 0);
+    cleanup_sub(st->sess, 50);
+}
+
+/**
+ * @brief Test: XPath filter that does not match notifications.
+ *
+ * Creates a subscription with an XPath filter that filters out notifications
+ * based on content (e.g., datastore type) and verifies behavior.
+ */
+static void
+test_xpath_filter_nomatch(void **state)
+{
+    struct state *st = *state;
+    uint64_t excluded_baseline;
+    int ret;
+
+    TLOG_INF("Testing XPath filter that should not match...");
+
+    setup_sub(st->sess, st->udp_port, 51, "NETCONF",
+            "/ietf-netconf-notifications:netconf-config-change[datastore='startup']");
+
+    /* discard notifs that we don't care about */
+    drain_notifications(st->udp_sockfd);
+
+    /* read baseline excluded-event-records counter */
+    ret = get_oper_counter(st->sess,
+            "/ietf-subscribed-notifications:subscriptions/subscription[id='51']"
+            "/receivers/receiver[name='recv1']/excluded-event-records", &excluded_baseline);
+    assert_int_equal(ret, 0);
+
+    TLOG_INF("Making configuration change to running datastore...");
+
+    /* make a configuration change to running datastore */
+    ret = sr_set_item_str(st->sess, "/test:test-leaf", "55", NULL, 0);
+    assert_int_equal(ret, SR_ERR_OK);
+    ret = sr_apply_changes(st->sess, 0);
+    assert_int_equal(ret, SR_ERR_OK);
+
+    TLOG_INF("Waiting for excluded-event-records to increment (notification was filtered)...");
+
+    /* wait for excluded-event-records to increment, proving the notification was filtered */
+    ret = wait_for_excluded_records_increment(st->sess, 51, excluded_baseline, COUNTER_WAIT_MS);
+    assert_int_equal(ret, 0);
+
+    TLOG_INF("excluded-event-records incremented - XPath filter correctly filtered out the notification");
+
+    sr_delete_item(st->sess, "/test:test-leaf", 0);
+    cleanup_sub(st->sess, 51);
+}
+
+/**
+ * @brief Test: XPath filter with edit target content filtering.
+ *
+ * Creates a subscription with an XPath filter that matches based on the
+ * target path in the edit list of netconf-config-change notifications.
+ */
+static void
+test_xpath_filter_edit_target(void **state)
+{
+    struct state *st = *state;
+    struct lyd_node *notif = NULL;
+    uint64_t excluded_baseline;
+    int ret;
+
+    TLOG_INF("Testing XPath filter matching edit target...");
+
+    setup_sub(st->sess, st->udp_port, 52, "NETCONF",
+            "/ietf-netconf-notifications:netconf-config-change[edit/target=\"/test:test-leaf\"]");
+
+    /* discard notifs that we don't care about */
+    drain_notifications(st->udp_sockfd);
+
+    /* read baseline excluded-event-records counter */
+    ret = get_oper_counter(st->sess,
+            "/ietf-subscribed-notifications:subscriptions/subscription[id='52']"
+            "/receivers/receiver[name='recv1']/excluded-event-records", &excluded_baseline);
+    assert_int_equal(ret, 0);
+
+    TLOG_INF("Making configuration change to a different target...");
+
+    /* change test:cont/dflt-leaf - this should NOT match the filter since the target is different */
+    ret = sr_set_item_str(st->sess, "/test:cont/dflt-leaf", "67", NULL, 0);
+    assert_int_equal(ret, SR_ERR_OK);
+    ret = sr_apply_changes(st->sess, 0);
+    assert_int_equal(ret, SR_ERR_OK);
+
+    TLOG_INF("Waiting for excluded-event-records to increment (notification was filtered)...");
+
+    /* wait for excluded-event-records to increment, proving the notification was filtered */
+    ret = wait_for_excluded_records_increment(st->sess, 52, excluded_baseline, COUNTER_WAIT_MS);
+    assert_int_equal(ret, 0);
+
+    TLOG_INF("excluded-event-records incremented - XPath filter correctly filtered out the notification based on edit target");
+
+    TLOG_INF("Making configuration change to test:test-leaf...");
+
+    /* change test:test-leaf - this should match the filter */
+    ret = sr_set_item_str(st->sess, "/test:test-leaf", "77", NULL, 0);
+    assert_int_equal(ret, SR_ERR_OK);
+    ret = sr_apply_changes(st->sess, 0);
+    assert_int_equal(ret, SR_ERR_OK);
+
+    TLOG_INF("Waiting for notification with matching edit target...");
+
+    /* should receive notification since edit target matches */
+    ret = receive_specific_notification(st->udp_sockfd, st->ly_ctx,
+            "/ietf-netconf-notifications:netconf-config-change", &notif, NULL);
+    assert_int_equal(ret, 0);
+    assert_non_null(notif);
+
+    TLOG_INF("Received notification - XPath filter with edit/target matched successfully");
+
+    lyd_free_all(notif);
+
+    sr_delete_item(st->sess, "/test:test-leaf", 0);
+    cleanup_sub(st->sess, 52);
+}
+
+/**
+ * @brief Test: Subtree filter that matches notifications.
+ *
+ * Creates a subscription with a subtree filter that matches netconf-config-change
+ * notifications and verifies that matching notifications are received.
+ */
+static void
+test_subtree_filter_match(void **state)
+{
+    struct state *st = *state;
+    struct lyd_node *notif = NULL;
+    int ret;
+
+    /*
+     * subtree filter that matches netconf-config-change notifications
+     * an empty element means "select this notification type"
+     */
+    const char *subtree_filter =
+            "<netconf-config-change xmlns=\"urn:ietf:params:xml:ns:yang:ietf-netconf-notifications\"/>";
+
+    TLOG_INF("Testing subtree filter that matches notifications...");
+
+    setup_sub_subtree(st->sess, st->udp_port, 60, "NETCONF", subtree_filter);
+
+    TLOG_INF("Making configuration change to trigger notification...");
+
+    /* make a configuration change */
+    ret = sr_set_item_str(st->sess, "/test:test-leaf", "88", NULL, 0);
+    assert_int_equal(ret, SR_ERR_OK);
+    ret = sr_apply_changes(st->sess, 0);
+    assert_int_equal(ret, SR_ERR_OK);
+
+    TLOG_INF("Waiting for netconf-config-change notification (should match subtree filter)...");
+
+    /* should receive notification since subtree filter matches */
+    ret = receive_specific_notification(st->udp_sockfd, st->ly_ctx,
+            "/ietf-netconf-notifications:netconf-config-change", &notif, NULL);
+    assert_int_equal(ret, 0);
+    assert_non_null(notif);
+
+    TLOG_INF("Received netconf-config-change notification - subtree filter matched successfully");
+
+    lyd_free_all(notif);
+
+    sr_delete_item(st->sess, "/test:test-leaf", 0);
+    cleanup_sub(st->sess, 60);
+}
+
+/**
+ * @brief Test: Subtree filter that does not match notifications.
+ *
+ * Creates a subscription with a subtree filter that filters out notifications
+ * based on content and verifies that non-matching notifications are not received.
+ */
+static void
+test_subtree_filter_nomatch(void **state)
+{
+    struct state *st = *state;
+    uint64_t excluded_baseline;
+    int ret;
+
+    /*
+     * subtree filter that matches only netconf-config-change with datastore=startup
+     * we're changing running, so this should NOT match
+     */
+    const char *subtree_filter =
+            "<netconf-config-change xmlns=\"urn:ietf:params:xml:ns:yang:ietf-netconf-notifications\">"
+            "<datastore>startup</datastore>"
+            "</netconf-config-change>";
+
+    TLOG_INF("Testing subtree filter that should not match...");
+
+    setup_sub_subtree(st->sess, st->udp_port, 61, "NETCONF", subtree_filter);
+
+    /* discard notifs that we don't care about */
+    drain_notifications(st->udp_sockfd);
+
+    /* read baseline excluded-event-records counter */
+    ret = get_oper_counter(st->sess,
+            "/ietf-subscribed-notifications:subscriptions/subscription[id='61']"
+            "/receivers/receiver[name='recv1']/excluded-event-records", &excluded_baseline);
+    assert_int_equal(ret, 0);
+
+    TLOG_INF("Making configuration change to running datastore...");
+
+    /* make a configuration change to running datastore */
+    ret = sr_set_item_str(st->sess, "/test:test-leaf", "99", NULL, 0);
+    assert_int_equal(ret, SR_ERR_OK);
+    ret = sr_apply_changes(st->sess, 0);
+    assert_int_equal(ret, SR_ERR_OK);
+
+    TLOG_INF("Waiting for excluded-event-records to increment (notification was filtered)...");
+
+    /* wait for excluded-event-records to increment, proving the notification was filtered */
+    ret = wait_for_excluded_records_increment(st->sess, 61, excluded_baseline, COUNTER_WAIT_MS);
+    assert_int_equal(ret, 0);
+
+    TLOG_INF("excluded-event-records incremented - subtree filter correctly filtered out the notification");
+
+    sr_delete_item(st->sess, "/test:test-leaf", 0);
+    cleanup_sub(st->sess, 61);
+}
+
+/**
+ * @brief Test: Subtree filter with containment node filtering.
+ *
+ * Creates a subscription with a subtree filter that uses containment nodes
+ * to match specific notification content.
+ */
+static void
+test_subtree_filter_containment(void **state)
+{
+    struct state *st = *state;
+    struct lyd_node *notif = NULL;
+    uint64_t excluded_baseline;
+    int ret;
+
+    /*
+     * subtree filter that matches netconf-config-change with datastore=running
+     */
+    const char *subtree_filter =
+            "<netconf-config-change xmlns=\"urn:ietf:params:xml:ns:yang:ietf-netconf-notifications\">"
+            "<datastore>running</datastore>"
+            "</netconf-config-change>";
+
+    TLOG_INF("Testing subtree filter with containment node...");
+
+    setup_sub_subtree(st->sess, st->udp_port, 62, "NETCONF", subtree_filter);
+
+    /* discard notifs that we don't care about */
+    drain_notifications(st->udp_sockfd);
+
+    /* read baseline excluded-event-records counter */
+    ret = get_oper_counter(st->sess,
+            "/ietf-subscribed-notifications:subscriptions/subscription[id='62']"
+            "/receivers/receiver[name='recv1']/excluded-event-records", &excluded_baseline);
+    assert_int_equal(ret, 0);
+
+    TLOG_INF("Making configuration change to startup datastore...");
+
+    /* make a configuration change to startup datastore - this should NOT match since the filter is for datastore=running */
+    ret = sr_session_switch_ds(st->sess, SR_DS_STARTUP);
+    assert_int_equal(ret, SR_ERR_OK);
+    ret = sr_set_item_str(st->sess, "/test:test-leaf", "100", NULL, 0);
+    assert_int_equal(ret, SR_ERR_OK);
+    ret = sr_apply_changes(st->sess, 0);
+    assert_int_equal(ret, SR_ERR_OK);
+
+    /* switch back to running before reading operational data */
+    ret = sr_session_switch_ds(st->sess, SR_DS_RUNNING);
+    assert_int_equal(ret, SR_ERR_OK);
+
+    TLOG_INF("Waiting for excluded-event-records to increment (notification was filtered)...");
+
+    /* wait for excluded-event-records to increment, proving the notification was filtered */
+    ret = wait_for_excluded_records_increment(st->sess, 62, excluded_baseline, COUNTER_WAIT_MS);
+    assert_int_equal(ret, 0);
+
+    TLOG_INF("excluded-event-records incremented - subtree filter correctly filtered out the notification based on datastore");
+
+    TLOG_INF("Making configuration change to running datastore...");
+
+    /* make a configuration change to running datastore - should match */
+    ret = sr_set_item_str(st->sess, "/test:test-leaf", "111", NULL, 0);
+    assert_int_equal(ret, SR_ERR_OK);
+    ret = sr_apply_changes(st->sess, 0);
+    assert_int_equal(ret, SR_ERR_OK);
+
+    TLOG_INF("Waiting for notification matching subtree containment filter...");
+
+    /* should receive notification since we're changing running datastore */
+    ret = receive_specific_notification(st->udp_sockfd, st->ly_ctx,
+            "/ietf-netconf-notifications:netconf-config-change", &notif, NULL);
+    assert_int_equal(ret, 0);
+    assert_non_null(notif);
+
+    TLOG_INF("Received notification - subtree containment filter matched successfully");
+
+    lyd_free_all(notif);
+
+    sr_delete_item(st->sess, "/test:test-leaf", 0);
+    cleanup_sub(st->sess, 62);
+}
+
+/**
+ * @brief Test: Subscription with XPath filter reference (stream-filter-name).
+ *
+ * Creates a named XPath filter, then creates a subscription that references
+ * it by name, and verifies that matching notifications are received.
+ */
+static void
+test_filter_ref_xpath_match(void **state)
+{
+    struct state *st = *state;
+    struct lyd_node *notif = NULL;
+    int ret;
+
+    TLOG_INF("Testing subscription with XPath filter reference...");
+
+    setup_sub_filter_ref(st->sess, st->udp_port, 70, "NETCONF", "my-xpath-filter",
+            "/ietf-netconf-notifications:netconf-config-change[datastore='running']");
+
+    /* drain subscription-started notification */
+    drain_notifications(st->udp_sockfd);
+
+    TLOG_INF("Making configuration change to running datastore to trigger notification...");
+
+    /* make a configuration change to running datastore */
+    ret = sr_set_item_str(st->sess, "/test:test-leaf", "200", NULL, 0);
+    assert_int_equal(ret, SR_ERR_OK);
+    ret = sr_apply_changes(st->sess, 0);
+    assert_int_equal(ret, SR_ERR_OK);
+
+    TLOG_INF("Waiting for netconf-config-change notification (should match xpath filter ref for datastore=running)...");
+
+    /* should receive notification since xpath filter reference matches running datastore */
+    ret = receive_specific_notification(st->udp_sockfd, st->ly_ctx,
+            "/ietf-netconf-notifications:netconf-config-change", &notif, NULL);
+    assert_int_equal(ret, 0);
+    assert_non_null(notif);
+
+    TLOG_INF("Received netconf-config-change notification - XPath filter reference with datastore predicate worked");
+
+    lyd_free_all(notif);
+
+    sr_delete_item(st->sess, "/test:test-leaf", 0);
+    delete_stream_filter(st->sess, "my-xpath-filter");
+    cleanup_sub(st->sess, 70);
+}
+
+/**
+ * @brief Test: Subscription with subtree filter reference (stream-filter-name).
+ *
+ * Creates a named subtree filter, then creates a subscription that references
+ * it by name, and verifies that matching notifications are received.
+ */
+static void
+test_filter_ref_subtree_match(void **state)
+{
+    struct state *st = *state;
+    struct lyd_node *notif = NULL;
+    int ret;
+
+    /*
+     * subtree filter that matches netconf-config-change notifications
+     * with datastore=running - uses containment node filtering
+     */
+    const char *subtree_filter =
+            "<netconf-config-change xmlns=\"urn:ietf:params:xml:ns:yang:ietf-netconf-notifications\">"
+            "<datastore>running</datastore>"
+            "</netconf-config-change>";
+
+    TLOG_INF("Testing subscription with subtree filter reference...");
+
+    /* create receiver instance */
+    ret = create_receiver_instance(st->sess, "test-recv", "127.0.0.1", st->udp_port);
+    assert_int_equal(ret, SR_ERR_OK);
+
+    /* create a named subtree filter */
+    ret = create_subtree_stream_filter(st->sess, "my-subtree-filter", subtree_filter);
+    assert_int_equal(ret, SR_ERR_OK);
+
+    /* create subscription referencing the filter by name */
+    ret = create_subscription_filter_ref(st->sess, 71, "NETCONF", "my-subtree-filter", "test-recv");
+    assert_int_equal(ret, SR_ERR_OK);
+
+    ret = sr_apply_changes(st->sess, 0);
+    assert_int_equal(ret, SR_ERR_OK);
+
+    /* drain subscription-started notification */
+    drain_notifications(st->udp_sockfd);
+
+    TLOG_INF("Making configuration change to running datastore to trigger notification...");
+
+    /* make a configuration change to running datastore */
+    ret = sr_set_item_str(st->sess, "/test:test-leaf", "201", NULL, 0);
+    assert_int_equal(ret, SR_ERR_OK);
+    ret = sr_apply_changes(st->sess, 0);
+    assert_int_equal(ret, SR_ERR_OK);
+
+    TLOG_INF("Waiting for netconf-config-change notification (should match subtree filter ref for datastore=running)...");
+
+    /* should receive notification since subtree filter reference matches running datastore */
+    ret = receive_specific_notification(st->udp_sockfd, st->ly_ctx,
+            "/ietf-netconf-notifications:netconf-config-change", &notif, NULL);
+    assert_int_equal(ret, 0);
+    assert_non_null(notif);
+
+    TLOG_INF("Received netconf-config-change notification - subtree filter reference with containment worked");
+
+    lyd_free_all(notif);
+
+    sr_delete_item(st->sess, "/test:test-leaf", 0);
+    delete_stream_filter(st->sess, "my-subtree-filter");
+    cleanup_sub(st->sess, 71);
+}
+
+/**
+ * @brief Test: Modifying a referenced XPath filter triggers subscription-modified.
+ *
+ * Creates a subscription with a filter reference, then modifies the referenced
+ * filter and verifies that a subscription-modified notification is received.
+ */
+static void
+test_filter_ref_xpath_modify(void **state)
+{
+    struct state *st = *state;
+    struct lyd_node *notif = NULL;
+    char path[512];
+    int ret;
+
+    TLOG_INF("Testing modification of referenced XPath filter...");
+
+    setup_sub_filter_ref(st->sess, st->udp_port, 72, "NETCONF", "modifiable-filter",
+            "/ietf-netconf-notifications:netconf-config-change");
+
+    /* drain subscription-started notification */
+    drain_notifications(st->udp_sockfd);
+
+    TLOG_INF("Modifying the referenced filter...");
+
+    /* modify the referenced filter */
+    snprintf(path, sizeof(path),
+            "/ietf-subscribed-notifications:filters/stream-filter[name='modifiable-filter']/stream-xpath-filter");
+    ret = sr_set_item_str(st->sess, path, "/ietf-netconf-notifications:*", NULL, 0);
+    assert_int_equal(ret, SR_ERR_OK);
+    ret = sr_apply_changes(st->sess, 0);
+    assert_int_equal(ret, SR_ERR_OK);
+
+    TLOG_INF("Waiting for subscription-modified notification...");
+
+    /* should receive subscription-modified notification */
+    ret = receive_specific_notification(st->udp_sockfd, st->ly_ctx,
+            "/ietf-subscribed-notifications:subscription-modified", &notif, NULL);
+    assert_int_equal(ret, 0);
+    assert_non_null(notif);
+
+    TLOG_INF("Received subscription-modified notification after filter modification");
+
+    lyd_free_all(notif);
+
+    delete_stream_filter(st->sess, "modifiable-filter");
+    cleanup_sub(st->sess, 72);
+}
+
+/**
+ * @brief Test: Modifying a referenced subtree filter triggers subscription-modified.
+ *
+ * Creates a subscription with a subtree filter reference, then modifies the
+ * referenced filter and verifies that a subscription-modified notification is received.
+ */
+static void
+test_filter_ref_subtree_modify(void **state)
+{
+    struct state *st = *state;
+    struct lyd_node *notif = NULL;
+    char path[512];
+    sr_val_t val;
+    int ret;
+
+    /* initial subtree filter */
+    const char *subtree_filter1 =
+            "<netconf-config-change xmlns=\"urn:ietf:params:xml:ns:yang:ietf-netconf-notifications\"/>";
+
+    /* modified subtree filter - more restrictive */
+    const char *subtree_filter2 =
+            "<netconf-config-change xmlns=\"urn:ietf:params:xml:ns:yang:ietf-netconf-notifications\">"
+            "<datastore>running</datastore>"
+            "</netconf-config-change>";
+
+    TLOG_INF("Testing modification of referenced subtree filter...");
+
+    /* create receiver instance */
+    ret = create_receiver_instance(st->sess, "test-recv", "127.0.0.1", st->udp_port);
+    assert_int_equal(ret, SR_ERR_OK);
+
+    /* create a named subtree filter */
+    ret = create_subtree_stream_filter(st->sess, "modifiable-subtree-filter", subtree_filter1);
+    assert_int_equal(ret, SR_ERR_OK);
+
+    /* create subscription referencing the filter by name */
+    ret = create_subscription_filter_ref(st->sess, 73, "NETCONF", "modifiable-subtree-filter", "test-recv");
+    assert_int_equal(ret, SR_ERR_OK);
+
+    ret = sr_apply_changes(st->sess, 0);
+    assert_int_equal(ret, SR_ERR_OK);
+
+    /* drain subscription-started notification */
+    drain_notifications(st->udp_sockfd);
+
+    TLOG_INF("Modifying the referenced subtree filter...");
+
+    /* modify the referenced filter */
+    memset(&val, 0, sizeof(val));
+    val.type = SR_ANYDATA_T;
+    val.data.anydata_val = (char *)subtree_filter2;
+
+    snprintf(path, sizeof(path),
+            "/ietf-subscribed-notifications:filters/stream-filter[name='modifiable-subtree-filter']/stream-subtree-filter");
+    ret = sr_set_item(st->sess, path, &val, 0);
+    assert_int_equal(ret, SR_ERR_OK);
+    ret = sr_apply_changes(st->sess, 0);
+    assert_int_equal(ret, SR_ERR_OK);
+
+    TLOG_INF("Waiting for subscription-modified notification...");
+
+    /* should receive subscription-modified notification */
+    ret = receive_specific_notification(st->udp_sockfd, st->ly_ctx,
+            "/ietf-subscribed-notifications:subscription-modified", &notif, NULL);
+    assert_int_equal(ret, 0);
+    assert_non_null(notif);
+
+    TLOG_INF("Received subscription-modified notification after subtree filter modification");
+
+    lyd_free_all(notif);
+
+    delete_stream_filter(st->sess, "modifiable-subtree-filter");
+    cleanup_sub(st->sess, 73);
+}
+
+/**
+ * @brief Test: Multiple subscriptions referencing the same filter.
+ *
+ * Creates two subscriptions referencing the same named filter, then modifies
+ * the filter and verifies that both subscriptions receive subscription-modified.
+ */
+static void
+test_filter_ref_multiple_subs(void **state)
+{
+    struct state *st = *state;
+    struct lyd_node *notif = NULL;
+    char path[512];
+    int ret, modified_count;
+
+    TLOG_INF("Testing multiple subscriptions referencing the same filter...");
+
+    /* create receiver instance */
+    ret = create_receiver_instance(st->sess, "test-recv", "127.0.0.1", st->udp_port);
+    assert_int_equal(ret, SR_ERR_OK);
+
+    /* create a named xpath filter */
+    ret = create_xpath_stream_filter(st->sess, "shared-filter",
+            "/ietf-netconf-notifications:netconf-config-change");
+    assert_int_equal(ret, SR_ERR_OK);
+
+    /* create two subscriptions referencing the same filter */
+    ret = create_subscription_filter_ref(st->sess, 74, "NETCONF", "shared-filter", "test-recv");
+    assert_int_equal(ret, SR_ERR_OK);
+    ret = create_subscription_filter_ref(st->sess, 75, "NETCONF", "shared-filter", "test-recv");
+    assert_int_equal(ret, SR_ERR_OK);
+
+    ret = sr_apply_changes(st->sess, 0);
+    assert_int_equal(ret, SR_ERR_OK);
+
+    /* drain subscription-started notifications */
+    drain_notifications(st->udp_sockfd);
+
+    TLOG_INF("Modifying the shared filter...");
+
+    /* modify the shared filter */
+    snprintf(path, sizeof(path),
+            "/ietf-subscribed-notifications:filters/stream-filter[name='shared-filter']/stream-xpath-filter");
+    ret = sr_set_item_str(st->sess, path, "/ietf-netconf-notifications:*", NULL, 0);
+    assert_int_equal(ret, SR_ERR_OK);
+    ret = sr_apply_changes(st->sess, 0);
+    assert_int_equal(ret, SR_ERR_OK);
+
+    TLOG_INF("Waiting for subscription-modified notifications from both subscriptions...");
+
+    /* should receive two subscription-modified notifications */
+    modified_count = 0;
+    ret = receive_specific_notification(st->udp_sockfd, st->ly_ctx,
+            "/ietf-subscribed-notifications:subscription-modified", &notif, NULL);
+    if ((ret == 0) && notif) {
+        modified_count++;
+        lyd_free_all(notif);
+        notif = NULL;
+    }
+
+    ret = receive_specific_notification(st->udp_sockfd, st->ly_ctx,
+            "/ietf-subscribed-notifications:subscription-modified", &notif, NULL);
+    if ((ret == 0) && notif) {
+        modified_count++;
+        lyd_free_all(notif);
+        notif = NULL;
+    }
+
+    assert_int_equal(modified_count, 2);
+    TLOG_INF("Received %d subscription-modified notifications - both subscriptions were notified", modified_count);
+
+    /* cleanup */
+    delete_subscription(st->sess, 74);
+    delete_subscription(st->sess, 75);
+    delete_stream_filter(st->sess, "shared-filter");
+    delete_receiver_instance(st->sess, "test-recv");
+    sr_apply_changes(st->sess, 0);
+}
+
+/**
+ * @brief Test: XPath filter reference that does not match notifications.
+ *
+ * Creates a subscription with an XPath filter reference that filters out
+ * notifications and verifies that non-matching notifications are not received.
+ */
+static void
+test_filter_ref_xpath_nomatch(void **state)
+{
+    struct state *st = *state;
+    uint64_t excluded_baseline;
+    int ret;
+
+    TLOG_INF("Testing XPath filter reference that should not match...");
+
+    setup_sub_filter_ref(st->sess, st->udp_port, 76, "NETCONF", "nomatch-filter",
+            "/ietf-netconf-notifications:netconf-session-start");
+
+    /* drain subscription-started notification */
+    drain_notifications(st->udp_sockfd);
+
+    /* read baseline excluded-event-records counter */
+    ret = get_oper_counter(st->sess,
+            "/ietf-subscribed-notifications:subscriptions/subscription[id='76']"
+            "/receivers/receiver[name='recv1']/excluded-event-records", &excluded_baseline);
+    assert_int_equal(ret, 0);
+
+    TLOG_INF("Making configuration change to trigger notification...");
+
+    /* make a configuration change - this generates netconf-config-change, not session-start */
+    ret = sr_set_item_str(st->sess, "/test:test-leaf", "34", NULL, 0);
+    assert_int_equal(ret, SR_ERR_OK);
+    ret = sr_apply_changes(st->sess, 0);
+    assert_int_equal(ret, SR_ERR_OK);
+
+    TLOG_INF("Waiting for excluded-event-records to increment (notification was filtered)...");
+
+    /* wait for excluded-event-records to increment, proving the notification was filtered */
+    ret = wait_for_excluded_records_increment(st->sess, 76, excluded_baseline, COUNTER_WAIT_MS);
+    assert_int_equal(ret, 0);
+
+    TLOG_INF("excluded-event-records incremented - XPath filter reference correctly filtered out the notification");
+
+    sr_delete_item(st->sess, "/test:test-leaf", 0);
+    delete_stream_filter(st->sess, "nomatch-filter");
+    cleanup_sub(st->sess, 76);
+}
+
+/**
+ * @brief Test: Retrieve all supported operational data leaves for a subscription.
+ *
+ * Uses SR_DS_OPERATIONAL and sr_get_data() to read all leaves provided by
+ * sysrepo-notifd operational callbacks for configured subscriptions.
+ */
+static void
+test_oper_data_get_all_supported(void **state)
+{
+    struct state *st = *state;
+    struct lyd_node *notif = NULL;
+    struct lyd_node *node = NULL;
+    sr_data_t *data = NULL;
+    LY_ERR lyrc;
+    int ret;
+
+    TLOG_INF("Testing retrieval of all supported operational leaves...");
+
+    setup_sub(st->sess, st->udp_port, 90, "NETCONF", NULL);
+
+    ret = receive_specific_notification(st->udp_sockfd, st->ly_ctx,
+            "/ietf-subscribed-notifications:subscription-started", &notif, NULL);
+    assert_int_equal(ret, 0);
+    assert_non_null(notif);
+    lyd_free_all(notif);
+    notif = NULL;
+
+    TLOG_INF("Retrieving operational data for the subscription...");
+
+    ret = sr_session_switch_ds(st->sess, SR_DS_OPERATIONAL);
+    assert_int_equal(ret, SR_ERR_OK);
+
+    ret = sr_get_data(st->sess, "/ietf-subscribed-notifications:subscriptions/subscription[id='90']", 0, 0, 0, &data);
+    assert_int_equal(ret, SR_ERR_OK);
+    assert_non_null(data);
+    assert_non_null(data->tree);
+
+    /* check for presence of all supported leaves */
+    lyrc = lyd_find_path(data->tree,
+            "/ietf-subscribed-notifications:subscriptions/subscription[id='90']/replay-start-time", 0, &node);
+    if (lyrc == LY_SUCCESS) {
+        /* some notifications may remain in the replay log at the time we read operational data */
+        assert_non_null(node);
+        assert_non_null(lyd_get_value(node));
+    } else {
+        assert_int_equal(lyrc, LY_EINCOMPLETE);
+    }
+
+    lyrc = lyd_find_path(data->tree,
+            "/ietf-subscribed-notifications:subscriptions/subscription[id='90']/configured-subscription-state", 0, &node);
+    assert_int_equal(lyrc, LY_SUCCESS);
+    assert_non_null(node);
+    assert_non_null(lyd_get_value(node));
+    assert_string_equal(lyd_get_value(node), "valid");
+
+    lyrc = lyd_find_path(data->tree,
+            "/ietf-subscribed-notifications:subscriptions/subscription[id='90']/receivers/receiver[name='recv1']/sent-event-records", 0,
+            &node);
+    assert_int_equal(lyrc, LY_SUCCESS);
+    assert_non_null(node);
+    assert_non_null(lyd_get_value(node));
+    assert_true(atoi(lyd_get_value(node)) > 0);
+
+    lyrc = lyd_find_path(data->tree,
+            "/ietf-subscribed-notifications:subscriptions/subscription[id='90']/receivers/receiver[name='recv1']/excluded-event-records",
+            0, &node);
+    assert_int_equal(lyrc, LY_SUCCESS);
+    assert_non_null(node);
+    assert_non_null(lyd_get_value(node));
+    assert_int_equal(atoi(lyd_get_value(node)), 0);
+
+    lyrc = lyd_find_path(data->tree,
+            "/ietf-subscribed-notifications:subscriptions/subscription[id='90']/receivers/receiver[name='recv1']/state", 0, &node);
+    assert_int_equal(lyrc, LY_SUCCESS);
+    assert_non_null(node);
+    assert_non_null(lyd_get_value(node));
+    assert_string_equal(lyd_get_value(node), "active");
+
+    sr_release_data(data);
+    data = NULL;
+
+    ret = sr_session_switch_ds(st->sess, SR_DS_RUNNING);
+    assert_int_equal(ret, SR_ERR_OK);
+
+    cleanup_sub(st->sess, 90);
+}
+
+/**
+ * @brief Test: sent-event-records operational value changes after another sent notification.
+ */
+static void
+test_oper_data_sent_event_records_change(void **state)
+{
+    struct state *st = *state;
+    struct lyd_node *notif = NULL;
+    char *val_str = NULL;
+    uint64_t sent_before, sent_after;
+    int ret;
+
+    TLOG_INF("Testing sent-event-records operational counter change...");
+
+    setup_sub(st->sess, st->udp_port, 91, "NETCONF",
+            "/ietf-netconf-notifications:netconf-config-change");
+
+    /* drain subscription-started and initial netconf-config-change notifications */
+    ret = receive_specific_notification(st->udp_sockfd, st->ly_ctx,
+            "/ietf-subscribed-notifications:subscription-started", &notif, NULL);
+    assert_int_equal(ret, 0);
+    assert_non_null(notif);
+    lyd_free_all(notif);
+    notif = NULL;
+
+    ret = receive_specific_notification(st->udp_sockfd, st->ly_ctx,
+            "/ietf-netconf-notifications:netconf-config-change", &notif, NULL);
+    assert_int_equal(ret, 0);
+    assert_non_null(notif);
+    lyd_free_all(notif);
+    notif = NULL;
+
+    TLOG_INF("Retrieving initial sent-event-records value...");
+
+    val_str = get_oper_leaf_str(st->sess,
+            "/ietf-subscribed-notifications:subscriptions/subscription[id='91']/receivers/receiver[name='recv1']/sent-event-records");
+    assert_non_null(val_str);
+    sent_before = strtoull(val_str, NULL, 10);
+    free(val_str);
+
+    TLOG_INF("Making configuration change to trigger notification...");
+
+    ret = sr_set_item_str(st->sess, "/test:test-leaf", "67", NULL, 0);
+    assert_int_equal(ret, SR_ERR_OK);
+    ret = sr_apply_changes(st->sess, 0);
+    assert_int_equal(ret, SR_ERR_OK);
+
+    ret = receive_specific_notification(st->udp_sockfd, st->ly_ctx,
+            "/ietf-netconf-notifications:netconf-config-change", &notif, NULL);
+    assert_int_equal(ret, 0);
+    assert_non_null(notif);
+    lyd_free_all(notif);
+    notif = NULL;
+
+    TLOG_INF("Retrieving sent-event-records value after sending another notification...");
+
+    val_str = get_oper_leaf_str(st->sess,
+            "/ietf-subscribed-notifications:subscriptions/subscription[id='91']/receivers/receiver[name='recv1']/sent-event-records");
+    assert_non_null(val_str);
+    sent_after = strtoull(val_str, NULL, 10);
+    free(val_str);
+    assert_true(sent_after > sent_before);
+
+    sr_delete_item(st->sess, "/test:test-leaf", 0);
+    cleanup_sub(st->sess, 91);
+}
+
+static void
+test_receiver_reset_action(void **state)
+{
+    struct state *st = *state;
+    struct lyd_node *notif = NULL;
+    sr_val_t *output = NULL;
+    char *state_val = NULL;
+    size_t output_count = 0;
+    int ret;
+
+    TLOG_INF("Testing receiver reset action with backoff reconnect...");
+
+    setup_sub(st->sess, st->udp_port, 91, "NETCONF",
+            "/ietf-netconf-notifications:netconf-config-change");
+
+    /* drain subscription-started notification */
+    ret = receive_specific_notification(st->udp_sockfd, st->ly_ctx,
+            "/ietf-subscribed-notifications:subscription-started", &notif, NULL);
+    assert_int_equal(ret, 0);
+    assert_non_null(notif);
+    lyd_free_all(notif);
+    notif = NULL;
+
+    /* drain netconf-config-change caused by creating the subscription */
+    ret = receive_specific_notification(st->udp_sockfd, st->ly_ctx,
+            "/ietf-netconf-notifications:netconf-config-change", &notif, NULL);
+    assert_int_equal(ret, 0);
+    assert_non_null(notif);
+    lyd_free_all(notif);
+    notif = NULL;
+
+    TLOG_INF("Checking initial state of the receiver...");
+
+    state_val = get_oper_leaf_str(st->sess,
+            "/ietf-subscribed-notifications:subscriptions/subscription[id='91']/receivers/receiver[name='recv1']/state");
+    assert_non_null(state_val);
+    assert_string_equal(state_val, "active");
+    free(state_val);
+
+    TLOG_INF("Performing receiver reset action...");
+
+    /* perform the receiver reset action */
+    ret = sr_rpc_send(st->sess, "/ietf-subscribed-notifications:subscriptions/subscription[id='91']/receivers/receiver[name='recv1']/reset",
+            NULL, 0, 0, &output, &output_count);
+    assert_int_equal(ret, SR_ERR_OK);
+    assert_non_null(output);
+    assert_int_equal(output_count, 1);
+    sr_free_values(output, output_count);
+
+    TLOG_INF("Receiver reset action performed, checking state of the receiver...");
+
+    state_val = get_oper_leaf_str(st->sess,
+            "/ietf-subscribed-notifications:subscriptions/subscription[id='91']/receivers/receiver[name='recv1']/state");
+    assert_non_null(state_val);
+    assert_string_equal(state_val, "connecting");
+    free(state_val);
+
+    TLOG_INF("Triggering a notification to cause backoff reconnect...");
+
+    /* make a config change - the daemon should auto-reconnect and deliver the notification */
+    ret = sr_set_item_str(st->sess, "/test:test-leaf", "104", NULL, 0);
+    assert_int_equal(ret, SR_ERR_OK);
+    ret = sr_apply_changes(st->sess, 0);
+    assert_int_equal(ret, SR_ERR_OK);
+
+    TLOG_INF("Waiting for subscription-started (from backoff reconnect)...");
+
+    /* first, the daemon reconnects and sends subscription-started - use long timeout for backoff */
+    ret = receive_specific_notification_timeout(st->udp_sockfd, st->ly_ctx, LONG_TIMEOUT_MS,
+            "/ietf-subscribed-notifications:subscription-started", &notif, NULL);
+    assert_int_equal(ret, 0);
+    assert_non_null(notif);
+    lyd_free_all(notif);
+    notif = NULL;
+
+    TLOG_INF("Waiting for netconf-config-change (after reconnect)...");
+
+    /* then, the actual notification is sent */
+    ret = receive_specific_notification(st->udp_sockfd, st->ly_ctx,
+            "/ietf-netconf-notifications:netconf-config-change", &notif, NULL);
+    assert_int_equal(ret, 0);
+    assert_non_null(notif);
+    lyd_free_all(notif);
+    notif = NULL;
+
+    TLOG_INF("Checking receiver state after backoff reconnect...");
+
+    state_val = get_oper_leaf_str(st->sess,
+            "/ietf-subscribed-notifications:subscriptions/subscription[id='91']/receivers/receiver[name='recv1']/state");
+    assert_non_null(state_val);
+    assert_string_equal(state_val, "active");
+    free(state_val);
+
+    sr_delete_item(st->sess, "/test:test-leaf", 0);
+    cleanup_sub(st->sess, 91);
+}
+
+/**
+ * @brief Test: Set configured-replay before replay support, then enable replay and verify delivery.
+ *
+ * Sets configured-replay before sr_set_module_replay_support, expecting
+ * subscription-terminated with replay-not-supported. Then enables replay,
+ * makes a config change (stored for replay), deletes and re-sets
+ * configured-replay, and verifies: replayed netconf-config-change +
+ * subscription-modified + live netconf-config-change.
+ */
+static void
+test_configured_replay(void **state)
+{
+    struct state *st = *state;
+    struct lyd_node *notif = NULL;
+    char replay_path[256];
+    int ret;
+    int got_modified = 0, got_ncc = 0, got_replay_completed = 0;
+    time_t deadline;
+
+    memset(replay_path, 0, sizeof(replay_path));
+
+    snprintf(replay_path, sizeof(replay_path),
+            "/ietf-subscribed-notifications:subscriptions/subscription[id='93']/configured-replay");
+
+    TLOG_INF("Testing configured-replay...");
+
+    setup_sub(st->sess, st->udp_port, 93, "NETCONF",
+            "/ietf-netconf-notifications:netconf-config-change");
+
+    /* receive subscription-started */
+    ret = receive_specific_notification(st->udp_sockfd, st->ly_ctx,
+            "/ietf-subscribed-notifications:subscription-started", &notif, NULL);
+    assert_int_equal(ret, 0);
+    assert_non_null(notif);
+    lyd_free_all(notif);
+    notif = NULL;
+
+    /* drain the netconf-config-change from creating the subscription */
+    drain_notifications(st->udp_sockfd);
+
+    TLOG_INF("Setting configured-replay before replay support is enabled, expecting failure...");
+
+    /* set configured-replay BEFORE enabling replay support - should fail */
+    ret = sr_set_item_str(st->sess, replay_path, NULL, NULL, 0);
+    assert_int_equal(ret, SR_ERR_OK);
+    ret = sr_apply_changes(st->sess, 0);
+    assert_int_equal(ret, SR_ERR_UNSUPPORTED);
+
+    TLOG_INF("Enabling replay support...");
+
+    /* enable replay support */
+    ret = sr_set_module_replay_support(st->conn, "ietf-netconf-notifications", 1);
+    assert_int_equal(ret, SR_ERR_OK);
+
+    TLOG_INF("Making config change to generate notification stored for replay...");
+
+    /* make a config change - generates ncc stored for replay (sub is INVALID, won't receive live) */
+    ret = sr_set_item_str(st->sess, "/test:test-leaf", "42", NULL, 0);
+    assert_int_equal(ret, SR_ERR_OK);
+    ret = sr_apply_changes(st->sess, 0);
+    assert_int_equal(ret, SR_ERR_OK);
+
+    TLOG_INF("Re-setting configured-replay...");
+
+    /* set configured-replay again - now replay is supported */
+    ret = sr_set_item_str(st->sess, replay_path, NULL, NULL, 0);
+    assert_int_equal(ret, SR_ERR_OK);
+    ret = sr_apply_changes(st->sess, 0);
+    assert_int_equal(ret, SR_ERR_OK);
+
+    TLOG_INF("Waiting for subscription-modified, replayed ncc, and replay-completed...");
+
+    /* expect: subscription-modified + replayed ncc + replay-completed within a bounded total time */
+    got_modified = got_ncc = got_replay_completed = 0;
+    deadline = time(NULL) + 15;
+
+    while ((time(NULL) < deadline) && !(got_modified && got_ncc && got_replay_completed)) {
+        ret = receive_notification_timeout(st->udp_sockfd, st->ly_ctx, 500, &notif, NULL);
+        if (ret == 1) {
+            /* short timeout expired, retry within deadline */
+            continue;
+        }
+        assert_int_equal(ret, 0);
+        assert_non_null(notif);
+
+        if (!strcmp(notif->schema->name, "subscription-modified")) {
+            got_modified = 1;
+        } else if (!strcmp(notif->schema->name, "netconf-config-change")) {
+            got_ncc = 1;
+        } else if (!strcmp(notif->schema->name, "replay-completed")) {
+            got_replay_completed = 1;
+        }
+
+        lyd_free_all(notif);
+        notif = NULL;
+    }
+
+    assert_true(got_modified && got_ncc && got_replay_completed);
+
+    if (notif) {
+        lyd_free_all(notif);
+        notif = NULL;
+    }
+
+    /* cleanup */
+    sr_set_module_replay_support(st->conn, "ietf-netconf-notifications", 0);
+    sr_delete_item(st->sess, "/test:test-leaf", 0);
+    cleanup_sub(st->sess, 93);
+}
+
+/**
+ * @brief Test: Modify subscription source-address and verify sender source IP changes.
+ */
+static void
+test_source_address_modify(void **state)
+{
+    struct state *st = *state;
+    struct lyd_node *notif = NULL;
+    char path[512];
+    char first_source[INET_ADDRSTRLEN];
+    char second_source[INET_ADDRSTRLEN];
+    char alternate_source[INET_ADDRSTRLEN];
+    const char *initial_source = "127.0.0.1";
+    int ret;
+
+    memset(first_source, 0, sizeof(first_source));
+    memset(second_source, 0, sizeof(second_source));
+    memset(alternate_source, 0, sizeof(alternate_source));
+
+    if (!find_alternate_loopback_ipv4(initial_source, alternate_source, sizeof(alternate_source))) {
+        skip();
+        return;
+    }
+
+    TLOG_INF("Testing source-address change from %s to %s", initial_source, alternate_source);
+
+    ret = create_receiver_instance(st->sess, "test-recv", "127.0.0.1", st->udp_port);
+    assert_int_equal(ret, SR_ERR_OK);
+
+    ret = create_subscription(st->sess, 92, "NETCONF", NULL, "test-recv");
+    assert_int_equal(ret, SR_ERR_OK);
+
+    snprintf(path, sizeof(path),
+            "/ietf-subscribed-notifications:subscriptions/subscription[id='92']/source-address");
+    ret = sr_set_item_str(st->sess, path, initial_source, NULL, 0);
+    assert_int_equal(ret, SR_ERR_OK);
+
+    ret = sr_apply_changes(st->sess, 0);
+    assert_int_equal(ret, SR_ERR_OK);
+
+    ret = receive_specific_notification_ext(st->udp_sockfd, st->ly_ctx, NOTIF_TIMEOUT_MS,
+            "/ietf-subscribed-notifications:subscription-started", &notif, NULL,
+            first_source, sizeof(first_source));
+    assert_int_equal(ret, 0);
+    assert_non_null(notif);
+    assert_string_equal(first_source, initial_source);
+    lyd_free_all(notif);
+    notif = NULL;
+
+    /* drain the initial netconf-config-change notification caused by the subscription creation */
+    ret = receive_specific_notification(st->udp_sockfd, st->ly_ctx,
+            "/ietf-netconf-notifications:netconf-config-change", &notif, NULL);
+    assert_int_equal(ret, 0);
+    assert_non_null(notif);
+    lyd_free_all(notif);
+    notif = NULL;
+
+    TLOG_INF("Modifying source-address to %s", alternate_source);
+
+    ret = sr_set_item_str(st->sess, path, alternate_source, NULL, 0);
+    assert_int_equal(ret, SR_ERR_OK);
+
+    ret = sr_apply_changes(st->sess, 0);
+    assert_int_equal(ret, SR_ERR_OK);
+
+    /* source address modified, so we should receive a subscription-modified notification with the new source IP */
+    ret = receive_specific_notification_ext(st->udp_sockfd, st->ly_ctx, NOTIF_TIMEOUT_MS,
+            "/ietf-subscribed-notifications:subscription-modified", &notif, NULL,
+            second_source, sizeof(second_source));
+    assert_int_equal(ret, 0);
+    assert_non_null(notif);
+    assert_string_equal(second_source, alternate_source);
+    lyd_free_all(notif);
+    notif = NULL;
+
+    cleanup_sub(st->sess, 92);
+}
+
+/**
+ * @brief Test: Change receiver instance reference from one receiver to another.
+ *
+ * Creates a subscription with receiver instance A, then changes the subscription
+ * to point to receiver instance B. Verifies the configuration change is applied
+ * successfully and that subscription-started and subscription-terminated notifications are sent to the correct receivers.
+ */
+static void
+test_receiver_instance_ref_change(void **state)
+{
+    struct state *st = *state;
+    struct lyd_node *notif = NULL;
+    char path[512];
+    int ret, recv2_sockfd = -1;
+
+    TLOG_INF("Creating first and second receiver instances...");
+
+    /*
+     Create two receiver instances
+     */
+    ret = create_receiver_instance(st->sess, "recv-1", "127.0.0.1", st->udp_port);
+    assert_int_equal(ret, SR_ERR_OK);
+    ret = create_receiver_instance(st->sess, "recv-2", "127.0.0.1", st->udp_port + 1);
+    assert_int_equal(ret, SR_ERR_OK);
+
+    /* create a socket for the second receiver */
+    recv2_sockfd = create_udp_receiver_socket(st->udp_port + 1);
+    assert_true(recv2_sockfd >= 0);
+
+    /*
+     Create subscription pointing to recv-1
+     */
+    ret = create_subscription(st->sess, 100, "NETCONF", NULL, "recv-1");
+    assert_int_equal(ret, SR_ERR_OK);
+    ret = sr_apply_changes(st->sess, 0);
+    assert_int_equal(ret, SR_ERR_OK);
+
+    TLOG_INF("Created subscription pointing to recv-1");
+
+    /* Drain notifications */
+    drain_notifications(st->udp_sockfd);
+
+    TLOG_INF("Changing receiver instance reference from recv-1 to recv-2...");
+
+    /*
+     Change subscription to point to recv-2
+     */
+    snprintf(path, sizeof(path),
+            "/ietf-subscribed-notifications:subscriptions/subscription[id='100']/receivers/receiver[name='recv1']/ietf-subscribed-notif-receivers:receiver-instance-ref");
+    ret = sr_set_item_str(st->sess, path, "recv-2", NULL, 0);
+    assert_int_equal(ret, SR_ERR_OK);
+
+    ret = sr_apply_changes(st->sess, 0);
+    assert_int_equal(ret, SR_ERR_OK);
+
+    TLOG_INF("Receiver instance reference changed to recv-2");
+
+    /*
+     Receive subscription-terminated
+     */
+    ret = receive_specific_notification(st->udp_sockfd, st->ly_ctx,
+            "/ietf-subscribed-notifications:subscription-terminated", &notif, NULL);
+    assert_int_equal(ret, 0);
+    assert_non_null(notif);
+    TLOG_INF("Received subscription-terminated notification");
+
+    lyd_free_all(notif);
+    notif = NULL;
+
+    /*
+     Receive subscription-started, it will be sent to the new receiver instance (recv-2)
+     */
+    ret = receive_specific_notification(recv2_sockfd, st->ly_ctx,
+            "/ietf-subscribed-notifications:subscription-started", &notif, NULL);
+    assert_int_equal(ret, 0);
+    assert_non_null(notif);
+    TLOG_INF("Received subscription-started notification");
+
+    lyd_free_all(notif);
+    notif = NULL;
+
+    /*
+     Cleanup
+     */
+    delete_subscription(st->sess, 100);
+    delete_receiver_instance(st->sess, "recv-1");
+    delete_receiver_instance(st->sess, "recv-2");
+    sr_apply_changes(st->sess, 0);
+    if (recv2_sockfd >= 0) {
+        close(recv2_sockfd);
+    }
+}
+
+static int
+running_with_valgrind(void)
+{
+    char *ld_preload;
+
+    ld_preload = getenv("LD_PRELOAD");
+    if (ld_preload && strstr(ld_preload, "vgpreload")) {
+        return 1;
+    }
+    return 0;
+}
+
+/**
+ * @brief Test: Stop-time reached triggers subscription-completed and concluded state.
+ */
+static void
+test_stop_time_concluded(void **state)
+{
+    struct state *st = *state;
+    struct lyd_node *notif = NULL;
+    time_t now;
+    char stop_time_str[64];
+    char *state_val = NULL;
+    char path[512];
+    int ret;
+
+    TLOG_INF("Testing stop-time reaching concluded state...");
+
+    /* create receiver instance */
+    ret = create_receiver_instance(st->sess, "test-recv", "127.0.0.1", st->udp_port);
+    assert_int_equal(ret, SR_ERR_OK);
+
+    /* create subscription */
+    ret = create_subscription(st->sess, 200, "NETCONF", NULL, "test-recv");
+    assert_int_equal(ret, SR_ERR_OK);
+
+    /* set stop-time to a few seconds from now */
+    now = time(NULL);
+    if (running_with_valgrind()) {
+        /* Valgrind can cause significant delays, so set a longer stop-time */
+        now += 6;
+    } else {
+        now += 3;
+    }
+    strftime(stop_time_str, sizeof(stop_time_str), "%Y-%m-%dT%H:%M:%SZ", gmtime(&now));
+
+    snprintf(path, sizeof(path),
+            "/ietf-subscribed-notifications:subscriptions/subscription[id='200']/stop-time");
+    ret = sr_set_item_str(st->sess, path, stop_time_str, NULL, 0);
+    assert_int_equal(ret, SR_ERR_OK);
+
+    /* apply all changes */
+    ret = sr_apply_changes(st->sess, 0);
+    assert_int_equal(ret, SR_ERR_OK);
+
+    TLOG_INF("Waiting for subscription-started notification...");
+
+    /* receive subscription-started */
+    ret = receive_specific_notification(st->udp_sockfd, st->ly_ctx,
+            "/ietf-subscribed-notifications:subscription-started", &notif, NULL);
+    assert_int_equal(ret, 0);
+    assert_non_null(notif);
+    lyd_free_all(notif);
+    notif = NULL;
+
+    TLOG_INF("Waiting for subscription-completed notification (stop-time will expire)...");
+
+    /* wait for subscription-completed after stop-time expires, using a long timeout */
+    ret = receive_specific_notification_timeout(st->udp_sockfd, st->ly_ctx, LONG_TIMEOUT_MS,
+            "/ietf-subscribed-notifications:subscription-completed", &notif, NULL);
+    assert_int_equal(ret, 0);
+    assert_non_null(notif);
+
+    TLOG_INF("Received subscription-completed notification successfully");
+
+    lyd_free_all(notif);
+    notif = NULL;
+
+    TLOG_INF("Checking operational state is 'concluded'...");
+
+    state_val = get_oper_leaf_str(st->sess,
+            "/ietf-subscribed-notifications:subscriptions/subscription[id='200']/configured-subscription-state");
+    assert_non_null(state_val);
+    assert_string_equal(state_val, "concluded");
+    free(state_val);
+
+    cleanup_sub(st->sess, 200);
+}
+
+/* MAIN */
+int
+main(void)
+{
+    const struct CMUnitTest tests[] = {
+        cmocka_unit_test_setup(test_subscription_started, clear_subs_notifs),
+        cmocka_unit_test_setup(test_subscription_terminated, clear_subs_notifs),
+        cmocka_unit_test_setup(test_subscription_modified, clear_subs_notifs),
+        cmocka_unit_test_setup(test_multiple_subscriptions, clear_subs_notifs),
+        cmocka_unit_test_setup(test_config_change_notification, clear_subs_notifs),
+        cmocka_unit_test_setup(test_udp_notif_header, clear_subs_notifs),
+        cmocka_unit_test_setup(test_message_id_increment, clear_subs_notifs),
+        cmocka_unit_test_setup(test_xpath_filter_match, clear_subs_notifs),
+        cmocka_unit_test_setup(test_xpath_filter_nomatch, clear_subs_notifs),
+        cmocka_unit_test_setup(test_xpath_filter_edit_target, clear_subs_notifs),
+        cmocka_unit_test_setup(test_subtree_filter_match, clear_subs_notifs),
+        cmocka_unit_test_setup(test_subtree_filter_nomatch, clear_subs_notifs),
+        cmocka_unit_test_setup(test_subtree_filter_containment, clear_subs_notifs),
+        cmocka_unit_test_setup(test_filter_ref_xpath_match, clear_subs_notifs),
+        cmocka_unit_test_setup(test_filter_ref_subtree_match, clear_subs_notifs),
+        cmocka_unit_test_setup(test_filter_ref_xpath_modify, clear_subs_notifs),
+        cmocka_unit_test_setup(test_filter_ref_subtree_modify, clear_subs_notifs),
+        cmocka_unit_test_setup(test_filter_ref_multiple_subs, clear_subs_notifs),
+        cmocka_unit_test_setup(test_filter_ref_xpath_nomatch, clear_subs_notifs),
+        cmocka_unit_test_setup(test_oper_data_get_all_supported, clear_subs_notifs),
+        cmocka_unit_test_setup(test_oper_data_sent_event_records_change, clear_subs_notifs),
+        cmocka_unit_test_setup(test_receiver_reset_action, clear_subs_notifs),
+        cmocka_unit_test_setup(test_configured_replay, clear_subs_notifs),
+        cmocka_unit_test_setup(test_source_address_modify, clear_subs_notifs),
+        cmocka_unit_test_setup(test_receiver_instance_ref_change, clear_subs_notifs),
+        cmocka_unit_test_setup(test_stop_time_concluded, clear_subs_notifs),
+    };
+
+    test_init();
+    return cmocka_run_group_tests(tests, setup, teardown);
+}

--- a/tests/test_sub_notif.c
+++ b/tests/test_sub_notif.c
@@ -380,8 +380,9 @@ test_replay_start_time(void **state)
     /* subscribe to notifs with start-time */
     assert_int_equal(SR_ERR_OK, srsn_subscribe(st->sess, "NETCONF", NULL, NULL, &ts, 0, NULL, &replay_start_time, &fd, &sub_id));
 
-    /* there are notifs from time earlier than the start time */
-    assert_int_equal(replay_start_time.tv_sec, 0);
+    /* replay must start after it was enabled for the 2nd module */
+    assert_true(replay_start_time.tv_sec > ts.tv_sec ||
+            (replay_start_time.tv_sec == ts.tv_sec && replay_start_time.tv_nsec > ts.tv_nsec));
 
     /* read replayed notification */
     assert_int_equal(SR_ERR_OK, srsn_poll(fd, 1000));


### PR DESCRIPTION
## Summary

- Implement `sysrepo-notifd`, a standalone notification daemon that handles `ietf-subscribed-notifications` configured subscriptions notification replay, storage, and UDP relay
- Store and expose the replay-start timestamp (when replay was first enabled) to support `replay-log-creation-time` from `ietf-subscribed-notifications`
- Add test suite for the notification daemon (`test_notifd`)

## API Changes

**`sr_get_module_replay_support()`** - unchanged, kept original signature:
```c
int sr_get_module_replay_support(sr_conn_ctx_t *conn, const char *module_name,
        struct timespec *earliest_notif, int *enabled);
```

**`sr_get_module_replay_start()`** - new function:
```c
int sr_get_module_replay_start(sr_conn_ctx_t *conn, const char *module_name,
        const struct timespec *after, struct timespec *earliest_notif, struct timespec *replay_start);
```
- Parameter `after`: optional filter to get the earliest stored notification at or after this time
- Parameter `earliest_notif`: optional timestamp of the earliest stored notification (at or after `after`)
- Parameter `replay_start`: returns when replay was enabled, zeroed if replay is currently disabled

`Notification Plugin API`:

- **`srntf_earliest_get`** callback signature changed: added `const struct timespec *after` parameter
- New callback **`srntf_replay_start_get`**: returns the timestamp when replay was enabled for a module