### PR TITLE
sysrepo-notifd: Resolve default encoding based on enabled features

### DIFF
--- a/src/executables/sysrepo-notifd/notifd.h
+++ b/src/executables/sysrepo-notifd/notifd.h
@@ -136,11 +136,31 @@ typedef enum {
  * @brief Notification encoding type.
  */
 typedef enum {
-    NOTIF_ENCODING_UNSET = 0,   /**< not set, left to the underlying transport default */
+    NOTIF_ENCODING_UNSET = 0,   /**< not set, resolved to the underlying transport default when sending */
     NOTIF_ENCODING_XML,         /**< XML encoding */
     NOTIF_ENCODING_JSON,        /**< JSON encoding */
     NOTIF_ENCODING_CBOR         /**< CBOR encoding */
 } notif_encoding_t;
+
+/**
+ * @brief Static description of a notification encoding.
+ *
+ * Single source of truth for mapping between the internal encoding enum,
+ * its YANG identity, the module and feature that gate its availability, and
+ * whether the daemon actually implements serialization for it.
+ *
+ * The order of entries in the encoding registry (see notifd_config.c) defines
+ * the default encoding priority: the first entry has the highest priority.
+ */
+typedef struct notif_encoding_info_s {
+    notif_encoding_t encoding;      /**< internal encoding enum value */
+    const char *identity;           /**< YANG encoding identity name (e.g. "encode-xml") */
+    const char *identityref;        /**< fully qualified identityref value
+                                         (e.g. "ietf-subscribed-notifications:encode-xml") */
+    const char *module;             /**< YANG module defining the identity and the gating feature */
+    const char *feature;            /**< YANG feature gating the encoding availability */
+    int implemented;                /**< whether the daemon can serialize notifications in this encoding */
+} notif_encoding_info_t;
 
 /**
  * @brief Establish a transport connection for a notification receiver.
@@ -250,16 +270,18 @@ typedef void (*notif_transport_config_destroy_cb)(void *cfg);
 typedef int (*notif_transport_config_validate_cb)(const struct lyd_node *node);
 
 /**
- * @brief Get the default encoding for this transport.
+ * @brief Resolve the default encoding for this transport.
  *
  * Called when a subscription's encoding is not explicitly configured
- * (NOTIF_ENCODING_UNSET). Per RFC 8639, the encoding leaf description states
- * that for a configured subscription the encoding "will be the default encoding
- * for an underlying transport." Each transport must define its default.
+ * (::NOTIF_ENCODING_UNSET), in which case the `encoding` leaf description of
+ * RFC 8639 states it "will be the default encoding for an underlying transport."
+ * The transport must choose an encoding that the daemon implements and whose
+ * gating YANG feature is enabled in @p ly_ctx.
  *
- * @return The transport's default encoding.
+ * @param[in] ly_ctx libyang context used to evaluate YANG features.
+ * @return The transport's default encoding, or ::NOTIF_ENCODING_UNSET if none is usable.
  */
-typedef notif_encoding_t (*notif_transport_default_encoding_cb)(void);
+typedef notif_encoding_t (*notif_transport_default_encoding_cb)(const struct ly_ctx *ly_ctx);
 
 /**
  * @brief Transport operations vtable.
@@ -307,7 +329,8 @@ struct notif_receiver_inst_s {
 typedef struct notif_cb_data_s {
     notifd_ctx_t *ctx;          /**< main daemon context */
     notif_receiver_t *recv;     /**< receiver to send the notification to */
-    notif_encoding_t encoding;  /**< notification encoding to use for sending */
+    notif_encoding_t encoding;  /**< configured subscription encoding (::NOTIF_ENCODING_UNSET if not
+                                     configured, resolved to the transport default when sending) */
 } notif_cb_data_t;
 
 /**

--- a/src/executables/sysrepo-notifd/notifd_common.h
+++ b/src/executables/sysrepo-notifd/notifd_common.h
@@ -62,6 +62,75 @@ const notif_transport_ops_t *notif_transport_find_by_identity(const char *identi
 
 /*
  * ---------------------------------------------------------------------------
+ * Encoding registry (defined in notifd_config.c)
+ * ---------------------------------------------------------------------------
+ */
+
+/**
+ * @brief Registry of all known notification encodings, terminated by an entry
+ * with a NULL @p identity.
+ *
+ * The entry order defines the priority when resolving the default encoding:
+ * the first implemented encoding whose YANG feature is enabled wins.
+ */
+extern const notif_encoding_info_t notif_encoding_registry[];
+
+/**
+ * @brief Find the encoding registry entry for an internal encoding value.
+ *
+ * @param[in] encoding Encoding to look up.
+ * @return Registry entry, or NULL if the encoding is not in the registry.
+ */
+const notif_encoding_info_t *notif_encoding_info_find(notif_encoding_t encoding);
+
+/**
+ * @brief Find the encoding registry entry for a YANG encoding identityref.
+ *
+ * @param[in] identity Fully qualified identityref value (e.g. "ietf-subscribed-notifications:encode-xml").
+ * @return Registry entry, or NULL if the identity is not in the registry.
+ */
+const notif_encoding_info_t *notif_encoding_info_find_by_identity(const char *identity);
+
+/**
+ * @brief Check whether the YANG feature gating an encoding is enabled.
+ *
+ * @param[in] ly_ctx libyang context to evaluate the feature in.
+ * @param[in] info Encoding registry entry.
+ * @return 1 if the module is implemented and the feature is enabled, 0 otherwise.
+ */
+int notif_encoding_feature_enabled(const struct ly_ctx *ly_ctx, const notif_encoding_info_t *info);
+
+/**
+ * @brief Resolve the default notification encoding.
+ *
+ * Returns the first registry entry (registry order = priority) that is
+ * implemented by the daemon and whose gating YANG feature is enabled.
+ *
+ * @param[in] ly_ctx libyang context to evaluate the features in.
+ * @return The default encoding, or ::NOTIF_ENCODING_UNSET if none is usable.
+ */
+notif_encoding_t notif_encoding_resolve_default(const struct ly_ctx *ly_ctx);
+
+/**
+ * @brief Resolve the encoding to use for sending a notification.
+ *
+ * If @p encoding is ::NOTIF_ENCODING_UNSET, asks the transport for its default
+ * (which itself respects enabled YANG features). Then verifies that the resulting
+ * encoding is implemented by the daemon and that its gating YANG feature is
+ * enabled in @p ly_ctx. This is the single shared resolution path used both when
+ * building state-change notifications (to decide whether to include the encoding
+ * leaf) and when sending notifications (to pick the serialization format).
+ *
+ * @param[in] encoding Configured encoding, or ::NOTIF_ENCODING_UNSET to use the transport default.
+ * @param[in] ly_ctx libyang context to evaluate the features in.
+ * @param[in] ops Transport operations (used to obtain the default encoding). May be NULL.
+ * @return The resolved encoding, or ::NOTIF_ENCODING_UNSET if none is usable.
+ */
+notif_encoding_t notif_encoding_resolve(notif_encoding_t encoding, const struct ly_ctx *ly_ctx,
+        const notif_transport_ops_t *ops);
+
+/*
+ * ---------------------------------------------------------------------------
  * Functions from notifd_config.c
  * ---------------------------------------------------------------------------
  */
@@ -658,7 +727,8 @@ int notif_receiver_reconnect(notifd_ctx_t *notifd_ctx, notif_sub_t *sub, notif_r
  *
  * @param[in] notif Notification data tree to wrap and encode.
  * @param[in] ts Event timestamp for <eventTime> (mandatory).
- * @param[in] encoding Encoding format (XML, JSON, or UNSET which defaults to JSON; CBOR not supported).
+ * @param[in] encoding Encoding format, must be resolved by the caller (::NOTIF_ENCODING_UNSET
+ *            is rejected with ::SR_ERR_INVAL_ARG).
  * @param[out] data Encoded message (caller must free).
  * @param[out] data_len Length of encoded message.
  * @return ::SR_ERR_OK on success, ::SR_ERR_UNSUPPORTED for CBOR, other error codes on failure.
@@ -677,10 +747,13 @@ int notif_rfc5277_encode(const struct lyd_node *notif, const struct timespec *ts
  * @param[in] receiver Receiver to send to.
  * @param[in] notif Notification data tree to send.
  * @param[in] timestamp Event timestamp, or NULL for current time.
- * @param[in] encoding Encoding format for the notification payload.
+ * @param[in] encoding Encoding format for the notification payload. May be
+ *            ::NOTIF_ENCODING_UNSET, in which case it is resolved to the transport
+ *            default encoding before sending.
  * @return ::SR_ERR_OK on success, ::SR_ERR_INVAL_ARG if receiver or notif is NULL,
  *         ::SR_ERR_OPERATION_FAILED if the receiver is not connected or not active,
- *         ::SR_ERR_UNSUPPORTED if no transport ops available, or other error codes.
+ *         ::SR_ERR_UNSUPPORTED if no transport ops are available or no default encoding is usable,
+ *         or other error codes.
  */
 int notif_receiver_send(notifd_ctx_t *notifd_ctx, notif_receiver_t *receiver, const struct lyd_node *notif,
         const struct timespec *timestamp, notif_encoding_t encoding);

--- a/src/executables/sysrepo-notifd/notifd_config.c
+++ b/src/executables/sysrepo-notifd/notifd_config.c
@@ -99,6 +99,119 @@ notif_transport_find_by_container(const char *container_name)
 
 /*
  * ---------------------------------------------------------------------------
+ * Encoding registry
+ * ---------------------------------------------------------------------------
+ */
+
+const notif_encoding_info_t notif_encoding_registry[] = {
+    {
+        NOTIF_ENCODING_XML, "encode-xml", "ietf-subscribed-notifications:encode-xml",
+        "ietf-subscribed-notifications", "encode-xml", 1
+    },
+    {
+        NOTIF_ENCODING_JSON, "encode-json", "ietf-subscribed-notifications:encode-json",
+        "ietf-subscribed-notifications", "encode-json", 1
+    },
+    {
+        NOTIF_ENCODING_CBOR, "encode-cbor", "ietf-udp-notif-transport:encode-cbor",
+        "ietf-udp-notif-transport", "encode-cbor", 0
+    },
+    /* sentinel terminator; not findable by the lookup functions (loops terminate on NULL identity) */
+    {NOTIF_ENCODING_UNSET, NULL, NULL, NULL, NULL, 0}
+};
+
+const notif_encoding_info_t *
+notif_encoding_info_find(notif_encoding_t encoding)
+{
+    const notif_encoding_info_t *info;
+
+    for (info = notif_encoding_registry; info->identity; info++) {
+        if (info->encoding == encoding) {
+            return info;
+        }
+    }
+
+    return NULL;
+}
+
+const notif_encoding_info_t *
+notif_encoding_info_find_by_identity(const char *identity)
+{
+    const notif_encoding_info_t *info;
+
+    if (!identity) {
+        return NULL;
+    }
+
+    for (info = notif_encoding_registry; info->identity; info++) {
+        if (!strcmp(info->identityref, identity)) {
+            return info;
+        }
+    }
+
+    return NULL;
+}
+
+int
+notif_encoding_feature_enabled(const struct ly_ctx *ly_ctx, const notif_encoding_info_t *info)
+{
+    const struct lys_module *mod;
+
+    assert(ly_ctx && info);
+
+    mod = ly_ctx_get_module_implemented(ly_ctx, info->module);
+    if (!mod) {
+        return 0;
+    }
+
+    return lys_feature_value(mod, info->feature) == LY_SUCCESS ? 1 : 0;
+}
+
+notif_encoding_t
+notif_encoding_resolve_default(const struct ly_ctx *ly_ctx)
+{
+    const notif_encoding_info_t *info;
+
+    assert(ly_ctx);
+
+    for (info = notif_encoding_registry; info->identity; info++) {
+        if (!info->implemented) {
+            continue;
+        }
+        if (notif_encoding_feature_enabled(ly_ctx, info)) {
+            return info->encoding;
+        }
+    }
+
+    return NOTIF_ENCODING_UNSET;
+}
+
+notif_encoding_t
+notif_encoding_resolve(notif_encoding_t encoding, const struct ly_ctx *ly_ctx,
+        const notif_transport_ops_t *ops)
+{
+    const notif_encoding_info_t *info;
+
+    assert(ly_ctx);
+
+    /* if not explicitly configured, ask the transport for its default */
+    if (encoding == NOTIF_ENCODING_UNSET) {
+        if (ops && ops->default_encoding) {
+            encoding = ops->default_encoding(ly_ctx);
+        }
+    }
+
+    /* reject encodings that are not implemented or whose feature is disabled */
+    info = notif_encoding_info_find(encoding);
+    if (!info || !info->implemented || !notif_encoding_feature_enabled(ly_ctx, info)) {
+        return NOTIF_ENCODING_UNSET;
+    }
+
+    return encoding;
+}
+
+/*
+ * ---------------------------------------------------------------------------
  * Helpers
  * ---------------------------------------------------------------------------
  */
@@ -170,20 +283,20 @@ notif_encoding_parse(const struct lyd_node *node, notif_encoding_t *encoding)
 {
     int rc = SR_ERR_OK;
     const char *value;
+    const notif_encoding_info_t *info;
 
     *encoding = NOTIF_ENCODING_UNSET;
 
-    value = ((struct lyd_node_term *)node)->value.ident->name;
-    if (!strcmp(value, "encode-xml")) {
-        *encoding = NOTIF_ENCODING_XML;
-    } else if (!strcmp(value, "encode-json")) {
-        *encoding = NOTIF_ENCODING_JSON;
-    } else if (!strcmp(value, "encode-cbor")) {
-        SRNTF_LOG_ERR("CBOR encoding is not yet supported.");
-        rc = SR_ERR_UNSUPPORTED;
-    } else {
+    value = lyd_get_value(node);
+    info = notif_encoding_info_find_by_identity(value);
+    if (!info) {
         SRNTF_LOG_ERR("Unsupported encoding \"%s\".", value);
         rc = SR_ERR_UNSUPPORTED;
+    } else if (!info->implemented) {
+        SRNTF_LOG_ERR("Encoding \"%s\" is not supported by this implementation.", value);
+        rc = SR_ERR_UNSUPPORTED;
+    } else {
+        *encoding = info->encoding;
     }
 
     return rc;
@@ -1537,18 +1650,41 @@ handle_stream_filter(notifd_ctx_t *notifd_ctx, const struct lyd_node *node, int 
 static int
 sub_change_validate_encoding(sr_session_ctx_t *session, sr_event_t event, const struct lyd_node *node)
 {
+    int rc = SR_ERR_OK;
     const char *value;
+    const notif_encoding_info_t *info;
 
-    value = ((struct lyd_node_term *)node)->value.ident->name;
-    if (!strcmp(value, "encode-xml") || !strcmp(value, "encode-json")) {
-        return SR_ERR_OK;
-    } else if (!strcmp(value, "encode-cbor")) {
-        SRNTF_VALIDATE_ERR(session, event, SR_ERR_UNSUPPORTED, "CBOR encoding is not yet supported.");
-        return SR_ERR_UNSUPPORTED;
-    } else {
+    value = lyd_get_value(node);
+    info = notif_encoding_info_find_by_identity(value);
+    if (!info) {
         SRNTF_VALIDATE_ERR(session, event, SR_ERR_UNSUPPORTED, "Unsupported encoding \"%s\".", value);
-        return SR_ERR_UNSUPPORTED;
+        rc = SR_ERR_UNSUPPORTED;
+    } else if (!info->implemented) {
+        SRNTF_VALIDATE_ERR(session, event, SR_ERR_UNSUPPORTED,
+                "Encoding \"%s\" is not supported by this implementation.", value);
+        rc = SR_ERR_UNSUPPORTED;
+    } else if (!notif_encoding_feature_enabled(LYD_CTX(node), info)) {
+        SRNTF_VALIDATE_ERR(session, event, SR_ERR_UNSUPPORTED,
+                "Encoding \"%s\" cannot be used, feature \"%s\" is disabled in module \"%s\".",
+                value, info->feature, info->module);
+        rc = SR_ERR_UNSUPPORTED;
     }
+
+    return rc;
+}
+
+static int
+sub_change_validate_default_encoding(sr_session_ctx_t *session, sr_event_t event, const struct lyd_node *sub_node)
+{
+    int rc = SR_ERR_OK;
+
+    if (notif_encoding_resolve_default(LYD_CTX(sub_node)) == NOTIF_ENCODING_UNSET) {
+        SRNTF_VALIDATE_ERR(session, event, SR_ERR_UNSUPPORTED,
+                "No encoding configured and no supported encoding available (all encoding features are disabled).");
+        rc = SR_ERR_UNSUPPORTED;
+    }
+
+    return rc;
 }
 
 static int
@@ -1665,6 +1801,12 @@ sub_change_validate(notifd_ctx_t *notifd_ctx, sr_session_ctx_t *session, sr_even
                 rc = r;
                 goto cleanup;
             }
+        } else {
+            /* no explicit encoding, there must be a usable default */
+            if ((r = sub_change_validate_default_encoding(session, event, node))) {
+                rc = r;
+                goto cleanup;
+            }
         }
 
         /* stream must map to an existing module */
@@ -1734,11 +1876,13 @@ sub_change_validate(notifd_ctx_t *notifd_ctx, sr_session_ctx_t *session, sr_even
         goto cleanup;
     }
     while (!sr_get_change_tree_next(session, iter, &op, &node, &prev_value, &prev_list, &prev_dflt)) {
-        if ((op != SR_OP_CREATED) && (op != SR_OP_MODIFIED)) {
+        node_name = LYD_NAME(node);
+
+        /* skip non-created/modified ops, except for encoding deletion which needs default validation */
+        if ((op != SR_OP_CREATED) && (op != SR_OP_MODIFIED) &&
+                !((op == SR_OP_DELETED) && !strcmp(node_name, "encoding"))) {
             continue;
         }
-
-        node_name = LYD_NAME(node);
 
         if (!strcmp(node_name, "stream")) {
             /* stream changed - validate new stream exists */
@@ -1758,9 +1902,18 @@ sub_change_validate(notifd_ctx_t *notifd_ctx, sr_session_ctx_t *session, sr_even
                 }
             }
         } else if (!strcmp(node_name, "encoding")) {
-            if ((r = sub_change_validate_encoding(session, event, node))) {
-                rc = r;
-                goto cleanup;
+            if (op == SR_OP_DELETED) {
+                /* encoding removed, there must be a usable default */
+                if ((r = sub_change_validate_default_encoding(session, event, node))) {
+                    rc = r;
+                    goto cleanup;
+                }
+            } else {
+                /* encoding created/modified, validate the new value */
+                if ((r = sub_change_validate_encoding(session, event, node))) {
+                    rc = r;
+                    goto cleanup;
+                }
             }
         } else if (!strcmp(node_name, "stream-subtree-filter")) {
             if ((r = sub_change_validate_subtree_filter(session, event, node))) {

--- a/src/executables/sysrepo-notifd/notifd_runtime.c
+++ b/src/executables/sysrepo-notifd/notifd_runtime.c
@@ -68,10 +68,9 @@ subscription_state_change_notif_new(const struct ly_ctx *ly_ctx, notif_sub_t *su
     struct lyd_node *tree = NULL;
     char *id_str = NULL, *stop_time_str = NULL, *start_time_str = NULL;
     struct timespec *start_time, *stop_time;
-    const char *encoding_str = NULL, *feat_name = NULL;
     notif_encoding_t encoding;
     const notif_transport_ops_t *ops = NULL;
-    const struct lys_module *mod = NULL;
+    const notif_encoding_info_t *enc_info = NULL;
 
     *notif = NULL;
 
@@ -154,35 +153,18 @@ subscription_state_change_notif_new(const struct ly_ctx *ly_ctx, notif_sub_t *su
 
     /* encoding */
     if (fields & NOTIF_FIELD_ENCODING) {
-        /* resolve the encoding, defaulting to the transport's default if not explicitly configured */
-        encoding = sub->encoding;
-        if (encoding == NOTIF_ENCODING_UNSET) {
-            ops = notif_transport_find_by_identity(sub->transport);
-            if (ops && ops->default_encoding) {
-                encoding = ops->default_encoding();
-            }
+        /* resolve the encoding (shared path: transport default + feature check) */
+        ops = notif_transport_find_by_identity(sub->transport);
+        encoding = notif_encoding_resolve(sub->encoding, ly_ctx, ops);
+        enc_info = notif_encoding_info_find(encoding);
+        if (!enc_info) {
+            SRNTF_LOG_ERR("Failed to resolve encoding for subscription %" PRIu32 ".", sub->id);
+            rc = SR_ERR_UNSUPPORTED;
+            goto cleanup;
         }
-        switch (encoding) {
-        case NOTIF_ENCODING_XML:
-            encoding_str = "ietf-subscribed-notifications:encode-xml";
-            feat_name = "encode-xml";
-            break;
-        case NOTIF_ENCODING_JSON:
-            encoding_str = "ietf-subscribed-notifications:encode-json";
-            feat_name = "encode-json";
-            break;
-        default:
-            break;
-        }
-        /* only include the encoding field if the corresponding feature is enabled */
-        if (encoding_str) {
-            mod = ly_ctx_get_module_implemented(ly_ctx, "ietf-subscribed-notifications");
-            if (mod && (lys_feature_value(mod, feat_name) == LY_SUCCESS)) {
-                if (lyd_new_path(tree, ly_ctx, "encoding", encoding_str, 0, NULL)) {
-                    rc = SR_ERR_LY;
-                    goto cleanup;
-                }
-            }
+        if (lyd_new_path(tree, ly_ctx, "encoding", enc_info->identityref, 0, NULL)) {
+            rc = SR_ERR_LY;
+            goto cleanup;
         }
     }
 
@@ -458,14 +440,9 @@ notif_receiver_backoff_reconnect(notifd_ctx_t *notifd_ctx, notif_receiver_t *rec
         goto disconnect;
     }
 
-    /* send the notification directly via transport */
+    /* send the notification through the standard send path, resolving the default encoding as needed */
     clock_gettime(CLOCK_REALTIME, &event_ts);
-    if (receiver->ops) {
-        rc = receiver->ops->send(receiver, receiver->inst->transport_config, start_notif, &event_ts, receiver->cb_data.encoding);
-    } else {
-        SRNTF_LOG_ERR("No transport ops for receiver \"%s\".", receiver->name);
-        rc = SR_ERR_UNSUPPORTED;
-    }
+    rc = notif_receiver_send(notifd_ctx, receiver, start_notif, &event_ts, receiver->cb_data.encoding);
     lyd_free_all(start_notif);
     sr_session_release_context(notifd_ctx->sr_sess);
     if (rc) {
@@ -535,12 +512,21 @@ notif_receiver_send(notifd_ctx_t *UNUSED(notifd_ctx), notif_receiver_t *receiver
     SRNTF_LOG_INF("Sending notification \"%s\" to receiver \"%s\" over %s.", notif_path, receiver->name,
             receiver->ops ? receiver->ops->name : "unknown");
 
-    if (receiver->ops) {
-        rc = receiver->ops->send(receiver, receiver->inst->transport_config, notif, &ts, encoding);
-    } else {
+    if (!receiver->ops) {
         SRNTF_LOG_ERR("No transport ops for receiver \"%s\".", receiver->name);
         rc = SR_ERR_UNSUPPORTED;
+        goto cleanup;
     }
+
+    /* resolve the encoding, defaulting to the transport default and checking enabled features */
+    encoding = notif_encoding_resolve(encoding, LYD_CTX(notif), receiver->ops);
+    if (encoding == NOTIF_ENCODING_UNSET) {
+        SRNTF_LOG_ERR("No usable encoding for notification \"%s\", all encoding features are disabled.", notif_path);
+        rc = SR_ERR_UNSUPPORTED;
+        goto cleanup;
+    }
+
+    rc = receiver->ops->send(receiver, receiver->inst->transport_config, notif, &ts, encoding);
     if (rc) {
         goto cleanup;
     }

--- a/src/executables/sysrepo-notifd/notifd_udp.c
+++ b/src/executables/sysrepo-notifd/notifd_udp.c
@@ -96,24 +96,33 @@ typedef enum {
 /**
  * @brief Convert notification encoding to UDP-Notif media type.
  *
- * @param[in] encoding Notification encoding.
- * @return UDP-Notif media type value.
+ * @param[in] encoding Notification encoding, must be resolved (not ::NOTIF_ENCODING_UNSET).
+ * @param[out] media_type Set to the UDP-Notif media type value.
+ * @return SR_ERR_OK on success, error code on failure.
  */
-static udp_notif_media_type_t
-encoding_to_media_type(notif_encoding_t encoding)
+static int
+encoding_to_media_type(notif_encoding_t encoding, udp_notif_media_type_t *media_type)
 {
+    int rc = SR_ERR_OK;
+
     switch (encoding) {
     case NOTIF_ENCODING_XML:
-        return UDP_NOTIF_MT_XML;
+        *media_type = UDP_NOTIF_MT_XML;
+        break;
     case NOTIF_ENCODING_JSON:
-        return UDP_NOTIF_MT_JSON;
+        *media_type = UDP_NOTIF_MT_JSON;
+        break;
     case NOTIF_ENCODING_CBOR:
-        return UDP_NOTIF_MT_CBOR;
+        *media_type = UDP_NOTIF_MT_CBOR;
+        break;
     case NOTIF_ENCODING_UNSET:
     default:
-        /* default to JSON if not set */
-        return UDP_NOTIF_MT_JSON;
+        SRNTF_LOG_ERR("Encoding must be resolved before notification serialization.");
+        rc = SR_ERR_INVAL_ARG;
+        break;
     }
+
+    return rc;
 }
 
 /**
@@ -218,15 +227,15 @@ notif_rfc5277_encode(const struct lyd_node *notif, const struct timespec *ts,
         format = LYD_XML;
         break;
     case NOTIF_ENCODING_JSON:
-    case NOTIF_ENCODING_UNSET:
         format = LYD_JSON;
         break;
     case NOTIF_ENCODING_CBOR:
         SRNTF_LOG_ERR("CBOR encoding is not yet implemented.");
         rc = SR_ERR_UNSUPPORTED;
         goto cleanup;
+    case NOTIF_ENCODING_UNSET:
     default:
-        SRNTF_LOG_ERR("Unknown encoding type %d.", encoding);
+        SRNTF_LOG_ERR("Encoding must be resolved before notification serialization.");
         rc = SR_ERR_INVAL_ARG;
         goto cleanup;
     }
@@ -667,7 +676,9 @@ udp_transport_send_cb(notif_receiver_t *recv, void *cfg,
     }
 
     /* get media type */
-    media_type = encoding_to_media_type(encoding);
+    if ((rc = encoding_to_media_type(encoding, &media_type))) {
+        goto cleanup;
+    }
 
     /* get current message ID and increment for next message atomically */
     message_id = ATOMIC_ADD_RELAXED(udp_recv->message_id, 1);
@@ -848,10 +859,16 @@ udp_transport_config_validate_cb(const struct lyd_node *UNUSED(node))
     return SR_ERR_OK;
 }
 
+/**
+ * @brief Get the default UDP-Notif encoding, the first implemented encoding whose YANG feature is enabled.
+ *
+ * @param[in] ly_ctx libyang context used for checking enabled features.
+ * @return Default encoding or ::NOTIF_ENCODING_UNSET if none is usable.
+ */
 static notif_encoding_t
-udp_transport_default_encoding_cb(void)
+udp_transport_default_encoding_cb(const struct ly_ctx *ly_ctx)
 {
-    return NOTIF_ENCODING_JSON;
+    return notif_encoding_resolve_default(ly_ctx);
 }
 
 /*

--- a/tests/test_notifd.c
+++ b/tests/test_notifd.c
@@ -3532,12 +3532,50 @@ test_encoding_modify(void **state)
 }
 
 /**
+ * @brief Test: Configuring CBOR encoding must be rejected (not implemented).
+ *
+ * Attempts to create a subscription with the encode-cbor identity and verifies
+ * that it is rejected with an error, since CBOR serialization is not implemented
+ * by the daemon (registry entry has implemented = 0).
+ */
+static void
+test_encoding_cbor_unsupported(void **state)
+{
+    struct state *st = *state;
+    char path[512];
+    int ret;
+
+    TLOG_INF("Attempting to create subscription with CBOR encoding...");
+
+    ret = create_receiver_instance(st->sess, "test-recv", "127.0.0.1", st->udp_port);
+    assert_int_equal(ret, SR_ERR_OK);
+
+    ret = _set_sub_common(st->sess, 112, "NETCONF", "test-recv");
+    assert_int_equal(ret, SR_ERR_OK);
+
+    /* set encoding to CBOR */
+    snprintf(path, sizeof(path),
+            "/ietf-subscribed-notifications:subscriptions/subscription[id='112']/encoding");
+    ret = sr_set_item_str(st->sess, path, "ietf-udp-notif-transport:encode-cbor", NULL, 0);
+    if (ret == SR_ERR_OK) {
+        /* CBOR is not implemented, the apply must fail at validation */
+        ret = sr_apply_changes(st->sess, 0);
+    }
+    assert_int_not_equal(ret, SR_ERR_OK);
+
+    TLOG_INF("CBOR encoding correctly rejected as unsupported");
+
+    cleanup_sub(st->sess, 112);
+}
+
+/**
  * @brief Test: Verify transport default encoding when encoding leaf is not set.
  *
  * Creates a subscription without setting the encoding leaf, then verifies that
- * the UDP transport's default encoding (JSON) is used: the UDP-Notif media type
- * must be JSON and the subscription-started notification must carry the
- * encoding leaf set to encode-json.
+ * the feature-aware transport default encoding is used: the highest-priority
+ * encoding whose YANG feature is enabled (XML). The UDP-Notif media type must
+ * be XML and the subscription-started notification must carry the encoding
+ * leaf set to encode-xml.
  */
 static void
 test_default_encoding(void **state)
@@ -3568,16 +3606,16 @@ test_default_encoding(void **state)
     /* verify it's a subscription-started notification */
     assert_string_equal(notif->schema->name, "subscription-started");
 
-    /* media type must be JSON (the UDP transport default) */
-    assert_int_equal(header.media_type, UDP_NOTIF_MT_JSON);
+    /* media type must be XML (the highest-priority encoding with an enabled feature) */
+    assert_int_equal(header.media_type, UDP_NOTIF_MT_XML);
 
-    /* the encoding leaf must be present and set to encode-json */
+    /* the encoding leaf must be present and set to encode-xml */
     ret = lyd_find_path(notif, "encoding", 0, &node);
     assert_int_equal(ret, LY_SUCCESS);
     assert_non_null(node);
-    assert_string_equal(lyd_get_value(node), "ietf-subscribed-notifications:encode-json");
+    assert_string_equal(lyd_get_value(node), "ietf-subscribed-notifications:encode-xml");
 
-    TLOG_INF("Default encoding (JSON) verified successfully");
+    TLOG_INF("Default encoding (XML) verified successfully");
 
     lyd_free_all(notif);
 
@@ -3585,26 +3623,33 @@ test_default_encoding(void **state)
 }
 
 /**
- * @brief Teardown: re-enable the encode-json feature after test_encoding_feature_disabled.
+ * @brief Teardown: re-enable the encoding features after test_encoding_feature_disabled.
  *
  * Runs even if the test failed on an assertion, so that subsequent test runs
  * start with both features enabled. Must release the context reference so that
  * sr_enable_module_feature can acquire the write lock it needs.
  */
 static int
-re_enable_encode_json(void **state)
+re_enable_encoding_features(void **state)
 {
     struct state *st = *state;
     int ret;
 
-    /* release context so the feature change can acquire a write lock */
+    /* release context so the feature changes can acquire a write lock */
     if (st->ly_ctx) {
         sr_release_context(st->conn);
         st->ly_ctx = NULL;
     }
 
+    /* best-effort; if it fails the next test run's setup will reinstall */
+    ret = sr_enable_module_feature(st->conn, "ietf-subscribed-notifications", "encode-xml");
+    if (ret) {
+        TLOG_WRN("Failed to re-enable encode-xml: %s", sr_strerror(ret));
+    }
     ret = sr_enable_module_feature(st->conn, "ietf-subscribed-notifications", "encode-json");
-    (void)ret; /* best-effort; if it fails the next test run's setup will reinstall */
+    if (ret) {
+        TLOG_WRN("Failed to re-enable encode-json: %s", sr_strerror(ret));
+    }
 
     /* re-acquire context for the global teardown */
     st->ly_ctx = sr_acquire_context(st->conn);
@@ -3613,15 +3658,17 @@ re_enable_encode_json(void **state)
 }
 
 /**
- * @brief Test: Verify the encoding field is omitted when encode-json is disabled.
+ * @brief Test: Default encoding resolution skips disabled features.
  *
- * Disables the encode-json feature, creates a subscription without an explicit
- * encoding, then verifies that the subscription-started notification is still
- * sent (with JSON media type, since the transport default is unaffected by the
- * feature) but the encoding leaf is absent (the identity does not exist in the
- * schema when the feature is off).
+ * Disables the encode-json and encode-xml features and verifies that creating
+ * a subscription without an explicit encoding fails (there is no usable
+ * default). Then re-enables encode-json only and verifies that explicitly
+ * configuring encode-xml is rejected (its feature is disabled), and that
+ * a subscription without an explicit encoding is created, uses the JSON media
+ * type, and carries the encoding leaf set to encode-json (the higher-priority
+ * encode-xml is skipped because its feature is disabled).
  *
- * Must be the last test in the suite because it disables a YANG feature.
+ * Must be the last test in the suite because it disables YANG features.
  */
 static void
 test_encoding_feature_disabled(void **state)
@@ -3629,27 +3676,85 @@ test_encoding_feature_disabled(void **state)
     struct state *st = *state;
     struct lyd_node *notif = NULL, *node = NULL;
     udp_notif_header_t header;
+    sr_session_ctx_t *tmp_sess = NULL;
+    char path[512];
     int ret;
 
-    TLOG_INF("Disabling encode-json feature...");
+    TLOG_INF("Disabling encode-json and encode-xml features...");
 
-    /* release the context reference so sr_disable_module_feature can acquire
-     * the write lock it needs to change the libyang context */
+    /* release the context reference so the feature changes can acquire
+     * the write lock they need to change the libyang context */
     sr_release_context(st->conn);
     st->ly_ctx = NULL;
 
     ret = sr_disable_module_feature(st->conn, "ietf-subscribed-notifications", "encode-json");
     assert_int_equal(ret, SR_ERR_OK);
+    ret = sr_disable_module_feature(st->conn, "ietf-subscribed-notifications", "encode-xml");
+    assert_int_equal(ret, SR_ERR_OK);
 
-    /* re-acquire the context (now with encode-json disabled) */
+    /* re-acquire the context (now with both encoding features disabled) */
     st->ly_ctx = sr_acquire_context(st->conn);
 
-    TLOG_INF("Creating subscription without encoding (feature disabled)...");
+    /* use a throwaway session for the failing apply so that any state left
+     * by the failed change is dropped with it */
+    ret = sr_session_start(st->conn, SR_DS_RUNNING, &tmp_sess);
+    assert_int_equal(ret, SR_ERR_OK);
+
+    TLOG_INF("Creating subscription without encoding (no usable default)...");
+
+    ret = create_receiver_instance(tmp_sess, "test-recv", "127.0.0.1", st->udp_port);
+    assert_int_equal(ret, SR_ERR_OK);
+
+    ret = _set_sub_common(tmp_sess, 111, "NETCONF", "test-recv");
+    assert_int_equal(ret, SR_ERR_OK);
+
+    /* must fail, there is no encoding the daemon could use */
+    ret = sr_apply_changes(tmp_sess, 0);
+    assert_int_not_equal(ret, SR_ERR_OK);
+
+    sr_session_stop(tmp_sess);
+
+    TLOG_INF("Re-enabling encode-json only...");
+
+    sr_release_context(st->conn);
+    st->ly_ctx = NULL;
+
+    ret = sr_enable_module_feature(st->conn, "ietf-subscribed-notifications", "encode-json");
+    assert_int_equal(ret, SR_ERR_OK);
+
+    /* re-acquire the context (now with encode-json enabled, encode-xml disabled) */
+    st->ly_ctx = sr_acquire_context(st->conn);
+
+    /* verify that explicitly configuring a disabled-feature encoding is rejected */
+    TLOG_INF("Attempting to explicitly configure encode-xml (feature disabled)...");
+
+    ret = sr_session_start(st->conn, SR_DS_RUNNING, &tmp_sess);
+    assert_int_equal(ret, SR_ERR_OK);
+
+    ret = create_receiver_instance(tmp_sess, "test-recv", "127.0.0.1", st->udp_port);
+    assert_int_equal(ret, SR_ERR_OK);
+
+    ret = _set_sub_common(tmp_sess, 113, "NETCONF", "test-recv");
+    assert_int_equal(ret, SR_ERR_OK);
+
+    snprintf(path, sizeof(path),
+            "/ietf-subscribed-notifications:subscriptions/subscription[id='113']/encoding");
+    ret = sr_set_item_str(tmp_sess, path, "ietf-subscribed-notifications:encode-xml", NULL, 0);
+    if (ret == SR_ERR_OK) {
+        /* if the identity was accepted, the validation must still reject it */
+        ret = sr_apply_changes(tmp_sess, 0);
+    }
+    assert_int_not_equal(ret, SR_ERR_OK);
+
+    sr_session_stop(tmp_sess);
+
+    TLOG_INF("Explicitly configured disabled-feature encoding correctly rejected");
+
+    TLOG_INF("Creating subscription without encoding (encode-xml default skipped)...");
 
     ret = create_receiver_instance(st->sess, "test-recv", "127.0.0.1", st->udp_port);
     assert_int_equal(ret, SR_ERR_OK);
 
-    /* no encoding leaf set; the identity encode-json does not exist now */
     ret = _set_sub_common(st->sess, 111, "NETCONF", "test-recv");
     assert_int_equal(ret, SR_ERR_OK);
 
@@ -3665,7 +3770,7 @@ test_encoding_feature_disabled(void **state)
     /* verify it's a subscription-started notification */
     assert_string_equal(notif->schema->name, "subscription-started");
 
-    /* media type must still be JSON (transport default, unaffected by feature) */
+    /* media type must be JSON, the XML default is skipped because its feature is disabled */
     assert_int_equal(header.media_type, UDP_NOTIF_MT_JSON);
 
     /* verify id is present (sanity check that the notification is well-formed) */
@@ -3674,12 +3779,13 @@ test_encoding_feature_disabled(void **state)
     assert_non_null(node);
     assert_int_equal(strtoul(lyd_get_value(node), NULL, 10), 111);
 
-    /* the encoding leaf must be absent: the identity does not exist in the schema */
+    /* the encoding leaf must be present and set to encode-json */
     ret = lyd_find_path(notif, "encoding", 0, &node);
-    assert_int_not_equal(ret, LY_SUCCESS);
-    assert_null(node);
+    assert_int_equal(ret, LY_SUCCESS);
+    assert_non_null(node);
+    assert_string_equal(lyd_get_value(node), "ietf-subscribed-notifications:encode-json");
 
-    TLOG_INF("Encoding field correctly omitted with feature disabled");
+    TLOG_INF("Default encoding correctly resolved to JSON with encode-xml disabled");
 
     lyd_free_all(notif);
 
@@ -3727,10 +3833,11 @@ main(void)
         cmocka_unit_test_setup(test_source_address_modify, clear_subs_notifs),
         cmocka_unit_test_setup(test_receiver_instance_ref_change, clear_subs_notifs),
         cmocka_unit_test_setup(test_stop_time_concluded, clear_subs_notifs),
+        cmocka_unit_test_setup(test_encoding_cbor_unsupported, clear_subs_notifs),
         cmocka_unit_test_setup(test_default_encoding, clear_subs_notifs),
         cmocka_unit_test_setup(test_encoding_modify, clear_subs_notifs),
-        /* test_encoding_feature_disabled must be last: it disables the encode-json feature */
-        cmocka_unit_test_setup_teardown(test_encoding_feature_disabled, clear_subs_notifs, re_enable_encode_json),
+        /* test_encoding_feature_disabled must be last: it disables the encoding features */
+        cmocka_unit_test_setup_teardown(test_encoding_feature_disabled, clear_subs_notifs, re_enable_encoding_features),
     };
 
     test_init();


### PR DESCRIPTION
The UDP transport's default encoding was hardcoded to JSON, ignoring whether the encode-json feature was actually enabled. Replace the hardcoded default with a feature-aware encoding registry that resolves the default as the highest-priority implemented encoding whose gating YANG feature is enabled (XML > JSON > CBOR). Also reject subscriptions at validation time when no usable default encoding exists, and add a feature check for explicitly configured encodings at send time.