### PR TITLE
sysrepo-notifd: coexist with other notification publishers

### DIFF
--- a/src/executables/sysrepo-notifd/main.c
+++ b/src/executables/sysrepo-notifd/main.c
@@ -532,7 +532,10 @@ sub_change_modify_recv_instances(notifd_ctx_t *notifd_ctx, sr_session_ctx_t *ses
 
         /* all these nodes are under the receiver-instance list, so find it */
         recv_inst = receiver_inst_find_by_node(notifd_ctx, node);
-        assert(recv_inst);
+        if (!recv_inst) {
+            /* not tracked, so serviced by another publisher */
+            continue;
+        }
 
         r = receiver_inst_config_change(recv_inst, node, op);
 
@@ -610,7 +613,10 @@ sub_change_modify_subscriptions(notifd_ctx_t *notifd_ctx, sr_session_ctx_t *sess
 
         /* all these nodes are under the subscription list, so find it */
         sub = subscription_find_by_node(notifd_ctx, node);
-        assert(sub);
+        if (!sub) {
+            /* not tracked, so serviced by another publisher */
+            continue;
+        }
 
         if (!strcmp(node_name, "stream")) {
             r = handle_stream(sub, node, op);
@@ -678,7 +684,10 @@ sub_change_modify_receivers(notifd_ctx_t *notifd_ctx, sr_session_ctx_t *session)
 
         /* all these nodes are under the receiver list, so find the subscription */
         sub = subscription_find_by_node(notifd_ctx, node);
-        assert(sub);
+        if (!sub) {
+            /* not tracked, so serviced by another publisher */
+            continue;
+        }
 
         if (!strcmp(node_name, "receiver")) {
             if (op == SR_OP_CREATED) {
@@ -936,7 +945,8 @@ replay_start_time_oper_get(sr_session_ctx_t *UNUSED(session), uint32_t UNUSED(su
     }
 
     if (!(sub = subscription_find_by_node(notifd_ctx, *parent))) {
-        SRNTF_LOG_ERR("Failed to find subscription for replay-start-time operational data request.");
+        /* not serviced by this daemon, its state is provided by the publisher that services it */
+        SRNTF_LOG_DBG("Providing no replay-start-time of a subscription of another publisher.");
         goto cleanup;
     }
 
@@ -977,7 +987,8 @@ configured_sub_state_oper_get(sr_session_ctx_t *UNUSED(session), uint32_t UNUSED
     }
 
     if (!(sub = subscription_find_by_node(notifd_ctx, *parent))) {
-        SRNTF_LOG_ERR("Failed to find subscription for \"%s\" operational data request.", path);
+        /* not serviced by this daemon, its state is provided by the publisher that services it */
+        SRNTF_LOG_DBG("Providing no \"%s\" data of a subscription of another publisher.", path);
         goto cleanup;
     }
 
@@ -1012,7 +1023,8 @@ sent_event_records_oper_get(sr_session_ctx_t *UNUSED(session), uint32_t UNUSED(s
     }
 
     if (!(sub = subscription_find_by_node(notifd_ctx, *parent))) {
-        SRNTF_LOG_ERR("Failed to find subscription for \"%s\" operational data request.", path);
+        /* not serviced by this daemon, its state is provided by the publisher that services it */
+        SRNTF_LOG_DBG("Providing no \"%s\" data of a subscription of another publisher.", path);
         goto cleanup;
     }
 
@@ -1020,8 +1032,16 @@ sent_event_records_oper_get(sr_session_ctx_t *UNUSED(session), uint32_t UNUSED(s
         goto cleanup;
     }
     if (!(recv = receiver_find_by_name(sub, lyd_get_value(name_node)))) {
-        SRNTF_LOG_ERR("Failed to find receiver for \"%s\" operational data request.", path);
-        rc = SR_ERR_NOT_FOUND;
+        /* the subscription is ours but the receiver was not created, it has no state to provide */
+        SRNTF_LOG_DBG("Providing no \"%s\" data of receiver \"%s\", it is not serviced.", path,
+                lyd_get_value(name_node));
+        goto cleanup;
+    }
+
+    if (!recv->srsn_data.sub_id) {
+        /* dispatch is not running for this receiver, there are no counters to provide */
+        SRNTF_LOG_DBG("Providing no \"%s\" data of receiver \"%s\", its dispatch is not running.", path,
+                recv->name);
         goto cleanup;
     }
 
@@ -1064,7 +1084,8 @@ excluded_event_records_oper_get(sr_session_ctx_t *UNUSED(session), uint32_t UNUS
     }
 
     if (!(sub = subscription_find_by_node(notifd_ctx, *parent))) {
-        SRNTF_LOG_ERR("Failed to find subscription for \"%s\" operational data request.", path);
+        /* not serviced by this daemon, its state is provided by the publisher that services it */
+        SRNTF_LOG_DBG("Providing no \"%s\" data of a subscription of another publisher.", path);
         goto cleanup;
     }
 
@@ -1072,8 +1093,16 @@ excluded_event_records_oper_get(sr_session_ctx_t *UNUSED(session), uint32_t UNUS
         goto cleanup;
     }
     if (!(recv = receiver_find_by_name(sub, lyd_get_value(name_node)))) {
-        SRNTF_LOG_ERR("Failed to find receiver for \"%s\" operational data request.", path);
-        rc = SR_ERR_NOT_FOUND;
+        /* the subscription is ours but the receiver was not created, it has no state to provide */
+        SRNTF_LOG_DBG("Providing no \"%s\" data of receiver \"%s\", it is not serviced.", path,
+                lyd_get_value(name_node));
+        goto cleanup;
+    }
+
+    if (!recv->srsn_data.sub_id) {
+        /* dispatch is not running for this receiver, there are no counters to provide */
+        SRNTF_LOG_DBG("Providing no \"%s\" data of receiver \"%s\", its dispatch is not running.", path,
+                recv->name);
         goto cleanup;
     }
 
@@ -1114,7 +1143,8 @@ receiver_state_oper_get(sr_session_ctx_t *UNUSED(session), uint32_t UNUSED(sub_i
     }
 
     if (!(sub = subscription_find_by_node(notifd_ctx, *parent))) {
-        SRNTF_LOG_ERR("Failed to find subscription for \"%s\" operational data request.", path);
+        /* not serviced by this daemon, its state is provided by the publisher that services it */
+        SRNTF_LOG_DBG("Providing no \"%s\" data of a subscription of another publisher.", path);
         goto cleanup;
     }
 
@@ -1122,8 +1152,9 @@ receiver_state_oper_get(sr_session_ctx_t *UNUSED(session), uint32_t UNUSED(sub_i
         goto cleanup;
     }
     if (!(recv = receiver_find_by_name(sub, lyd_get_value(name_node)))) {
-        SRNTF_LOG_ERR("Failed to find receiver for \"%s\" operational data request.", path);
-        rc = SR_ERR_NOT_FOUND;
+        /* the subscription is ours but the receiver was not created, it has no state to provide */
+        SRNTF_LOG_DBG("Providing no \"%s\" data of receiver \"%s\", it is not serviced.", path,
+                lyd_get_value(name_node));
         goto cleanup;
     }
 
@@ -1156,10 +1187,15 @@ register_oper_data_providers(notifd_ctx_t *notifd_ctx, sr_subscription_ctx_t **s
         return r;
     }
 
+    /*
+     * All the providers are subscribed with ::SR_SUBSCR_OPER_MERGE because this daemon is not the only
+     * publisher of the shared ietf-subscribed-notifications:subscriptions subtree.
+     */
+
     /* replay-start-time */
     if (replay_enabled) {
         path = "/ietf-subscribed-notifications:subscriptions/subscription/replay-start-time";
-        if ((r = sr_oper_get_subscribe(sess, module, path, replay_start_time_oper_get, notifd_ctx, 0, subscr))) {
+        if ((r = sr_oper_get_subscribe(sess, module, path, replay_start_time_oper_get, notifd_ctx, SR_SUBSCR_OPER_MERGE, subscr))) {
             SRNTF_LOG_ERR("Failed to subscribe for replay-start-time operational data.");
             return r;
         }
@@ -1167,28 +1203,28 @@ register_oper_data_providers(notifd_ctx_t *notifd_ctx, sr_subscription_ctx_t **s
 
     /* configured-subscription-state */
     path = "/ietf-subscribed-notifications:subscriptions/subscription/configured-subscription-state";
-    if ((r = sr_oper_get_subscribe(sess, module, path, configured_sub_state_oper_get, notifd_ctx, 0, subscr))) {
+    if ((r = sr_oper_get_subscribe(sess, module, path, configured_sub_state_oper_get, notifd_ctx, SR_SUBSCR_OPER_MERGE, subscr))) {
         SRNTF_LOG_ERR("Failed to subscribe for configured-subscription-state operational data.");
         return r;
     }
 
     /* sent-event-records */
     path = "/ietf-subscribed-notifications:subscriptions/subscription/receivers/receiver/sent-event-records";
-    if ((r = sr_oper_get_subscribe(sess, module, path, sent_event_records_oper_get, notifd_ctx, 0, subscr))) {
+    if ((r = sr_oper_get_subscribe(sess, module, path, sent_event_records_oper_get, notifd_ctx, SR_SUBSCR_OPER_MERGE, subscr))) {
         SRNTF_LOG_ERR("Failed to subscribe for sent-event-records operational data.");
         return r;
     }
 
     /* excluded-event-records */
     path = "/ietf-subscribed-notifications:subscriptions/subscription/receivers/receiver/excluded-event-records";
-    if ((r = sr_oper_get_subscribe(sess, module, path, excluded_event_records_oper_get, notifd_ctx, 0, subscr))) {
+    if ((r = sr_oper_get_subscribe(sess, module, path, excluded_event_records_oper_get, notifd_ctx, SR_SUBSCR_OPER_MERGE, subscr))) {
         SRNTF_LOG_ERR("Failed to subscribe for excluded-event-records operational data.");
         return r;
     }
 
     /* receiver state */
     path = "/ietf-subscribed-notifications:subscriptions/subscription/receivers/receiver/state";
-    if ((r = sr_oper_get_subscribe(sess, module, path, receiver_state_oper_get, notifd_ctx, 0, subscr))) {
+    if ((r = sr_oper_get_subscribe(sess, module, path, receiver_state_oper_get, notifd_ctx, SR_SUBSCR_OPER_MERGE, subscr))) {
         SRNTF_LOG_ERR("Failed to subscribe for receiver state operational data.");
         return r;
     }
@@ -1228,7 +1264,11 @@ receiver_reset_rpc_cb(sr_session_ctx_t *UNUSED(session), uint32_t UNUSED(sub_id)
     state_locked = 1;
 
     if (!(sub = subscription_find_by_node(notifd_ctx, input))) {
-        SRNTF_LOG_ERR("Failed to find subscription for receiver reset RPC.");
+        /*
+         * Not serviced by this daemon, the reset belongs to the publisher that services it.
+         * (sysrepo keeps only the reply of the lowest prio subscriber of an action)
+         */
+        SRNTF_LOG_DBG("Ignoring the reset action of a subscription of another publisher.");
         goto cleanup;
     }
 
@@ -1237,8 +1277,9 @@ receiver_reset_rpc_cb(sr_session_ctx_t *UNUSED(session), uint32_t UNUSED(sub_id)
         goto cleanup;
     }
     if (!(recv = receiver_find_by_name(sub, lyd_get_value(name_node)))) {
-        SRNTF_LOG_ERR("Failed to find receiver for receiver reset RPC.");
-        rc = SR_ERR_NOT_FOUND;
+        /* the subscription is ours but the receiver was not created, there is nothing to reset */
+        SRNTF_LOG_DBG("Ignoring the reset action of receiver \"%s\", it is not serviced.",
+                lyd_get_value(name_node));
         goto cleanup;
     }
 

--- a/src/executables/sysrepo-notifd/notifd.h
+++ b/src/executables/sysrepo-notifd/notifd.h
@@ -379,8 +379,10 @@ struct notif_sub_s {
     char *xpath_filter;                 /**< optional XPath filter */
     const notif_transport_ops_t *ops;   /**< transport servicing the subscription, only the
                                              subscriptions with a transport of this daemon are
-                                             tracked at all; NULL only if the "transport" leaf
-                                             was removed by a configuration change */
+                                             tracked at all; the receiver instances of all its
+                                             receivers must use this very transport; NULL only
+                                             if the "transport" leaf was removed by a
+                                             configuration change */
     notif_encoding_t encoding;          /**< notification encoding */
     struct timespec stop_time;          /**< optional stop time */
     int replay;                         /**< whether to replay notifications */

--- a/src/executables/sysrepo-notifd/notifd.h
+++ b/src/executables/sysrepo-notifd/notifd.h
@@ -377,7 +377,10 @@ struct notif_sub_s {
     char *stream;                       /**< stream name */
     char *filter_ref;                   /**< optional stream filter name (e.g., XPath or subtree filter) */
     char *xpath_filter;                 /**< optional XPath filter */
-    char *transport;                    /**< notification transport identity-ref (e.g. "ietf-udp-notif-transport:udp-notif") */
+    const notif_transport_ops_t *ops;   /**< transport servicing the subscription, only the
+                                             subscriptions with a transport of this daemon are
+                                             tracked at all; NULL only if the "transport" leaf
+                                             was removed by a configuration change */
     notif_encoding_t encoding;          /**< notification encoding */
     struct timespec stop_time;          /**< optional stop time */
     int replay;                         /**< whether to replay notifications */

--- a/src/executables/sysrepo-notifd/notifd_config.c
+++ b/src/executables/sysrepo-notifd/notifd_config.c
@@ -31,6 +31,7 @@
 
 /* forward declarations */
 void receiver_destroy(notifd_ctx_t *notifd_ctx, notif_sub_t *sub, notif_receiver_t *receiver);
+static void receiver_instance_destroy(notifd_ctx_t *notifd_ctx, notif_receiver_inst_t *recv_inst);
 
 /*
  * ---------------------------------------------------------------------------
@@ -91,6 +92,61 @@ notif_transport_find_by_container(const char *container_name)
     for (i = 0; transport_registry[i]; i++) {
         if (!strcmp(transport_registry[i]->config_container_name, container_name)) {
             return transport_registry[i];
+        }
+    }
+
+    return NULL;
+}
+
+/**
+ * @brief Find the transport this daemon would use to service a configured subscription.
+ *
+ * The subscriptions list is shared with every other notification publisher on the system.
+ * This daemon services only the subscriptions with a transport it implements, all the others are
+ * ignored completely - their configuration and their state alike belong to the publisher servicing them.
+ *
+ * Note that the subscription-level "transport" leaf is not mandatory in the model, since
+ * ietf-subscribed-notif-receivers moved the transport down to the receiver instances. This
+ * daemon requires it nevertheless, it is what tells its own subscriptions apart from the rest.
+ *
+ * @param[in] node Subscription list node.
+ * @return Transport of the subscription, NULL if it is not serviced by this daemon.
+ */
+static const notif_transport_ops_t *
+notif_transport_find_by_sub_node(const struct lyd_node *node)
+{
+    struct lyd_node *n;
+
+    if (lyd_find_path(node, "transport", 0, &n)) {
+        /* no transport, the subscription is none of our business */
+        return NULL;
+    }
+
+    return notif_transport_find_by_identity(lyd_get_value(n));
+}
+
+/**
+ * @brief Find the transport of a receiver instance, which is the case of its "transport-type" choice.
+ *
+ * Receiver instances of transports this daemon does not implement belong to another publisher,
+ * just like the subscriptions using them (see ::notif_transport_find_by_sub_node()).
+ *
+ * @param[in] node Receiver-instance list node.
+ * @param[out] config_node Transport configuration container of the instance, NULL if there is none.
+ * @return Transport of the receiver instance, NULL if it is not serviced by this daemon.
+ */
+static const notif_transport_ops_t *
+notif_transport_find_by_recv_inst_node(const struct lyd_node *node, const struct lyd_node **config_node)
+{
+    const struct lyd_node *child;
+    const notif_transport_ops_t *ops;
+
+    *config_node = NULL;
+
+    LY_LIST_FOR(lyd_child(node), child) {
+        if ((ops = notif_transport_find_by_container(LYD_NAME(child)))) {
+            *config_node = child;
+            return ops;
         }
     }
 
@@ -860,20 +916,13 @@ handle_transport(notif_sub_t *sub, const struct lyd_node *node, sr_change_oper_t
 {
     int rc = SR_ERR_OK;
 
-    /* mandatory leaf, need to handle all but move */
+    /* the subscription is tracked, so it was created with a transport of ours, need to handle all but move */
     if ((op == SR_OP_CREATED) || (op == SR_OP_MODIFIED)) {
-        /* switch to the new value */
-        free(sub->transport);
-        sub->transport = strdup(lyd_get_value(node));
-        if (!sub->transport) {
-            rc = SR_ERR_NO_MEMORY;
-            ERRMEM;
-            goto cleanup;
-        }
+        /* switch to the new transport */
+        sub->ops = notif_transport_find_by_identity(lyd_get_value(node));
     } else if (op == SR_OP_DELETED) {
-        /* clear transport */
-        free(sub->transport);
-        sub->transport = NULL;
+        /* clear the transport */
+        sub->ops = NULL;
     }
 
     if ((op == SR_OP_CREATED) || (op == SR_OP_MODIFIED) || (op == SR_OP_DELETED)) {
@@ -881,10 +930,6 @@ handle_transport(notif_sub_t *sub, const struct lyd_node *node, sr_change_oper_t
         sub->modified = 1;
     }
 
-cleanup:
-    if (rc) {
-        sub_invalidate(sub, NULL);
-    }
     return rc;
 }
 
@@ -1106,18 +1151,6 @@ subscription_from_node(notifd_ctx_t *notifd_ctx, const struct lyd_node *node, no
         }
     }
 
-    /* transport (mandatory for configured subs, even though it is not mandatory in the model), refine "transport" */
-    if ((rc = get_descendant_mandatory(node, "transport", &n))) {
-        goto cleanup;
-    }
-    if (!notif_transport_find_by_identity(lyd_get_value(n))) {
-        SRNTF_LOG_ERR("Unsupported transport \"%s\".", lyd_get_value(n));
-        rc = SR_ERR_UNSUPPORTED;
-        goto cleanup;
-    }
-    sub->transport = strdup(lyd_get_value(n));
-    CHECK_ERRMEM_GOTO(sub->transport, rc, cleanup);
-
     /* purpose */
     get_descendant_optional(node, "purpose", &n);
     if (n) {
@@ -1170,7 +1203,14 @@ int
 subscription_create_from_node(notifd_ctx_t *notifd_ctx, const struct lyd_node *node)
 {
     int rc = SR_ERR_OK;
+    const notif_transport_ops_t *ops;
     notif_sub_t *sub, **sub_ptr = NULL;
+
+    /* only the subscriptions with a transport of ours are serviced by this daemon */
+    if (!(ops = notif_transport_find_by_sub_node(node))) {
+        SRNTF_LOG_DBG("Ignoring subscription \"%s\" of another publisher.", lyd_get_value(lyd_child(node)));
+        return SR_ERR_OK;
+    }
 
     /* create a new sub and add it to the context array */
     sub = calloc(1, sizeof *sub);
@@ -1179,13 +1219,16 @@ subscription_create_from_node(notifd_ctx_t *notifd_ctx, const struct lyd_node *n
     *sub_ptr = sub;
     sub->state = NOTIF_SUB_STATE_VALID;
 
-    /* parse the subscription */
+    /* the transport is resolved, the rest of the configuration is parsed below */
+    sub->ops = ops;
     if ((rc = subscription_from_node(notifd_ctx, node, sub))) {
         goto cleanup;
     }
 
 cleanup:
     if (rc) {
+        /* keep the subscription tracked but invalid, its state is reported in the operational data
+         * and the daemon is expected to service it once its configuration is fixed */
         subscription_receivers_disconnect(notifd_ctx, sub);
         sub_invalidate(sub, NULL);
         if (!sub_ptr) {
@@ -1214,7 +1257,6 @@ subscription_destroy(notifd_ctx_t *notifd_ctx, notif_sub_t *sub)
     free(sub->stream);
     free(sub->xpath_filter);
     free(sub->filter_ref);
-    free(sub->transport);
     free(sub->purpose);
     free(sub->local_address);
     for (i = LY_ARRAY_COUNT(sub->receivers); i > 0; i--) {
@@ -1240,8 +1282,10 @@ subscription_destroy_from_node(notifd_ctx_t *notifd_ctx, const struct lyd_node *
 
     /* try to find the sub */
     if (!(sub = subscription_find_by_node(notifd_ctx, node))) {
-        SRNTF_LOG_ERR("Failed to find subscription \"%s\" for destruction.", lyd_get_value(lyd_child(node)));
-        return SR_ERR_NOT_FOUND;
+        /* not tracked, so serviced by another publisher */
+        SRNTF_LOG_DBG("Ignoring destruction of subscription \"%s\" of another publisher.",
+                lyd_get_value(lyd_child(node)));
+        return SR_ERR_OK;
     }
 
     /* if the sub is still valid, send subscription-terminated notification to all receivers */
@@ -1394,12 +1438,11 @@ cleanup:
  */
 
 static int
-receiver_instance_from_node(const struct lyd_node *node, notif_receiver_inst_t *recv_inst)
+receiver_instance_from_node(const struct lyd_node *node, const struct lyd_node *config_node,
+        const notif_transport_ops_t *ops, notif_receiver_inst_t *recv_inst)
 {
     int rc = SR_ERR_OK;
     struct lyd_node *n;
-    struct lyd_node *child;
-    const notif_transport_ops_t *ops;
 
     /* receiver instance name */
     if ((rc = get_descendant_mandatory(node, "name", &n))) {
@@ -1408,18 +1451,11 @@ receiver_instance_from_node(const struct lyd_node *node, notif_receiver_inst_t *
     recv_inst->name = strdup(lyd_get_value(n));
     CHECK_ERRMEM_GOTO(recv_inst->name, rc, cleanup);
 
-    /* find the transport config container by iterating children */
-    LY_LIST_FOR(lyd_child(node), child) {
-        ops = notif_transport_find_by_container(LYD_NAME(child));
-        if (ops) {
-            recv_inst->type = ops->type;
-            recv_inst->ops = ops;
-
-            if ((rc = ops->config_parse(child, &recv_inst->transport_config))) {
-                goto cleanup;
-            }
-            break;
-        }
+    /* transport and its configuration, both already resolved by the caller */
+    recv_inst->type = ops->type;
+    recv_inst->ops = ops;
+    if ((rc = ops->config_parse(config_node, &recv_inst->transport_config))) {
+        goto cleanup;
     }
 
 cleanup:
@@ -1430,20 +1466,37 @@ int
 receiver_instance_create_from_node(notifd_ctx_t *notifd_ctx, const struct lyd_node *node)
 {
     int rc = SR_ERR_OK;
-    notif_receiver_inst_t *recv_inst, **recv_inst_ptr;
+    const struct lyd_node *config_node;
+    const notif_transport_ops_t *ops;
+    notif_receiver_inst_t *recv_inst, **recv_inst_ptr = NULL;
+
+    /* only the receiver instances with a transport of ours are serviced by this daemon */
+    if (!(ops = notif_transport_find_by_recv_inst_node(node, &config_node))) {
+        SRNTF_LOG_DBG("Ignoring receiver instance \"%s\" of another publisher.", lyd_get_value(lyd_child(node)));
+        return SR_ERR_OK;
+    }
 
     /* create a new receiver instance and add it to the context array */
-    LY_ARRAY_NEW_GOTO(LYD_CTX(node), notifd_ctx->recv_insts, recv_inst_ptr, rc, cleanup);
     recv_inst = calloc(1, sizeof *recv_inst);
-    CHECK_ERRMEM_GOTO(recv_inst, rc, cleanup);
+    CHECK_ERRMEM_RET(recv_inst);
+    LY_ARRAY_NEW_GOTO(LYD_CTX(node), notifd_ctx->recv_insts, recv_inst_ptr, rc, cleanup);
     *recv_inst_ptr = recv_inst;
 
     /* parse the receiver instance */
-    if ((rc = receiver_instance_from_node(node, recv_inst))) {
+    if ((rc = receiver_instance_from_node(node, config_node, ops, recv_inst))) {
         goto cleanup;
     }
 
 cleanup:
+    if (rc) {
+        /* unlike a subscription, an unusable receiver instance has no state of its own to report,
+         * the subscriptions referencing it are invalidated instead */
+        if (recv_inst_ptr) {
+            receiver_instance_destroy(notifd_ctx, recv_inst);
+        } else {
+            free(recv_inst);
+        }
+    }
     return rc;
 }
 
@@ -1482,8 +1535,10 @@ receiver_instance_destroy_from_node(notifd_ctx_t *notifd_ctx, const struct lyd_n
 
     /* find the receiver instance */
     if (!(recv_inst = receiver_inst_find_by_node(notifd_ctx, node))) {
-        SRNTF_LOG_ERR("Receiver instance with name \"%s\" not found for deletion.", lyd_get_value(lyd_child(node)));
-        return SR_ERR_NOT_FOUND;
+        /* not tracked, so serviced by another publisher */
+        SRNTF_LOG_DBG("Ignoring destruction of receiver instance \"%s\" of another publisher.",
+                lyd_get_value(lyd_child(node)));
+        return SR_ERR_OK;
     }
 
     /* destroy the receiver instance, no need to lock as no subs can point to it anymore */
@@ -1770,6 +1825,7 @@ sub_change_validate(notifd_ctx_t *notifd_ctx, sr_session_ctx_t *session, sr_even
     const char *stream, *xpath_filter;
     struct timespec stop_time, start_time;
     notif_sub_t *sub;
+    const notif_transport_ops_t *ops;
 
     /* validate created subscriptions */
     if ((rc = sr_get_changes_iter(session, "/ietf-subscribed-notifications:subscriptions/subscription", &iter))) {
@@ -1782,20 +1838,16 @@ sub_change_validate(notifd_ctx_t *notifd_ctx, sr_session_ctx_t *session, sr_even
             continue;
         }
 
-        /* transport - validate against registered transports */
-        if (!lyd_find_path(node, "transport", 0, &n)) {
-            const notif_transport_ops_t *ops;
+        /* validate only the subscriptions serviced by this daemon, the configuration of the others
+         * is not ours to reject */
+        if (!(ops = notif_transport_find_by_sub_node(node))) {
+            continue;
+        }
 
-            ops = notif_transport_find_by_identity(lyd_get_value(n));
-            if (!ops) {
-                SRNTF_VALIDATE_ERR(session, event, SR_ERR_UNSUPPORTED, "Unsupported transport \"%s\".", lyd_get_value(n));
-                rc = SR_ERR_UNSUPPORTED;
-                goto cleanup;
-            }
-            if (ops->config_validate && (r = ops->config_validate(node))) {
-                rc = r;
-                goto cleanup;
-            }
+        /* transport-specific validation */
+        if (ops->config_validate && (r = ops->config_validate(node))) {
+            rc = r;
+            goto cleanup;
         }
 
         /* encoding */
@@ -1887,6 +1939,13 @@ sub_change_validate(notifd_ctx_t *notifd_ctx, sr_session_ctx_t *session, sr_even
             continue;
         }
 
+        /* validate only the changes of the subscriptions serviced by this daemon; the diff of
+         * a modified subscription does not include its "transport" leaf, so it is the tracked
+         * state that decides here (see ::notif_transport_find_by_sub_node()) */
+        if (!(sub = subscription_find_by_node(notifd_ctx, node))) {
+            continue;
+        }
+
         if (!strcmp(node_name, "stream")) {
             /* stream changed - validate new stream exists */
             if ((r = sub_change_validate_stream(notifd_ctx, session, event, lyd_get_value(node), NULL))) {
@@ -1895,8 +1954,7 @@ sub_change_validate(notifd_ctx_t *notifd_ctx, sr_session_ctx_t *session, sr_even
             }
 
             /* if configured-replay is set on the existing sub, also check replay support for new stream */
-            sub = subscription_find_by_node(notifd_ctx, node);
-            if (sub && sub->replay) {
+            if (sub->replay) {
                 if ((r = stream_supports_replay(notifd_ctx, lyd_get_value(node), sub->xpath_filter,
                         &start_time))) {
                     SRNTF_VALIDATE_ERR(session, event, r, "Stream \"%s\" does not support replay.", lyd_get_value(node));
@@ -1930,10 +1988,9 @@ sub_change_validate(notifd_ctx_t *notifd_ctx, sr_session_ctx_t *session, sr_even
             }
 
             /* check stop-time is not in the past */
-            sub = subscription_find_by_node(notifd_ctx, node);
             start_time.tv_sec = 0;
             start_time.tv_nsec = 0;
-            if (sub && (sub->start_time.tv_sec || sub->start_time.tv_nsec)) {
+            if (sub->start_time.tv_sec || sub->start_time.tv_nsec) {
                 start_time = sub->start_time;
             }
 
@@ -1944,8 +2001,7 @@ sub_change_validate(notifd_ctx_t *notifd_ctx, sr_session_ctx_t *session, sr_even
             }
         } else if (!strcmp(node_name, "configured-replay")) {
             /* replay being enabled on existing sub, check stream supports it */
-            sub = subscription_find_by_node(notifd_ctx, node);
-            if (sub && sub->stream) {
+            if (sub->stream) {
                 if ((r = stream_supports_replay(notifd_ctx, sub->stream, sub->xpath_filter,
                         &start_time))) {
                     SRNTF_VALIDATE_ERR(session, event, r, "Stream \"%s\" does not support replay.", sub->stream);

--- a/src/executables/sysrepo-notifd/notifd_config.c
+++ b/src/executables/sysrepo-notifd/notifd_config.c
@@ -317,6 +317,33 @@ subscription_state2str(notif_sub_state_t state)
     }
 }
 
+/**
+ * @brief Check that a receiver instance uses the transport of a subscription.
+ *
+ * RFC 8639 makes the subscription "transport" leaf apply to all the receivers of the
+ * subscription, so a receiver instance of any other transport cannot be serviced, even
+ * when this daemon implements it. The instance transport is the one actually used for
+ * the delivery, while the subscription transport is the one announced in the
+ * subscription state change notifications and the one deciding whether the whole
+ * subscription is serviced by this daemon at all.
+ *
+ * @param[in] sub Subscription of the receiver.
+ * @param[in] recv_inst Receiver instance referenced by the receiver.
+ * @return SR_ERR_OK if the transports match, error code otherwise.
+ */
+static int
+receiver_inst_transport_check(const notif_sub_t *sub, const notif_receiver_inst_t *recv_inst)
+{
+    if (recv_inst->ops == sub->ops) {
+        return SR_ERR_OK;
+    }
+
+    SRNTF_LOG_ERR("Receiver instance \"%s\" uses transport \"%s\" instead of the transport \"%s\" of "
+            "subscription %" PRIu32 ".", recv_inst->name, recv_inst->ops->transport_identity,
+            sub->ops ? sub->ops->transport_identity : "none", sub->id);
+    return SR_ERR_UNSUPPORTED;
+}
+
 const char *
 receiver_state2str(notif_recv_state_t state)
 {
@@ -1041,6 +1068,9 @@ handle_receiver_instance_ref(notifd_ctx_t *notifd_ctx, notif_sub_t *sub, const s
             rc = SR_ERR_NOT_FOUND;
             goto cleanup;
         }
+        if ((rc = receiver_inst_transport_check(sub, new_inst))) {
+            goto cleanup;
+        }
     } else if (op == SR_OP_DELETED) {
         /* the instance ref is being removed */
         new_inst = NULL;
@@ -1336,6 +1366,9 @@ receiver_from_node(notifd_ctx_t *notifd_ctx, const struct lyd_node *node, notif_
             rc = SR_ERR_NOT_FOUND;
             goto cleanup;
         }
+        if ((rc = receiver_inst_transport_check(receiver->sub, receiver->inst))) {
+            goto cleanup;
+        }
         receiver->ops = receiver->inst->ops;
     }
 
@@ -1381,6 +1414,10 @@ receiver_create_from_node(notifd_ctx_t *notifd_ctx, notif_sub_t *sub, const stru
     }
 
 cleanup:
+    if (rc) {
+        /* the subscription cannot be serviced with this receiver */
+        sub_invalidate(sub, NULL);
+    }
     return rc;
 }
 
@@ -1813,6 +1850,38 @@ cleanup:
     return rc;
 }
 
+/**
+ * @brief Validate that a receiver instance uses the transport of the subscription referencing it.
+ *
+ * Only the instances already created by this daemon can be checked. An instance created by
+ * the very same change is not created yet and the transport of an instance of another
+ * publisher is unknown, both are reported by ::receiver_inst_transport_check() when the
+ * change is being applied.
+ *
+ * @param[in] notifd_ctx Daemon context.
+ * @param[in] session Implicit session.
+ * @param[in] event Sysrepo event.
+ * @param[in] inst_name Name of the referenced receiver instance.
+ * @param[in] ops Transport of the subscription.
+ * @return SR_ERR_OK if the transports match, error code otherwise.
+ */
+static int
+sub_change_validate_recv_inst(notifd_ctx_t *notifd_ctx, sr_session_ctx_t *session, sr_event_t event,
+        const char *inst_name, const notif_transport_ops_t *ops)
+{
+    notif_receiver_inst_t *recv_inst;
+
+    recv_inst = receiver_inst_find_by_name(notifd_ctx, inst_name);
+    if (!recv_inst || (recv_inst->ops == ops)) {
+        return SR_ERR_OK;
+    }
+
+    SRNTF_VALIDATE_ERR(session, event, SR_ERR_UNSUPPORTED, "Receiver instance \"%s\" uses transport \"%s\" "
+            "instead of the subscription transport \"%s\".", inst_name, recv_inst->ops->transport_identity,
+            ops ? ops->transport_identity : "none");
+    return SR_ERR_UNSUPPORTED;
+}
+
 int
 sub_change_validate(notifd_ctx_t *notifd_ctx, sr_session_ctx_t *session, sr_event_t event)
 {
@@ -1822,8 +1891,10 @@ sub_change_validate(notifd_ctx_t *notifd_ctx, sr_session_ctx_t *session, sr_even
     const struct lyd_node *node;
     const char *prev_value, *prev_list, *node_name;
     struct lyd_node *n;
+    struct ly_set *set = NULL;
     const char *stream, *xpath_filter;
     struct timespec stop_time, start_time;
+    uint32_t i;
     notif_sub_t *sub;
     const notif_transport_ops_t *ops;
 
@@ -1849,6 +1920,20 @@ sub_change_validate(notifd_ctx_t *notifd_ctx, sr_session_ctx_t *session, sr_even
             rc = r;
             goto cleanup;
         }
+
+        /* all the receivers must use receiver instances of the subscription transport */
+        if (lyd_find_xpath(node, "receivers/receiver/ietf-subscribed-notif-receivers:receiver-instance-ref", &set)) {
+            rc = SR_ERR_LY;
+            goto cleanup;
+        }
+        for (i = 0; i < set->count; i++) {
+            if ((r = sub_change_validate_recv_inst(notifd_ctx, session, event, lyd_get_value(set->dnodes[i]), ops))) {
+                rc = r;
+                goto cleanup;
+            }
+        }
+        ly_set_free(set, NULL);
+        set = NULL;
 
         /* encoding */
         if (!lyd_find_path(node, "encoding", 0, &n)) {
@@ -1981,6 +2066,12 @@ sub_change_validate(notifd_ctx_t *notifd_ctx, sr_session_ctx_t *session, sr_even
                 rc = r;
                 goto cleanup;
             }
+        } else if (!strcmp(node_name, "receiver-instance-ref")) {
+            /* the referenced instance must use the transport of the subscription */
+            if ((r = sub_change_validate_recv_inst(notifd_ctx, session, event, lyd_get_value(node), sub->ops))) {
+                rc = r;
+                goto cleanup;
+            }
         } else if (!strcmp(node_name, "stop-time")) {
             if (ly_time_str2ts(lyd_get_value(node), &stop_time)) {
                 rc = SR_ERR_LY;
@@ -2016,6 +2107,7 @@ sub_change_validate(notifd_ctx_t *notifd_ctx, sr_session_ctx_t *session, sr_even
 
 cleanup:
     sr_free_change_iter(iter);
+    ly_set_free(set, NULL);
     return rc;
 }
 

--- a/src/executables/sysrepo-notifd/notifd_runtime.c
+++ b/src/executables/sysrepo-notifd/notifd_runtime.c
@@ -69,7 +69,6 @@ subscription_state_change_notif_new(const struct ly_ctx *ly_ctx, notif_sub_t *su
     char *id_str = NULL, *stop_time_str = NULL, *start_time_str = NULL;
     struct timespec *start_time, *stop_time;
     notif_encoding_t encoding;
-    const notif_transport_ops_t *ops = NULL;
     const notif_encoding_info_t *enc_info = NULL;
 
     *notif = NULL;
@@ -144,8 +143,8 @@ subscription_state_change_notif_new(const struct ly_ctx *ly_ctx, notif_sub_t *su
     }
 
     /* transport */
-    if ((fields & NOTIF_FIELD_TRANSPORT) && sub->transport) {
-        if (lyd_new_path(tree, ly_ctx, "transport", sub->transport, 0, NULL)) {
+    if ((fields & NOTIF_FIELD_TRANSPORT) && sub->ops) {
+        if (lyd_new_path(tree, ly_ctx, "transport", sub->ops->transport_identity, 0, NULL)) {
             rc = SR_ERR_LY;
             goto cleanup;
         }
@@ -154,8 +153,7 @@ subscription_state_change_notif_new(const struct ly_ctx *ly_ctx, notif_sub_t *su
     /* encoding */
     if (fields & NOTIF_FIELD_ENCODING) {
         /* resolve the encoding (shared path: transport default + feature check) */
-        ops = notif_transport_find_by_identity(sub->transport);
-        encoding = notif_encoding_resolve(sub->encoding, ly_ctx, ops);
+        encoding = notif_encoding_resolve(sub->encoding, ly_ctx, sub->ops);
         enc_info = notif_encoding_info_find(encoding);
         if (!enc_info) {
             SRNTF_LOG_ERR("Failed to resolve encoding for subscription %" PRIu32 ".", sub->id);

--- a/tests/files/notifd-other-publisher.yang
+++ b/tests/files/notifd-other-publisher.yang
@@ -1,0 +1,40 @@
+module notifd-other-publisher {
+    namespace "urn:notifd-other-publisher";
+    prefix nop;
+
+    yang-version 1.1;
+
+    import ietf-subscribed-notifications {
+        prefix sn;
+    }
+
+    import ietf-subscribed-notif-receivers {
+        prefix snr;
+    }
+
+    description
+        "Transport of a notification publisher other than sysrepo-notifd, such as an
+         HTTP-notif based server. The daemon must ignore the subscriptions and the
+         receiver instances using it, they are none of its business.";
+
+    identity other-notif {
+        base sn:transport;
+        description
+            "Transport implemented by another notification publisher.";
+    }
+
+    augment "/sn:subscriptions/snr:receiver-instances/snr:receiver-instance/snr:transport-type" {
+        case other-notif {
+            container other-notif-receiver {
+                description
+                    "Configuration of a receiver of the other publisher.";
+                leaf endpoint {
+                    type string;
+                    mandatory true;
+                    description
+                        "Opaque address of the receiver.";
+                }
+            }
+        }
+    }
+}

--- a/tests/test_notifd.c
+++ b/tests/test_notifd.c
@@ -846,6 +846,7 @@ install_test_modules(sr_conn_ctx_t *conn)
         SN_YANG_DIR "/ietf-udp-client@2025-05-14.yang",
         SN_YANG_DIR "/ietf-udp-notif-transport@2025-06-04.yang",
         TESTS_SRC_DIR "/files/test.yang",
+        TESTS_SRC_DIR "/files/notifd-other-publisher.yang",
         NULL
     };
     const char *sub_ntf_feats[] = {"configured", "xpath", "replay", "subtree", "encode-xml", "encode-json", NULL};
@@ -853,7 +854,8 @@ install_test_modules(sr_conn_ctx_t *conn)
         NULL, NULL, NULL, NULL, NULL,  /* interfaces, iana-if-type, ip, network-instance, restconf */
         sub_ntf_feats,                 /* ietf-subscribed-notifications */
         NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL,  /* other modules */
-        NULL                           /* test.yang */
+        NULL,                          /* test.yang */
+        NULL                           /* notifd-other-publisher.yang */
     };
 
     return sr_install_modules(conn, schema_paths, SN_YANG_DIR, features);
@@ -869,6 +871,7 @@ static int
 remove_test_modules(sr_conn_ctx_t *conn)
 {
     const char *module_names[] = {
+        "notifd-other-publisher",
         "test",
         "ietf-udp-notif-transport",
         "ietf-udp-client",
@@ -3732,6 +3735,329 @@ test_restart_existing_config(void **state)
 }
 
 /**
+ * @brief Create the configuration of another notification publisher.
+ *
+ * A receiver instance with a transport this daemon does not implement and two subscriptions
+ * using it, one declaring the transport of the other publisher and one with no
+ * subscription-level transport at all, which the model allows.
+ *
+ * @param[in] sess Sysrepo session.
+ * @return 0 on success, error code on failure.
+ */
+static int
+create_other_publisher_config(sr_session_ctx_t *sess)
+{
+    int rc;
+
+    rc = sr_set_item_str(sess, "/ietf-subscribed-notifications:subscriptions"
+            "/ietf-subscribed-notif-receivers:receiver-instances/receiver-instance[name='other-inst']"
+            "/notifd-other-publisher:other-notif-receiver/endpoint", "https://[::1]/telemetry", NULL, 0);
+    if (rc) {
+        return rc;
+    }
+
+    rc = sr_set_item_str(sess, "/ietf-subscribed-notifications:subscriptions/subscription[id='241']/stream",
+            "NETCONF", NULL, 0);
+    if (rc) {
+        return rc;
+    }
+    rc = sr_set_item_str(sess, "/ietf-subscribed-notifications:subscriptions/subscription[id='241']/transport",
+            "notifd-other-publisher:other-notif", NULL, 0);
+    if (rc) {
+        return rc;
+    }
+    rc = sr_set_item_str(sess, "/ietf-subscribed-notifications:subscriptions/subscription[id='241']"
+            "/receivers/receiver[name='other-recv']/ietf-subscribed-notif-receivers:receiver-instance-ref",
+            "other-inst", NULL, 0);
+    if (rc) {
+        return rc;
+    }
+
+    rc = sr_set_item_str(sess, "/ietf-subscribed-notifications:subscriptions/subscription[id='242']/stream",
+            "NETCONF", NULL, 0);
+    if (rc) {
+        return rc;
+    }
+    rc = sr_set_item_str(sess, "/ietf-subscribed-notifications:subscriptions/subscription[id='242']"
+            "/receivers/receiver[name='other-recv']/ietf-subscribed-notif-receivers:receiver-instance-ref",
+            "other-inst", NULL, 0);
+    if (rc) {
+        return rc;
+    }
+
+    return SR_ERR_OK;
+}
+
+/**
+ * @brief Read the operational data of all the configured subscriptions.
+ *
+ * @param[in] sess Sysrepo session.
+ * @param[out] data Retrieved data.
+ * @return Error code (SR_ERR_OK on success).
+ */
+static int
+get_oper_subscriptions(sr_session_ctx_t *sess, sr_data_t **data)
+{
+    int ret;
+
+    ret = sr_session_switch_ds(sess, SR_DS_OPERATIONAL);
+    assert_int_equal(ret, SR_ERR_OK);
+
+    ret = sr_get_data(sess, "/ietf-subscribed-notifications:subscriptions", 0, 0, 0, data);
+
+    assert_int_equal(sr_session_switch_ds(sess, SR_DS_RUNNING), SR_ERR_OK);
+    return ret;
+}
+
+/**
+ * @brief Count the instances of a node in a data tree.
+ *
+ * @param[in] tree Data tree to search.
+ * @param[in] xpath XPath to evaluate.
+ * @return Number of the matching nodes.
+ */
+static uint32_t
+node_count(const struct lyd_node *tree, const char *xpath)
+{
+    struct ly_set *set = NULL;
+    uint32_t count;
+
+    assert_int_equal(lyd_find_xpath(tree, xpath, &set), LY_SUCCESS);
+    count = set->count;
+    ly_set_free(set, NULL);
+
+    return count;
+}
+
+/**
+ * @brief Operational get callback of another notification publisher.
+ *
+ * Provides the state of its own receivers, the very nodes the daemon provides for its receivers.
+ */
+static int
+other_publisher_state_cb(sr_session_ctx_t *session, uint32_t sub_id, const char *module_name, const char *path,
+        const char *request_xpath, uint32_t request_id, struct lyd_node **parent, void *private_data)
+{
+    struct lyd_node *node;
+
+    (void)session;
+    (void)sub_id;
+    (void)module_name;
+    (void)path;
+    (void)request_xpath;
+    (void)request_id;
+    (void)private_data;
+
+    if (!parent || !*parent) {
+        return SR_ERR_OK;
+    }
+
+    /* provide the state of the receivers of the other publisher only */
+    if (lyd_find_path(*parent, "name", 0, &node) || strcmp(lyd_get_value(node), "other-recv")) {
+        return SR_ERR_OK;
+    }
+    if (lyd_new_term(*parent, NULL, "state", "suspended", 0, NULL)) {
+        return SR_ERR_LY;
+    }
+
+    return SR_ERR_OK;
+}
+
+/**
+ * @brief Reset action callback of another notification publisher.
+ */
+static int
+other_publisher_reset_cb(sr_session_ctx_t *session, uint32_t sub_id, const char *op_path,
+        const struct lyd_node *input, sr_event_t event, uint32_t request_id, struct lyd_node *output,
+        void *private_data)
+{
+    struct lyd_node *node;
+
+    (void)session;
+    (void)sub_id;
+    (void)op_path;
+    (void)event;
+    (void)request_id;
+    (void)private_data;
+
+    /* answer for the receivers of the other publisher only */
+    if (lyd_find_path(lyd_parent(input), "name", 0, &node) || strcmp(lyd_get_value(node), "other-recv")) {
+        return SR_ERR_OK;
+    }
+    if (lyd_new_term(output, NULL, "time", "2026-01-01T00:00:00Z", LYD_NEW_VAL_OUTPUT, NULL)) {
+        return SR_ERR_LY;
+    }
+
+    return SR_ERR_OK;
+}
+
+/**
+ * @brief Test: Subscriptions of another notification publisher are ignored, not broken.
+ *
+ * The "subscriptions" subtree is shared by all the notification publishers on the system, so it
+ * may contain subscriptions with a transport this daemon does not implement (an HTTP-based
+ * telemetry server, for example). The daemon must neither reject their configuration nor
+ * provide (or delete) any of their state, while keeping its own subscriptions serviced.
+ */
+static void
+test_other_publisher(void **state)
+{
+    struct state *st = *state;
+    struct lyd_node *notif = NULL;
+    sr_subscription_ctx_t *subscr = NULL;
+    sr_data_t *data = NULL;
+    sr_val_t *output = NULL;
+    size_t output_count = 0;
+    char *state_val;
+    int ret;
+
+    TLOG_INF("Creating a subscription serviced by the daemon...");
+
+    setup_sub(st->sess, st->udp_port, 240, "NETCONF", NULL);
+    ret = receive_specific_notification(st->udp_sockfd, st->ly_ctx,
+            "/ietf-subscribed-notifications:subscription-started", &notif, NULL);
+    assert_int_equal(ret, 0);
+    assert_non_null(notif);
+    lyd_free_all(notif);
+    notif = NULL;
+    drain_notifications(st->udp_sockfd);
+
+    TLOG_INF("Creating the configuration of another publisher...");
+
+    /* neither an unimplemented transport nor a subscription without any transport may be rejected */
+    ret = create_other_publisher_config(st->sess);
+    assert_int_equal(ret, SR_ERR_OK);
+    ret = sr_apply_changes(st->sess, 0);
+    assert_int_equal(ret, SR_ERR_OK);
+    drain_notifications(st->udp_sockfd);
+
+    TLOG_INF("Reading the operational data of all the subscriptions...");
+
+    /* used to fail as a whole, the daemon answered "Item not found" for the receivers it does not service */
+    ret = get_oper_subscriptions(st->sess, &data);
+    assert_int_equal(ret, SR_ERR_OK);
+    assert_non_null(data);
+
+    /* the state of our own receiver is provided ... */
+    assert_int_equal(node_count(data->tree, "/ietf-subscribed-notifications:subscriptions"
+            "/subscription[id='240']/receivers/receiver[name='recv1']/state"), 1);
+    assert_int_equal(node_count(data->tree, "/ietf-subscribed-notifications:subscriptions"
+            "/subscription[id='240']/configured-subscription-state"), 1);
+
+    /* ... the state of the other publisher's subscriptions is not, we know nothing about them */
+    assert_int_equal(node_count(data->tree, "/ietf-subscribed-notifications:subscriptions"
+            "/subscription[id='241']/receivers/receiver[name='other-recv']/state"), 0);
+    assert_int_equal(node_count(data->tree, "/ietf-subscribed-notifications:subscriptions"
+            "/subscription[id='241']/configured-subscription-state"), 0);
+    assert_int_equal(node_count(data->tree, "/ietf-subscribed-notifications:subscriptions"
+            "/subscription[id='242']/receivers/receiver[name='other-recv']/state"), 0);
+    assert_int_equal(node_count(data->tree, "/ietf-subscribed-notifications:subscriptions"
+            "/subscription[id='242']/configured-subscription-state"), 0);
+    sr_release_data(data);
+    data = NULL;
+
+    TLOG_INF("Modifying a subscription of the other publisher...");
+
+    ret = sr_set_item_str(st->sess, "/ietf-subscribed-notifications:subscriptions/subscription[id='241']/purpose",
+            "telemetry", NULL, 0);
+    assert_int_equal(ret, SR_ERR_OK);
+    ret = sr_apply_changes(st->sess, 0);
+    assert_int_equal(ret, SR_ERR_OK);
+    drain_notifications(st->udp_sockfd);
+
+    /* the daemon is alive and its own subscription untouched */
+    state_val = get_oper_leaf_str(st->sess, "/ietf-subscribed-notifications:subscriptions"
+            "/subscription[id='240']/configured-subscription-state");
+    assert_non_null(state_val);
+    assert_string_equal(state_val, "valid");
+    free(state_val);
+
+    TLOG_INF("Providing the state of the other publisher's receivers...");
+
+    /* the other publisher provides the state of its receivers on the very paths the daemon uses */
+    ret = sr_oper_get_subscribe(st->sess, "ietf-subscribed-notifications",
+            "/ietf-subscribed-notifications:subscriptions/subscription/receivers/receiver/state",
+            other_publisher_state_cb, NULL, SR_SUBSCR_OPER_MERGE, &subscr);
+    assert_int_equal(ret, SR_ERR_OK);
+
+    /* the state of both publishers is in the operational data */
+    state_val = get_oper_leaf_str(st->sess, "/ietf-subscribed-notifications:subscriptions"
+            "/subscription[id='241']/receivers/receiver[name='other-recv']/state");
+    assert_non_null(state_val);
+    assert_string_equal(state_val, "suspended");
+    free(state_val);
+    state_val = get_oper_leaf_str(st->sess, "/ietf-subscribed-notifications:subscriptions"
+            "/subscription[id='240']/receivers/receiver[name='recv1']/state");
+    assert_non_null(state_val);
+    assert_string_equal(state_val, "active");
+    free(state_val);
+
+    TLOG_INF("Restarting the daemon with the other publisher's provider in place...");
+
+    /* the daemon could not even subscribe for the operational data without SR_SUBSCR_OPER_MERGE now */
+    stop_notifd(st->notifd_pid);
+    st->notifd_pid = 0;
+    drain_notifications(st->udp_sockfd);
+    ret = start_notifd(&st->notifd_pid);
+    assert_int_equal(ret, 0);
+
+    ret = receive_specific_notification_timeout(st->udp_sockfd, st->ly_ctx, LONG_TIMEOUT_MS,
+            "/ietf-subscribed-notifications:subscription-started", &notif, NULL);
+    assert_int_equal(ret, 0);
+    assert_non_null(notif);
+    lyd_free_all(notif);
+    notif = NULL;
+    drain_notifications(st->udp_sockfd);
+
+    state_val = get_oper_leaf_str(st->sess, "/ietf-subscribed-notifications:subscriptions"
+            "/subscription[id='240']/configured-subscription-state");
+    assert_non_null(state_val);
+    assert_string_equal(state_val, "valid");
+    free(state_val);
+
+    TLOG_INF("Deleting the configuration of the other publisher...");
+
+    assert_int_equal(delete_subscription(st->sess, 241), SR_ERR_OK);
+    assert_int_equal(delete_subscription(st->sess, 242), SR_ERR_OK);
+    assert_int_equal(delete_receiver_instance(st->sess, "other-inst"), SR_ERR_OK);
+    ret = sr_apply_changes(st->sess, 0);
+    assert_int_equal(ret, SR_ERR_OK);
+    drain_notifications(st->udp_sockfd);
+
+    /* our own subscription is still serviced */
+    state_val = get_oper_leaf_str(st->sess, "/ietf-subscribed-notifications:subscriptions"
+            "/subscription[id='240']/receivers/receiver[name='recv1']/state");
+    assert_non_null(state_val);
+    assert_string_equal(state_val, "active");
+    free(state_val);
+
+    TLOG_INF("Resetting our receiver with the other publisher subscribed for the action...");
+
+    /* the reset action is subscribed by both publishers, each with its own priority (sysrepo
+     * allows a single subscription per priority) and the daemon must keep answering for its
+     * own receivers */
+    ret = sr_rpc_subscribe_tree(st->sess, "/ietf-subscribed-notifications:subscriptions"
+            "/subscription/receivers/receiver/reset", other_publisher_reset_cb, NULL, 1, 0, &subscr);
+    assert_int_equal(ret, SR_ERR_OK);
+
+    ret = sr_rpc_send(st->sess, "/ietf-subscribed-notifications:subscriptions"
+            "/subscription[id='240']/receivers/receiver[name='recv1']/reset", NULL, 0, 0,
+            &output, &output_count);
+    assert_int_equal(ret, SR_ERR_OK);
+    assert_int_equal(output_count, 1);
+    sr_free_values(output, output_count);
+
+    state_val = get_oper_leaf_str(st->sess, "/ietf-subscribed-notifications:subscriptions"
+            "/subscription[id='240']/receivers/receiver[name='recv1']/state");
+    assert_non_null(state_val);
+    assert_string_equal(state_val, "connecting");
+    free(state_val);
+
+    sr_unsubscribe(subscr);
+    cleanup_sub(st->sess, 240);
+}
+
+/**
  * @brief Test: Verify that changing the encoding of an existing subscription
  * takes effect on subsequent notifications.
  *
@@ -4143,6 +4469,7 @@ main(void)
         cmocka_unit_test_setup(test_receiver_add_delete_dispatch, clear_subs_notifs),
         cmocka_unit_test_setup(test_receiver_delete_keeps_subscription, clear_subs_notifs),
         cmocka_unit_test_setup(test_restart_existing_config, clear_subs_notifs),
+        cmocka_unit_test_setup(test_other_publisher, clear_subs_notifs),
         cmocka_unit_test_setup(test_stop_time_concluded, clear_subs_notifs),
         cmocka_unit_test_setup(test_encoding_cbor_unsupported, clear_subs_notifs),
         cmocka_unit_test_setup(test_default_encoding, clear_subs_notifs),


### PR DESCRIPTION
The `subscriptions` tree is shared by every notification publisher on the system, so the daemon now decides ownership in exactly one place - the transport resolved from the subscription (or receiver instance) node - and services only what it implements. Everything else is ignored completely.

All the operational data providers now use `SR_SUBSCR_OPER_MERGE`.

A subscription with a transport that *no* publisher implements is now silently ignored instead of rejected with `SR_ERR_UNSUPPORTED`. No publisher can tell  whether another one services it.

New `test_other_publisher` in `tests/test_notifd.c` with a `notifd-other-publisher.yang` fixture covering coexisting with other publishers.