### PR TITLE
3778: hm sub BUGFIX nested notification filtered by shared ancestor key

### DIFF
--- a/src/shm_sub.c
+++ b/src/shm_sub.c
@@ -4711,7 +4711,7 @@ cleanup:
 /**
  * @brief Whether a notification is valid (not filtered out) for a notif subscription.
  *
- * @param[in] input Operation input data tree.
+ * @param[in] notif Notification node (the operation node itself).
  * @param[in] xpath Full subscription XPath.
  * @return 0 if not, non-zero is it is.
  */
@@ -4719,22 +4719,44 @@ static int
 sr_shmsub_notif_listen_filter_is_valid(const struct lyd_node *notif, const char *xpath)
 {
     sr_error_info_t *err_info = NULL;
-    ly_bool result;
+    struct ly_set *set = NULL;
+    const struct lyd_node *node;
+    uint32_t i;
+    int valid = 0;
 
     if (!xpath) {
         return 1;
     }
 
-    if (lyd_eval_xpath(notif, xpath, &result)) {
-        SR_ERRINFO_INT(&err_info);
+    /* evaluate the filter on the whole notification data tree, which for a nested notification also includes
+     * its data-tree ancestors */
+    if ((err_info = sr_lyd_find_xpath(notif, xpath, &set))) {
         sr_errinfo_free(&err_info);
         return 0;
-    } else if (result) {
-        /* valid subscription */
-        return 1;
     }
 
-    return 0;
+    /* The notification passes the filter only if the notification itself, one of its descendants, or one of its
+     * ancestors is selected. A match on an unrelated node (e.g. a shared ancestor list key of a sibling instance,
+     * emitted as a separate union branch by the subtree-to-XPath conversion) must not deliver the notification. */
+    for (i = 0; !valid && (i < set->count); ++i) {
+        /* selected node is the notification or its descendant */
+        for (node = set->dnodes[i]; node; node = lyd_parent(node)) {
+            if (node == notif) {
+                valid = 1;
+                break;
+            }
+        }
+        /* selected node is an ancestor of the notification */
+        for (node = notif; !valid && node; node = lyd_parent(node)) {
+            if (node == set->dnodes[i]) {
+                valid = 1;
+                break;
+            }
+        }
+    }
+
+    ly_set_free(set, NULL);
+    return valid;
 }
 
 sr_error_info_t *


### PR DESCRIPTION
## Problem

  A **subtree filter** on a **nested notification** is delivered for every sibling list instance that shares the
  notification's ancestor list keys, instead of only the targeted instance. An equivalent **XPath filter** works
  correctly.

  Reproduced with a 3GPP-style model where a notification (`anr-notif`) lives under
  `ManagedElement[id]/GNBCUCPFunction[id]/NRCellCU[id]/attributes/pw_notification`, with several `NRCellCU`
  instances under the same CU. Subscribing (RFC 5277 `create-subscription`) with a subtree filter selecting one cell
  delivers the notification for **all** cells under that CU.

  ## Root cause

  `srsn_filter_subtree2xpath()` converts the subtree filter into a **union** of XPaths, where each ancestor list key
  becomes its own selection branch:

  ( /me:ManagedElement[id='ME1']/id
  | /me:ManagedElement[id='ME1']/g:GNBCUCPFunction[id='GNB1']/id
  | /me:ManagedElement[id='ME1']/g:GNBCUCPFunction[id='GNB1']/c:NRCellCU[id='CELL1']/id
  | .../c:NRCellCU[id='CELL1']/attributes/pw:pw_notification/anr-notif )

  `sr_shmsub_notif_listen_filter_is_valid()` (`src/shm_sub.c`) then used `lyd_eval_xpath()`, which reports a match
  when the expression selects **any** node in the notification tree. For a nested notification the tree carries the
  notification's data-tree ancestors, so the shared-ancestor-key branches (`ManagedElement[id='ME1']/id`,
  `GNBCUCPFunction[id='GNB1']/id`) match for **every** cell under the same parents — the deeper
  `NRCellCU[id='CELL1']` predicate never gets to exclude the wrong instance. An XPath filter is passed verbatim as a
  single path, so it is unaffected.

  ## Fix

  Evaluate the filter as a node set (`sr_lyd_find_xpath`) and deliver the notification only when a selected node is
  the notification itself, one of its descendants, or one of its ancestors. Matches on unrelated nodes (a sibling
  instance's ancestor key leaf) no longer trigger delivery.

  The change is **strictly more restrictive** than the previous any-node test, so it cannot introduce new deliveries
  — only remove the spurious ones. Legitimate ancestor-scoped subtree filters (e.g. "all notifications under this
  GNBCUCPFunction") still deliver, because the selected node is a genuine ancestor of the notification.

  ## Validation

  Verified against libyang using the exact union XPath produced by the conversion:

  | Notification fired on | Subscription filter | Old behavior | New behavior | Expected |
  |---|---|---|---|---|
  | target cell | target cell | deliver | deliver | deliver |
  | sibling cell (same CU) | target cell | **deliver (bug)** | filtered out | filtered out |

  ## Notes

  - Versions observed: netopeer2 v2.4.5; sysrepo v3.7.11
  - A cmocka regression test can be added under `tests/test_notif.c` on request.