### PR TITLE
Make test_notifd failures debuggable

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -31,21 +31,33 @@ if(NOT SR_HAVE_PTHREAD_BARRIER)
     list(APPEND test_sources "pthread_barrier.c")
 endif()
 
+# directory with the sysrepo-notifd log and PID files of test_notifd, generated into
+# both the test config header and the cleanup script so that they cannot get out of sync
+set(TEST_NOTIFD_DATA_DIR ${PROJECT_BINARY_DIR}/test_notifd_data)
+
 # generate config
 configure_file("${PROJECT_SOURCE_DIR}/tests/tcommon.h.in" "${PROJECT_BINARY_DIR}/tests/tcommon.h" ESCAPE_QUOTES @ONLY)
 
+# generate the script killing the daemons left behind by an aborted test_notifd
+configure_file("${PROJECT_SOURCE_DIR}/tests/scripts/kill_notifd.sh.in" "${PROJECT_BINARY_DIR}/tests/scripts/kill_notifd.sh" ESCAPE_QUOTES @ONLY)
+
+set(TEST_KILL_NOTIFD_CMD ${PROJECT_BINARY_DIR}/tests/scripts/kill_notifd.sh)
 set(TEST_CLEAR_REPOS_CMD rm -rf ${PROJECT_BINARY_DIR}/test_repositories)
 set(TEST_CLEAR_SHM_CMD find /dev/shm/ -maxdepth 1 -readable -name _tests_sr_* -delete)
 if(${CMAKE_VERSION} VERSION_GREATER "3.7")
-    # tests cleanup fixtures
+    # tests cleanup fixtures, the daemons must be killed before their SHM is removed
+    add_test(NAME tests_kill_notifd
+        COMMAND ${TEST_KILL_NOTIFD_CMD}
+    )
+    set_tests_properties(tests_kill_notifd PROPERTIES FIXTURES_CLEANUP tests_cleanup)
     add_test(NAME tests_clear_repos
         COMMAND ${TEST_CLEAR_REPOS_CMD}
     )
-    set_tests_properties(tests_clear_repos PROPERTIES FIXTURES_CLEANUP tests_cleanup)
+    set_tests_properties(tests_clear_repos PROPERTIES FIXTURES_CLEANUP tests_cleanup DEPENDS tests_kill_notifd)
     add_test(NAME tests_clear_shm
         COMMAND ${TEST_CLEAR_SHM_CMD}
     )
-    set_tests_properties(tests_clear_shm PROPERTIES FIXTURES_CLEANUP tests_cleanup)
+    set_tests_properties(tests_clear_shm PROPERTIES FIXTURES_CLEANUP tests_cleanup DEPENDS tests_kill_notifd)
 endif()
 
 if(ENABLE_TESTS)
@@ -79,6 +91,7 @@ if(ENABLE_TESTS)
             "SYSREPO_REPOSITORY_PATH=${PROJECT_BINARY_DIR}/test_repositories/${test_name}"
             "SYSREPO_SHM_PREFIX=_tests_sr_${test_name}"
             "SR_ENV_RUN_TESTS=1"
+            "TEST_NAME=${test_name}"
         )
 
         # avoid loading installed plugins by sysrepo-plugind
@@ -108,6 +121,7 @@ if(ENABLE_VALGRIND_TESTS)
             "SYSREPO_REPOSITORY_PATH=${PROJECT_BINARY_DIR}/test_repositories/${test_name}"
             "SYSREPO_SHM_PREFIX=_tests_sr_${test_name}"
             "SR_ENV_RUN_TESTS=1"
+            "TEST_NAME=${test_name}"
         )
 
         # avoid loading installed plugins by sysrepo-plugind
@@ -125,6 +139,7 @@ endif()
 
 # phony target for clearing all sysrepo test data
 add_custom_target(test_clean
+    COMMAND ${TEST_KILL_NOTIFD_CMD} --remove-data
     COMMAND ${TEST_CLEAR_REPOS_CMD}
     COMMAND ${TEST_CLEAR_SHM_CMD}
 )

--- a/tests/scripts/kill_notifd.sh.in
+++ b/tests/scripts/kill_notifd.sh.in
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+
+# Kill any sysrepo-notifd daemon left behind by an aborted test_notifd run. The PID files are
+# created by the daemons themselves, one directory per test variant. With the "--remove-data"
+# argument the whole daemon data directory is removed as well, which is what "make test_clean" uses.
+
+NOTIFD_DATA_DIR="@TEST_NOTIFD_DATA_DIR@"
+
+# CMake always generates an absolute path inside the build directory here, but verify it anyway.
+# This is the only guard the "rm -rf" below has, an empty or unexpected value must never be able
+# to turn it into removing an unrelated directory.
+case "$NOTIFD_DATA_DIR" in
+    /?*/test_notifd_data)
+        ;;
+    *)
+        echo "Refusing to use \"$NOTIFD_DATA_DIR\" as the notifd test data directory!"
+        exit 1
+        ;;
+esac
+
+for PIDFILE in "$NOTIFD_DATA_DIR"/*/sysrepo-notifd.pid; do
+    if [ ! -f "$PIDFILE" ]; then
+        continue
+    fi
+
+    PID=$(cat "$PIDFILE")
+
+    # only kill the process if it really still is a daemon, the PID may have been reused
+    case "$(ps -p "$PID" -o comm= 2>/dev/null)" in
+        *sysrepo-notifd*)
+            kill "$PID"
+            ;;
+    esac
+
+    rm -f "$PIDFILE"
+done
+
+if [ "$1" = "--remove-data" ]; then
+    # only ever the directory validated above, which always is "<build dir>/test_notifd_data"
+    rm -rf "$NOTIFD_DATA_DIR"
+fi
+
+exit 0

--- a/tests/tcommon.h.in
+++ b/tests/tcommon.h.in
@@ -20,6 +20,9 @@
 
 #define TESTS_REPO_DIR "@TESTS_REPO_DIR@"
 
+/** directory with the sysrepo-notifd log and PID files of test_notifd */
+#define TESTS_NOTIFD_DATA_DIR "@TEST_NOTIFD_DATA_DIR@"
+
 /* path to all compiled executables */
 #define SR_BINARY_DIR "@PROJECT_BINARY_DIR@"
 

--- a/tests/test_notifd.c
+++ b/tests/test_notifd.c
@@ -47,6 +47,12 @@
 /** Path to sysrepoctl executable */
 #define SYSREPOCTL_PATH SR_BINARY_DIR "/sysrepoctl"
 
+/** Name of the daemon log file, kept after the tests end to make a failure debuggable */
+#define NOTIFD_LOG_NAME "sysrepo-notifd.log"
+
+/** Name of the daemon PID file, used by the ctest cleanup fixture to kill a leftover daemon */
+#define NOTIFD_PID_NAME "sysrepo-notifd.pid"
+
 /** Directory containing YANG modules */
 #define SCHEMA_DIR TESTS_SRC_DIR "/../modules"
 
@@ -850,8 +856,30 @@ start_notifd(pid_t *pid)
     pid_t child_pid;
     int pipefd[2];
     struct pollfd pfd;
-    int i, status, ret;
+    int i, status, ret, logfd;
     char c;
+    char run_dir[256], log_path[512], pid_path[512];
+    const char *test_name;
+
+    /* keep the files of every test variant separate, the variants may run in parallel */
+    test_name = getenv("TEST_NAME");
+    if (!test_name) {
+        test_name = "test_notifd";
+    }
+    snprintf(run_dir, sizeof(run_dir), "%s/%s", TESTS_NOTIFD_DATA_DIR, test_name);
+    snprintf(log_path, sizeof(log_path), "%s/%s", run_dir, NOTIFD_LOG_NAME);
+    snprintf(pid_path, sizeof(pid_path), "%s/%s", run_dir, NOTIFD_PID_NAME);
+
+    /* create the directory for the daemon log and PID file */
+    if (mkdir(TESTS_NOTIFD_DATA_DIR, 00755) && (errno != EEXIST)) {
+        TLOG_ERR("Failed to create directory \"%s\" (%s)", TESTS_NOTIFD_DATA_DIR, strerror(errno));
+        return -1;
+    }
+    if (mkdir(run_dir, 00755) && (errno != EEXIST)) {
+        TLOG_ERR("Failed to create directory \"%s\" (%s)", run_dir, strerror(errno));
+        return -1;
+    }
+    TLOG_INF("sysrepo-notifd log file \"%s\"", log_path);
 
     /* create pipe with CLOEXEC so exec() automatically closes the write end */
     if (pipe2(pipefd, O_CLOEXEC) < 0) {
@@ -869,9 +897,19 @@ start_notifd(pid_t *pid)
         /* child process - close read end, keep write end for failure signaling */
         close(pipefd[0]);
 
-        execlp(NOTIFD_PATH, "sysrepo-notifd", "-d", "-v", "info", "-s", SCHEMA_DIR, (char *)NULL);
+        /* redirect the daemon output into its own log file, it would be interleaved with the test output otherwise */
+        logfd = open(log_path, O_WRONLY | O_CREAT | O_TRUNC, 00600);
+        if (logfd == -1) {
+            goto child_error;
+        }
+        dup2(logfd, STDOUT_FILENO);
+        dup2(logfd, STDERR_FILENO);
+        close(logfd);
 
-        /* exec failed - signal parent by writing to pipe before exiting */
+        execlp(NOTIFD_PATH, "sysrepo-notifd", "-d", "-v", "info", "-s", SCHEMA_DIR, "-p", pid_path, (char *)NULL);
+
+child_error:
+        /* setup or exec failed - signal parent by writing to pipe before exiting */
         c = 1;
         write(pipefd[1], &c, 1);
         _exit(1);
@@ -907,9 +945,9 @@ start_notifd(pid_t *pid)
     }
 
     if (pfd.revents & POLLIN) {
-        /* exec failed - child wrote error byte before _exit() */
+        /* setup or exec failed - child wrote error byte before _exit() */
         waitpid(child_pid, &status, 0);
-        TLOG_ERR("sysrepo-notifd exec failed with status %d", status);
+        TLOG_ERR("sysrepo-notifd failed to start with status %d", status);
         return -1;
     }
 
@@ -3840,6 +3878,7 @@ main(void)
         cmocka_unit_test_setup_teardown(test_encoding_feature_disabled, clear_subs_notifs, re_enable_encoding_features),
     };
 
+    setenv("CMOCKA_TEST_ABORT", "1", 1);
     test_init();
     return cmocka_run_group_tests(tests, setup, teardown);
 }

--- a/tests/test_notifd.c
+++ b/tests/test_notifd.c
@@ -18,6 +18,7 @@
 #include <arpa/inet.h>
 #include <errno.h>
 #include <fcntl.h>
+#include <inttypes.h>
 #include <netinet/in.h>
 #include <poll.h>
 #include <pthread.h>
@@ -58,9 +59,6 @@
 
 /** Directory containing subscribed_notifications YANG modules */
 #define SN_YANG_DIR TESTS_SRC_DIR "/../modules/subscribed_notifications"
-
-/** UDP port for testing */
-#define TEST_UDP_PORT 47950
 
 /** UDP-Notif protocol constants */
 #define UDP_NOTIF_VERSION 1
@@ -390,32 +388,43 @@ add_segment(pending_message_t *pending, uint16_t segment_num, int is_last,
 /**
  * @brief Create UDP socket for receiving notifications.
  *
- * @param[in] port Port to listen on.
+ * The port is always assigned by the system so that several tests, such as the plain and the
+ * valgrind variant of this one, may receive notifications at the same time. SO_REUSEADDR is
+ * deliberately not set, it would let them silently bind the very same port and steal each
+ * other's notifications.
+ *
+ * @param[out] port Port the socket was bound to.
  * @return Socket FD on success, -1 on error.
  */
 static int
-create_udp_receiver_socket(uint16_t port)
+create_udp_receiver_socket(uint16_t *port)
 {
     int sockfd;
     struct sockaddr_in addr;
-    int opt = 1;
+    socklen_t addr_len;
 
     sockfd = socket(AF_INET, SOCK_DGRAM, 0);
     if (sockfd < 0) {
         return -1;
     }
 
-    setsockopt(sockfd, SOL_SOCKET, SO_REUSEADDR, &opt, sizeof(opt));
-
     memset(&addr, 0, sizeof(addr));
     addr.sin_family = AF_INET;
-    addr.sin_port = htons(port);
+    addr.sin_port = htons(0);
     addr.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
 
     if (bind(sockfd, (struct sockaddr *)&addr, sizeof(addr)) < 0) {
         close(sockfd);
         return -1;
     }
+
+    /* learn the assigned port */
+    addr_len = sizeof(addr);
+    if (getsockname(sockfd, (struct sockaddr *)&addr, &addr_len) < 0) {
+        close(sockfd);
+        return -1;
+    }
+    *port = ntohs(addr.sin_port);
 
     return sockfd;
 }
@@ -1309,15 +1318,13 @@ setup(void **state)
         return 1;
     }
 
-    /* find available port */
-    st->udp_port = TEST_UDP_PORT;
-
-    /* create UDP receiver socket */
-    st->udp_sockfd = create_udp_receiver_socket(st->udp_port);
+    /* create UDP receiver socket on a free port assigned by the system */
+    st->udp_sockfd = create_udp_receiver_socket(&st->udp_port);
     if (st->udp_sockfd < 0) {
         TLOG_ERR("Failed to create UDP socket");
         return 1;
     }
+    TLOG_INF("Receiving notifications on port %" PRIu16, st->udp_port);
 
     /* start sysrepo-notifd */
     if (start_notifd(&st->notifd_pid)) {
@@ -3294,20 +3301,21 @@ test_receiver_instance_ref_change(void **state)
     struct lyd_node *notif = NULL;
     char path[512];
     int ret, recv2_sockfd = -1;
+    uint16_t recv2_port = 0;
 
     TLOG_INF("Creating first and second receiver instances...");
+
+    /* create a socket for the second receiver first, its port is assigned by the system */
+    recv2_sockfd = create_udp_receiver_socket(&recv2_port);
+    assert_true(recv2_sockfd >= 0);
 
     /*
      Create two receiver instances
      */
     ret = create_receiver_instance(st->sess, "recv-1", "127.0.0.1", st->udp_port);
     assert_int_equal(ret, SR_ERR_OK);
-    ret = create_receiver_instance(st->sess, "recv-2", "127.0.0.1", st->udp_port + 1);
+    ret = create_receiver_instance(st->sess, "recv-2", "127.0.0.1", recv2_port);
     assert_int_equal(ret, SR_ERR_OK);
-
-    /* create a socket for the second receiver */
-    recv2_sockfd = create_udp_receiver_socket(st->udp_port + 1);
-    assert_true(recv2_sockfd >= 0);
 
     /*
      Create subscription pointing to recv-1


### PR DESCRIPTION
Two test-only changes to `test_notifd`, ported from the netopeer2 test setup.

- Set `CMOCKA_TEST_ABORT` so the first failed assert aborts instead of cascading into the remaining tests.
- Redirect the `sysrepo-notifd` output into a per-variant log file under `test_notifd_data/`, kept until `make test_clean`.
- Let the daemon write a PID file and add a ctest cleanup fixture that kills a daemon left behind by an aborted run before its SHM is removed.
- Fix the receiver socket binding a hardcoded UDP port, which made the plain and valgrind variants steal each other's notifications under `ctest -j`.
