### PR TITLE
notifd BUGFIX RFC 5277 notification envelopes and sub state-change fields

### DIFF
--- a/examples/notifd/notifd_client.c
+++ b/examples/notifd/notifd_client.c
@@ -453,23 +453,37 @@ print_notification(struct lyd_node *envp, struct lyd_node *notif, const udp_noti
 
     mt_name = (hdr->media_type < 4) ? media_type_names[hdr->media_type] : "unknown";
 
-    /* link the inner notification into the envelope for combined pretty-printing */
-    if (envp && notif) {
-        /* eventTime is the only opaque child of the envelope before the notification is linked in */
-        event_time = lyd_child(envp);
-
-        lyd_insert_child(envp, notif);
-        notif = NULL;
-
-        /* libyang inserts schema nodes before opaque ones, so eventTime ended up after the
-           notification; move it back to the front so it is printed before the notification */
-        if (event_time && (event_time != lyd_child(envp))) {
-            lyd_insert_before(lyd_child(envp), event_time);
-        }
-
-        lyd_print_mem(&payload, envp, format, LYD_PRINT_SIBLINGS);
+    /* skip envelope linking if either tree is missing, payload degrades to "(failed to format)" */
+    if (!envp || !notif) {
+        goto print;
     }
 
+    /* eventTime is the only opaque child of the envelope before the notification is linked in */
+    event_time = lyd_child(envp);
+
+    /* link the inner notification into the envelope for combined pretty-printing */
+    if (lyd_insert_child(envp, notif)) {
+        fprintf(stderr, "Failed to link notification into the envelope\n");
+        goto print;
+    }
+
+    /* ownership transferred to envp */
+    notif = NULL;
+
+    /* libyang inserts schema nodes before opaque ones, so eventTime ended up after the
+       notification; move it back to the front so it is printed before the notification */
+    if (event_time && (event_time != lyd_child(envp))) {
+        if (lyd_insert_before(lyd_child(envp), event_time)) {
+            /* purely cosmetic failure, eventTime is just printed after the notification */
+            fprintf(stderr, "Failed to reorder eventTime before the notification\n");
+        }
+    }
+
+    if (lyd_print_mem(&payload, envp, format, LYD_PRINT_SIBLINGS)) {
+        fprintf(stderr, "Failed to format notification\n");
+    }
+
+print:
     printf("\n--- Notification ---\n");
     printf("  Path:          %s\n", path);
     printf("  Publisher ID:  %" PRIu32 "\n", hdr->publisher_id);
@@ -496,6 +510,7 @@ print_notification(struct lyd_node *envp, struct lyd_node *notif, const udp_noti
 
     free(path);
     free(payload);
+    lyd_free_all(notif);
 }
 
 /**
@@ -657,7 +672,8 @@ receive_next:
         goto cleanup;
     }
 
-    /* notif is linked into envp by print_notification, so only envp is freed in cleanup */
+    /* print_notification takes ownership of notif (links it into envp or frees it on failure),
+       so only envp is freed in cleanup */
     print_notification(envp, notif, &hdr, format);
     notif = NULL;
 

--- a/examples/notifd/notifd_client.c
+++ b/examples/notifd/notifd_client.c
@@ -426,17 +426,25 @@ add_segment(pending_message_t *pending, uint16_t segment_num, int is_last,
 }
 
 /**
- * @brief Print a notification data tree in a human-readable format.
+ * @brief Print a notification in a human-readable format.
  *
- * @param[in] notif Notification data tree.
+ * The inner notification is linked into the parsed envelope tree so that the
+ * full RFC 5277 envelope (including eventTime and the inner notification) is
+ * pretty-printed with proper indentation.
+ *
+ * @param[in] envp RFC 5277 envelope data tree (contains eventTime).
+ * @param[in] notif Notification data tree (used for the path and linked into envp).
  * @param[in] hdr UDP-Notif header that carried the notification.
+ * @param[in] format Payload format (LYD_JSON or LYD_XML).
  */
 static void
-print_notification(const struct lyd_node *notif, const udp_notif_header_t *hdr)
+print_notification(struct lyd_node *envp, struct lyd_node *notif, const udp_notif_header_t *hdr, LYD_FORMAT format)
 {
     char *path = NULL;
     char *payload = NULL;
     const char *mt_name;
+    const char *line, *next;
+    struct lyd_node *event_time = NULL;
 
     path = lyd_path(notif, LYD_PATH_STD, NULL, 0);
     if (!path) {
@@ -445,16 +453,44 @@ print_notification(const struct lyd_node *notif, const udp_notif_header_t *hdr)
 
     mt_name = (hdr->media_type < 4) ? media_type_names[hdr->media_type] : "unknown";
 
+    /* link the inner notification into the envelope for combined pretty-printing */
+    if (envp && notif) {
+        /* eventTime is the only opaque child of the envelope before the notification is linked in */
+        event_time = lyd_child(envp);
+
+        lyd_insert_child(envp, notif);
+        notif = NULL;
+
+        /* libyang inserts schema nodes before opaque ones, so eventTime ended up after the
+           notification; move it back to the front so it is printed before the notification */
+        if (event_time && (event_time != lyd_child(envp))) {
+            lyd_insert_before(lyd_child(envp), event_time);
+        }
+
+        lyd_print_mem(&payload, envp, format, LYD_PRINT_SIBLINGS);
+    }
+
     printf("\n--- Notification ---\n");
     printf("  Path:          %s\n", path);
     printf("  Publisher ID:  %" PRIu32 "\n", hdr->publisher_id);
     printf("  Message ID:    %" PRIu32 "\n", hdr->message_id);
     printf("  Media Type:    %s\n", mt_name);
-
-    if (!lyd_print_mem(&payload, notif, LYD_JSON, 0)) {
-        printf("  Payload:\n%s\n", payload);
+    printf("  Payload:\n");
+    if (payload) {
+        line = payload;
+        while (line && *line) {
+            next = strchr(line, '\n');
+            if (next) {
+                printf("  %.*s\n", (int)(next - line), line);
+                line = next + 1;
+            } else {
+                printf("  %s\n", line);
+                break;
+            }
+        }
+    } else {
+        printf("  (failed to format)\n");
     }
-
     printf("---------------------\n");
     fflush(stdout);
 
@@ -484,8 +520,10 @@ receive_notification(int sockfd, sr_conn_ctx_t *conn, int timeout_ms)
     size_t payload_len, reassembled_len;
     struct ly_in *in = NULL;
     struct lyd_node *notif = NULL;
+    struct lyd_node *envp = NULL;
     const struct ly_ctx *ly_ctx = NULL;
     LYD_FORMAT format;
+    enum lyd_type dt;
     pending_message_t *pending;
     char *reassembled = NULL;
     char *payload_str = NULL;
@@ -611,13 +649,17 @@ receive_next:
         goto cleanup;
     }
 
-    if (lyd_parse_op(ly_ctx, NULL, in, format, LYD_TYPE_NOTIF_YANG, 0, NULL, &notif)) {
+    /* parse the RFC 5277 notification envelope; choose the parse type by encoding */
+    dt = (format == LYD_XML) ? LYD_TYPE_NOTIF_NETCONF : LYD_TYPE_NOTIF_RESTCONF;
+    if (lyd_parse_op(ly_ctx, NULL, in, format, dt, 0, &envp, &notif)) {
         fprintf(stderr, "Failed to parse notification: %s\n", ly_err_last(ly_ctx)->msg);
         rc = -1;
         goto cleanup;
     }
 
-    print_notification(notif, &hdr);
+    /* notif is linked into envp by print_notification, so only envp is freed in cleanup */
+    print_notification(envp, notif, &hdr, format);
+    notif = NULL;
 
     /* release context right after we're done using it */
     sr_release_context(conn);
@@ -626,6 +668,7 @@ receive_next:
 cleanup:
     free(payload_str);
     lyd_free_all(notif);
+    lyd_free_all(envp);
     ly_in_free(in, 0);
     if (ly_ctx) {
         sr_release_context(conn);

--- a/scripts/setup_notifd.sh
+++ b/scripts/setup_notifd.sh
@@ -32,7 +32,7 @@ SCTL_MODULES=`$SYSREPOCTL -l`
 
 # modules to install with their features
 MODULES=(
-"ietf-subscribed-notifications@2019-09-09.yang -e configured -e replay -e subtree -e xpath"
+"ietf-subscribed-notifications@2019-09-09.yang -e configured -e replay -e subtree -e xpath -e encode-xml -e encode-json"
 "ietf-subscribed-notif-receivers@2024-02-01.yang"
 "ietf-udp-notif-transport@2025-06-04.yang"
 )

--- a/src/executables/sysrepo-notifd/main.c
+++ b/src/executables/sysrepo-notifd/main.c
@@ -652,6 +652,8 @@ sub_change_modify_subscriptions(notifd_ctx_t *notifd_ctx, sr_session_ctx_t *sess
             r = handle_purpose(sub, node, op);
         } else if (!strcmp(node_name, "source-address")) {
             r = handle_source_address(notifd_ctx, sub, node, op);
+        } else if (!strcmp(node_name, "transport")) {
+            r = handle_transport(sub, node, op);
         } else {
             r = 0;
         }

--- a/src/executables/sysrepo-notifd/notifd.h
+++ b/src/executables/sysrepo-notifd/notifd.h
@@ -84,6 +84,21 @@
  */
 #define NOTIFD_RECV_RECONNECT_MAX_SEC 60
 
+/**
+ * @brief RFC 5277 NETCONF notification envelope namespace.
+ *
+ * Used for the <notification> wrapper and its <eventTime> child element.
+ */
+#define NOTIFD_NOTIF_XML_NS "urn:ietf:params:xml:ns:netconf:notification:1.0"
+
+/**
+ * @brief RFC 8040 Section 6.4 JSON envelope module name for the <notification> element.
+ *
+ * For JSON encoding, the <notification> element is placed in the "ietf-restconf"
+ * module namespace, as specified in RFC 8040 Section 6.4.
+ */
+#define NOTIFD_NOTIF_JSON_MODULE "ietf-restconf"
+
 /* forward declarations */
 typedef struct notifd_ctx_s notifd_ctx_t;
 typedef struct notif_sub_s notif_sub_t;
@@ -235,6 +250,18 @@ typedef void (*notif_transport_config_destroy_cb)(void *cfg);
 typedef int (*notif_transport_config_validate_cb)(const struct lyd_node *node);
 
 /**
+ * @brief Get the default encoding for this transport.
+ *
+ * Called when a subscription's encoding is not explicitly configured
+ * (NOTIF_ENCODING_UNSET). Per RFC 8639, the encoding leaf description states
+ * that for a configured subscription the encoding "will be the default encoding
+ * for an underlying transport." Each transport must define its default.
+ *
+ * @return The transport's default encoding.
+ */
+typedef notif_encoding_t (*notif_transport_default_encoding_cb)(void);
+
+/**
  * @brief Transport operations vtable.
  *
  * Each transport type implements this interface, enabling polymorphic
@@ -255,6 +282,7 @@ typedef struct notif_transport_ops_s {
     notif_transport_config_change_cb config_change;     /**< handle incremental config changes */
     notif_transport_config_destroy_cb config_destroy;   /**< free transport config */
     notif_transport_config_validate_cb config_validate; /**< validate transport config */
+    notif_transport_default_encoding_cb default_encoding; /**< get default encoding when not configured */
 } notif_transport_ops_t;
 
 /**

--- a/src/executables/sysrepo-notifd/notifd.h
+++ b/src/executables/sysrepo-notifd/notifd.h
@@ -326,6 +326,7 @@ struct notif_sub_s {
     char *stream;                       /**< stream name */
     char *filter_ref;                   /**< optional stream filter name (e.g., XPath or subtree filter) */
     char *xpath_filter;                 /**< optional XPath filter */
+    char *transport;                    /**< notification transport identity-ref (e.g. "ietf-udp-notif-transport:udp-notif") */
     notif_encoding_t encoding;          /**< notification encoding */
     struct timespec stop_time;          /**< optional stop time */
     int replay;                         /**< whether to replay notifications */

--- a/src/executables/sysrepo-notifd/notifd_common.h
+++ b/src/executables/sysrepo-notifd/notifd_common.h
@@ -657,14 +657,14 @@ int notif_receiver_reconnect(notifd_ctx_t *notifd_ctx, notif_sub_t *sub, notif_r
  * CBOR encoding is not supported.
  *
  * @param[in] notif Notification data tree to wrap and encode.
- * @param[in] ts Event timestamp for <eventTime>, or NULL for the current time.
+ * @param[in] ts Event timestamp for <eventTime> (mandatory).
  * @param[in] encoding Encoding format (XML, JSON, or UNSET which defaults to JSON; CBOR not supported).
  * @param[out] data Encoded message (caller must free).
  * @param[out] data_len Length of encoded message.
  * @return ::SR_ERR_OK on success, ::SR_ERR_UNSUPPORTED for CBOR, other error codes on failure.
  */
 int notif_rfc5277_encode(const struct lyd_node *notif, const struct timespec *ts,
-        notif_encoding_t encoding, char **data, size_t *data_len);
+        notif_encoding_t encoding, char **data, uint32_t *data_len);
 
 /**
  * @brief Send a single notification to a specific receiver over its transport.

--- a/src/executables/sysrepo-notifd/notifd_common.h
+++ b/src/executables/sysrepo-notifd/notifd_common.h
@@ -28,6 +28,14 @@
  */
 extern const notif_transport_ops_t udp_transport_ops;
 
+/**
+ * @brief Find a registered transport by its YANG identity value.
+ *
+ * @param[in] identity YANG identity string (e.g. "ietf-udp-notif-transport:udp-notif").
+ * @return Pointer to the matching transport ops, or NULL if not found.
+ */
+const notif_transport_ops_t *notif_transport_find_by_identity(const char *identity);
+
 /** @brief Bitmask: include the `stream` field in a state-change notification. */
 #define NOTIF_FIELD_STREAM         0x01
 
@@ -355,9 +363,6 @@ int handle_purpose(notif_sub_t *sub, const struct lyd_node *node, sr_change_oper
 /**
  * @brief Handle a change to the `transport` leaf of a subscription.
  *
- * On create/modify, duplicates the new transport identity-ref string. On delete,
- * frees it. Marks the subscription as modified.
- *
  * @param[in,out] sub Subscription being modified.
  * @param[in] node The YANG `transport` leaf node.
  * @param[in] op Sysrepo change operation.
@@ -641,6 +646,25 @@ int notif_receiver_backoff_reconnect(notifd_ctx_t *notifd_ctx, notif_receiver_t 
  * @return ::SR_ERR_OK on success, error code on failure.
  */
 int notif_receiver_reconnect(notifd_ctx_t *notifd_ctx, notif_sub_t *sub, notif_receiver_t *receiver, notif_receiver_inst_t *new_inst);
+
+/**
+ * @brief Encode a YANG notification into an RFC 5277 notification message.
+ *
+ * Wraps the given notification data tree in the RFC 5277 <notification> envelope
+ * (with the mandatory <eventTime> child set from @p ts) and serializes it in the
+ * requested encoding. For XML the envelope is the RFC 5277 XML structure; for
+ * JSON it is the RFC 8040 Section 6.4 JSON mapping of that same structure.
+ * CBOR encoding is not supported.
+ *
+ * @param[in] notif Notification data tree to wrap and encode.
+ * @param[in] ts Event timestamp for <eventTime>, or NULL for the current time.
+ * @param[in] encoding Encoding format (XML, JSON, or UNSET which defaults to JSON; CBOR not supported).
+ * @param[out] data Encoded message (caller must free).
+ * @param[out] data_len Length of encoded message.
+ * @return ::SR_ERR_OK on success, ::SR_ERR_UNSUPPORTED for CBOR, other error codes on failure.
+ */
+int notif_rfc5277_encode(const struct lyd_node *notif, const struct timespec *ts,
+        notif_encoding_t encoding, char **data, size_t *data_len);
 
 /**
  * @brief Send a single notification to a specific receiver over its transport.

--- a/src/executables/sysrepo-notifd/notifd_common.h
+++ b/src/executables/sysrepo-notifd/notifd_common.h
@@ -40,6 +40,18 @@ extern const notif_transport_ops_t udp_transport_ops;
 /** @brief Bitmask: include the `replay-start-time` field in a state-change notification. */
 #define NOTIF_FIELD_REPLAY_START   0x08
 
+/** @brief Bitmask: include the `transport` field in a state-change notification. */
+#define NOTIF_FIELD_TRANSPORT      0x10
+
+/** @brief Bitmask: include the `encoding` field in a state-change notification. */
+#define NOTIF_FIELD_ENCODING       0x20
+
+/** @brief Bitmask: include the `purpose` field in a state-change notification. */
+#define NOTIF_FIELD_PURPOSE         0x40
+
+/** @brief Bitmask: include the `stream-filter-name` field in a state-change notification. */
+#define NOTIF_FIELD_FILTER_REF     0x80
+
 /*
  * ---------------------------------------------------------------------------
  * Functions from notifd_config.c
@@ -341,6 +353,19 @@ int handle_configured_replay(notifd_ctx_t *notifd_ctx, notif_sub_t *sub, const s
 int handle_purpose(notif_sub_t *sub, const struct lyd_node *node, sr_change_oper_t op);
 
 /**
+ * @brief Handle a change to the `transport` leaf of a subscription.
+ *
+ * On create/modify, duplicates the new transport identity-ref string. On delete,
+ * frees it. Marks the subscription as modified.
+ *
+ * @param[in,out] sub Subscription being modified.
+ * @param[in] node The YANG `transport` leaf node.
+ * @param[in] op Sysrepo change operation.
+ * @return ::SR_ERR_OK on success, ::SR_ERR_NO_MEMORY on allocation failure.
+ */
+int handle_transport(notif_sub_t *sub, const struct lyd_node *node, sr_change_oper_t op);
+
+/**
  * @brief Handle a change to the `source-address` leaf of a subscription.
  *
  * On create/modify/delete, updates the local address and reconnects ALL
@@ -504,7 +529,8 @@ int timespec_cmp(const struct timespec *ts1, const struct timespec *ts2);
 /**
  * @brief Send a `subscription-started` notification to one or all receivers.
  *
- * Includes stream, xpath-filter, stop-time, and replay-start-time fields.
+ * Includes stream, filter (stream-filter-name or stream-xpath-filter), stop-time,
+ * replay-start-time, transport, encoding, and purpose fields.
  * Does not skip inactive receivers -- send failures are fatal.
  *
  * @param[in] notifd_ctx Daemon context.
@@ -530,7 +556,8 @@ int subscription_terminated_notif_send(notifd_ctx_t *notifd_ctx, notif_sub_t *su
 /**
  * @brief Send a `subscription-modified` notification to one or all receivers.
  *
- * Includes stream, xpath-filter, stop-time, and replay-start-time fields.
+ * Includes stream, filter (stream-filter-name or stream-xpath-filter), stop-time,
+ * replay-start-time, transport, encoding, and purpose fields.
  * Skips inactive receivers silently.
  *
  * @param[in] notifd_ctx Daemon context.

--- a/src/executables/sysrepo-notifd/notifd_config.c
+++ b/src/executables/sysrepo-notifd/notifd_config.c
@@ -605,6 +605,7 @@ int
 handle_encoding(notif_sub_t *sub, const struct lyd_node *node, sr_change_oper_t op)
 {
     int rc = SR_ERR_OK;
+    notif_receiver_t *receiver;
 
     /* optional leaf, need to handle all but move */
     if ((op == SR_OP_CREATED) || (op == SR_OP_MODIFIED)) {
@@ -618,6 +619,11 @@ handle_encoding(notif_sub_t *sub, const struct lyd_node *node, sr_change_oper_t 
     }
 
     if ((op == SR_OP_CREATED) || (op == SR_OP_MODIFIED) || (op == SR_OP_DELETED)) {
+        /* propagate the new encoding to all receivers */
+        LY_ARRAY_FOR(sub->receivers, notif_receiver_t, receiver) {
+            receiver->cb_data.encoding = sub->encoding;
+        }
+
         /* mark sub as modified so we know to send subscription-modified notification */
         sub->modified = 1;
     }
@@ -719,6 +725,39 @@ handle_purpose(notif_sub_t *sub, const struct lyd_node *node, sr_change_oper_t o
         /* clear purpose */
         free(sub->purpose);
         sub->purpose = NULL;
+    }
+
+    if ((op == SR_OP_CREATED) || (op == SR_OP_MODIFIED) || (op == SR_OP_DELETED)) {
+        /* mark sub as modified so we know to send subscription-modified notification */
+        sub->modified = 1;
+    }
+
+cleanup:
+    if (rc) {
+        sub_invalidate(sub, NULL);
+    }
+    return rc;
+}
+
+int
+handle_transport(notif_sub_t *sub, const struct lyd_node *node, sr_change_oper_t op)
+{
+    int rc = SR_ERR_OK;
+
+    /* mandatory leaf, need to handle all but move */
+    if ((op == SR_OP_CREATED) || (op == SR_OP_MODIFIED)) {
+        /* switch to the new value */
+        free(sub->transport);
+        sub->transport = strdup(lyd_get_value(node));
+        if (!sub->transport) {
+            rc = SR_ERR_NO_MEMORY;
+            ERRMEM;
+            goto cleanup;
+        }
+    } else if (op == SR_OP_DELETED) {
+        /* clear transport */
+        free(sub->transport);
+        sub->transport = NULL;
     }
 
     if ((op == SR_OP_CREATED) || (op == SR_OP_MODIFIED) || (op == SR_OP_DELETED)) {
@@ -960,6 +999,8 @@ subscription_from_node(notifd_ctx_t *notifd_ctx, const struct lyd_node *node, no
         rc = SR_ERR_UNSUPPORTED;
         goto cleanup;
     }
+    sub->transport = strdup(lyd_get_value(n));
+    CHECK_ERRMEM_GOTO(sub->transport, rc, cleanup);
 
     /* purpose */
     get_descendant_optional(node, "purpose", &n);
@@ -1057,6 +1098,7 @@ subscription_destroy(notifd_ctx_t *notifd_ctx, notif_sub_t *sub)
     free(sub->stream);
     free(sub->xpath_filter);
     free(sub->filter_ref);
+    free(sub->transport);
     free(sub->purpose);
     free(sub->local_address);
     for (i = LY_ARRAY_COUNT(sub->receivers); i > 0; i--) {

--- a/src/executables/sysrepo-notifd/notifd_runtime.c
+++ b/src/executables/sysrepo-notifd/notifd_runtime.c
@@ -69,6 +69,10 @@ subscription_state_change_notif_new(const struct ly_ctx *ly_ctx, notif_sub_t *su
     char *id_str = NULL, *stop_time_str = NULL, *start_time_str = NULL;
     struct timespec *start_time, *stop_time;
     const char *encoding_str = NULL;
+    notif_encoding_t encoding;
+    const notif_transport_ops_t *ops = NULL;
+    const struct lys_module *mod = NULL;
+    const char *feat_name = NULL;
 
     *notif = NULL;
 
@@ -150,21 +154,35 @@ subscription_state_change_notif_new(const struct ly_ctx *ly_ctx, notif_sub_t *su
     }
 
     /* encoding */
-    if ((fields & NOTIF_FIELD_ENCODING) && (sub->encoding != NOTIF_ENCODING_UNSET)) {
-        switch (sub->encoding) {
+    if (fields & NOTIF_FIELD_ENCODING) {
+        /* resolve the encoding, defaulting to the transport's default if not explicitly configured */
+        encoding = sub->encoding;
+        if (encoding == NOTIF_ENCODING_UNSET) {
+            ops = notif_transport_find_by_identity(sub->transport);
+            if (ops && ops->default_encoding) {
+                encoding = ops->default_encoding();
+            }
+        }
+        switch (encoding) {
         case NOTIF_ENCODING_XML:
             encoding_str = "ietf-subscribed-notifications:encode-xml";
+            feat_name = "encode-xml";
             break;
         case NOTIF_ENCODING_JSON:
             encoding_str = "ietf-subscribed-notifications:encode-json";
+            feat_name = "encode-json";
             break;
         default:
             break;
         }
+        /* only include the encoding field if the corresponding feature is enabled */
         if (encoding_str) {
-            if (lyd_new_path(tree, ly_ctx, "encoding", encoding_str, 0, NULL)) {
-                rc = SR_ERR_LY;
-                goto cleanup;
+            mod = ly_ctx_get_module_implemented(ly_ctx, "ietf-subscribed-notifications");
+            if (mod && (lys_feature_value(mod, feat_name) == LY_SUCCESS)) {
+                if (lyd_new_path(tree, ly_ctx, "encoding", encoding_str, 0, NULL)) {
+                    rc = SR_ERR_LY;
+                    goto cleanup;
+                }
             }
         }
     }
@@ -382,7 +400,7 @@ int
 notif_receiver_backoff_reconnect(notifd_ctx_t *notifd_ctx, notif_receiver_t *receiver)
 {
     int rc = SR_ERR_OK;
-    struct timespec now;
+    struct timespec now, event_ts;
     uint32_t backoff_sec, shift;
     time_t elapsed;
     const struct ly_ctx *ly_ctx;
@@ -442,8 +460,9 @@ notif_receiver_backoff_reconnect(notifd_ctx_t *notifd_ctx, notif_receiver_t *rec
     }
 
     /* send the notification directly via transport */
+    clock_gettime(CLOCK_REALTIME, &event_ts);
     if (receiver->ops) {
-        rc = receiver->ops->send(receiver, receiver->inst->transport_config, start_notif, &now, receiver->cb_data.encoding);
+        rc = receiver->ops->send(receiver, receiver->inst->transport_config, start_notif, &event_ts, receiver->cb_data.encoding);
     } else {
         SRNTF_LOG_ERR("No transport ops for receiver \"%s\".", receiver->name);
         rc = SR_ERR_UNSUPPORTED;
@@ -507,8 +526,8 @@ notif_receiver_send(notifd_ctx_t *UNUSED(notifd_ctx), notif_receiver_t *receiver
     }
 
     if (!timestamp) {
-        /* get the current time */
-        clock_gettime(COMPAT_CLOCK_ID, &ts);
+        /* get the current wall-clock time for the event timestamp */
+        clock_gettime(CLOCK_REALTIME, &ts);
     } else {
         /* use the provided timestamp */
         ts = *timestamp;

--- a/src/executables/sysrepo-notifd/notifd_runtime.c
+++ b/src/executables/sysrepo-notifd/notifd_runtime.c
@@ -68,6 +68,7 @@ subscription_state_change_notif_new(const struct ly_ctx *ly_ctx, notif_sub_t *su
     struct lyd_node *tree = NULL;
     char *id_str = NULL, *stop_time_str = NULL, *start_time_str = NULL;
     struct timespec *start_time, *stop_time;
+    const char *encoding_str = NULL;
 
     *notif = NULL;
 
@@ -95,8 +96,13 @@ subscription_state_change_notif_new(const struct ly_ctx *ly_ctx, notif_sub_t *su
         }
     }
 
-    /* xpath filter */
-    if ((fields & NOTIF_FIELD_XPATH_FILTER) && sub->xpath_filter) {
+    /* filter: stream-filter-name (by-reference) takes precedence over stream-xpath-filter (choice) */
+    if ((fields & NOTIF_FIELD_FILTER_REF) && sub->filter_ref) {
+        if (lyd_new_path(tree, ly_ctx, "stream-filter-name", sub->filter_ref, 0, NULL)) {
+            rc = SR_ERR_LY;
+            goto cleanup;
+        }
+    } else if ((fields & NOTIF_FIELD_XPATH_FILTER) && sub->xpath_filter) {
         if (lyd_new_path(tree, ly_ctx, "stream-xpath-filter", sub->xpath_filter, 0, NULL)) {
             rc = SR_ERR_LY;
             goto cleanup;
@@ -135,6 +141,42 @@ subscription_state_change_notif_new(const struct ly_ctx *ly_ctx, notif_sub_t *su
         }
     }
 
+    /* transport */
+    if ((fields & NOTIF_FIELD_TRANSPORT) && sub->transport) {
+        if (lyd_new_path(tree, ly_ctx, "transport", sub->transport, 0, NULL)) {
+            rc = SR_ERR_LY;
+            goto cleanup;
+        }
+    }
+
+    /* encoding */
+    if ((fields & NOTIF_FIELD_ENCODING) && (sub->encoding != NOTIF_ENCODING_UNSET)) {
+        switch (sub->encoding) {
+        case NOTIF_ENCODING_XML:
+            encoding_str = "ietf-subscribed-notifications:encode-xml";
+            break;
+        case NOTIF_ENCODING_JSON:
+            encoding_str = "ietf-subscribed-notifications:encode-json";
+            break;
+        default:
+            break;
+        }
+        if (encoding_str) {
+            if (lyd_new_path(tree, ly_ctx, "encoding", encoding_str, 0, NULL)) {
+                rc = SR_ERR_LY;
+                goto cleanup;
+            }
+        }
+    }
+
+    /* purpose */
+    if ((fields & NOTIF_FIELD_PURPOSE) && sub->purpose) {
+        if (lyd_new_path(tree, ly_ctx, "purpose", sub->purpose, 0, NULL)) {
+            rc = SR_ERR_LY;
+            goto cleanup;
+        }
+    }
+
     /* reason */
     if (reason) {
         if (lyd_new_path(tree, ly_ctx, "reason", reason, 0, NULL)) {
@@ -159,7 +201,8 @@ subscription_started_notif_new(const struct ly_ctx *ly_ctx, notif_sub_t *sub, st
 {
     return subscription_state_change_notif_new(ly_ctx, sub,
             "/ietf-subscribed-notifications:subscription-started",
-            NOTIF_FIELD_STREAM | NOTIF_FIELD_XPATH_FILTER | NOTIF_FIELD_STOP_TIME | NOTIF_FIELD_REPLAY_START,
+            NOTIF_FIELD_STREAM | NOTIF_FIELD_XPATH_FILTER | NOTIF_FIELD_STOP_TIME | NOTIF_FIELD_REPLAY_START |
+            NOTIF_FIELD_TRANSPORT | NOTIF_FIELD_ENCODING | NOTIF_FIELD_PURPOSE | NOTIF_FIELD_FILTER_REF,
             NULL, notif);
 }
 
@@ -178,7 +221,8 @@ subscription_modified_notif_new(const struct ly_ctx *ly_ctx, notif_sub_t *sub, s
 {
     return subscription_state_change_notif_new(ly_ctx, sub,
             "/ietf-subscribed-notifications:subscription-modified",
-            NOTIF_FIELD_STREAM | NOTIF_FIELD_XPATH_FILTER | NOTIF_FIELD_STOP_TIME | NOTIF_FIELD_REPLAY_START,
+            NOTIF_FIELD_STREAM | NOTIF_FIELD_XPATH_FILTER | NOTIF_FIELD_STOP_TIME | NOTIF_FIELD_REPLAY_START |
+            NOTIF_FIELD_TRANSPORT | NOTIF_FIELD_ENCODING | NOTIF_FIELD_PURPOSE | NOTIF_FIELD_FILTER_REF,
             NULL, notif);
 }
 
@@ -252,7 +296,8 @@ subscription_started_notif_send(notifd_ctx_t *notifd_ctx, notif_sub_t *sub, noti
 {
     return subscription_state_change_notif_send(notifd_ctx, sub, receiver,
             "/ietf-subscribed-notifications:subscription-started",
-            NOTIF_FIELD_STREAM | NOTIF_FIELD_XPATH_FILTER | NOTIF_FIELD_STOP_TIME | NOTIF_FIELD_REPLAY_START,
+            NOTIF_FIELD_STREAM | NOTIF_FIELD_XPATH_FILTER | NOTIF_FIELD_STOP_TIME | NOTIF_FIELD_REPLAY_START |
+            NOTIF_FIELD_TRANSPORT | NOTIF_FIELD_ENCODING | NOTIF_FIELD_PURPOSE | NOTIF_FIELD_FILTER_REF,
             NULL, "subscription-started", 0);
 }
 
@@ -270,7 +315,8 @@ subscription_modified_notif_send(notifd_ctx_t *notifd_ctx, notif_sub_t *sub, not
 {
     return subscription_state_change_notif_send(notifd_ctx, sub, receiver,
             "/ietf-subscribed-notifications:subscription-modified",
-            NOTIF_FIELD_STREAM | NOTIF_FIELD_XPATH_FILTER | NOTIF_FIELD_STOP_TIME | NOTIF_FIELD_REPLAY_START,
+            NOTIF_FIELD_STREAM | NOTIF_FIELD_XPATH_FILTER | NOTIF_FIELD_STOP_TIME | NOTIF_FIELD_REPLAY_START |
+            NOTIF_FIELD_TRANSPORT | NOTIF_FIELD_ENCODING | NOTIF_FIELD_PURPOSE | NOTIF_FIELD_FILTER_REF,
             NULL, "subscription-modified", 1);
 }
 

--- a/src/executables/sysrepo-notifd/notifd_runtime.c
+++ b/src/executables/sysrepo-notifd/notifd_runtime.c
@@ -68,11 +68,10 @@ subscription_state_change_notif_new(const struct ly_ctx *ly_ctx, notif_sub_t *su
     struct lyd_node *tree = NULL;
     char *id_str = NULL, *stop_time_str = NULL, *start_time_str = NULL;
     struct timespec *start_time, *stop_time;
-    const char *encoding_str = NULL;
+    const char *encoding_str = NULL, *feat_name = NULL;
     notif_encoding_t encoding;
     const notif_transport_ops_t *ops = NULL;
     const struct lys_module *mod = NULL;
-    const char *feat_name = NULL;
 
     *notif = NULL;
 
@@ -100,7 +99,7 @@ subscription_state_change_notif_new(const struct ly_ctx *ly_ctx, notif_sub_t *su
         }
     }
 
-    /* filter: stream-filter-name (by-reference) takes precedence over stream-xpath-filter (choice) */
+    /* filter: stream-filter-name (by-reference) or stream-xpath-filter (choice) */
     if ((fields & NOTIF_FIELD_FILTER_REF) && sub->filter_ref) {
         if (lyd_new_path(tree, ly_ctx, "stream-filter-name", sub->filter_ref, 0, NULL)) {
             rc = SR_ERR_LY;

--- a/src/executables/sysrepo-notifd/notifd_udp.c
+++ b/src/executables/sysrepo-notifd/notifd_udp.c
@@ -191,31 +191,22 @@ udp_notif_seg_opt_build(uint8_t *opt, uint16_t segment_num, int is_last)
 
 int
 notif_rfc5277_encode(const struct lyd_node *notif, const struct timespec *ts,
-        notif_encoding_t encoding, char **data, size_t *data_len)
+        notif_encoding_t encoding, char **data, uint32_t *data_len)
 {
     int rc = SR_ERR_OK, inner_len;
-    struct timespec localts;
-    const struct timespec *ets;
     char *datetime = NULL, *inner = NULL, *json_end;
     LYD_FORMAT format;
 
     *data = NULL;
     *data_len = 0;
 
-    if (!notif) {
+    if (!notif || !ts) {
         SRNTF_LOG_ERR("Invalid arguments to encode notification.");
         return SR_ERR_INVAL_ARG;
     }
 
-    /* determine the event timestamp, defaulting to the current wall-clock time */
-    ets = ts;
-    if (!ets) {
-        clock_gettime(CLOCK_REALTIME, &localts);
-        ets = &localts;
-    }
-
     /* format eventTime as a YANG date-and-time string */
-    if (ly_time_ts2str(ets, &datetime)) {
+    if (ly_time_ts2str(ts, &datetime)) {
         SRNTF_LOG_ERR("Failed to format eventTime.");
         rc = SR_ERR_LY;
         goto cleanup;
@@ -243,7 +234,8 @@ notif_rfc5277_encode(const struct lyd_node *notif, const struct timespec *ts,
     /* serialize the inner notification data tree;
      * LYD_PRINT_SHRINK is mandatory for the JSON splice below, which assumes
      * compact output (no whitespace) so that strrchr(inner, '}') finds the
-     * true structural closing brace of the top-level object */
+     * true structural closing brace of the top-level object. Also makes the UDP payload smaller.
+     */
     if (lyd_print_mem(&inner, notif, format, LYD_PRINT_SHRINK)) {
         SRNTF_LOG_ERR("Failed to encode notification.");
         rc = SR_ERR_LY;
@@ -278,7 +270,7 @@ notif_rfc5277_encode(const struct lyd_node *notif, const struct timespec *ts,
         }
     }
 
-    *data_len = strlen(*data);
+    *data_len = (uint32_t)strlen(*data);
 
 cleanup:
     free(datetime);
@@ -295,7 +287,7 @@ cleanup:
  * @return SR_ERR_OK on success, error code on failure.
  */
 static int
-udp_notif_segment_send(notif_receiver_t *recv, const uint8_t *buf, size_t len)
+udp_notif_segment_send(notif_receiver_t *recv, const uint8_t *buf, uint32_t len)
 {
     udp_conn_ctx_t *conn;
     ssize_t sent;
@@ -311,8 +303,8 @@ udp_notif_segment_send(notif_receiver_t *recv, const uint8_t *buf, size_t len)
         return SR_ERR_SYS;
     }
 
-    if ((size_t)sent != len) {
-        SRNTF_LOG_ERR("Incomplete UDP-Notif send to receiver \"%s\": sent %zd of %zu bytes.", recv->name, sent, len);
+    if ((uint32_t)sent != len) {
+        SRNTF_LOG_ERR("Incomplete UDP-Notif send to receiver \"%s\": sent %zd of %" PRIu32 " bytes.", recv->name, sent, len);
         return SR_ERR_SYS;
     }
 
@@ -332,13 +324,12 @@ udp_notif_segment_send(notif_receiver_t *recv, const uint8_t *buf, size_t len)
  */
 static int
 udp_notif_send_unsegmented(notif_receiver_t *recv, udp_notif_receiver_t *udp_recv, udp_notif_media_type_t media_type,
-        const char *payload, size_t payload_len, uint32_t message_id)
+        const char *payload, uint32_t payload_len, uint32_t message_id)
 {
     int rc;
-    uint8_t *buf = NULL;
-    size_t buf_len;
-    uint8_t header_len = UDP_NOTIF_HDR_SIZE;
+    uint8_t *buf = NULL, header_len = UDP_NOTIF_HDR_SIZE;
     uint16_t message_len;
+    uint32_t buf_len;
 
     buf_len = header_len + payload_len;
     message_len = (uint16_t)buf_len;
@@ -374,16 +365,13 @@ udp_notif_send_unsegmented(notif_receiver_t *recv, udp_notif_receiver_t *udp_rec
  */
 static int
 udp_notif_send_segmented(notif_receiver_t *recv, udp_notif_receiver_t *udp_recv, udp_notif_media_type_t media_type,
-        const char *payload, size_t payload_len, uint32_t message_id, uint16_t max_segment_size)
+        const char *payload, uint32_t payload_len, uint32_t message_id, uint16_t max_segment_size)
 {
     int rc = SR_ERR_OK;
     uint8_t *buf = NULL;
-    size_t buf_len;
+    uint32_t buf_len, max_payload_per_segment, offset = 0, chunk_len;
     uint8_t header_len = UDP_NOTIF_HDR_SIZE + UDP_NOTIF_SEG_OPT_SIZE;
-    size_t max_payload_per_segment;
-    size_t offset = 0;
     uint16_t segment_num = 0;
-    size_t chunk_len;
     int is_last;
 
     /* calculate max payload per segment */
@@ -651,11 +639,9 @@ udp_transport_send_cb(notif_receiver_t *recv, void *cfg,
 {
     int rc;
     char *payload = NULL;
-    size_t payload_len;
+    uint32_t payload_len, message_id, total_msg_len;
     udp_notif_media_type_t media_type;
-    uint32_t message_id;
     uint16_t max_segment_size;
-    size_t total_msg_len;
     udp_notif_receiver_t *udp_recv = (udp_notif_receiver_t *)cfg;
     udp_conn_ctx_t *conn;
 
@@ -704,7 +690,7 @@ udp_transport_send_cb(notif_receiver_t *recv, void *cfg,
         rc = udp_notif_send_segmented(recv, udp_recv, media_type, payload, payload_len, message_id, max_segment_size);
     } else {
         /* message too large but segmentation disabled */
-        SRNTF_LOG_ERR("Notification message too large (%zu bytes) and segmentation is disabled.",
+        SRNTF_LOG_ERR("Notification message too large (%" PRIu32 " bytes) and segmentation is disabled.",
                 payload_len);
         rc = SR_ERR_INVAL_ARG;
         goto cleanup;

--- a/src/executables/sysrepo-notifd/notifd_udp.c
+++ b/src/executables/sysrepo-notifd/notifd_udp.c
@@ -189,24 +189,39 @@ udp_notif_seg_opt_build(uint8_t *opt, uint16_t segment_num, int is_last)
     opt[3] = seg_field & 0xFF;
 }
 
-/**
- * @brief Encode a notification to the specified format.
- *
- * @param[in] notif Notification data tree.
- * @param[in] encoding Encoding format.
- * @param[out] data Encoded data (caller must free).
- * @param[out] data_len Length of encoded data.
- * @return SR_ERR_OK on success, error code on failure.
- */
-static int
-notif_encode(const struct lyd_node *notif, notif_encoding_t encoding, char **data, size_t *data_len)
+int
+notif_rfc5277_encode(const struct lyd_node *notif, const struct timespec *ts,
+        notif_encoding_t encoding, char **data, size_t *data_len)
 {
+    int rc = SR_ERR_OK, inner_len;
+    struct timespec localts;
+    const struct timespec *ets;
+    char *datetime = NULL, *inner = NULL, *json_end;
     LYD_FORMAT format;
-    uint32_t print_flags = LYD_PRINT_SHRINK;
 
     *data = NULL;
     *data_len = 0;
 
+    if (!notif) {
+        SRNTF_LOG_ERR("Invalid arguments to encode notification.");
+        return SR_ERR_INVAL_ARG;
+    }
+
+    /* determine the event timestamp, defaulting to the current wall-clock time */
+    ets = ts;
+    if (!ets) {
+        clock_gettime(CLOCK_REALTIME, &localts);
+        ets = &localts;
+    }
+
+    /* format eventTime as a YANG date-and-time string */
+    if (ly_time_ts2str(ets, &datetime)) {
+        SRNTF_LOG_ERR("Failed to format eventTime.");
+        rc = SR_ERR_LY;
+        goto cleanup;
+    }
+
+    /* select the encoding format */
     switch (encoding) {
     case NOTIF_ENCODING_XML:
         format = LYD_XML;
@@ -216,21 +231,59 @@ notif_encode(const struct lyd_node *notif, notif_encoding_t encoding, char **dat
         format = LYD_JSON;
         break;
     case NOTIF_ENCODING_CBOR:
-        /* TODO: CBOR encoding not yet supported */
         SRNTF_LOG_ERR("CBOR encoding is not yet implemented.");
-        return SR_ERR_UNSUPPORTED;
+        rc = SR_ERR_UNSUPPORTED;
+        goto cleanup;
     default:
         SRNTF_LOG_ERR("Unknown encoding type %d.", encoding);
-        return SR_ERR_INVAL_ARG;
+        rc = SR_ERR_INVAL_ARG;
+        goto cleanup;
     }
 
-    if (lyd_print_mem(data, notif, format, print_flags)) {
+    /* serialize the inner notification data tree;
+     * LYD_PRINT_SHRINK is mandatory for the JSON splice below, which assumes
+     * compact output (no whitespace) so that strrchr(inner, '}') finds the
+     * true structural closing brace of the top-level object */
+    if (lyd_print_mem(&inner, notif, format, LYD_PRINT_SHRINK)) {
         SRNTF_LOG_ERR("Failed to encode notification.");
-        return SR_ERR_LY;
+        rc = SR_ERR_LY;
+        goto cleanup;
+    }
+
+    /* wrap the inner notification in the RFC 5277 <notification> envelope */
+    if (format == LYD_XML) {
+        if (asprintf(data, "<notification xmlns=\"%s\"><eventTime>%s</eventTime>%s</notification>",
+                NOTIFD_NOTIF_XML_NS, datetime, inner) == -1) {
+            *data = NULL;
+            rc = SR_ERR_NO_MEMORY;
+            ERRMEM;
+            goto cleanup;
+        }
+    } else {
+        /* JSON: inner is {"module:notification":{...}}, splice it without the outer braces */
+        json_end = strrchr(inner, '}');
+        if (!json_end || (json_end == inner)) {
+            SRNTF_LOG_ERR("Invalid JSON notification encoding.");
+            rc = SR_ERR_INTERNAL;
+            goto cleanup;
+        }
+        /* length of the inner content excluding the outer braces */
+        inner_len = (int)(json_end - inner - 1);
+        if (asprintf(data, "{\"%s:notification\":{\"eventTime\":\"%s\",%.*s}}",
+                NOTIFD_NOTIF_JSON_MODULE, datetime, inner_len, inner + 1) == -1) {
+            *data = NULL;
+            rc = SR_ERR_NO_MEMORY;
+            ERRMEM;
+            goto cleanup;
+        }
     }
 
     *data_len = strlen(*data);
-    return SR_ERR_OK;
+
+cleanup:
+    free(datetime);
+    free(inner);
+    return rc;
 }
 
 /**
@@ -606,8 +659,6 @@ udp_transport_send_cb(notif_receiver_t *recv, void *cfg,
     udp_notif_receiver_t *udp_recv = (udp_notif_receiver_t *)cfg;
     udp_conn_ctx_t *conn;
 
-    (void)timestamp;
-
     if (!recv || !udp_recv || !notif) {
         return SR_ERR_INVAL_ARG;
     }
@@ -623,8 +674,8 @@ udp_transport_send_cb(notif_receiver_t *recv, void *cfg,
         return SR_ERR_OPERATION_FAILED;
     }
 
-    /* encode the notification */
-    rc = notif_encode(notif, encoding, &payload, &payload_len);
+    /* encode the notification in the RFC 5277 <notification> envelope */
+    rc = notif_rfc5277_encode(notif, timestamp, encoding, &payload, &payload_len);
     if (rc != SR_ERR_OK) {
         goto cleanup;
     }
@@ -811,6 +862,12 @@ udp_transport_config_validate_cb(const struct lyd_node *UNUSED(node))
     return SR_ERR_OK;
 }
 
+static notif_encoding_t
+udp_transport_default_encoding_cb(void)
+{
+    return NOTIF_ENCODING_JSON;
+}
+
 /*
  * ---------------------------------------------------------------------------
  * UDP transport ops vtable definition
@@ -830,4 +887,5 @@ const notif_transport_ops_t udp_transport_ops = {
     .config_change = udp_transport_config_change_cb,
     .config_destroy = udp_transport_config_destroy_cb,
     .config_validate = udp_transport_config_validate_cb,
+    .default_encoding = udp_transport_default_encoding_cb,
 };

--- a/tests/test_notifd.c
+++ b/tests/test_notifd.c
@@ -789,7 +789,7 @@ install_test_modules(sr_conn_ctx_t *conn)
         TESTS_SRC_DIR "/files/test.yang",
         NULL
     };
-    const char *sub_ntf_feats[] = {"configured", "xpath", "replay", "subtree", NULL};
+    const char *sub_ntf_feats[] = {"configured", "xpath", "replay", "subtree", "encode-xml", "encode-json", NULL};
     const char **features[] = {
         NULL, NULL, NULL, NULL, NULL,  /* interfaces, iana-if-type, ip, network-instance, restconf */
         sub_ntf_feats,                 /* ietf-subscribed-notifications */
@@ -1594,6 +1594,149 @@ test_subscription_started(void **state)
     lyd_free_all(notif);
 
     cleanup_sub(st->sess, 1);
+}
+
+/**
+ * @brief Test: Verify subscription-started notification contains all required fields.
+ *
+ * Creates a subscription with stream, transport, encoding, purpose, and
+ * stream-xpath-filter, then verifies each field is present in the
+ * subscription-started notification.
+ */
+static void
+test_subscription_started_fields(void **state)
+{
+    struct state *st = *state;
+    struct lyd_node *notif = NULL, *node = NULL;
+    char path[512];
+    int ret;
+
+    TLOG_INF("Creating receiver instance and subscription with all fields...");
+
+    ret = create_receiver_instance(st->sess, "test-recv", "127.0.0.1", st->udp_port);
+    assert_int_equal(ret, SR_ERR_OK);
+
+    ret = _set_sub_common(st->sess, 100, "NETCONF", "test-recv");
+    assert_int_equal(ret, SR_ERR_OK);
+
+    /* set xpath filter */
+    snprintf(path, sizeof(path),
+            "/ietf-subscribed-notifications:subscriptions/subscription[id='100']/stream-xpath-filter");
+    ret = sr_set_item_str(st->sess, path, "/ietf-netconf-notifications:*", NULL, 0);
+    assert_int_equal(ret, SR_ERR_OK);
+
+    /* set encoding */
+    snprintf(path, sizeof(path),
+            "/ietf-subscribed-notifications:subscriptions/subscription[id='100']/encoding");
+    ret = sr_set_item_str(st->sess, path, "ietf-subscribed-notifications:encode-xml", NULL, 0);
+    assert_int_equal(ret, SR_ERR_OK);
+
+    /* set purpose */
+    snprintf(path, sizeof(path),
+            "/ietf-subscribed-notifications:subscriptions/subscription[id='100']/purpose");
+    ret = sr_set_item_str(st->sess, path, "test-purpose", NULL, 0);
+    assert_int_equal(ret, SR_ERR_OK);
+
+    ret = sr_apply_changes(st->sess, 0);
+    assert_int_equal(ret, SR_ERR_OK);
+
+    TLOG_INF("Waiting for subscription-started notification...");
+
+    ret = receive_notification(st->udp_sockfd, st->ly_ctx, &notif, NULL);
+    assert_int_equal(ret, 0);
+    assert_non_null(notif);
+
+    /* verify it's a subscription-started notification */
+    assert_string_equal(notif->schema->name, "subscription-started");
+
+    /* verify id */
+    ret = lyd_find_path(notif, "id", 0, &node);
+    assert_int_equal(ret, LY_SUCCESS);
+    assert_non_null(node);
+    assert_int_equal(strtoul(lyd_get_value(node), NULL, 10), 100);
+
+    /* verify stream */
+    ret = lyd_find_path(notif, "stream", 0, &node);
+    assert_int_equal(ret, LY_SUCCESS);
+    assert_non_null(node);
+    assert_string_equal(lyd_get_value(node), "NETCONF");
+
+    /* verify transport */
+    ret = lyd_find_path(notif, "transport", 0, &node);
+    assert_int_equal(ret, LY_SUCCESS);
+    assert_non_null(node);
+    assert_string_equal(lyd_get_value(node), "ietf-udp-notif-transport:udp-notif");
+
+    /* verify encoding */
+    ret = lyd_find_path(notif, "encoding", 0, &node);
+    assert_int_equal(ret, LY_SUCCESS);
+    assert_non_null(node);
+    assert_string_equal(lyd_get_value(node), "ietf-subscribed-notifications:encode-xml");
+
+    /* verify purpose */
+    ret = lyd_find_path(notif, "purpose", 0, &node);
+    assert_int_equal(ret, LY_SUCCESS);
+    assert_non_null(node);
+    assert_string_equal(lyd_get_value(node), "test-purpose");
+
+    /* verify stream-xpath-filter */
+    ret = lyd_find_path(notif, "stream-xpath-filter", 0, &node);
+    assert_int_equal(ret, LY_SUCCESS);
+    assert_non_null(node);
+    assert_string_equal(lyd_get_value(node), "/ietf-netconf-notifications:*");
+
+    TLOG_INF("All subscription-started fields verified successfully");
+
+    lyd_free_all(notif);
+
+    cleanup_sub(st->sess, 100);
+}
+
+/**
+ * @brief Test: Verify subscription-started notification with stream-filter-name.
+ *
+ * Creates a subscription that references a named stream filter, then verifies
+ * the stream-filter-name field is present in the notification (instead of
+ * stream-xpath-filter).
+ */
+static void
+test_subscription_started_filter_ref(void **state)
+{
+    struct state *st = *state;
+    struct lyd_node *notif = NULL, *node = NULL;
+    int ret;
+
+    TLOG_INF("Creating receiver instance, stream filter, and filter-ref subscription...");
+
+    setup_sub_filter_ref(st->sess, st->udp_port, 101, "NETCONF", "field-test-filter",
+            "/ietf-netconf-notifications:*");
+
+    TLOG_INF("Waiting for subscription-started notification...");
+
+    ret = receive_notification(st->udp_sockfd, st->ly_ctx, &notif, NULL);
+    assert_int_equal(ret, 0);
+    assert_non_null(notif);
+
+    /* verify it's a subscription-started notification */
+    assert_string_equal(notif->schema->name, "subscription-started");
+
+    /* verify stream-filter-name is present */
+    ret = lyd_find_path(notif, "stream-filter-name", 0, &node);
+    assert_int_equal(ret, LY_SUCCESS);
+    assert_non_null(node);
+    assert_string_equal(lyd_get_value(node), "field-test-filter");
+
+    /* verify stream-xpath-filter is NOT present (choice: by-reference takes precedence) */
+    ret = lyd_find_path(notif, "stream-xpath-filter", 0, &node);
+    assert_int_equal(ret, LY_ENOTFOUND);
+
+    TLOG_INF("stream-filter-name verified successfully");
+
+    lyd_free_all(notif);
+
+    cleanup_sub(st->sess, 101);
+    delete_stream_filter(st->sess, "field-test-filter");
+    sr_apply_changes(st->sess, 0);
 }
 
 /**
@@ -3181,6 +3324,8 @@ main(void)
 {
     const struct CMUnitTest tests[] = {
         cmocka_unit_test_setup(test_subscription_started, clear_subs_notifs),
+        cmocka_unit_test_setup(test_subscription_started_fields, clear_subs_notifs),
+        cmocka_unit_test_setup(test_subscription_started_filter_ref, clear_subs_notifs),
         cmocka_unit_test_setup(test_subscription_terminated, clear_subs_notifs),
         cmocka_unit_test_setup(test_subscription_modified, clear_subs_notifs),
         cmocka_unit_test_setup(test_multiple_subscriptions, clear_subs_notifs),

--- a/tests/test_notifd.c
+++ b/tests/test_notifd.c
@@ -3424,6 +3424,275 @@ test_stop_time_concluded(void **state)
     cleanup_sub(st->sess, 200);
 }
 
+/**
+ * @brief Test: Verify that changing the encoding of an existing subscription
+ * takes effect on subsequent notifications.
+ *
+ * Creates a subscription with JSON encoding, triggers a notification and
+ * verifies it is received as JSON. Then modifies the encoding to XML, triggers
+ * another notification and verifies it is received as XML. This catches the
+ * bug where the receiver's cached encoding was not updated on modification.
+ */
+static void
+test_encoding_modify(void **state)
+{
+    struct state *st = *state;
+    struct lyd_node *notif = NULL;
+    udp_notif_header_t header;
+    char path[512];
+    int ret;
+
+    TLOG_INF("Creating subscription with JSON encoding...");
+
+    ret = create_receiver_instance(st->sess, "test-recv", "127.0.0.1", st->udp_port);
+    assert_int_equal(ret, SR_ERR_OK);
+
+    /* set common fields and an XPath filter that matches netconf-config-change */
+    ret = _set_sub_common(st->sess, 120, "NETCONF", "test-recv");
+    assert_int_equal(ret, SR_ERR_OK);
+
+    snprintf(path, sizeof(path),
+            "/ietf-subscribed-notifications:subscriptions/subscription[id='120']/stream-xpath-filter");
+    ret = sr_set_item_str(st->sess, path, "/ietf-netconf-notifications:netconf-config-change", NULL, 0);
+    assert_int_equal(ret, SR_ERR_OK);
+
+    /* set encoding to JSON */
+    snprintf(path, sizeof(path),
+            "/ietf-subscribed-notifications:subscriptions/subscription[id='120']/encoding");
+    ret = sr_set_item_str(st->sess, path, "ietf-subscribed-notifications:encode-json", NULL, 0);
+    assert_int_equal(ret, SR_ERR_OK);
+
+    ret = sr_apply_changes(st->sess, 0);
+    assert_int_equal(ret, SR_ERR_OK);
+
+    TLOG_INF("Waiting for subscription-started notification...");
+
+    /* receive and discard subscription-started */
+    ret = receive_specific_notification(st->udp_sockfd, st->ly_ctx,
+            "/ietf-subscribed-notifications:subscription-started", &notif, NULL);
+    assert_int_equal(ret, 0);
+    lyd_free_all(notif);
+    notif = NULL;
+
+    TLOG_INF("Triggering a notification (should be JSON)...");
+
+    /* make a config change to produce a netconf-config-change notification */
+    ret = sr_set_item_str(st->sess, "/test:test-leaf", "1", NULL, 0);
+    assert_int_equal(ret, SR_ERR_OK);
+    ret = sr_apply_changes(st->sess, 0);
+    assert_int_equal(ret, SR_ERR_OK);
+
+    /* receive the notification and verify it is JSON */
+    ret = receive_specific_notification(st->udp_sockfd, st->ly_ctx,
+            "/ietf-netconf-notifications:netconf-config-change", &notif, &header);
+    assert_int_equal(ret, 0);
+    assert_non_null(notif);
+    assert_int_equal(header.media_type, UDP_NOTIF_MT_JSON);
+    lyd_free_all(notif);
+    notif = NULL;
+
+    TLOG_INF("Modifying encoding to XML...");
+
+    /* change the encoding to XML */
+    ret = sr_set_item_str(st->sess, path, "ietf-subscribed-notifications:encode-xml", NULL, 0);
+    assert_int_equal(ret, SR_ERR_OK);
+    ret = sr_apply_changes(st->sess, 0);
+    assert_int_equal(ret, SR_ERR_OK);
+
+    TLOG_INF("Waiting for subscription-modified notification...");
+
+    /* receive and discard subscription-modified */
+    ret = receive_specific_notification(st->udp_sockfd, st->ly_ctx,
+            "/ietf-subscribed-notifications:subscription-modified", &notif, NULL);
+    assert_int_equal(ret, 0);
+    lyd_free_all(notif);
+    notif = NULL;
+
+    TLOG_INF("Triggering another notification (should be XML)...");
+
+    /* make another config change to produce a second notification */
+    ret = sr_set_item_str(st->sess, "/test:test-leaf", "2", NULL, 0);
+    assert_int_equal(ret, SR_ERR_OK);
+    ret = sr_apply_changes(st->sess, 0);
+    assert_int_equal(ret, SR_ERR_OK);
+
+    /* receive the notification and verify it is now XML */
+    ret = receive_specific_notification(st->udp_sockfd, st->ly_ctx,
+            "/ietf-netconf-notifications:netconf-config-change", &notif, &header);
+    assert_int_equal(ret, 0);
+    assert_non_null(notif);
+    assert_int_equal(header.media_type, UDP_NOTIF_MT_XML);
+
+    TLOG_INF("Encoding change took effect on subsequent notifications");
+
+    lyd_free_all(notif);
+
+    sr_delete_item(st->sess, "/test:test-leaf", 0);
+    cleanup_sub(st->sess, 120);
+}
+
+/**
+ * @brief Test: Verify transport default encoding when encoding leaf is not set.
+ *
+ * Creates a subscription without setting the encoding leaf, then verifies that
+ * the UDP transport's default encoding (JSON) is used: the UDP-Notif media type
+ * must be JSON and the subscription-started notification must carry the
+ * encoding leaf set to encode-json.
+ */
+static void
+test_default_encoding(void **state)
+{
+    struct state *st = *state;
+    struct lyd_node *notif = NULL, *node = NULL;
+    udp_notif_header_t header;
+    int ret;
+
+    TLOG_INF("Creating subscription without encoding to test transport default...");
+
+    ret = create_receiver_instance(st->sess, "test-recv", "127.0.0.1", st->udp_port);
+    assert_int_equal(ret, SR_ERR_OK);
+
+    /* set only the common fields (stream, transport, receiver-ref); no encoding */
+    ret = _set_sub_common(st->sess, 110, "NETCONF", "test-recv");
+    assert_int_equal(ret, SR_ERR_OK);
+
+    ret = sr_apply_changes(st->sess, 0);
+    assert_int_equal(ret, SR_ERR_OK);
+
+    TLOG_INF("Waiting for subscription-started notification...");
+
+    ret = receive_notification(st->udp_sockfd, st->ly_ctx, &notif, &header);
+    assert_int_equal(ret, 0);
+    assert_non_null(notif);
+
+    /* verify it's a subscription-started notification */
+    assert_string_equal(notif->schema->name, "subscription-started");
+
+    /* media type must be JSON (the UDP transport default) */
+    assert_int_equal(header.media_type, UDP_NOTIF_MT_JSON);
+
+    /* the encoding leaf must be present and set to encode-json */
+    ret = lyd_find_path(notif, "encoding", 0, &node);
+    assert_int_equal(ret, LY_SUCCESS);
+    assert_non_null(node);
+    assert_string_equal(lyd_get_value(node), "ietf-subscribed-notifications:encode-json");
+
+    TLOG_INF("Default encoding (JSON) verified successfully");
+
+    lyd_free_all(notif);
+
+    cleanup_sub(st->sess, 110);
+}
+
+/**
+ * @brief Teardown: re-enable the encode-json feature after test_encoding_feature_disabled.
+ *
+ * Runs even if the test failed on an assertion, so that subsequent test runs
+ * start with both features enabled. Must release the context reference so that
+ * sr_enable_module_feature can acquire the write lock it needs.
+ */
+static int
+re_enable_encode_json(void **state)
+{
+    struct state *st = *state;
+    int ret;
+
+    /* release context so the feature change can acquire a write lock */
+    if (st->ly_ctx) {
+        sr_release_context(st->conn);
+        st->ly_ctx = NULL;
+    }
+
+    ret = sr_enable_module_feature(st->conn, "ietf-subscribed-notifications", "encode-json");
+    (void)ret; /* best-effort; if it fails the next test run's setup will reinstall */
+
+    /* re-acquire context for the global teardown */
+    st->ly_ctx = sr_acquire_context(st->conn);
+
+    return 0;
+}
+
+/**
+ * @brief Test: Verify the encoding field is omitted when encode-json is disabled.
+ *
+ * Disables the encode-json feature, creates a subscription without an explicit
+ * encoding, then verifies that the subscription-started notification is still
+ * sent (with JSON media type, since the transport default is unaffected by the
+ * feature) but the encoding leaf is absent (the identity does not exist in the
+ * schema when the feature is off).
+ *
+ * Must be the last test in the suite because it disables a YANG feature.
+ */
+static void
+test_encoding_feature_disabled(void **state)
+{
+    struct state *st = *state;
+    struct lyd_node *notif = NULL, *node = NULL;
+    udp_notif_header_t header;
+    int ret;
+
+    TLOG_INF("Disabling encode-json feature...");
+
+    /* release the context reference so sr_disable_module_feature can acquire
+     * the write lock it needs to change the libyang context */
+    sr_release_context(st->conn);
+    st->ly_ctx = NULL;
+
+    ret = sr_disable_module_feature(st->conn, "ietf-subscribed-notifications", "encode-json");
+    assert_int_equal(ret, SR_ERR_OK);
+
+    /* re-acquire the context (now with encode-json disabled) */
+    st->ly_ctx = sr_acquire_context(st->conn);
+
+    TLOG_INF("Creating subscription without encoding (feature disabled)...");
+
+    ret = create_receiver_instance(st->sess, "test-recv", "127.0.0.1", st->udp_port);
+    assert_int_equal(ret, SR_ERR_OK);
+
+    /* no encoding leaf set; the identity encode-json does not exist now */
+    ret = _set_sub_common(st->sess, 111, "NETCONF", "test-recv");
+    assert_int_equal(ret, SR_ERR_OK);
+
+    ret = sr_apply_changes(st->sess, 0);
+    assert_int_equal(ret, SR_ERR_OK);
+
+    TLOG_INF("Waiting for subscription-started notification...");
+
+    ret = receive_notification(st->udp_sockfd, st->ly_ctx, &notif, &header);
+    assert_int_equal(ret, 0);
+    assert_non_null(notif);
+
+    /* verify it's a subscription-started notification */
+    assert_string_equal(notif->schema->name, "subscription-started");
+
+    /* media type must still be JSON (transport default, unaffected by feature) */
+    assert_int_equal(header.media_type, UDP_NOTIF_MT_JSON);
+
+    /* verify id is present (sanity check that the notification is well-formed) */
+    ret = lyd_find_path(notif, "id", 0, &node);
+    assert_int_equal(ret, LY_SUCCESS);
+    assert_non_null(node);
+    assert_int_equal(strtoul(lyd_get_value(node), NULL, 10), 111);
+
+    /* the encoding leaf must be absent: the identity does not exist in the schema */
+    ret = lyd_find_path(notif, "encoding", 0, &node);
+    assert_int_not_equal(ret, LY_SUCCESS);
+    assert_null(node);
+
+    TLOG_INF("Encoding field correctly omitted with feature disabled");
+
+    lyd_free_all(notif);
+
+    /* release context before cleanup so notifd can process the deletion */
+    sr_release_context(st->conn);
+    st->ly_ctx = NULL;
+
+    cleanup_sub(st->sess, 111);
+
+    /* re-acquire context for the teardown function */
+    st->ly_ctx = sr_acquire_context(st->conn);
+}
+
 /* MAIN */
 int
 main(void)
@@ -3458,6 +3727,10 @@ main(void)
         cmocka_unit_test_setup(test_source_address_modify, clear_subs_notifs),
         cmocka_unit_test_setup(test_receiver_instance_ref_change, clear_subs_notifs),
         cmocka_unit_test_setup(test_stop_time_concluded, clear_subs_notifs),
+        cmocka_unit_test_setup(test_default_encoding, clear_subs_notifs),
+        cmocka_unit_test_setup(test_encoding_modify, clear_subs_notifs),
+        /* test_encoding_feature_disabled must be last: it disables the encode-json feature */
+        cmocka_unit_test_setup_teardown(test_encoding_feature_disabled, clear_subs_notifs, re_enable_encode_json),
     };
 
     test_init();

--- a/tests/test_notifd.c
+++ b/tests/test_notifd.c
@@ -438,6 +438,8 @@ receive_notification_ext(int sockfd, const struct ly_ctx *ly_ctx, int timeout_ms
     size_t payload_len, reassembled_len;
     struct ly_in *in = NULL;
     LYD_FORMAT format;
+    enum lyd_type dt;
+    struct lyd_node *envp = NULL;
     pending_message_t *pending;
     char *reassembled = NULL;
     char *payload_str = NULL;
@@ -569,16 +571,20 @@ receive_next:
         goto cleanup;
     }
 
-    if (lyd_parse_op(ly_ctx, NULL, in, format, LYD_TYPE_NOTIF_YANG, 0, NULL, notif)) {
+    /* parse the RFC 5277 notification envelope; choose the parse type by encoding */
+    dt = (format == LYD_XML) ? LYD_TYPE_NOTIF_NETCONF : LYD_TYPE_NOTIF_RESTCONF;
+    if (lyd_parse_op(ly_ctx, NULL, in, format, dt, 0, &envp, notif)) {
         TLOG_ERR("Failed to parse notification: %s", ly_err_last(ly_ctx)->msg);
-        ly_in_free(in, 0);
         goto cleanup;
     }
 
-    ly_in_free(in, 0);
+    /* the envelope (with eventTime) is returned separately from the inner notification;
+     * *notif holds the inner notification for the caller to use and free */
     rc = 0;
 
 cleanup:
+    ly_in_free(in, 0);
+    lyd_free_all(envp);
     free(payload_str);
     return rc;
 }
@@ -1737,6 +1743,106 @@ test_subscription_started_filter_ref(void **state)
     cleanup_sub(st->sess, 101);
     delete_stream_filter(st->sess, "field-test-filter");
     sr_apply_changes(st->sess, 0);
+}
+
+/**
+ * @brief Test: Verify subscription-started notification with JSON encoding.
+ *
+ * Creates a subscription with encoding set to encode-json, then verifies the
+ * media type is JSON and the notification is parsed correctly through the
+ * RFC 8040 Section 6.4 JSON envelope.
+ */
+static void
+test_subscription_started_json(void **state)
+{
+    struct state *st = *state;
+    struct lyd_node *notif = NULL, *node = NULL;
+    udp_notif_header_t header;
+    char path[512];
+    int ret;
+
+    TLOG_INF("Creating receiver instance and JSON-encoded subscription...");
+
+    ret = create_receiver_instance(st->sess, "test-recv", "127.0.0.1", st->udp_port);
+    assert_int_equal(ret, SR_ERR_OK);
+
+    ret = _set_sub_common(st->sess, 102, "NETCONF", "test-recv");
+    assert_int_equal(ret, SR_ERR_OK);
+
+    /* set xpath filter */
+    snprintf(path, sizeof(path),
+            "/ietf-subscribed-notifications:subscriptions/subscription[id='102']/stream-xpath-filter");
+    ret = sr_set_item_str(st->sess, path, "/ietf-netconf-notifications:*", NULL, 0);
+    assert_int_equal(ret, SR_ERR_OK);
+
+    /* set encoding to JSON */
+    snprintf(path, sizeof(path),
+            "/ietf-subscribed-notifications:subscriptions/subscription[id='102']/encoding");
+    ret = sr_set_item_str(st->sess, path, "ietf-subscribed-notifications:encode-json", NULL, 0);
+    assert_int_equal(ret, SR_ERR_OK);
+
+    /* set purpose */
+    snprintf(path, sizeof(path),
+            "/ietf-subscribed-notifications:subscriptions/subscription[id='102']/purpose");
+    ret = sr_set_item_str(st->sess, path, "test-purpose-json", NULL, 0);
+    assert_int_equal(ret, SR_ERR_OK);
+
+    ret = sr_apply_changes(st->sess, 0);
+    assert_int_equal(ret, SR_ERR_OK);
+
+    TLOG_INF("Waiting for subscription-started notification...");
+
+    ret = receive_notification(st->udp_sockfd, st->ly_ctx, &notif, &header);
+    assert_int_equal(ret, 0);
+    assert_non_null(notif);
+
+    /* verify media type is JSON */
+    assert_int_equal(header.media_type, UDP_NOTIF_MT_JSON);
+
+    /* verify it's a subscription-started notification */
+    assert_string_equal(notif->schema->name, "subscription-started");
+
+    /* verify id */
+    ret = lyd_find_path(notif, "id", 0, &node);
+    assert_int_equal(ret, LY_SUCCESS);
+    assert_non_null(node);
+    assert_int_equal(strtoul(lyd_get_value(node), NULL, 10), 102);
+
+    /* verify stream */
+    ret = lyd_find_path(notif, "stream", 0, &node);
+    assert_int_equal(ret, LY_SUCCESS);
+    assert_non_null(node);
+    assert_string_equal(lyd_get_value(node), "NETCONF");
+
+    /* verify transport */
+    ret = lyd_find_path(notif, "transport", 0, &node);
+    assert_int_equal(ret, LY_SUCCESS);
+    assert_non_null(node);
+    assert_string_equal(lyd_get_value(node), "ietf-udp-notif-transport:udp-notif");
+
+    /* verify encoding */
+    ret = lyd_find_path(notif, "encoding", 0, &node);
+    assert_int_equal(ret, LY_SUCCESS);
+    assert_non_null(node);
+    assert_string_equal(lyd_get_value(node), "ietf-subscribed-notifications:encode-json");
+
+    /* verify purpose */
+    ret = lyd_find_path(notif, "purpose", 0, &node);
+    assert_int_equal(ret, LY_SUCCESS);
+    assert_non_null(node);
+    assert_string_equal(lyd_get_value(node), "test-purpose-json");
+
+    /* verify stream-xpath-filter */
+    ret = lyd_find_path(notif, "stream-xpath-filter", 0, &node);
+    assert_int_equal(ret, LY_SUCCESS);
+    assert_non_null(node);
+    assert_string_equal(lyd_get_value(node), "/ietf-netconf-notifications:*");
+
+    TLOG_INF("JSON subscription-started notification verified successfully");
+
+    lyd_free_all(notif);
+
+    cleanup_sub(st->sess, 102);
 }
 
 /**
@@ -3326,6 +3432,7 @@ main(void)
         cmocka_unit_test_setup(test_subscription_started, clear_subs_notifs),
         cmocka_unit_test_setup(test_subscription_started_fields, clear_subs_notifs),
         cmocka_unit_test_setup(test_subscription_started_filter_ref, clear_subs_notifs),
+        cmocka_unit_test_setup(test_subscription_started_json, clear_subs_notifs),
         cmocka_unit_test_setup(test_subscription_terminated, clear_subs_notifs),
         cmocka_unit_test_setup(test_subscription_modified, clear_subs_notifs),
         cmocka_unit_test_setup(test_multiple_subscriptions, clear_subs_notifs),


### PR DESCRIPTION
Fix UDP notifications to use RFC 5277 envelopes and include all subscription-policy fields in state-change notifications.