### PR TITLE
log UPDATE configurable log level for logging callback

### DIFF
--- a/src/log.c
+++ b/src/log.c
@@ -37,6 +37,7 @@ sr_log_level_t sr_stderr_ll = SR_LL_NONE;   /**< stderr log level */
 sr_log_level_t sr_syslog_ll = SR_LL_NONE;   /**< syslog log level */
 int syslog_open;                            /**< Whether syslog was opened */
 sr_log_cb sr_lcb;                           /**< Logging callback */
+sr_log_level_t sr_lcb_ll = SR_LL_DBG;       /**< logging callback log level */
 
 /**
  * @brief String error list.
@@ -107,6 +108,12 @@ sr_api_ret(sr_session_ctx_t *session, sr_error_info_t *err_info)
     return err_code;
 }
 
+int
+sr_log_ll_wanted(sr_log_level_t ll)
+{
+    return (ll <= sr_stderr_ll) || (ll <= sr_syslog_ll) || (sr_lcb && (ll <= sr_lcb_ll));
+}
+
 void
 sr_log_msg(int plugin, sr_log_level_t ll, const char *msg)
 {
@@ -150,7 +157,7 @@ sr_log_msg(int plugin, sr_log_level_t ll, const char *msg)
     }
 
     /* logging callback */
-    if (sr_lcb) {
+    if (sr_lcb && ll <= sr_lcb_ll) {
         sr_lcb(ll, msg);
     }
 }
@@ -322,6 +329,11 @@ sr_log(sr_log_level_t ll, const char *format, ...)
     char *msg;
     int msg_len = 0;
 
+    if (!sr_log_ll_wanted(ll)) {
+        /* no destination wants this level, do not waste time formatting the message */
+        return;
+    }
+
     va_start(ap, format);
     sr_vsprintf(&msg, &msg_len, 0, format, ap);
     va_end(ap);
@@ -475,6 +487,11 @@ srplg_log(const char *plg_name, sr_log_level_t ll, const char *format, ...)
         return;
     }
 
+    if (!sr_log_ll_wanted(ll)) {
+        /* no destination wants this level, do not waste time formatting the message */
+        return;
+    }
+
     /* store plugin name first */
     off = msg_len = asprintf(&msg, "%s: ", plg_name);
     ++msg_len;
@@ -535,4 +552,16 @@ API void
 sr_log_set_cb(sr_log_cb log_callback)
 {
     sr_lcb = log_callback;
+}
+
+API void
+sr_log_set_cb_level(sr_log_level_t log_level)
+{
+    sr_lcb_ll = log_level;
+}
+
+API sr_log_level_t
+sr_log_get_cb_level(void)
+{
+    return sr_lcb_ll;
 }

--- a/src/log.c
+++ b/src/log.c
@@ -109,9 +109,9 @@ sr_api_ret(sr_session_ctx_t *session, sr_error_info_t *err_info)
 }
 
 int
-sr_log_ll_wanted(sr_log_level_t ll)
+sr_log_msg_hidden(sr_log_level_t ll)
 {
-    return (ll <= sr_stderr_ll) || (ll <= sr_syslog_ll) || (sr_lcb && (ll <= sr_lcb_ll));
+    return (ll > sr_stderr_ll) && (ll > sr_syslog_ll) && (!sr_lcb || (ll > sr_lcb_ll));
 }
 
 void
@@ -157,7 +157,7 @@ sr_log_msg(int plugin, sr_log_level_t ll, const char *msg)
     }
 
     /* logging callback */
-    if (sr_lcb && ll <= sr_lcb_ll) {
+    if (sr_lcb && (ll <= sr_lcb_ll)) {
         sr_lcb(ll, msg);
     }
 }
@@ -329,7 +329,7 @@ sr_log(sr_log_level_t ll, const char *format, ...)
     char *msg;
     int msg_len = 0;
 
-    if (!sr_log_ll_wanted(ll)) {
+    if (sr_log_msg_hidden(ll)) {
         /* no destination wants this level, do not waste time formatting the message */
         return;
     }
@@ -487,7 +487,7 @@ srplg_log(const char *plg_name, sr_log_level_t ll, const char *format, ...)
         return;
     }
 
-    if (!sr_log_ll_wanted(ll)) {
+    if (sr_log_msg_hidden(ll)) {
         /* no destination wants this level, do not waste time formatting the message */
         return;
     }

--- a/src/log.h
+++ b/src/log.h
@@ -60,9 +60,9 @@ int sr_api_ret(sr_session_ctx_t *session, sr_error_info_t *err_info);
  * (formatting a message, collecting data to print) that would be discarded.
  *
  * @param[in] ll Message log level.
- * @return Whether the message would be logged anywhere.
+ * @return Whether the message would not be logged anywhere.
  */
-int sr_log_ll_wanted(sr_log_level_t ll);
+int sr_log_msg_hidden(sr_log_level_t ll);
 
 /**
  * @brief Log a message.

--- a/src/log.h
+++ b/src/log.h
@@ -42,6 +42,7 @@
 extern sr_log_level_t sr_stderr_ll;  /**< stderr log level */
 extern sr_log_level_t sr_syslog_ll;  /**< syslog log level */
 extern sr_log_cb sr_lcb;             /**< logging callback */
+extern sr_log_level_t sr_lcb_ll;     /**< logging callback log level */
 
 /**
  * @brief Set error info to a session and return corresponding error code, if any.
@@ -51,6 +52,17 @@ extern sr_log_cb sr_lcb;             /**< logging callback */
  * @return Error code to be returned from an API function based on error info.
  */
 int sr_api_ret(sr_session_ctx_t *session, sr_error_info_t *err_info);
+
+/**
+ * @brief Check whether any log destination is interested in a message of some level.
+ *
+ * Mirrors the delivery conditions in ::sr_log_msg(), letting callers skip work
+ * (formatting a message, collecting data to print) that would be discarded.
+ *
+ * @param[in] ll Message log level.
+ * @return Whether the message would be logged anywhere.
+ */
+int sr_log_ll_wanted(sr_log_level_t ll);
 
 /**
  * @brief Log a message.

--- a/src/shm_ext.c
+++ b/src/shm_ext.c
@@ -293,7 +293,7 @@ sr_shmext_print(sr_mod_shm_t *mod_shm, sr_shm_t *shm_ext)
     sr_ext_hole_t *hole;
     sr_ext_shm_t *ext_shm = (sr_ext_shm_t *)shm_ext->addr;
 
-    if (!sr_log_ll_wanted(SR_LL_DBG)) {
+    if (sr_log_msg_hidden(SR_LL_DBG)) {
         /* nothing to print */
         return;
     }

--- a/src/shm_ext.c
+++ b/src/shm_ext.c
@@ -293,7 +293,7 @@ sr_shmext_print(sr_mod_shm_t *mod_shm, sr_shm_t *shm_ext)
     sr_ext_hole_t *hole;
     sr_ext_shm_t *ext_shm = (sr_ext_shm_t *)shm_ext->addr;
 
-    if ((sr_stderr_ll < SR_LL_DBG) && (sr_syslog_ll < SR_LL_DBG) && !sr_lcb) {
+    if (!sr_log_ll_wanted(SR_LL_DBG)) {
         /* nothing to print */
         return;
     }

--- a/src/sysrepo.h
+++ b/src/sysrepo.h
@@ -94,11 +94,28 @@ sr_log_level_t sr_log_get_syslog(void);
 
 /**
  * @brief Sets callback that will be called when a log entry would be populated.
- * Callback will be called for every message __regardless__ of any log level.
+ * By default the callback is called for every message regardless of any log level,
+ * this can be changed with ::sr_log_set_cb_level().
  *
  * @param[in] log_callback Callback to be called when a log entry would populated.
  */
 void sr_log_set_cb(sr_log_cb log_callback);
+
+/**
+ * @brief Enables / disables / changes log level (verbosity) of logging to log callback.
+ *
+ * By default, logging to callback is enabled on level ::SR_LL_DBG.
+ *
+ * @param[in] log_level Requested log level (verbosity).
+ */
+void sr_log_set_cb_level(sr_log_level_t log_level);
+
+/**
+ * @brief Learn current log callback log level.
+ *
+ * @return log callback log level.
+ */
+sr_log_level_t sr_log_get_cb_level(void);
 
 /** @} logging */
 


### PR DESCRIPTION
A callback set with sr_log_set_cb() was called for every message with no way to say which levels it wants. sr_shmext_print() also treats a registered callback as a request for debug output, so it built a full ext SHM dump on every subscription change even when the callback discarded it, and sr_log()/srplg_log() formatted every message before the level was checked.

Add sr_log_set_cb_level()/sr_log_get_cb_level() and skip formatting messages no destination wants. Defaults to SR_LL_DBG, so existing callers are unaffected.

Rationale: we register a callback that ignores SR_LL_DBG, but have to pay the cost of building every debug message anyway (mostly noticeable in the ext SHM dumps). Found it in an AddressSanitizer build, but it costs without sanitizers too.