### PR TITLE
notifd: fix dispatch state lock reacquire

### DIFF
--- a/src/executables/sysrepo-notifd/main.c
+++ b/src/executables/sysrepo-notifd/main.c
@@ -83,6 +83,19 @@ help_print(void)
             "\n");
 }
 
+void
+notifd_shutdown_request(void)
+{
+    pthread_mutex_lock(&lock);
+
+    if (!loop_finish) {
+        loop_finish = 1;
+        pthread_cond_signal(&cond);
+    }
+
+    pthread_mutex_unlock(&lock);
+}
+
 static void
 signal_handler(int sig)
 {
@@ -335,6 +348,28 @@ notifd_rwlock_unlock(pthread_rwlock_t *lock, const char *func)
     }
 }
 
+int
+notifd_state_wr_relock(notifd_ctx_t *notifd_ctx, const char *func, int *state_locked)
+{
+    uint32_t i;
+
+    for (i = 0; i < NOTIFD_STATE_RELOCK_ATTEMPTS; ++i) {
+        if (!notifd_rwlock_lock(&notifd_ctx->state_rwlock, 1, NOTIFD_CONTEXT_LOCK_TIMEOUT_MS, func)) {
+            return SR_ERR_OK;
+        }
+        SRNTF_LOG_WRN("%s: failed to reacquire the state lock, attempt %" PRIu32 " of %d.", func, i + 1,
+                NOTIFD_STATE_RELOCK_ATTEMPTS);
+    }
+
+    /* the shared state can no longer be accessed safely, there is nothing left to do but terminate */
+    SRNTF_LOG_ERR("%s: failed to reacquire the state lock, the daemon state is inconsistent, terminating.", func);
+    *state_locked = 0;
+    ATOMIC_STORE_RELAXED(notifd_ctx->state_wr_lost, 1);
+    notifd_shutdown_request();
+
+    return SR_ERR_LOCKED;
+}
+
 /**
   * @brief Send subscription-terminated notifications for all active subscriptions and mark them as concluded.
   *
@@ -345,7 +380,14 @@ notifd_graceful_shutdown(notifd_ctx_t *notifd_ctx)
 {
     LY_ARRAY_COUNT_TYPE i;
     notif_sub_t *sub;
-    int r;
+    int r, state_locked = 0;
+
+    if (ATOMIC_LOAD_RELAXED(notifd_ctx->state_wr_lost)) {
+        /* the state lock was lost, there is no safe way to terminate the subscriptions, the process exit
+         * closes all the receiver sockets anyway */
+        SRNTF_LOG_ERR("Skipping the graceful shutdown, the daemon state is inconsistent.");
+        return;
+    }
 
     /* CONFIG APPLY LOCK - needed because notification_dispatch_stop temporarily drops
      * state_rwlock while calling srsn_terminate(), and config_apply_mutex prevents
@@ -361,6 +403,7 @@ notifd_graceful_shutdown(notifd_ctx_t *notifd_ctx)
         notifd_mutex_unlock(&notifd_ctx->config_apply_mutex, __func__);
         return;
     }
+    state_locked = 1;
 
     LY_ARRAY_FOR(notifd_ctx->subs, i) {
         sub = notifd_ctx->subs[i];
@@ -374,10 +417,12 @@ notifd_graceful_shutdown(notifd_ctx_t *notifd_ctx)
     }
 
     /* destroy all subscriptions and receiver instances */
-    notifd_ctx_destroy(notifd_ctx);
+    notifd_ctx_destroy(notifd_ctx, &state_locked);
 
-    /* STATE UNLOCK */
-    notifd_rwlock_unlock(&notifd_ctx->state_rwlock, __func__);
+    if (state_locked) {
+        /* STATE UNLOCK */
+        notifd_rwlock_unlock(&notifd_ctx->state_rwlock, __func__);
+    }
 
     /* CONFIG APPLY UNLOCK */
     notifd_mutex_unlock(&notifd_ctx->config_apply_mutex, __func__);
@@ -555,7 +600,7 @@ cleanup:
 }
 
 static int
-sub_change_process_subscriptions(notifd_ctx_t *notifd_ctx, sr_session_ctx_t *session)
+sub_change_process_subscriptions(notifd_ctx_t *notifd_ctx, sr_session_ctx_t *session, int *state_locked)
 {
     int rc = SR_ERR_OK, r, prev_dflt;
     sr_change_iter_t *iter = NULL;
@@ -571,13 +616,19 @@ sub_change_process_subscriptions(notifd_ctx_t *notifd_ctx, sr_session_ctx_t *ses
         assert(LYD_NAME(node) && !strcmp(LYD_NAME(node), "subscription"));
 
         if (op == SR_OP_CREATED) {
-            if ((r = subscription_create_from_node(notifd_ctx, node))) {
+            if ((r = subscription_create_from_node(notifd_ctx, node, state_locked))) {
                 rc = r;
             }
         } else if (op == SR_OP_DELETED) {
-            if ((r = subscription_destroy_from_node(notifd_ctx, node))) {
+            if ((r = subscription_destroy_from_node(notifd_ctx, node, state_locked))) {
                 rc = r;
             }
+        }
+
+        if (!*state_locked) {
+            /* the state lock is lost, abort the whole transaction */
+            rc = SR_ERR_LOCKED;
+            break;
         }
     }
 
@@ -587,7 +638,7 @@ cleanup:
 }
 
 static int
-sub_change_modify_subscriptions(notifd_ctx_t *notifd_ctx, sr_session_ctx_t *session)
+sub_change_modify_subscriptions(notifd_ctx_t *notifd_ctx, sr_session_ctx_t *session, int *state_locked)
 {
     int rc = SR_ERR_OK, r, prev_dflt;
     sr_change_iter_t *iter = NULL;
@@ -649,7 +700,11 @@ sub_change_modify_subscriptions(notifd_ctx_t *notifd_ctx, sr_session_ctx_t *sess
     iter = NULL;
 
     /* send subscription-modified/subscription-terminated notification for all modified subs */
-    process_modified_subscriptions(notifd_ctx);
+    process_modified_subscriptions(notifd_ctx, state_locked);
+    if (!*state_locked) {
+        /* the state lock is lost, abort the whole transaction */
+        rc = SR_ERR_LOCKED;
+    }
 
 cleanup:
     sr_free_change_iter(iter);
@@ -657,7 +712,7 @@ cleanup:
 }
 
 static int
-sub_change_modify_receivers(notifd_ctx_t *notifd_ctx, sr_session_ctx_t *session)
+sub_change_modify_receivers(notifd_ctx_t *notifd_ctx, sr_session_ctx_t *session, int *state_locked)
 {
     int rc = SR_ERR_OK, r, prev_dflt;
     sr_change_iter_t *iter = NULL;
@@ -691,9 +746,9 @@ sub_change_modify_receivers(notifd_ctx_t *notifd_ctx, sr_session_ctx_t *session)
 
         if (!strcmp(node_name, "receiver")) {
             if (op == SR_OP_CREATED) {
-                r = receiver_create_from_node(notifd_ctx, sub, node);
+                r = receiver_create_from_node(notifd_ctx, sub, node, state_locked);
             } else if (op == SR_OP_DELETED) {
-                r = receiver_destroy_from_node(notifd_ctx, sub, node);
+                r = receiver_destroy_from_node(notifd_ctx, sub, node, state_locked);
             } else {
                 r = 0;
             }
@@ -706,12 +761,22 @@ sub_change_modify_receivers(notifd_ctx_t *notifd_ctx, sr_session_ctx_t *session)
         if (r) {
             rc = r;
         }
+
+        if (!*state_locked) {
+            /* the state lock is lost, abort the whole transaction */
+            rc = SR_ERR_LOCKED;
+            goto cleanup;
+        }
     }
     sr_free_change_iter(iter);
     iter = NULL;
 
     /* send subscription-modified/subscription-terminated for subs invalidated by receiver changes */
-    process_modified_subscriptions(notifd_ctx);
+    process_modified_subscriptions(notifd_ctx, state_locked);
+    if (!*state_locked) {
+        /* the state lock is lost, abort the whole transaction */
+        rc = SR_ERR_LOCKED;
+    }
 
 cleanup:
     sr_free_change_iter(iter);
@@ -766,6 +831,12 @@ subscribed_notifications_sub_change_cb(sr_session_ctx_t *session, uint32_t sub_i
     SRNTF_LOG_INF("Subscribed notifications subscription change callback with ID %" PRIu32 " invoked for event \"%s\".",
             operation_id, sr_event2str(event));
 
+    if (ATOMIC_LOAD_RELAXED(notifd_ctx->state_wr_lost)) {
+        /* the state lock was lost previously, the daemon state must not be touched anymore */
+        SRNTF_LOG_ERR("Refusing to apply the configuration, the daemon state is inconsistent.");
+        return SR_ERR_LOCKED;
+    }
+
     /* CONFIG APPLY LOCK */
     if ((rc = notifd_mutex_lock(&notifd_ctx->config_apply_mutex, NOTIFD_CONTEXT_LOCK_TIMEOUT_MS, __func__))) {
         return rc;
@@ -806,21 +877,30 @@ subscribed_notifications_sub_change_cb(sr_session_ctx_t *session, uint32_t sub_i
     }
 
     /* Step 3: process subscription list changes */
-    r = sub_change_process_subscriptions(notifd_ctx, session);
+    r = sub_change_process_subscriptions(notifd_ctx, session, &state_locked);
     if (r) {
         rc = r;
+    }
+    if (!state_locked) {
+        goto cleanup;
     }
 
     /* Step 4: modify subscriptions */
-    r = sub_change_modify_subscriptions(notifd_ctx, session);
+    r = sub_change_modify_subscriptions(notifd_ctx, session, &state_locked);
     if (r) {
         rc = r;
     }
+    if (!state_locked) {
+        goto cleanup;
+    }
 
     /* Step 5: add/modify/delete receivers */
-    r = sub_change_modify_receivers(notifd_ctx, session);
+    r = sub_change_modify_receivers(notifd_ctx, session, &state_locked);
     if (r) {
         rc = r;
+    }
+    if (!state_locked) {
+        goto cleanup;
     }
 
     /* Step 6: delete receiver instances */
@@ -860,6 +940,12 @@ subscribed_notifications_filter_change_cb(sr_session_ctx_t *session, uint32_t su
 
     SRNTF_LOG_INF("Subscribed notifications filter change callback with ID %" PRIu32 " invoked for event \"%s\".",
             operation_id, sr_event2str(event));
+
+    if (ATOMIC_LOAD_RELAXED(notifd_ctx->state_wr_lost)) {
+        /* the state lock was lost previously, the daemon state must not be touched anymore */
+        SRNTF_LOG_ERR("Refusing to apply the configuration, the daemon state is inconsistent.");
+        return SR_ERR_LOCKED;
+    }
 
     /* CONFIG APPLY LOCK */
     if ((rc = notifd_mutex_lock(&notifd_ctx->config_apply_mutex, NOTIFD_CONTEXT_LOCK_TIMEOUT_MS, __func__))) {
@@ -908,7 +994,11 @@ subscribed_notifications_filter_change_cb(sr_session_ctx_t *session, uint32_t su
     }
 
     /* send subscription-modified/subscription-terminated notification for affected subs */
-    process_modified_subscriptions(notifd_ctx);
+    process_modified_subscriptions(notifd_ctx, &state_locked);
+    if (!state_locked) {
+        /* the state lock is lost, abort the whole transaction */
+        rc = SR_ERR_LOCKED;
+    }
 
 cleanup:
     if (state_locked) {
@@ -1250,6 +1340,12 @@ receiver_reset_rpc_cb(sr_session_ctx_t *UNUSED(session), uint32_t UNUSED(sub_id)
     struct lyd_node *name_node = NULL;
     struct timespec ts_now;
     char *time_str = NULL;
+
+    if (ATOMIC_LOAD_RELAXED(notifd_ctx->state_wr_lost)) {
+        /* the state lock was lost previously, the daemon state must not be touched anymore */
+        SRNTF_LOG_ERR("Refusing to apply the configuration, the daemon state is inconsistent.");
+        return SR_ERR_LOCKED;
+    }
 
     /* CONFIG APPLY LOCK */
     if ((rc = notifd_mutex_lock(&notifd_ctx->config_apply_mutex, NOTIFD_CONTEXT_LOCK_TIMEOUT_MS, __func__))) {

--- a/src/executables/sysrepo-notifd/notifd.h
+++ b/src/executables/sysrepo-notifd/notifd.h
@@ -75,6 +75,14 @@
 #define NOTIFD_CONTEXT_LOCK_TIMEOUT_MS 10000
 
 /**
+ * @brief Number of attempts to reacquire the state write lock after it was temporarily dropped.
+ *
+ * Readers are not excluded by config_apply_mutex, so a stuck or continuous reader can make the
+ * reacquire time out. Give it a few tries before declaring the state lost, see ::notifd_ctx_s.state_wr_lost.
+ */
+#define NOTIFD_STATE_RELOCK_ATTEMPTS 3
+
+/**
  * @brief Base delay in seconds for receiver reconnect exponential backoff.
  */
 #define NOTIFD_RECV_RECONNECT_BASE_SEC 1
@@ -404,6 +412,10 @@ struct notifd_ctx_s {
     pthread_mutex_t config_apply_mutex;     /**< serialize config-apply operations; keeps a single apply
                                                  transaction active so state_rwlock write-lock ownership
                                                  cannot be stolen across temporary unlock/relock windows */
+    ATOMIC_T state_wr_lost;                 /**< Monotonic flag set permanently if state_rwlock
+                                                 could not be reacquired after a temporary unlock,
+                                                 indicating the shared state may be inconsistent
+                                                 and the daemon is shutting down. */
 
     notif_sub_t **subs;                     /**< configured subscriptions (sized-array, see libyang docs) */
     notif_receiver_inst_t **recv_insts;     /**< configured receiver instances (sized-array, see libyang docs) */

--- a/src/executables/sysrepo-notifd/notifd_common.h
+++ b/src/executables/sysrepo-notifd/notifd_common.h
@@ -248,9 +248,11 @@ notif_receiver_inst_t *receiver_inst_find_by_node(notifd_ctx_t *notifd_ctx, cons
  *
  * @param[in,out] notifd_ctx Daemon context (subscription is added to its array).
  * @param[in] node The YANG `subscription` list entry node.
- * @return ::SR_ERR_OK on success, error code on failure.
+ * @param[in,out] state_locked Whether the state write lock is held, set to 0 if it was lost, in
+ * which case the caller must unwind without accessing the shared state and without unlocking it.
+ * @return ::SR_ERR_OK on success, ::SR_ERR_LOCKED if the state lock was lost, error code on failure.
  */
-int subscription_create_from_node(notifd_ctx_t *notifd_ctx, const struct lyd_node *node);
+int subscription_create_from_node(notifd_ctx_t *notifd_ctx, const struct lyd_node *node, int *state_locked);
 
 /**
  * @brief Destroy a subscription identified by a YANG node within its subtree.
@@ -260,9 +262,11 @@ int subscription_create_from_node(notifd_ctx_t *notifd_ctx, const struct lyd_nod
  *
  * @param[in,out] notifd_ctx Daemon context.
  * @param[in] node YANG node within the subscription subtree to be deleted.
+ * @param[in,out] state_locked Whether the state write lock is held, set to 0 if it was lost, in
+ * which case the caller must unwind without accessing the shared state and without unlocking it.
  * @return ::SR_ERR_OK on success, ::SR_ERR_NOT_FOUND if the subscription cannot be found.
  */
-int subscription_destroy_from_node(notifd_ctx_t *notifd_ctx, const struct lyd_node *node);
+int subscription_destroy_from_node(notifd_ctx_t *notifd_ctx, const struct lyd_node *node, int *state_locked);
 
 /**
  * @brief Create a new receiver within a subscription from a YANG `receiver` node.
@@ -274,9 +278,12 @@ int subscription_destroy_from_node(notifd_ctx_t *notifd_ctx, const struct lyd_no
  * @param[in,out] notifd_ctx Daemon context.
  * @param[in,out] sub Parent subscription (receiver is added to its array).
  * @param[in] node The YANG `receiver` list entry node.
- * @return ::SR_ERR_OK on success, error code on failure.
+ * @param[in,out] state_locked Whether the state write lock is held, set to 0 if it was lost, in
+ * which case the caller must unwind without accessing the shared state and without unlocking it.
+ * @return ::SR_ERR_OK on success, ::SR_ERR_LOCKED if the state lock was lost, error code on failure.
  */
-int receiver_create_from_node(notifd_ctx_t *notifd_ctx, notif_sub_t *sub, const struct lyd_node *node);
+int receiver_create_from_node(notifd_ctx_t *notifd_ctx, notif_sub_t *sub, const struct lyd_node *node,
+        int *state_locked);
 
 /**
  * @brief Destroy a receiver identified by a YANG node within its subtree.
@@ -287,9 +294,12 @@ int receiver_create_from_node(notifd_ctx_t *notifd_ctx, notif_sub_t *sub, const 
  * @param[in,out] notifd_ctx Daemon context.
  * @param[in,out] sub Parent subscription.
  * @param[in] node YANG node within the receiver subtree to be deleted.
+ * @param[in,out] state_locked Whether the state write lock is held, set to 0 if it was lost, in
+ * which case the caller must unwind without accessing the shared state and without unlocking it.
  * @return ::SR_ERR_OK on success, ::SR_ERR_NOT_FOUND if the receiver cannot be found.
  */
-int receiver_destroy_from_node(notifd_ctx_t *notifd_ctx, notif_sub_t *sub, const struct lyd_node *node);
+int receiver_destroy_from_node(notifd_ctx_t *notifd_ctx, notif_sub_t *sub, const struct lyd_node *node,
+        int *state_locked);
 
 /**
  * @brief Create a new receiver instance from a YANG `receiver-instance` node.
@@ -509,8 +519,10 @@ int handle_stream_filter(notifd_ctx_t *notifd_ctx, const struct lyd_node *node, 
  * Resets the modified, resubscribe, and modif_err_reason flags.
  *
  * @param[in,out] notifd_ctx Daemon context.
+ * @param[in,out] state_locked Whether the state write lock is held, set to 0 if it was lost, in
+ * which case the caller must unwind without accessing the shared state and without unlocking it.
  */
-void process_modified_subscriptions(notifd_ctx_t *notifd_ctx);
+void process_modified_subscriptions(notifd_ctx_t *notifd_ctx, int *state_locked);
 
 /**
  * @brief Post-processing pass after receiver-instance configuration changes.
@@ -531,9 +543,12 @@ void process_modified_receiver_instances(notifd_ctx_t *notifd_ctx);
  *
  * @param[in] notifd_ctx Daemon context.
  * @param[in,out] sub Subscription to resubscribe.
- * @return ::SR_ERR_OK on success, error code from notification_dispatch_start on failure.
+ * @param[in,out] state_locked Whether the state write lock is held, set to 0 if it was lost, in
+ * which case the caller must unwind without accessing the shared state and without unlocking it.
+ * @return ::SR_ERR_OK on success, ::SR_ERR_LOCKED if the state lock was lost, error code from
+ * notification_dispatch_start on failure.
  */
-int subscription_resubscribe(notifd_ctx_t *notifd_ctx, notif_sub_t *sub);
+int subscription_resubscribe(notifd_ctx_t *notifd_ctx, notif_sub_t *sub, int *state_locked);
 
 /**
  * @brief Validate subscription changes during SR_EV_CHANGE or SR_EV_ENABLED (read-only).
@@ -582,8 +597,10 @@ int module_feature_is_enabled(notifd_ctx_t *notifd_ctx, const char *module_name,
  * The ::notifd_ctx_t struct itself is NOT freed (caller's responsibility).
  *
  * @param[in,out] notifd_ctx Daemon context to destroy. If NULL, returns immediately.
+ * @param[in,out] state_locked Whether the state write lock is held, set to 0 if it was lost, in
+ * which case the caller must unwind without accessing the shared state and without unlocking it.
  */
-void notifd_ctx_destroy(notifd_ctx_t *notifd_ctx);
+void notifd_ctx_destroy(notifd_ctx_t *notifd_ctx, int *state_locked);
 
 /*
  * ---------------------------------------------------------------------------
@@ -768,31 +785,40 @@ int notif_receiver_send(notifd_ctx_t *notifd_ctx, notif_receiver_t *receiver, co
  *
  * @warning The caller MUST hold both state_rwlock (write) AND config_apply_mutex.
  * The config_apply_mutex prevents another thread from stealing the write-lock
- * in the unlock/relock window.
+ * in the unlock/relock window. The write lock is held again on return unless
+ * @p state_locked was cleared.
  *
  * @param[in] notifd_ctx Daemon context (its sr_sess is used as the srsn subscription session,
  * its state_rwlock is temporarily unlocked/relocked).
  * @param[in] sub Subscription defining the stream, filter, and stop/start times.
  * @param[in] receiver Receiver whose srsn_data and cb_data will be populated.
- * @return ::SR_ERR_OK on success, error code on failure.
+ * @param[in,out] state_locked Whether the state write lock is held, set to 0 if it was lost, in
+ * which case the caller must unwind without accessing the shared state and without unlocking it.
+ * @return ::SR_ERR_OK on success, ::SR_ERR_LOCKED if the state lock was lost, another error code
+ * on failure.
  */
-int notification_dispatch_start(notifd_ctx_t *notifd_ctx, notif_sub_t *sub, notif_receiver_t *receiver);
+int notification_dispatch_start(notifd_ctx_t *notifd_ctx, notif_sub_t *sub, notif_receiver_t *receiver,
+        int *state_locked);
 
 /**
  * @brief Stop notification dispatch for a receiver.
  *
  * Terminates the srsn subscription and cleans up resources. Temporarily drops
  * the state write lock to allow srsn_terminate() to invoke the notification
- * callback (which acquires the state read lock).
+ * callback (which acquires the state read lock). If the dispatch was never
+ * started, the lock is not dropped at all.
  *
  * @warning The caller MUST hold both state_rwlock (write) AND config_apply_mutex.
  * The config_apply_mutex prevents another thread from stealing the write-lock
- * in the unlock/relock window.
+ * in the unlock/relock window. The write lock is held again on return unless
+ * @p state_locked was cleared.
  *
- * @param[in] notifd_ctx Daemon context (its state_rwlock is temporarily unlocked/relocked).
+ * @param[in] notifd_ctx Daemon context (its state_rwlock may be temporarily unlocked/relocked).
  * @param[in] receiver Receiver whose dispatch is being stopped.
+ * @param[in,out] state_locked Whether the state write lock is held, set to 0 if it was lost, in
+ * which case the caller must unwind without accessing the shared state and without unlocking it.
  */
-void notification_dispatch_stop(notifd_ctx_t *notifd_ctx, notif_receiver_t *receiver);
+void notification_dispatch_stop(notifd_ctx_t *notifd_ctx, notif_receiver_t *receiver, int *state_locked);
 
 /**
  * @brief Main notification callback invoked by the srsn dispatch thread.
@@ -849,5 +875,27 @@ int notifd_rwlock_lock(pthread_rwlock_t *lock, int is_write, uint32_t timeout_ms
  * @param[in] func Calling function name for error reporting.
  */
 void notifd_rwlock_unlock(pthread_rwlock_t *lock, const char *func);
+
+/**
+ * @brief Reacquire the state write lock after it was temporarily dropped.
+ *
+ * Retries ::NOTIFD_STATE_RELOCK_ATTEMPTS times, readers are not excluded by config_apply_mutex so
+ * a single attempt can time out on a stuck reader. On final failure the shared state is left
+ * unprotected, so @p state_locked is cleared for the unwinding call chain,
+ * notifd_ctx_s.state_wr_lost is latched for the other threads, and daemon termination is requested.
+ *
+ * @param[in] notifd_ctx Daemon context.
+ * @param[in] func Calling function name for error reporting.
+ * @param[in,out] state_locked Whether the state write lock is held, set to 0 if it was lost.
+ * @return ::SR_ERR_OK if the lock is held again, ::SR_ERR_LOCKED if it was lost.
+ */
+int notifd_state_wr_relock(notifd_ctx_t *notifd_ctx, const char *func, int *state_locked);
+
+/**
+ * @brief Request a graceful termination of the daemon, as if a terminating signal was received.
+ *
+ * May be called from any thread, has no effect if the termination was already requested.
+ */
+void notifd_shutdown_request(void);
 
 #endif /* COMMON_H_ */

--- a/src/executables/sysrepo-notifd/notifd_config.c
+++ b/src/executables/sysrepo-notifd/notifd_config.c
@@ -30,7 +30,7 @@
 #include <libyang/libyang.h>
 
 /* forward declarations */
-void receiver_destroy(notifd_ctx_t *notifd_ctx, notif_sub_t *sub, notif_receiver_t *receiver);
+void receiver_destroy(notifd_ctx_t *notifd_ctx, notif_sub_t *sub, notif_receiver_t *receiver, int *state_locked);
 static void receiver_instance_destroy(notifd_ctx_t *notifd_ctx, notif_receiver_inst_t *recv_inst);
 
 /*
@@ -1107,7 +1107,7 @@ cleanup:
  */
 
 static int
-subscription_from_node(notifd_ctx_t *notifd_ctx, const struct lyd_node *node, notif_sub_t *sub)
+subscription_from_node(notifd_ctx_t *notifd_ctx, const struct lyd_node *node, notif_sub_t *sub, int *state_locked)
 {
     int rc = SR_ERR_OK;
     struct lyd_node *n, *filter;
@@ -1201,7 +1201,7 @@ subscription_from_node(notifd_ctx_t *notifd_ctx, const struct lyd_node *node, no
         goto cleanup;
     }
     for (i = 0; i < set->count; i++) {
-        if ((rc = receiver_create_from_node(notifd_ctx, sub, set->dnodes[i]))) {
+        if ((rc = receiver_create_from_node(notifd_ctx, sub, set->dnodes[i], state_locked))) {
             goto cleanup;
         }
     }
@@ -1218,19 +1218,23 @@ cleanup:
  * @param[in] sub Subscription whose receivers should be disconnected.
  */
 static void
-subscription_receivers_disconnect(notifd_ctx_t *notifd_ctx, notif_sub_t *sub)
+subscription_receivers_disconnect(notifd_ctx_t *notifd_ctx, notif_sub_t *sub, int *state_locked)
 {
     notif_receiver_t *receiver;
 
     LY_ARRAY_FOR(sub->receivers, notif_receiver_t, receiver) {
         /* disconnect the receiver */
-        notification_dispatch_stop(notifd_ctx, receiver);
+        notification_dispatch_stop(notifd_ctx, receiver, state_locked);
+        if (!*state_locked) {
+            /* the state lock is lost, leave the rest of the receivers alone */
+            break;
+        }
         notif_receiver_disconnect(receiver);
     }
 }
 
 int
-subscription_create_from_node(notifd_ctx_t *notifd_ctx, const struct lyd_node *node)
+subscription_create_from_node(notifd_ctx_t *notifd_ctx, const struct lyd_node *node, int *state_locked)
 {
     int rc = SR_ERR_OK;
     const notif_transport_ops_t *ops;
@@ -1251,15 +1255,24 @@ subscription_create_from_node(notifd_ctx_t *notifd_ctx, const struct lyd_node *n
 
     /* the transport is resolved, the rest of the configuration is parsed below */
     sub->ops = ops;
-    if ((rc = subscription_from_node(notifd_ctx, node, sub))) {
+    if ((rc = subscription_from_node(notifd_ctx, node, sub, state_locked))) {
         goto cleanup;
     }
 
 cleanup:
     if (rc) {
+        if (!*state_locked) {
+            /* the state lock is lost, the receivers must not be disconnected (that needs the lock to be
+             * dropped and reacquired) and the sub must stay in the context array untouched */
+            return SR_ERR_LOCKED;
+        }
+
         /* keep the subscription tracked but invalid, its state is reported in the operational data
          * and the daemon is expected to service it once its configuration is fixed */
-        subscription_receivers_disconnect(notifd_ctx, sub);
+        subscription_receivers_disconnect(notifd_ctx, sub, state_locked);
+        if (!*state_locked) {
+            return SR_ERR_LOCKED;
+        }
         sub_invalidate(sub, NULL);
         if (!sub_ptr) {
             free(sub);
@@ -1275,7 +1288,7 @@ cleanup:
  * @param[in] sub Subscription to destroy.
  */
 static void
-subscription_destroy(notifd_ctx_t *notifd_ctx, notif_sub_t *sub)
+subscription_destroy(notifd_ctx_t *notifd_ctx, notif_sub_t *sub, int *state_locked)
 {
     LY_ARRAY_COUNT_TYPE i;
 
@@ -1283,16 +1296,23 @@ subscription_destroy(notifd_ctx_t *notifd_ctx, notif_sub_t *sub)
         return;
     }
 
+    /* destroy the receivers first, so that the sub is left intact for the readers if the state lock is lost */
+    for (i = LY_ARRAY_COUNT(sub->receivers); i > 0; i--) {
+        receiver_destroy(notifd_ctx, sub, &sub->receivers[i - 1], state_locked);
+        if (!*state_locked) {
+            /* the state lock is lost, neither the receivers nor the context array may be touched anymore */
+            return;
+        }
+    }
+    LY_ARRAY_FREE(sub->receivers);
+    sub->receivers = NULL;
+
     /* free members */
     free(sub->stream);
     free(sub->xpath_filter);
     free(sub->filter_ref);
     free(sub->purpose);
     free(sub->local_address);
-    for (i = LY_ARRAY_COUNT(sub->receivers); i > 0; i--) {
-        receiver_destroy(notifd_ctx, sub, &sub->receivers[i - 1]);
-    }
-    LY_ARRAY_FREE(sub->receivers);
 
     /* replace with the last and decrement array */
     LY_ARRAY_FOR(notifd_ctx->subs, i) {
@@ -1306,7 +1326,7 @@ subscription_destroy(notifd_ctx_t *notifd_ctx, notif_sub_t *sub)
 }
 
 int
-subscription_destroy_from_node(notifd_ctx_t *notifd_ctx, const struct lyd_node *node)
+subscription_destroy_from_node(notifd_ctx_t *notifd_ctx, const struct lyd_node *node, int *state_locked)
 {
     notif_sub_t *sub;
 
@@ -1325,7 +1345,7 @@ subscription_destroy_from_node(notifd_ctx_t *notifd_ctx, const struct lyd_node *
     }
 
     /* destroy the sub */
-    subscription_destroy(notifd_ctx, sub);
+    subscription_destroy(notifd_ctx, sub, state_locked);
 
     return SR_ERR_OK;
 }
@@ -1377,7 +1397,7 @@ cleanup:
 }
 
 int
-receiver_create_from_node(notifd_ctx_t *notifd_ctx, notif_sub_t *sub, const struct lyd_node *node)
+receiver_create_from_node(notifd_ctx_t *notifd_ctx, notif_sub_t *sub, const struct lyd_node *node, int *state_locked)
 {
     int rc = SR_ERR_OK, r;
     notif_receiver_t *receiver;
@@ -1393,7 +1413,7 @@ receiver_create_from_node(notifd_ctx_t *notifd_ctx, notif_sub_t *sub, const stru
     }
 
     /* start dispatch so this receiver can receive notifications */
-    if ((rc = notification_dispatch_start(notifd_ctx, sub, receiver))) {
+    if ((rc = notification_dispatch_start(notifd_ctx, sub, receiver, state_locked))) {
         goto cleanup;
     }
 
@@ -1414,7 +1434,7 @@ receiver_create_from_node(notifd_ctx_t *notifd_ctx, notif_sub_t *sub, const stru
     }
 
 cleanup:
-    if (rc) {
+    if (rc && *state_locked) {
         /* the subscription cannot be serviced with this receiver */
         sub_invalidate(sub, NULL);
     }
@@ -1422,14 +1442,18 @@ cleanup:
 }
 
 void
-receiver_destroy(notifd_ctx_t *notifd_ctx, notif_sub_t *sub, notif_receiver_t *receiver)
+receiver_destroy(notifd_ctx_t *notifd_ctx, notif_sub_t *sub, notif_receiver_t *receiver, int *state_locked)
 {
     if (!sub || !receiver) {
         return;
     }
 
     /* stop dispatch for this receiver */
-    notification_dispatch_stop(notifd_ctx, receiver);
+    notification_dispatch_stop(notifd_ctx, receiver, state_locked);
+    if (!*state_locked) {
+        /* the state lock is lost, the receiver array must stay as it is, the memory is freed on exit */
+        return;
+    }
 
     /* disconnect the receiver */
     notif_receiver_disconnect(receiver);
@@ -1444,7 +1468,7 @@ receiver_destroy(notifd_ctx_t *notifd_ctx, notif_sub_t *sub, notif_receiver_t *r
 }
 
 int
-receiver_destroy_from_node(notifd_ctx_t *notifd_ctx, notif_sub_t *sub, const struct lyd_node *node)
+receiver_destroy_from_node(notifd_ctx_t *notifd_ctx, notif_sub_t *sub, const struct lyd_node *node, int *state_locked)
 {
     int rc = SR_ERR_OK;
     notif_receiver_t *receiver;
@@ -1462,7 +1486,7 @@ receiver_destroy_from_node(notifd_ctx_t *notifd_ctx, notif_sub_t *sub, const str
     }
 
     /* destroy the receiver */
-    receiver_destroy(notifd_ctx, sub, receiver);
+    receiver_destroy(notifd_ctx, sub, receiver, state_locked);
 
 cleanup:
     return rc;
@@ -1590,17 +1614,21 @@ receiver_instance_destroy_from_node(notifd_ctx_t *notifd_ctx, const struct lyd_n
  */
 
 int
-subscription_resubscribe(notifd_ctx_t *notifd_ctx, notif_sub_t *sub)
+subscription_resubscribe(notifd_ctx_t *notifd_ctx, notif_sub_t *sub, int *state_locked)
 {
     int rc = SR_ERR_OK;
     notif_receiver_t *receiver;
 
     LY_ARRAY_FOR(sub->receivers, notif_receiver_t, receiver) {
         /* stop the dispatch, which will unsubscribe from sysrepo and stop all timers */
-        notification_dispatch_stop(notifd_ctx, receiver);
+        notification_dispatch_stop(notifd_ctx, receiver, state_locked);
+        if (!*state_locked) {
+            rc = SR_ERR_LOCKED;
+            goto cleanup;
+        }
 
         /* start the dispatch again with the new params, which will resubscribe to sysrepo and restart timers */
-        if ((rc = notification_dispatch_start(notifd_ctx, sub, receiver))) {
+        if ((rc = notification_dispatch_start(notifd_ctx, sub, receiver, state_locked))) {
             goto cleanup;
         }
     }
@@ -1610,7 +1638,7 @@ subscription_resubscribe(notifd_ctx_t *notifd_ctx, notif_sub_t *sub)
 }
 
 void
-process_modified_subscriptions(notifd_ctx_t *notifd_ctx)
+process_modified_subscriptions(notifd_ctx_t *notifd_ctx, int *state_locked)
 {
     int r;
     notif_sub_t **sub;
@@ -1618,7 +1646,11 @@ process_modified_subscriptions(notifd_ctx_t *notifd_ctx)
     /* go through all subs and send subscription-modified for those that are modified */
     LY_ARRAY_FOR(notifd_ctx->subs, notif_sub_t *, sub) {
         if ((*sub)->resubscribe) {
-            r = subscription_resubscribe(notifd_ctx, *sub);
+            r = subscription_resubscribe(notifd_ctx, *sub, state_locked);
+            if (!*state_locked) {
+                /* the state lock is lost, leave the rest of the subscriptions alone */
+                return;
+            }
             if (!r) {
                 (*sub)->state = NOTIF_SUB_STATE_VALID;
             } else {
@@ -2192,7 +2224,7 @@ cleanup:
 }
 
 void
-notifd_ctx_destroy(notifd_ctx_t *notifd_ctx)
+notifd_ctx_destroy(notifd_ctx_t *notifd_ctx, int *state_locked)
 {
     LY_ARRAY_COUNT_TYPE i;
 
@@ -2202,7 +2234,11 @@ notifd_ctx_destroy(notifd_ctx_t *notifd_ctx)
 
     /* destroy all subscriptions (includes stopping dispatch, disconnecting receivers, freeing memory) */
     for (i = LY_ARRAY_COUNT(notifd_ctx->subs); i > 0; i--) {
-        subscription_destroy(notifd_ctx, notifd_ctx->subs[i - 1]);
+        subscription_destroy(notifd_ctx, notifd_ctx->subs[i - 1], state_locked);
+        if (!*state_locked) {
+            /* the state lock is lost, the remaining memory is reclaimed by the process exit */
+            return;
+        }
     }
     notifd_ctx->subs = NULL;
 

--- a/src/executables/sysrepo-notifd/notifd_runtime.c
+++ b/src/executables/sysrepo-notifd/notifd_runtime.c
@@ -632,10 +632,15 @@ notification_dispatch_data_free(notif_receiver_t *receiver)
 }
 
 int
-notification_dispatch_start(notifd_ctx_t *notifd_ctx, notif_sub_t *sub, notif_receiver_t *receiver)
+notification_dispatch_start(notifd_ctx_t *notifd_ctx, notif_sub_t *sub, notif_receiver_t *receiver, int *state_locked)
 {
-    int rc = SR_ERR_OK, unlocked = 0;
+    int rc = SR_ERR_OK, r, unlocked = 0;
     struct timespec *stop_time, *start_time;
+
+    if (!*state_locked) {
+        /* the state lock was already lost, the state must not be touched and there is nothing to unlock */
+        return SR_ERR_LOCKED;
+    }
 
     stop_time = (sub->stop_time.tv_sec || sub->stop_time.tv_nsec) ? &sub->stop_time : NULL;
     start_time = (sub->start_time.tv_sec || sub->start_time.tv_nsec) ? &sub->start_time : NULL;
@@ -677,10 +682,9 @@ cleanup:
 
     if (unlocked) {
         /* WR LOCK, reacquire to finish updating the config */
-        if (notifd_rwlock_lock(&notifd_ctx->state_rwlock, 1, NOTIFD_CONTEXT_LOCK_TIMEOUT_MS, __func__)) {
-            SRNTF_LOG_ERR("Internal error: failed to acquire state lock to start notification dispatch for "
-                    "receiver \"%s\".", receiver->name);
-            return rc ? rc : SR_ERR_INTERNAL;
+        if ((r = notifd_state_wr_relock(notifd_ctx, __func__, state_locked))) {
+            /* the state lock is lost, unwind without touching the state */
+            return r;
         }
     }
 
@@ -691,8 +695,19 @@ cleanup:
 }
 
 void
-notification_dispatch_stop(notifd_ctx_t *notifd_ctx, notif_receiver_t *receiver)
+notification_dispatch_stop(notifd_ctx_t *notifd_ctx, notif_receiver_t *receiver, int *state_locked)
 {
+    if (!*state_locked) {
+        /* the state lock was already lost, the state must not be touched and there is nothing to unlock */
+        return;
+    }
+
+    if (!receiver->srsn_data.sub_id && (receiver->srsn_data.fd == -1) && !receiver->cb_data) {
+        /* dispatch was never started (or was already stopped), there is nothing to wait for so keep the
+         * state lock and avoid the unlock/relock window altogether */
+        goto unsubscribe;
+    }
+
     /* UNLOCK state lock, srsn_terminate will call notif cb, which will try to acquire the state lock to send
      * any remaining notifs. Nobody can steal our WR lock here, because the caller MUST hold config_apply_mutex,
      * which prevents another thread from acquiring the state WR lock in this window */
@@ -710,17 +725,17 @@ notification_dispatch_stop(notifd_ctx_t *notifd_ctx, notif_receiver_t *receiver)
         receiver->srsn_data.fd = -1;
     }
 
-    /* free before the lock is reacquired, which may fail */
+    /* free while the dispatch is guaranteed not to reference it anymore */
     free(receiver->cb_data);
     receiver->cb_data = NULL;
 
     /* WR LOCK, reacquire to finish updating the config before checking retval of srsn_terminate */
-    if (notifd_rwlock_lock(&notifd_ctx->state_rwlock, 1, NOTIFD_CONTEXT_LOCK_TIMEOUT_MS, __func__)) {
-        SRNTF_LOG_ERR("Internal error: failed to acquire state lock to stop notification dispatch for receiver \"%s\".",
-                receiver->name);
+    if (notifd_state_wr_relock(notifd_ctx, __func__, state_locked)) {
+        /* the state lock is lost, unwind without touching the state */
         return;
     }
 
+unsubscribe:
     if (receiver->srsn_data.sr_subscr) {
         sr_unsubscribe(receiver->srsn_data.sr_subscr);
         receiver->srsn_data.sr_subscr = NULL;
@@ -769,6 +784,11 @@ notifd_notification_cb(const struct lyd_node *notif, const struct timespec *time
     assert(data);
     notifd_ctx = data->ctx;
     assert(notifd_ctx);
+
+    if (ATOMIC_LOAD_RELAXED(notifd_ctx->state_wr_lost)) {
+        /* the state lock was lost, the state must not be read nor modified anymore */
+        return;
+    }
 
     /* STATE RD LOCK */
     if (notifd_rwlock_lock(&notifd_ctx->state_rwlock, 0, NOTIFD_CONTEXT_LOCK_TIMEOUT_MS, __func__)) {


### PR DESCRIPTION
`notification_dispatch_start()` and `notification_dispatch_stop()` drop the state write lock while talking to srsn and reacquire it before returning. On a reacquire timeout they used to just log and return without the lock, while every caller assumes it is held.  Retry the reacquire until it succeeds so that the documented contract "the write lock is held on return" always holds.