### PR TITLE
Notifd fixes + srsn new API

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -55,7 +55,7 @@ set(CMAKE_EXPORT_COMPILE_COMMANDS 1)
 # micro version is changed with a set of small changes or bugfixes anywhere in the project.
 set(SYSREPO_MAJOR_VERSION 5)
 set(SYSREPO_MINOR_VERSION 2)
-set(SYSREPO_MICRO_VERSION 13)
+set(SYSREPO_MICRO_VERSION 14)
 set(SYSREPO_VERSION ${SYSREPO_MAJOR_VERSION}.${SYSREPO_MINOR_VERSION}.${SYSREPO_MICRO_VERSION})
 
 # Version of the library

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -62,8 +62,8 @@ set(SYSREPO_VERSION ${SYSREPO_MAJOR_VERSION}.${SYSREPO_MINOR_VERSION}.${SYSREPO_
 # Major version is changed with every backward non-compatible API/ABI change, minor version changes
 # with backward compatible change and micro version is connected with any internal change of the library.
 set(SYSREPO_MAJOR_SOVERSION 8)
-set(SYSREPO_MINOR_SOVERSION 9)
-set(SYSREPO_MICRO_SOVERSION 4)
+set(SYSREPO_MINOR_SOVERSION 10)
+set(SYSREPO_MICRO_SOVERSION 0)
 set(SYSREPO_SOVERSION_FULL ${SYSREPO_MAJOR_SOVERSION}.${SYSREPO_MINOR_SOVERSION}.${SYSREPO_MICRO_SOVERSION})
 set(SYSREPO_SOVERSION ${SYSREPO_MAJOR_SOVERSION})
 

--- a/src/executables/sysrepo-notifd/main.c
+++ b/src/executables/sysrepo-notifd/main.c
@@ -488,43 +488,27 @@ cleanup:
 }
 
 /**
- * @brief Check whether any ancestor of a diff node has a create or delete operation.
+ * @brief Check whether the operation of a diff node is inherited from an ancestor.
  *
- * When an entire subtree is being created (e.g. on SR_EV_ENABLED where the top-level container gets
- * operation "create"), the XPath predicate [not(@yang:operation)] on list entries fails
- * to exclude them since the list entries themselves lack the metadata. This function
- * detects that case by walking up the tree and checking ancestors for create/delete.
- *
- * Since all nodes in a given change callback share the same ancestor chain, the result
- * is the same for every node - it only needs to be called once (on the first node) and cached.
+ * Such a node always belongs to a subtree created or deleted as a whole, the only inherited operations
+ * ::sr_get_change_tree_next() ever reports. It happens for the whole configuration on the "enabled"
+ * event, where only the top-level node gets the operation, and for the descendants of a created or
+ * deleted list entry, which the [not(@yang:operation)] predicates cannot filter out because they carry
+ * no metadata themselves.
  *
  * @param[in] node Diff node to check.
- * @return 1 if an ancestor has "create" or "delete" operation, 0 otherwise.
+ * @return 1 if the operation is inherited, 0 if @p node carries it itself.
  */
 static int
-node_ancestor_is_created_or_deleted(const struct lyd_node *node)
+node_oper_is_inherited(const struct lyd_node *node)
 {
-    const struct lyd_node *parent;
-    struct lyd_meta *meta;
-    const char *val;
-
-    for (parent = lyd_parent(node); parent; parent = lyd_parent(parent)) {
-        meta = lyd_find_meta(parent->meta, NULL, "yang:operation");
-        if (meta) {
-            val = lyd_get_meta_value(meta);
-            if (val && (!strcmp(val, "create") || !strcmp(val, "delete"))) {
-                return 1;
-            }
-        }
-    }
-
-    return 0;
+    return lyd_find_meta(node->meta, NULL, "yang:operation") ? 0 : 1;
 }
 
 static int
 sub_change_modify_recv_instances(notifd_ctx_t *notifd_ctx, sr_session_ctx_t *session)
 {
-    int rc = SR_ERR_OK, r, prev_dflt, ancestor_checked = 0, skip_all = 0;
+    int rc = SR_ERR_OK, r, prev_dflt;
     sr_change_iter_t *iter = NULL;
     sr_change_oper_t op;
     const struct lyd_node *node;
@@ -540,12 +524,9 @@ sub_change_modify_recv_instances(notifd_ctx_t *notifd_ctx, sr_session_ctx_t *ses
         node_name = LYD_NAME(node);
         SRNTF_LOG_DBG("Current node: %s", node_name);
 
-        /* check once whether an ancestor has create/delete (result is same for all nodes) */
-        if (!ancestor_checked) {
-            skip_all = node_ancestor_is_created_or_deleted(node);
-            ancestor_checked = 1;
-        }
-        if (skip_all) {
+        /* skip the receiver instances created/deleted as a whole, they are handled by the dedicated
+         * create/delete steps */
+        if (node_oper_is_inherited(node)) {
             continue;
         }
 
@@ -605,7 +586,7 @@ cleanup:
 static int
 sub_change_modify_subscriptions(notifd_ctx_t *notifd_ctx, sr_session_ctx_t *session)
 {
-    int rc = SR_ERR_OK, r, prev_dflt, ancestor_checked = 0, skip_all = 0;
+    int rc = SR_ERR_OK, r, prev_dflt;
     sr_change_iter_t *iter = NULL;
     sr_change_oper_t op;
     const struct lyd_node *node;
@@ -621,12 +602,9 @@ sub_change_modify_subscriptions(notifd_ctx_t *notifd_ctx, sr_session_ctx_t *sess
         node_name = LYD_NAME(node);
         SRNTF_LOG_DBG("Current node: %s", node_name);
 
-        /* check once whether an ancestor has create/delete (result is same for all nodes) */
-        if (!ancestor_checked) {
-            skip_all = node_ancestor_is_created_or_deleted(node);
-            ancestor_checked = 1;
-        }
-        if (skip_all) {
+        /* skip the subscriptions and receivers created/deleted as a whole, they are handled by
+         * sub_change_process_subscriptions() and sub_change_modify_receivers() */
+        if (node_oper_is_inherited(node)) {
             continue;
         }
 
@@ -675,7 +653,7 @@ cleanup:
 static int
 sub_change_modify_receivers(notifd_ctx_t *notifd_ctx, sr_session_ctx_t *session)
 {
-    int rc = SR_ERR_OK, r, prev_dflt, ancestor_checked = 0, skip_all = 0;
+    int rc = SR_ERR_OK, r, prev_dflt;
     sr_change_iter_t *iter = NULL;
     sr_change_oper_t op;
     const struct lyd_node *node;
@@ -691,12 +669,10 @@ sub_change_modify_receivers(notifd_ctx_t *notifd_ctx, sr_session_ctx_t *session)
         node_name = LYD_NAME(node);
         SRNTF_LOG_DBG("Current node: %s", node_name);
 
-        /* check once whether an ancestor has create/delete (result is same for all nodes) */
-        if (!ancestor_checked) {
-            skip_all = node_ancestor_is_created_or_deleted(node);
-            ancestor_checked = 1;
-        }
-        if (skip_all) {
+        /* skip the descendants of a created/deleted "receiver", the whole subtree is handled below for
+         * the list entry itself and processing them again would reconnect a just created receiver or
+         * fail to find a just destroyed one, invalidating the whole subscription */
+        if (node_oper_is_inherited(node)) {
             continue;
         }
 
@@ -860,7 +836,7 @@ static int
 subscribed_notifications_filter_change_cb(sr_session_ctx_t *session, uint32_t sub_id, const char *module_name, const char *xpath,
         sr_event_t event, uint32_t operation_id, void *private_data)
 {
-    int rc = SR_ERR_OK, r, prev_dflt, appl_locked = 0, state_locked = 0, ancestor_checked = 0, skip_all = 0;
+    int rc = SR_ERR_OK, r, prev_dflt, appl_locked = 0, state_locked = 0;
     notifd_ctx_t *notifd_ctx = (notifd_ctx_t *)private_data;
     sr_change_iter_t *iter = NULL;
     sr_change_oper_t op;
@@ -904,12 +880,9 @@ subscribed_notifications_filter_change_cb(sr_session_ctx_t *session, uint32_t su
         node_name = LYD_NAME(node);
         SRNTF_LOG_DBG("Current node: %s", node_name);
 
-        /* check once whether an ancestor has create/delete (result is same for all nodes) */
-        if (!ancestor_checked) {
-            skip_all = node_ancestor_is_created_or_deleted(node);
-            ancestor_checked = 1;
-        }
-        if (skip_all) {
+        /* skip the filters created/deleted as a whole, only a content change of an existing filter
+         * affects the referencing subscriptions and such a node always carries its own operation */
+        if (node_oper_is_inherited(node)) {
             continue;
         }
 

--- a/src/executables/sysrepo-notifd/main.c
+++ b/src/executables/sysrepo-notifd/main.c
@@ -1394,6 +1394,21 @@ main(int argc, char **argv)
         goto cleanup;
     }
 
+    /* register the oper data providers and the action BEFORE subscribing */
+    if (register_oper_data_providers(&notifd_ctx, &sr_subscr)) {
+        rc = EXIT_FAILURE;
+        goto cleanup;
+    }
+
+    /* subscribe for 'reset' action */
+    if (sr_rpc_subscribe_tree(notifd_ctx.sr_sess,
+            "/ietf-subscribed-notifications:subscriptions/subscription/receivers/receiver/reset",
+            receiver_reset_rpc_cb, &notifd_ctx, 0, 0, &sr_subscr)) {
+        SRNTF_LOG_ERR("Failed to subscribe for receiver reset action.");
+        rc = EXIT_FAILURE;
+        goto cleanup;
+    }
+
     /* subscribe for subscription changes (higher priority) */
     if (sr_module_change_subscribe(notifd_ctx.sr_sess, "ietf-subscribed-notifications",
             "/ietf-subscribed-notifications:subscriptions", subscribed_notifications_sub_change_cb,
@@ -1408,21 +1423,6 @@ main(int argc, char **argv)
             "/ietf-subscribed-notifications:filters", subscribed_notifications_filter_change_cb,
             &notifd_ctx, 1, SR_SUBSCR_ENABLED, &sr_subscr)) {
         SRNTF_LOG_ERR("Failed to subscribe for filters changes");
-        rc = EXIT_FAILURE;
-        goto cleanup;
-    }
-
-    /* register operational data provider callbacks */
-    if (register_oper_data_providers(&notifd_ctx, &sr_subscr)) {
-        rc = EXIT_FAILURE;
-        goto cleanup;
-    }
-
-    /* subscribe for 'reset' action */
-    if (sr_rpc_subscribe_tree(notifd_ctx.sr_sess,
-            "/ietf-subscribed-notifications:subscriptions/subscription/receivers/receiver/reset",
-            receiver_reset_rpc_cb, &notifd_ctx, 0, 0, &sr_subscr)) {
-        SRNTF_LOG_ERR("Failed to subscribe for receiver reset action.");
         rc = EXIT_FAILURE;
         goto cleanup;
     }

--- a/src/executables/sysrepo-notifd/notifd.h
+++ b/src/executables/sysrepo-notifd/notifd.h
@@ -328,7 +328,6 @@ struct notif_receiver_inst_s {
  */
 typedef struct notif_cb_data_s {
     notifd_ctx_t *ctx;          /**< main daemon context */
-    notif_receiver_t *recv;     /**< receiver to send the notification to */
 } notif_cb_data_t;
 
 /**
@@ -351,7 +350,10 @@ struct notif_receiver_s {
         uint32_t sub_id;                        /**< srsn subscription ID */
         int fd;                                 /**< notification pipe FD from srsn_subscribe */
     } srsn_data;                                /**< srsn subscription and dispatch data */
-    notif_cb_data_t cb_data;                    /**< callback data for srsn dispatch */
+    notif_cb_data_t *cb_data;                   /**< callback data for srsn dispatch.
+                                                     Its address identifies the receiver it belongs to -
+                                                     the address is used for receiver lookup in
+                                                     ::notifd_notification_cb() notification dispatch callback. */
 
     notif_sub_t *sub;                           /**< back-pointer to the parent subscription */
     struct timespec last_reconnect_attempt;     /**< time of the last reconnect attempt */

--- a/src/executables/sysrepo-notifd/notifd.h
+++ b/src/executables/sysrepo-notifd/notifd.h
@@ -329,8 +329,6 @@ struct notif_receiver_inst_s {
 typedef struct notif_cb_data_s {
     notifd_ctx_t *ctx;          /**< main daemon context */
     notif_receiver_t *recv;     /**< receiver to send the notification to */
-    notif_encoding_t encoding;  /**< configured subscription encoding (::NOTIF_ENCODING_UNSET if not
-                                     configured, resolved to the transport default when sending) */
 } notif_cb_data_t;
 
 /**

--- a/src/executables/sysrepo-notifd/notifd_common.h
+++ b/src/executables/sysrepo-notifd/notifd_common.h
@@ -763,8 +763,15 @@ int notif_receiver_send(notifd_ctx_t *notifd_ctx, notif_receiver_t *receiver, co
  *
  * Subscribes to the configured notification stream and adds a file-descriptor-based
  * dispatch entry. This begins the flow of notifications from sysrepo to the receiver.
+ * Temporarily drops the state write lock, the dispatch add waits for the dispatch thread,
+ * which may be executing the notification callback (that acquires the state read lock).
  *
- * @param[in] notifd_ctx Daemon context (its sr_sess is used as the srsn subscription session).
+ * @warning The caller MUST hold both state_rwlock (write) AND config_apply_mutex.
+ * The config_apply_mutex prevents another thread from stealing the write-lock
+ * in the unlock/relock window.
+ *
+ * @param[in] notifd_ctx Daemon context (its sr_sess is used as the srsn subscription session,
+ * its state_rwlock is temporarily unlocked/relocked).
  * @param[in] sub Subscription defining the stream, filter, and stop/start times.
  * @param[in] receiver Receiver whose srsn_data and cb_data will be populated.
  * @return ::SR_ERR_OK on success, error code on failure.

--- a/src/executables/sysrepo-notifd/notifd_config.c
+++ b/src/executables/sysrepo-notifd/notifd_config.c
@@ -718,7 +718,6 @@ int
 handle_encoding(notif_sub_t *sub, const struct lyd_node *node, sr_change_oper_t op)
 {
     int rc = SR_ERR_OK;
-    notif_receiver_t *receiver;
 
     /* optional leaf, need to handle all but move */
     if ((op == SR_OP_CREATED) || (op == SR_OP_MODIFIED)) {
@@ -732,11 +731,6 @@ handle_encoding(notif_sub_t *sub, const struct lyd_node *node, sr_change_oper_t 
     }
 
     if ((op == SR_OP_CREATED) || (op == SR_OP_MODIFIED) || (op == SR_OP_DELETED)) {
-        /* propagate the new encoding to all receivers */
-        LY_ARRAY_FOR(sub->receivers, notif_receiver_t, receiver) {
-            receiver->cb_data.encoding = sub->encoding;
-        }
-
         /* mark sub as modified so we know to send subscription-modified notification */
         sub->modified = 1;
     }

--- a/src/executables/sysrepo-notifd/notifd_config.c
+++ b/src/executables/sysrepo-notifd/notifd_config.c
@@ -307,11 +307,16 @@ stream_filter_xpath_get(sr_session_ctx_t *sess, const char *filter_name, char **
 {
     int rc = SR_ERR_OK;
     struct lyd_node *filter, *tree;
-    char *path = NULL;
+    char *path = NULL, quot;
     sr_data_t *data = NULL;
 
+    /* the predicate must use the canonical libyang quoting (single quotes unless the value itself contains
+     * one) because datastore plugins may match the requested path against the stored node paths */
+    quot = strchr(filter_name, '\'') ? '\"' : '\'';
+
     /* get the filter with this name */
-    if ((asprintf(&path, "/ietf-subscribed-notifications:filters/stream-filter[name=\"%s\"]", filter_name) == -1)) {
+    if ((asprintf(&path, "/ietf-subscribed-notifications:filters/stream-filter[name=%c%s%c]", quot, filter_name,
+            quot) == -1)) {
         rc = SR_ERR_NO_MEMORY;
         ERRMEM;
         goto cleanup;
@@ -326,6 +331,10 @@ stream_filter_xpath_get(sr_session_ctx_t *sess, const char *filter_name, char **
 
     /* data->tree points to filters cont, we go one level down to the filter instance */
     tree = lyd_child(data->tree);
+    if (!tree) {
+        /* no filter instance, so no filter to apply */
+        goto cleanup;
+    }
 
     /* because it's a choice, only one of the two filter types can be present */
     get_descendant_optional(tree, "stream-subtree-filter", &filter);

--- a/src/executables/sysrepo-notifd/notifd_runtime.c
+++ b/src/executables/sysrepo-notifd/notifd_runtime.c
@@ -603,10 +603,40 @@ cleanup:
  * ---------------------------------------------------------------------------
  */
 
+/**
+ * @brief Free the srsn subscription and dispatch data of a receiver that failed to start.
+ *
+ * Must not be called for an FD that the dispatch has taken over, use ::srsn_read_dispatch_del() instead.
+ *
+ * @param[in,out] receiver Receiver to clean up.
+ */
+static void
+notification_dispatch_data_free(notif_receiver_t *receiver)
+{
+    if (receiver->srsn_data.sub_id) {
+        /* terminate the srsn subscription, which removes its subscriptions from the sysrepo context */
+        srsn_terminate(receiver->srsn_data.sub_id, NULL);
+        receiver->srsn_data.sub_id = 0;
+    }
+
+    /* unsubscribe only after srsn_terminate(), which still uses the subscription context */
+    sr_unsubscribe(receiver->srsn_data.sr_subscr);
+    receiver->srsn_data.sr_subscr = NULL;
+
+    if (receiver->srsn_data.fd != -1) {
+        /* the dispatch never took over the FD, it is still ours to close */
+        close(receiver->srsn_data.fd);
+        receiver->srsn_data.fd = -1;
+    }
+
+    free(receiver->cb_data);
+    receiver->cb_data = NULL;
+}
+
 int
 notification_dispatch_start(notifd_ctx_t *notifd_ctx, notif_sub_t *sub, notif_receiver_t *receiver)
 {
-    int rc = SR_ERR_OK;
+    int rc = SR_ERR_OK, unlocked = 0;
     struct timespec *stop_time, *start_time;
 
     stop_time = (sub->stop_time.tv_sec || sub->stop_time.tv_nsec) ? &sub->stop_time : NULL;
@@ -617,7 +647,6 @@ notification_dispatch_start(notifd_ctx_t *notifd_ctx, notif_sub_t *sub, notif_re
             &receiver->srsn_data.sr_subscr, &sub->replay_start_time, &receiver->srsn_data.fd, &receiver->srsn_data.sub_id))) {
         SRNTF_LOG_ERR("Failed to subscribe for notifications for subscription ID %" PRIu32 " and receiver \"%s\".",
                 sub->id, receiver->name);
-        sub->modif_err_reason = "ietf-subscribed-notifications:no-such-subscription";
         goto cleanup;
     }
 
@@ -629,25 +658,36 @@ notification_dispatch_start(notifd_ctx_t *notifd_ctx, notif_sub_t *sub, notif_re
     }
     receiver->cb_data->ctx = notifd_ctx;
 
+    /* UNLOCK state lock, the dispatch add waits for the dispatch lock, which the dispatch thread holds while
+     * calling the notif cb, which needs the state lock. Nobody can steal our WR lock here, because the caller
+     * MUST hold config_apply_mutex, which prevents another thread from acquiring the state WR lock in this
+     * window. The receiver is not active yet, so no notifications are sent to it meanwhile. */
+    notifd_rwlock_unlock(&notifd_ctx->state_rwlock, __func__);
+    unlocked = 1;
+
     /* add notification dispatch, which takes over the FD on success */
     if ((rc = srsn_read_dispatch_add(receiver->srsn_data.fd, receiver->cb_data))) {
         SRNTF_LOG_ERR("Failed to add notification dispatch for subscription ID %" PRIu32 " and receiver \"%s\".",
                 sub->id, receiver->name);
-        sub->modif_err_reason = "ietf-subscribed-notifications:no-such-subscription";
-        goto cleanup;
     }
 
 cleanup:
     if (rc) {
-        /* unsubscribe */
-        sr_unsubscribe(receiver->srsn_data.sr_subscr);
-        receiver->srsn_data.sr_subscr = NULL;
-        if (receiver->srsn_data.fd != -1) {
-            close(receiver->srsn_data.fd);
-            receiver->srsn_data.fd = -1;
+        /* clean up before the state lock is reacquired, srsn_terminate() may wait for the dispatch thread */
+        notification_dispatch_data_free(receiver);
+    }
+
+    if (unlocked) {
+        /* WR LOCK, reacquire to finish updating the config */
+        if (notifd_rwlock_lock(&notifd_ctx->state_rwlock, 1, NOTIFD_CONTEXT_LOCK_TIMEOUT_MS, __func__)) {
+            SRNTF_LOG_ERR("Internal error: failed to acquire state lock to start notification dispatch for "
+                    "receiver \"%s\".", receiver->name);
+            return rc ? rc : SR_ERR_INTERNAL;
         }
-        free(receiver->cb_data);
-        receiver->cb_data = NULL;
+    }
+
+    if (rc) {
+        sub->modif_err_reason = "ietf-subscribed-notifications:no-such-subscription";
     }
     return rc;
 }
@@ -665,6 +705,17 @@ notification_dispatch_stop(notifd_ctx_t *notifd_ctx, notif_receiver_t *receiver)
         receiver->srsn_data.sub_id = 0;
     }
 
+    /* Remove the dispatch, which also closes the FD. Must be done without the state lock, the call waits
+     * for any running callback, which needs the lock. Afterwards no callback can reference our cb_data. */
+    if (receiver->srsn_data.fd != -1) {
+        srsn_read_dispatch_del(receiver->srsn_data.fd);
+        receiver->srsn_data.fd = -1;
+    }
+
+    /* free before the lock is reacquired, which may fail */
+    free(receiver->cb_data);
+    receiver->cb_data = NULL;
+
     /* WR LOCK, reacquire to finish updating the config before checking retval of srsn_terminate */
     if (notifd_rwlock_lock(&notifd_ctx->state_rwlock, 1, NOTIFD_CONTEXT_LOCK_TIMEOUT_MS, __func__)) {
         SRNTF_LOG_ERR("Internal error: failed to acquire state lock to stop notification dispatch for receiver \"%s\".",
@@ -676,12 +727,6 @@ notification_dispatch_stop(notifd_ctx_t *notifd_ctx, notif_receiver_t *receiver)
         sr_unsubscribe(receiver->srsn_data.sr_subscr);
         receiver->srsn_data.sr_subscr = NULL;
     }
-    if (receiver->srsn_data.fd != -1) {
-        close(receiver->srsn_data.fd);
-        receiver->srsn_data.fd = -1;
-    }
-    free(receiver->cb_data);
-    receiver->cb_data = NULL;
 }
 
 /*

--- a/src/executables/sysrepo-notifd/notifd_runtime.c
+++ b/src/executables/sysrepo-notifd/notifd_runtime.c
@@ -442,7 +442,7 @@ notif_receiver_backoff_reconnect(notifd_ctx_t *notifd_ctx, notif_receiver_t *rec
 
     /* send the notification through the standard send path, resolving the default encoding as needed */
     clock_gettime(CLOCK_REALTIME, &event_ts);
-    rc = notif_receiver_send(notifd_ctx, receiver, start_notif, &event_ts, receiver->cb_data.encoding);
+    rc = notif_receiver_send(notifd_ctx, receiver, start_notif, &event_ts, receiver->sub->encoding);
     lyd_free_all(start_notif);
     sr_session_release_context(notifd_ctx->sr_sess);
     if (rc) {
@@ -624,7 +624,6 @@ notification_dispatch_start(notifd_ctx_t *notifd_ctx, notif_sub_t *sub, notif_re
     /* set up notif cb data */
     receiver->cb_data.ctx = notifd_ctx;
     receiver->cb_data.recv = receiver;
-    receiver->cb_data.encoding = sub->encoding;
 
     /* add notification dispatch, set notifd_ctx and sub as user data - the pointer itself won't be
      * modified (stored as ** in notifd_ctx), but its content might be, so the callback will need to lock */
@@ -690,7 +689,6 @@ notifd_notification_cb(const struct lyd_node *notif, const struct timespec *time
     notif_cb_data_t *data = (notif_cb_data_t *)cb_data;
     notifd_ctx_t *notifd_ctx;
     notif_receiver_t *receiver;
-    notif_encoding_t encoding;
     notif_sub_t *sub;
     struct timespec now;
     uint32_t sub_id;
@@ -699,7 +697,6 @@ notifd_notification_cb(const struct lyd_node *notif, const struct timespec *time
     assert(data);
     notifd_ctx = data->ctx;
     receiver = data->recv;
-    encoding = data->encoding;
     assert(notifd_ctx && receiver);
 
     /* STATE RD LOCK */
@@ -800,7 +797,7 @@ notifd_notification_cb(const struct lyd_node *notif, const struct timespec *time
     }
 
     /* send the notification */
-    notif_receiver_send(notifd_ctx, receiver, notif, timestamp, encoding);
+    notif_receiver_send(notifd_ctx, receiver, notif, timestamp, receiver->sub->encoding);
 
 unlock:
     /* STATE UNLOCK */

--- a/src/executables/sysrepo-notifd/notifd_runtime.c
+++ b/src/executables/sysrepo-notifd/notifd_runtime.c
@@ -621,13 +621,16 @@ notification_dispatch_start(notifd_ctx_t *notifd_ctx, notif_sub_t *sub, notif_re
         goto cleanup;
     }
 
-    /* set up notif cb data */
-    receiver->cb_data.ctx = notifd_ctx;
-    receiver->cb_data.recv = receiver;
+    /* set up notif cb data, allocated separately from the receiver whose address may change */
+    if (!(receiver->cb_data = calloc(1, sizeof *receiver->cb_data))) {
+        SRNTF_LOG_ERR("Memory allocation failed.");
+        rc = SR_ERR_NO_MEMORY;
+        goto cleanup;
+    }
+    receiver->cb_data->ctx = notifd_ctx;
 
-    /* add notification dispatch, set notifd_ctx and sub as user data - the pointer itself won't be
-     * modified (stored as ** in notifd_ctx), but its content might be, so the callback will need to lock */
-    if ((rc = srsn_read_dispatch_add(receiver->srsn_data.fd, &receiver->cb_data))) {
+    /* add notification dispatch, which takes over the FD on success */
+    if ((rc = srsn_read_dispatch_add(receiver->srsn_data.fd, receiver->cb_data))) {
         SRNTF_LOG_ERR("Failed to add notification dispatch for subscription ID %" PRIu32 " and receiver \"%s\".",
                 sub->id, receiver->name);
         sub->modif_err_reason = "ietf-subscribed-notifications:no-such-subscription";
@@ -643,6 +646,8 @@ cleanup:
             close(receiver->srsn_data.fd);
             receiver->srsn_data.fd = -1;
         }
+        free(receiver->cb_data);
+        receiver->cb_data = NULL;
     }
     return rc;
 }
@@ -675,6 +680,8 @@ notification_dispatch_stop(notifd_ctx_t *notifd_ctx, notif_receiver_t *receiver)
         close(receiver->srsn_data.fd);
         receiver->srsn_data.fd = -1;
     }
+    free(receiver->cb_data);
+    receiver->cb_data = NULL;
 }
 
 /*
@@ -682,6 +689,29 @@ notification_dispatch_stop(notifd_ctx_t *notifd_ctx, notif_receiver_t *receiver)
  * Main notification callback (called by srsn dispatch thread)
  * ---------------------------------------------------------------------------
  */
+
+/**
+ * @brief Find the receiver dispatch callback data belong to.
+ *
+ * @param[in] notifd_ctx Daemon context.
+ * @param[in] data Callback data to look up.
+ * @return Receiver owning @p data, NULL if it no longer exists.
+ */
+static notif_receiver_t *
+receiver_find_by_cb_data(notifd_ctx_t *notifd_ctx, const notif_cb_data_t *data)
+{
+    LY_ARRAY_COUNT_TYPE i, j;
+
+    LY_ARRAY_FOR(notifd_ctx->subs, i) {
+        LY_ARRAY_FOR(notifd_ctx->subs[i]->receivers, j) {
+            if (notifd_ctx->subs[i]->receivers[j].cb_data == data) {
+                return &notifd_ctx->subs[i]->receivers[j];
+            }
+        }
+    }
+
+    return NULL;
+}
 
 void
 notifd_notification_cb(const struct lyd_node *notif, const struct timespec *timestamp, void *cb_data)
@@ -692,16 +722,19 @@ notifd_notification_cb(const struct lyd_node *notif, const struct timespec *time
     notif_sub_t *sub;
     struct timespec now;
     uint32_t sub_id;
-    LY_ARRAY_COUNT_TYPE i;
 
     assert(data);
     notifd_ctx = data->ctx;
-    receiver = data->recv;
-    assert(notifd_ctx && receiver);
+    assert(notifd_ctx);
 
     /* STATE RD LOCK */
     if (notifd_rwlock_lock(&notifd_ctx->state_rwlock, 0, NOTIFD_CONTEXT_LOCK_TIMEOUT_MS, __func__)) {
         return;
+    }
+
+    /* look up our receiver */
+    if (!(receiver = receiver_find_by_cb_data(notifd_ctx, data))) {
+        goto unlock;
     }
 
     sub = receiver->sub;
@@ -768,14 +801,7 @@ notifd_notification_cb(const struct lyd_node *notif, const struct timespec *time
             }
 
             /* re-find the receiver as it may have been moved in the array */
-            receiver = NULL;
-            LY_ARRAY_FOR(sub->receivers, i) {
-                if (&sub->receivers[i].cb_data == data) {
-                    receiver = &sub->receivers[i];
-                    break;
-                }
-            }
-            if (!receiver) {
+            if (!(receiver = receiver_find_by_cb_data(notifd_ctx, data))) {
                 goto unlock;
             }
 

--- a/src/utils/sn_common.c
+++ b/src/utils/sn_common.c
@@ -1151,6 +1151,10 @@ srsn_dispatch_add(int fd, void *cb_data)
         /* create the thread */
         if ((r = pthread_create(&snstate.tid, NULL, srsn_read_dispatch_thread, NULL))) {
             sr_errinfo_new(&err_info, SR_ERR_SYS, "Failed to create a thread (%s).", strerror(r));
+
+            /* roll back the new item, on error the FD is not registered */
+            --snstate.valid_pfds;
+            snstate.pfd_count = snstate.valid_pfds;
             goto cleanup;
         }
     }

--- a/src/utils/sn_common.c
+++ b/src/utils/sn_common.c
@@ -1059,6 +1059,13 @@ srsn_read_dispatch_thread(void *UNUSED(arg))
                 /* subscription terminated */
                 close(snstate.pfds[i].fd);
                 snstate.pfds[i].fd = -1;
+                snstate.cb_data[i] = NULL;
+                --snstate.valid_pfds;
+            } else if (snstate.pfds[i].revents & POLLNVAL) {
+                /* the FD was closed behind our back, just drop the item, closing again could affect
+                 * an unrelated FD that reused the number */
+                snstate.pfds[i].fd = -1;
+                snstate.cb_data[i] = NULL;
                 --snstate.valid_pfds;
             }
 
@@ -1160,6 +1167,41 @@ srsn_dispatch_add(int fd, void *cb_data)
     }
 
 cleanup:
+    /* DISPATCH UNLOCK */
+    pthread_mutex_unlock(&snstate.dispatch_lock);
+
+    return err_info;
+}
+
+sr_error_info_t *
+srsn_dispatch_del(int fd)
+{
+    sr_error_info_t *err_info = NULL;
+    uint32_t i;
+    int r;
+
+    /* DISPATCH LOCK, the dispatch thread holds it while calling the callback, so once acquired,
+     * no callback is running nor can start before we are done */
+    if ((r = pthread_mutex_lock(&snstate.dispatch_lock))) {
+        sr_errinfo_new(&err_info, SR_ERR_SYS, "Locking failed (%s: %s).", __func__, strerror(r));
+        return err_info;
+    }
+
+    for (i = 0; i < snstate.pfd_count; ++i) {
+        if (snstate.pfds[i].fd != fd) {
+            continue;
+        }
+
+        /* invalidate the item, it is removed from the arrays by the next add. Close the FD while still
+         * holding the lock, the dispatch thread closes it on POLLHUP under the same lock but then there
+         * is no valid item left to find here, so it is always closed exactly once. */
+        close(snstate.pfds[i].fd);
+        snstate.pfds[i].fd = -1;
+        snstate.cb_data[i] = NULL;
+        --snstate.valid_pfds;
+        break;
+    }
+
     /* DISPATCH UNLOCK */
     pthread_mutex_unlock(&snstate.dispatch_lock);
 

--- a/src/utils/sn_common.h
+++ b/src/utils/sn_common.h
@@ -311,6 +311,8 @@ sr_error_info_t *srsn_dispatch_init(sr_conn_ctx_t *conn, srsn_notif_cb cb);
 /**
  * @brief Add another FD handled by notification dispatch.
  *
+ * On success @p fd is owned by the dispatch, on error it is not registered and stays owned by the caller.
+ *
  * @param[in] fd Subscription FD.
  * @param[in] cb_data Callback data for @p fd.
  * @return err_info, NULL on success.

--- a/src/utils/sn_common.h
+++ b/src/utils/sn_common.h
@@ -320,6 +320,21 @@ sr_error_info_t *srsn_dispatch_init(sr_conn_ctx_t *conn, srsn_notif_cb cb);
 sr_error_info_t *srsn_dispatch_add(int fd, void *cb_data);
 
 /**
+ * @brief Remove an FD handled by notification dispatch and close it.
+ *
+ * Blocks until no callback is being processed, so on return the callback of @p fd is neither running
+ * nor can be called again and its callback data can be freed.
+ *
+ * Removing an FD that is not handled by the dispatch is not an error, the dispatch thread removes FDs
+ * itself once the peer closes them and there is no way for the caller to learn about it, so both cases
+ * are indistinguishable here and the guarantees above hold either way.
+ *
+ * @param[in] fd Subscription FD.
+ * @return err_info, NULL on success.
+ */
+sr_error_info_t *srsn_dispatch_del(int fd);
+
+/**
  * @brief Get the current count of subscriptions handled by dispatch.
  *
  * @return Subscription count.

--- a/src/utils/subscribed_notifications.c
+++ b/src/utils/subscribed_notifications.c
@@ -1080,6 +1080,19 @@ srsn_read_dispatch_add(int fd, void *cb_data)
     return sr_api_ret(NULL, err_info);
 }
 
+API int
+srsn_read_dispatch_del(int fd)
+{
+    sr_error_info_t *err_info = NULL;
+
+    SR_CHECK_ARG_APIRET(fd < 0, NULL, err_info);
+
+    /* remove from the pollfd structure */
+    err_info = srsn_dispatch_del(fd);
+
+    return sr_api_ret(NULL, err_info);
+}
+
 API uint32_t
 srsn_read_dispatch_count(void)
 {

--- a/src/utils/subscribed_notifications.h
+++ b/src/utils/subscribed_notifications.h
@@ -317,6 +317,13 @@ typedef void (*srsn_notif_cb)(const struct lyd_node *notif, const struct timespe
 /**
  * @brief Init read dispatch for notifications, overwrites any previous parameters.
  *
+ * The dispatch runs @p cb on a separate thread, so the callback and the FD it reads from are shared
+ * between that thread and the caller. To avoid data races, never close a dispatched FD directly and do
+ * not free its callback data while the FD is registered: use ::srsn_read_dispatch_del() to remove an FD,
+ * which closes it and blocks until the callback is no longer running for it, only then is it safe to free
+ * the callback data. The callback data must also stay valid and at a stable address for the whole time the
+ * FD is dispatched. Removing all FDs (or ::srsn_read_dispatch_destroy()) stops the thread.
+ *
  * @param[in] conn Connection that must not be terminated while the notifications are being processed.
  * @param[in] cb Callback to be called for each notification.
  * @return Error code (::SR_ERR_OK on success).
@@ -332,16 +339,35 @@ int srsn_read_dispatch_start(int fd, sr_conn_ctx_t *conn, srsn_notif_cb cb, void
  * @brief Add another subscription to be handled by the dispatched thread.
  *
  * The thread is automatically started on the first @p fd and terminated when the last
- * one is closed.
+ * one is closed by the peer.
  *
- * On success @p fd is owned by the dispatch, which closes it once the subscription terminates, so it
- * must never be closed by the caller. On error @p fd is not registered and stays owned by the caller.
+ * On success @p fd is owned by the dispatch, which closes it once the subscription terminates or when
+ * removed by ::srsn_read_dispatch_del(), so it must never be closed by the caller. On error @p fd is
+ * not registered and stays owned by the caller.
  *
  * @param[in] fd Subscription file descriptor to read from.
  * @param[in] cb_data User @p cb callback data for the @p fd.
  * @return Error code (::SR_ERR_OK on success).
  */
 int srsn_read_dispatch_add(int fd, void *cb_data);
+
+/**
+ * @brief Remove a subscription from being handled by the dispatched thread and close its FD.
+ *
+ * Blocks until the dispatched thread is not processing any notification, so once this function returns,
+ * the callback is neither running for @p fd nor can be called for it again and the callback data of
+ * @p fd can be freed.
+ *
+ * It is not an error to remove an FD that is no longer handled by the dispatched thread, which closes
+ * FDs of terminated subscriptions on its own without notifying the caller. So, calling this function
+ * is always the correct way of learning that the callback data of @p fd can be freed.
+ *
+ * @param[in] fd Subscription file descriptor previously added by ::srsn_read_dispatch_add(), closed
+ * unless the dispatched thread has already closed it after the subscription terminated, in which case
+ * its number must not have been reused for another dispatch FD, which would be removed instead.
+ * @return Error code (::SR_ERR_OK on success).
+ */
+int srsn_read_dispatch_del(int fd);
 
 /**
  * @brief Get the number of subscriptions currently handled by the dispatched thread.

--- a/src/utils/subscribed_notifications.h
+++ b/src/utils/subscribed_notifications.h
@@ -334,6 +334,9 @@ int srsn_read_dispatch_start(int fd, sr_conn_ctx_t *conn, srsn_notif_cb cb, void
  * The thread is automatically started on the first @p fd and terminated when the last
  * one is closed.
  *
+ * On success @p fd is owned by the dispatch, which closes it once the subscription terminates, so it
+ * must never be closed by the caller. On error @p fd is not registered and stays owned by the caller.
+ *
  * @param[in] fd Subscription file descriptor to read from.
  * @param[in] cb_data User @p cb callback data for the @p fd.
  * @return Error code (::SR_ERR_OK on success).

--- a/tests/test_notifd.c
+++ b/tests/test_notifd.c
@@ -3471,6 +3471,94 @@ test_stop_time_concluded(void **state)
 }
 
 /**
+ * @brief Test: Verify that adding and removing receivers of a live subscription keeps the
+ * notification dispatch coherent.
+ *
+ * Adding and removing receivers moves the remaining ones in the receivers array, so the callback data
+ * pointer held by the srsn read dispatch must stay valid. Otherwise the dispatch thread accesses freed
+ * memory and notifd crashes or wedges, blocking any further configuration change.
+ */
+static void
+test_receiver_add_delete_dispatch(void **state)
+{
+    struct state *st = *state;
+    struct lyd_node *notif = NULL;
+    char path[512], *state_val;
+    int ret, i;
+
+    TLOG_INF("Testing receiver add/delete keeps notification dispatch coherent...");
+
+    /* subscription with a single receiver "recv1", only config change notifications */
+    setup_sub(st->sess, st->udp_port, 210, "NETCONF",
+            "/ietf-netconf-notifications:netconf-config-change");
+
+    /* receive subscription-started for recv1 */
+    ret = receive_specific_notification(st->udp_sockfd, st->ly_ctx,
+            "/ietf-subscribed-notifications:subscription-started", &notif, NULL);
+    assert_int_equal(ret, 0);
+    assert_non_null(notif);
+    lyd_free_all(notif);
+    notif = NULL;
+
+    drain_notifications(st->udp_sockfd);
+
+    TLOG_INF("Adding more receivers, reallocating the receivers array...");
+
+    /* each added receiver reallocates the receivers array, moving the already dispatched ones */
+    for (i = 2; i <= 4; ++i) {
+        snprintf(path, sizeof(path),
+                "/ietf-subscribed-notifications:subscriptions/subscription[id='210']"
+                "/receivers/receiver[name='recv%d']/ietf-subscribed-notif-receivers:receiver-instance-ref", i);
+        ret = sr_set_item_str(st->sess, path, "test-recv", NULL, 0);
+        assert_int_equal(ret, SR_ERR_OK);
+        ret = sr_apply_changes(st->sess, 0);
+        assert_int_equal(ret, SR_ERR_OK);
+
+        drain_notifications(st->udp_sockfd);
+    }
+
+    TLOG_INF("Deleting receivers, compacting the receivers array...");
+
+    /* deleting a receiver stops its dispatch and moves the last receiver into its place */
+    for (i = 1; i <= 3; ++i) {
+        snprintf(path, sizeof(path),
+                "/ietf-subscribed-notifications:subscriptions/subscription[id='210']"
+                "/receivers/receiver[name='recv%d']", i);
+        ret = sr_delete_item(st->sess, path, 0);
+        assert_int_equal(ret, SR_ERR_OK);
+        ret = sr_apply_changes(st->sess, 0);
+        assert_int_equal(ret, SR_ERR_OK);
+
+        drain_notifications(st->udp_sockfd);
+    }
+
+    TLOG_INF("Checking notifd survived the churn and is still fully functional...");
+
+    /* notifd must still be alive and serving operational data */
+    state_val = get_oper_leaf_str(st->sess,
+            "/ietf-subscribed-notifications:subscriptions/subscription[id='210']"
+            "/configured-subscription-state");
+    assert_non_null(state_val);
+    free(state_val);
+
+    /* and it must still process configuration changes and set up new dispatches, so replace the
+     * churned subscription with a fresh one and expect it to come up normally */
+    cleanup_sub(st->sess, 210);
+    drain_notifications(st->udp_sockfd);
+
+    setup_sub(st->sess, st->udp_port, 211, "NETCONF",
+            "/ietf-netconf-notifications:netconf-config-change");
+
+    ret = receive_specific_notification_timeout(st->udp_sockfd, st->ly_ctx, LONG_TIMEOUT_MS,
+            "/ietf-subscribed-notifications:subscription-started", &notif, NULL);
+    assert_int_equal(ret, 0);
+    assert_non_null(notif);
+    lyd_free_all(notif);
+
+    cleanup_sub(st->sess, 211);
+}
+
+/**
  * @brief Test: Verify that changing the encoding of an existing subscription
  * takes effect on subsequent notifications.
  *
@@ -3879,6 +3967,7 @@ main(void)
         cmocka_unit_test_setup(test_configured_replay, clear_subs_notifs),
         cmocka_unit_test_setup(test_source_address_modify, clear_subs_notifs),
         cmocka_unit_test_setup(test_receiver_instance_ref_change, clear_subs_notifs),
+        cmocka_unit_test_setup(test_receiver_add_delete_dispatch, clear_subs_notifs),
         cmocka_unit_test_setup(test_stop_time_concluded, clear_subs_notifs),
         cmocka_unit_test_setup(test_encoding_cbor_unsupported, clear_subs_notifs),
         cmocka_unit_test_setup(test_default_encoding, clear_subs_notifs),

--- a/tests/test_notifd.c
+++ b/tests/test_notifd.c
@@ -3476,8 +3476,9 @@ test_stop_time_concluded(void **state)
  *
  * Creates a subscription with JSON encoding, triggers a notification and
  * verifies it is received as JSON. Then modifies the encoding to XML, triggers
- * another notification and verifies it is received as XML. This catches the
- * bug where the receiver's cached encoding was not updated on modification.
+ * another notification and verifies it is received as XML. This catches a receiver
+ * sending in the encoding configured when its dispatch was started instead of the
+ * one currently configured for the subscription.
  */
 static void
 test_encoding_modify(void **state)

--- a/tests/test_notifd.c
+++ b/tests/test_notifd.c
@@ -692,6 +692,44 @@ receive_specific_notification_timeout(int sockfd, const struct ly_ctx *ly_ctx, i
     return receive_specific_notification_ext(sockfd, ly_ctx, timeout_ms, expected_path, notif, header, NULL, 0);
 }
 
+/**
+ * @brief Count the notifications of a single type received until the socket goes quiet.
+ *
+ * Waits for the first notification of any type and then keeps reading until nothing else arrives, so
+ * that a duplicate is detected instead of silently ignored.
+ *
+ * @param[in] sockfd UDP socket FD.
+ * @param[in] ly_ctx libyang context.
+ * @param[in] path Path of the notification to count.
+ * @return Number of notifications matching @p path, notifications of other types are discarded.
+ */
+static uint32_t
+count_notifications(int sockfd, const struct ly_ctx *ly_ctx, const char *path)
+{
+    struct lyd_node *notif = NULL;
+    char *notif_path;
+    uint32_t count = 0;
+    int timeout_ms = NOTIF_TIMEOUT_MS;
+
+    while (!receive_notification_ext(sockfd, ly_ctx, timeout_ms, &notif, NULL, NULL, 0)) {
+        /* the first notification may take a while, any further one is already waiting */
+        timeout_ms = DRAIN_TIMEOUT_MS;
+        if (!notif) {
+            continue;
+        }
+
+        notif_path = lyd_path(notif, LYD_PATH_STD, NULL, 0);
+        if (notif_path && !strcmp(notif_path, path)) {
+            ++count;
+        }
+        free(notif_path);
+        lyd_free_all(notif);
+        notif = NULL;
+    }
+
+    return count;
+}
+
 static int
 can_bind_local_ipv4(const char *address)
 {
@@ -3559,6 +3597,141 @@ test_receiver_add_delete_dispatch(void **state)
 }
 
 /**
+ * @brief Test: Verify that deleting one receiver leaves the subscription and its other receivers alone.
+ *
+ * The deleted receiver is reported as a created/deleted list entry followed by its descendant nodes,
+ * which carry no operation of their own. Processing those descendants after the entry itself has been
+ * destroyed fails to find the receiver and invalidates the whole subscription, terminating every other
+ * receiver with it.
+ */
+static void
+test_receiver_delete_keeps_subscription(void **state)
+{
+    struct state *st = *state;
+    struct lyd_node *notif = NULL;
+    char path[512], *sub_state;
+    int ret;
+    uint32_t count;
+
+    TLOG_INF("Testing that deleting a receiver keeps the subscription...");
+
+    /* subscription with receivers "recv1" and "recv2" */
+    setup_sub(st->sess, st->udp_port, 220, "NETCONF", "/ietf-netconf-notifications:netconf-config-change");
+    snprintf(path, sizeof(path),
+            "/ietf-subscribed-notifications:subscriptions/subscription[id='220']"
+            "/receivers/receiver[name='recv2']/ietf-subscribed-notif-receivers:receiver-instance-ref");
+    ret = sr_set_item_str(st->sess, path, "test-recv", NULL, 0);
+    assert_int_equal(ret, SR_ERR_OK);
+    ret = sr_apply_changes(st->sess, 0);
+    assert_int_equal(ret, SR_ERR_OK);
+
+    drain_notifications(st->udp_sockfd);
+
+    TLOG_INF("Deleting receiver \"recv1\"...");
+
+    snprintf(path, sizeof(path),
+            "/ietf-subscribed-notifications:subscriptions/subscription[id='220']/receivers/receiver[name='recv1']");
+    ret = sr_delete_item(st->sess, path, 0);
+    assert_int_equal(ret, SR_ERR_OK);
+    ret = sr_apply_changes(st->sess, 0);
+    assert_int_equal(ret, SR_ERR_OK);
+
+    /* only the deleted receiver may be terminated, "recv2" must be left alone */
+    count = count_notifications(st->udp_sockfd, st->ly_ctx,
+            "/ietf-subscribed-notifications:subscription-terminated");
+    assert_int_equal(count, 1);
+
+    /* and the subscription itself must still be valid */
+    sub_state = get_oper_leaf_str(st->sess,
+            "/ietf-subscribed-notifications:subscriptions/subscription[id='220']/configured-subscription-state");
+    assert_non_null(sub_state);
+    assert_string_equal(sub_state, "valid");
+    free(sub_state);
+
+    TLOG_INF("Checking that \"recv2\" still receives notifications...");
+
+    ret = sr_set_item_str(st->sess, "/test:test-leaf", "220", NULL, 0);
+    assert_int_equal(ret, SR_ERR_OK);
+    ret = sr_apply_changes(st->sess, 0);
+    assert_int_equal(ret, SR_ERR_OK);
+
+    ret = receive_specific_notification(st->udp_sockfd, st->ly_ctx,
+            "/ietf-netconf-notifications:netconf-config-change", &notif, NULL);
+    assert_int_equal(ret, 0);
+    assert_non_null(notif);
+    lyd_free_all(notif);
+
+    cleanup_sub(st->sess, 220);
+}
+
+/**
+ * @brief Test: Verify that restarting the daemon over an existing configuration works.
+ *
+ * On the "enabled" event the whole configuration is presented as a single created subtree, with only
+ * the top-level node carrying the operation. Every subscription and receiver below it therefore looks
+ * created without saying so, and processing them in the modify steps as well as in the create ones
+ * would set up a second dispatch for every receiver, delivering each notification twice.
+ */
+static void
+test_restart_existing_config(void **state)
+{
+    struct state *st = *state;
+    struct lyd_node *notif = NULL;
+    char *sub_state;
+    int ret;
+    uint32_t count;
+
+    TLOG_INF("Creating a subscription to be loaded again on restart...");
+
+    setup_sub(st->sess, st->udp_port, 221, "NETCONF", "/ietf-netconf-notifications:netconf-config-change");
+    ret = receive_specific_notification(st->udp_sockfd, st->ly_ctx,
+            "/ietf-subscribed-notifications:subscription-started", &notif, NULL);
+    assert_int_equal(ret, 0);
+    assert_non_null(notif);
+    lyd_free_all(notif);
+    notif = NULL;
+    drain_notifications(st->udp_sockfd);
+
+    TLOG_INF("Restarting sysrepo-notifd with the configuration in place...");
+
+    stop_notifd(st->notifd_pid);
+    st->notifd_pid = 0;
+    drain_notifications(st->udp_sockfd);
+
+    ret = start_notifd(&st->notifd_pid);
+    assert_int_equal(ret, 0);
+
+    /* the subscription must be picked up from the datastore and started again */
+    ret = receive_specific_notification_timeout(st->udp_sockfd, st->ly_ctx, LONG_TIMEOUT_MS,
+            "/ietf-subscribed-notifications:subscription-started", &notif, NULL);
+    assert_int_equal(ret, 0);
+    assert_non_null(notif);
+    lyd_free_all(notif);
+    notif = NULL;
+
+    sub_state = get_oper_leaf_str(st->sess,
+            "/ietf-subscribed-notifications:subscriptions/subscription[id='221']/configured-subscription-state");
+    assert_non_null(sub_state);
+    assert_string_equal(sub_state, "valid");
+    free(sub_state);
+
+    drain_notifications(st->udp_sockfd);
+
+    TLOG_INF("Checking that the restarted receiver is dispatched exactly once...");
+
+    ret = sr_set_item_str(st->sess, "/test:test-leaf", "221", NULL, 0);
+    assert_int_equal(ret, SR_ERR_OK);
+    ret = sr_apply_changes(st->sess, 0);
+    assert_int_equal(ret, SR_ERR_OK);
+
+    count = count_notifications(st->udp_sockfd, st->ly_ctx,
+            "/ietf-netconf-notifications:netconf-config-change");
+    assert_int_equal(count, 1);
+
+    cleanup_sub(st->sess, 221);
+}
+
+/**
  * @brief Test: Verify that changing the encoding of an existing subscription
  * takes effect on subsequent notifications.
  *
@@ -3968,6 +4141,8 @@ main(void)
         cmocka_unit_test_setup(test_source_address_modify, clear_subs_notifs),
         cmocka_unit_test_setup(test_receiver_instance_ref_change, clear_subs_notifs),
         cmocka_unit_test_setup(test_receiver_add_delete_dispatch, clear_subs_notifs),
+        cmocka_unit_test_setup(test_receiver_delete_keeps_subscription, clear_subs_notifs),
+        cmocka_unit_test_setup(test_restart_existing_config, clear_subs_notifs),
         cmocka_unit_test_setup(test_stop_time_concluded, clear_subs_notifs),
         cmocka_unit_test_setup(test_encoding_cbor_unsupported, clear_subs_notifs),
         cmocka_unit_test_setup(test_default_encoding, clear_subs_notifs),


### PR DESCRIPTION
Fix multiple issues in sysrepo-notifd and introduce new API `srsn_read_dispatch_del` to avoid data races with SRSN dispatch thread.